### PR TITLE
Add new header comment location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -644,8 +644,8 @@ Choose from the list of available rules:
   - ``commentType`` (``'comment'``, ``'PHPDoc'``): comment syntax type; defaults to
     ``'comment'``
   - ``header`` (``string``): proper header content; required
-  - ``location`` (``'after_declare_strict'``, ``'after_open'``): the location of the
-    inserted header; defaults to ``'after_declare_strict'``
+  - ``location`` (``'after_declare_strict'``, ``'after_namespace'``, ``'after_open'``): the
+    location of the inserted header; defaults to ``'after_declare_strict'``
   - ``separate`` (``'both'``, ``'bottom'``, ``'none'``, ``'top'``): whether the header should be
     separated from the file content with a new line; defaults to ``'both'``
 

--- a/tests/Fixer/Comment/HeaderCommentFixerTest.php
+++ b/tests/Fixer/Comment/HeaderCommentFixerTest.php
@@ -375,7 +375,7 @@ echo 1;'
                     'header' => '',
                     'location' => new \stdClass(),
                 ],
-                'Invalid configuration: The option "location" with value stdClass is invalid. Accepted values are: "after_open", "after_declare_strict".',
+                'Invalid configuration: The option "location" with value stdClass is invalid. Accepted values are: "after_open", "after_declare_strict", "after_namespace".',
             ],
             [
                 [


### PR DESCRIPTION
This pull requests adds a new location for the header_comment configuration: `'after_namespace'`. If configured, the header is inserted after the namespace declaration. In none namespace declaration is found, the default `'after_declare_strict'` configuration is used to find the correct header position.