### PR TITLE
BinaryOperatorSpacesFixer: align_single_space bug

### DIFF
--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -401,6 +401,17 @@ $a//
                     );',
                 ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE]],
             ],
+            [
+                '<?php
+$fooooo = 111    === 0;
+$bar    = 333333 === 0;
+                ',
+                '<?php
+$fooooo = 111 === 0;
+$bar = 333333 === 0;
+                ',
+                ['default' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE],
+            ],
         ];
     }
 


### PR DESCRIPTION
The code is fixed the right way, but only after second run.

#### Input
```php
$fooooo = 111 === 0;
$bar = 333333 === 0;
```
#### Test output
```diff
--- Expected
+++ Actual
@@ @@
 <?php
-$fooooo = 111    === 0;
+$fooooo = 111 === 0;
 $bar    = 333333 === 0;
```