### PR TITLE
Add support for outputting to stdout

### DIFF
--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -111,6 +111,7 @@ final class FixCommand extends Command
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats.'),
                     new InputOption('stop-on-violation', '', InputOption::VALUE_NONE, 'Stop execution on first violation.'),
                     new InputOption('show-progress', '', InputOption::VALUE_REQUIRED, 'Type of progress indicator (none, run-in, estimating, estimating-max or dots).'),
+                    new InputOption('stdout', '', InputOption::VALUE_NONE, 'Send output to stdout'),
                 ]
             )
             ->setDescription('Fixes a directory or a file.')
@@ -144,17 +145,21 @@ final class FixCommand extends Command
                 'stop-on-violation' => $input->getOption('stop-on-violation'),
                 'verbosity' => $verbosity,
                 'show-progress' => $input->getOption('show-progress'),
+                'stdout' => $input->getOption('stdout'),
             ],
             getcwd(),
             $this->toolInfo
         );
 
+        // Supress any text-based errors when target is stdout.
         $reporter = $resolver->getReporter();
-
-        $stdErr = $output instanceof ConsoleOutputInterface
-            ? $output->getErrorOutput()
-            : ('txt' === $reporter->getFormat() ? $output : null)
-        ;
+        if ($resolver->isStdOut()) {
+            $stdErr = null;
+        } else {
+            $stdErr = $output instanceof ConsoleOutputInterface
+                ? $output->getErrorOutput()
+                : ('txt' === $reporter->getFormat() ? $output : null);
+        }
 
         if (null !== $stdErr) {
             if (null !== $passedConfig && null !== $passedRules) {
@@ -213,7 +218,8 @@ final class FixCommand extends Command
             $resolver->isDryRun(),
             $resolver->getCacheManager(),
             $resolver->getDirectory(),
-            $resolver->shouldStopOnViolation()
+            $resolver->shouldStopOnViolation(),
+            $resolver->isStdOut()
         );
 
         $this->stopwatch->start('fixFiles');

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -130,6 +130,7 @@ final class ConfigurationResolver
         'stop-on-violation' => null,
         'using-cache' => null,
         'verbosity' => null,
+        'stdout' => null,
     ];
 
     private $cacheFile;
@@ -555,6 +556,14 @@ final class ConfigurationResolver
     }
 
     /**
+     * @return bool
+     */
+    public function isStdOut()
+    {
+        return true === $this->options['stdout'];
+    }
+
+    /**
      * Compute file candidates for config file.
      *
      * @return string[]
@@ -617,6 +626,10 @@ final class ConfigurationResolver
      */
     private function getFormat()
     {
+        if ($this->isStdOut()) {
+            return 'null';
+        }
+
         if (null === $this->format) {
             $this->format = null === $this->options['format']
                 ? $this->getConfig()->getFormat()

--- a/src/Report/NullReporter.php
+++ b/src/Report/NullReporter.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Report;
+
+/**
+ * @author Boris Gorbylev <ekho@ekho.name>
+ *
+ * @internal
+ */
+final class NullReporter implements ReporterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFormat()
+    {
+        return 'null';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(ReportSummary $reportSummary)
+    {
+    }
+}

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -95,7 +95,8 @@ final class Runner
         $isDryRun,
         CacheManagerInterface $cacheManager,
         DirectoryInterface $directory = null,
-        $stopOnViolation = false
+        $stopOnViolation = false,
+        $stdOut = false
     ) {
         $this->finder = $finder;
         $this->fixers = $fixers;
@@ -107,6 +108,7 @@ final class Runner
         $this->cacheManager = $cacheManager;
         $this->directory = $directory ?: new Directory('');
         $this->stopOnViolation = $stopOnViolation;
+        $this->stdOut = $stdOut;
     }
 
     /**
@@ -244,7 +246,9 @@ final class Runner
                 return;
             }
 
-            if (!$this->isDryRun) {
+            if ($this->stdOut) {
+                fwrite(STDOUT, $new);
+            } elseif (!$this->isDryRun) {
                 if (false === @file_put_contents($file->getRealPath(), $new)) {
                     $error = error_get_last();
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -287,7 +287,7 @@ final class ConfigurationResolverTest extends TestCase
     public function testResolveConfigFileChooseFileWithInvalidFormat()
     {
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessageRegExp('/^The format "xls" is not defined, supported are "checkstyle", "json", "junit", "txt", "xml"\.$/');
+        $this->expectExceptionMessageRegExp('/^The format "xls" is not defined, supported are "checkstyle", "json", "junit", "null", "txt", "xml"\.$/');
 
         $dirBase = $this->getFixtureDir();
 
@@ -968,7 +968,7 @@ final class ConfigurationResolverTest extends TestCase
 
         $options = $definition->getOptions();
         $this->assertSame(
-            ['path-mode', 'allow-risky', 'config', 'dry-run', 'rules', 'using-cache', 'cache-file', 'diff', 'diff-format', 'format', 'stop-on-violation', 'show-progress'],
+            ['path-mode', 'allow-risky', 'config', 'dry-run', 'rules', 'using-cache', 'cache-file', 'diff', 'diff-format', 'format', 'stop-on-violation', 'show-progress', 'stdout'],
             array_keys($options),
             'Expected options mismatch, possibly test needs updating.'
         );
@@ -984,6 +984,7 @@ final class ConfigurationResolverTest extends TestCase
             'diff-format' => 'udiff',
             'format' => 'json',
             'stop-on-violation' => true,
+            'stdout' => false,
         ]);
 
         $this->assertTrue($resolver->shouldStopOnViolation());

--- a/tests/Report/NullReporterTest.php
+++ b/tests/Report/NullReporterTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Report;
+
+use PhpCsFixer\Report\NullReporter;
+
+/**
+ * @author Boris Gorbylev <ekho@ekho.name>
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Report\NullReporter
+ */
+final class NullReporterTest extends AbstractReporterTestCase
+{
+    public function createSimpleReport()
+    {
+    }
+
+    public function createWithDiffReport()
+    {
+    }
+
+    public function createWithAppliedFixersReport()
+    {
+    }
+
+    public function createWithTimeAndMemoryReport()
+    {
+    }
+
+    public function createComplexReport()
+    {
+    }
+
+    protected function createReporter()
+    {
+        return new NullReporter();
+    }
+
+    protected function getFormat()
+    {
+        return 'null';
+    }
+
+    protected function createNoErrorReport()
+    {
+    }
+
+    protected function assertFormat($expected, $input)
+    {
+        $this->markTestSkipped('NullReporterTest skipped');
+    }
+}

--- a/tests/Report/ReporterFactoryTest.php
+++ b/tests/Report/ReporterFactoryTest.php
@@ -51,7 +51,7 @@ final class ReporterFactoryTest extends TestCase
 
         $builder->registerBuiltInReporters();
         $this->assertSame(
-            ['checkstyle', 'json', 'junit', 'txt', 'xml'],
+            ['checkstyle', 'json', 'junit', 'null', 'txt', 'xml'],
             $builder->getFormats()
         );
     }

--- a/tests/TextDiffTest.php
+++ b/tests/TextDiffTest.php
@@ -94,7 +94,7 @@ TEST;
         sort($formats);
 
         $this->assertSame(
-            ['checkstyle', 'json', 'junit', 'txt', 'xml'],
+            ['checkstyle', 'json', 'junit', 'null', 'txt', 'xml'],
             $formats
         );
     }


### PR DESCRIPTION
Fixes #2011

This PR adds basic support for outputting the result to stdout with the `--stdout` command line parameter.

Only one file is supported, though if you did pass multiple files it would just stream them all to stdout. In reality, if your wanting stdout then your probably not caring much for multiple files. But in any case, better support for that could be added in the future.

## Use case for this PR

To improve formatter extensions/plugins for e.g. Visual Studio Code, Atom, Sublime, etc.

If for example you had a `formatOnSave` option configured, the workflow in editors at the moment is this:

1. Document Saved (to disk)
2. Exec php-cs-fixer (takes 2+ secs)
3. Editor polls/detects change to file on disk
4. Reload document

If at any point during this the user has changed the file, the editor will essentially corrupt it and show an error message, it'll then force you to re-open the file, discarding any changes you made. This interrupts your workflow and isn't a good experience. There is currently NO way around this because php-cs-fixer doesn't even allow outputting to a different file, as a workaround.

With this PR, the workflow becomes much improved:

1. Intercept document about to be saved (e.g. in vscode, `onWillSaveTextDocument`)
2. Std-in the code to php-cs-fixer (response 2+ secs)
3. Std-out from cs fixer
4. Update contents of document
5. Save to disk

This avoids multiple disk saves, it also allows you to cancel/discard the output from php-cs-fixer if the document has subsequently been changed.