### PR TITLE
[Bug] BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE apply fix every consecutive run

### DIFF
--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -401,6 +401,14 @@ $a//
                     );',
                 ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE]],
             ],
+            'bug multiple runs' => [
+                '<?php
+$a = $a - $c + 1;
+$b = $b + $c - 1;
+                ',
+                null,
+                ['default' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE],
+            ],
         ];
     }
 


### PR DESCRIPTION
Origin
```php
$a = $a - $c + 1;
$b = $b + $c - 1;
```
First run
```php
$a = $a      - $c + 1;
$b = $b           + $c - 1;
```
Second run
```php
$a = $a                - $c + 1;
$b = $b                     + $c - 1;
```
And so on :bomb: 

At the time of writing, this is solely a bug report. Unless this description changes, anyone willing to fix this is welcomed to try so, as I'm currently a bit busy.