### PR TITLE
Fix PHPStan errors related to Tokens array access 

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,16 +36,6 @@ parameters:
 			path: src/AbstractDoctrineAnnotationFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/AbstractDoctrineAnnotationFixer.php
-
-		-
-			message: "#^Cannot call method isClassy\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/AbstractDoctrineAnnotationFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/AbstractDoctrineAnnotationFixer.php
@@ -76,29 +66,14 @@ parameters:
 			path: src/AbstractFopenFlagFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/AbstractLinesBeforeNamespaceFixer.php
-
-		-
 			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
 			count: 2
-			path: src/AbstractLinesBeforeNamespaceFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
 			path: src/AbstractLinesBeforeNamespaceFixer.php
 
 		-
 			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
 			count: 1
 			path: src/AbstractLinesBeforeNamespaceFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 10
-			path: src/AbstractNoUselessElseFixer.php
 
 		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
@@ -108,16 +83,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
-			path: src/AbstractNoUselessElseFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/AbstractNoUselessElseFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
 			path: src/AbstractNoUselessElseFixer.php
 
 		-
@@ -131,23 +96,8 @@ parameters:
 			path: src/AbstractNoUselessElseFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/AbstractNoUselessElseFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/AbstractNoUselessElseFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
 			count: 2
-			path: src/AbstractNoUselessElseFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
 			path: src/AbstractNoUselessElseFixer.php
 
 		-
@@ -164,16 +114,6 @@ parameters:
 			message: "#^Cannot call method getPriority\\(\\) on PhpCsFixer\\\\Fixer\\\\FixerInterface\\|false\\.$#"
 			count: 1
 			path: src/AbstractProxyFixer.php
-
-		-
-			message: "#^Cannot call method isKeyword\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/AbstractPsrAutoloadingFixer.php
-
-		-
-			message: "#^Cannot call method isMagicConstant\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/AbstractPsrAutoloadingFixer.php
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
@@ -1016,11 +956,6 @@ parameters:
 			path: src/FileRemoval.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Alias/BacktickToShellExecFixer.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\Alias\\\\BacktickToShellExecFixer\\:\\:fixBackticks\\(\\) has parameter \\$backtickTokens with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Fixer/Alias/BacktickToShellExecFixer.php
@@ -1052,16 +987,6 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\!\\=\\= between null and int will always evaluate to true\\.$#"
-			count: 1
-			path: src/Fixer/Alias/EregToPregFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Alias/EregToPregFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Alias/EregToPregFixer.php
 
@@ -1101,11 +1026,6 @@ parameters:
 			path: src/Fixer/Alias/NoAliasFunctionsFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Alias/NoAliasFunctionsFixer.php
-
-		-
 			message: "#^Cannot assign offset \\(int\\|string\\) to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
 			count: 1
 			path: src/Fixer/Alias/NoAliasFunctionsFixer.php
@@ -1136,27 +1056,12 @@ parameters:
 			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
 
 		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
-
-		-
 			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
 
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
 
@@ -1171,22 +1076,7 @@ parameters:
 			path: src/Fixer/Alias/PowToExponentiationFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Alias/PowToExponentiationFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Alias/PowToExponentiationFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Alias/PowToExponentiationFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/Alias/PowToExponentiationFixer.php
 
@@ -1226,38 +1116,8 @@ parameters:
 			path: src/Fixer/Alias/RandomApiMigrationFixer.php
 
 		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Alias/SetTypeToCastFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Alias/SetTypeToCastFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Alias/SetTypeToCastFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Alias/SetTypeToCastFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
-			path: src/Fixer/Alias/SetTypeToCastFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Alias/SetTypeToCastFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
 			path: src/Fixer/Alias/SetTypeToCastFixer.php
 
 		-
@@ -1267,16 +1127,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#6 \\$secondArgumentStart of method PhpCsFixer\\\\Fixer\\\\Alias\\\\SetTypeToCastFixer\\:\\:removeSettypeCall\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Alias/SetTypeToCastFixer.php
-
-		-
-			message: "#^Parameter \\#3 \\$argumentToken of method PhpCsFixer\\\\Fixer\\\\Alias\\\\SetTypeToCastFixer\\:\\:findSettypeNullCall\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Alias/SetTypeToCastFixer.php
-
-		-
-			message: "#^Parameter \\#3 \\$argumentToken of method PhpCsFixer\\\\Fixer\\\\Alias\\\\SetTypeToCastFixer\\:\\:fixSettypeCall\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/Alias/SetTypeToCastFixer.php
 
@@ -1301,11 +1151,6 @@ parameters:
 			path: src/Fixer/ArrayNotation/ArraySyntaxFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ArrayNotation/ArraySyntaxFixer.php
-
-		-
 			message: "#^Variable method call on \\$this\\(PhpCsFixer\\\\Fixer\\\\ArrayNotation\\\\ArraySyntaxFixer\\)\\.$#"
 			count: 1
 			path: src/Fixer/ArrayNotation/ArraySyntaxFixer.php
@@ -1326,32 +1171,7 @@ parameters:
 			path: src/Fixer/ArrayNotation/ArraySyntaxFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ArrayNotation/NoMultilineWhitespaceAroundDoubleArrowFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ArrayNotation/NoMultilineWhitespaceAroundDoubleArrowFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ArrayNotation/NoMultilineWhitespaceAroundDoubleArrowFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ArrayNotation/NoTrailingCommaInSinglelineArrayFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ArrayNotation/NoTrailingCommaInSinglelineArrayFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ArrayNotation/NoTrailingCommaInSinglelineArrayFixer.php
 
@@ -1361,22 +1181,7 @@ parameters:
 			path: src/Fixer/ArrayNotation/NoTrailingCommaInSinglelineArrayFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
 
@@ -1396,17 +1201,7 @@ parameters:
 			path: src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
 
@@ -1426,21 +1221,6 @@ parameters:
 			path: src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
@@ -1456,42 +1236,7 @@ parameters:
 			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixer.php
 
@@ -1499,11 +1244,6 @@ parameters:
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\ArrayNotation\\\\WhitespaceAfterCommaInArrayFixer\\:\\:skipNonArrayElements\\(\\) should return int but returns int\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 34
-			path: src/Fixer/Basic/BracesFixer.php
 
 		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
@@ -1516,18 +1256,8 @@ parameters:
 			path: src/Fixer/Basic/BracesFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 20
-			path: src/Fixer/Basic/BracesFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 4
-			path: src/Fixer/Basic/BracesFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 21
 			path: src/Fixer/Basic/BracesFixer.php
 
 		-
@@ -1548,11 +1278,6 @@ parameters:
 		-
 			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
 			count: 4
-			path: src/Fixer/Basic/BracesFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 15
 			path: src/Fixer/Basic/BracesFixer.php
 
 		-
@@ -1583,16 +1308,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in &&, mixed given on the left side\\.$#"
 			count: 1
-			path: src/Fixer/Basic/BracesFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 13
-			path: src/Fixer/Basic/BracesFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 8
 			path: src/Fixer/Basic/BracesFixer.php
 
 		-
@@ -1641,11 +1356,6 @@ parameters:
 			path: src/Fixer/Basic/BracesFixer.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Basic/BracesFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$structureTokenIndex of method PhpCsFixer\\\\Fixer\\\\Basic\\\\BracesFixer\\:\\:findParenthesisEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
 			path: src/Fixer/Basic/BracesFixer.php
@@ -1681,11 +1391,6 @@ parameters:
 			path: src/Fixer/Basic/BracesFixer.php
 
 		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Basic/BracesFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Basic\\\\BracesFixer\\:\\:detectIndent\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/Basic/BracesFixer.php
@@ -1707,16 +1412,6 @@ parameters:
 
 		-
 			message: "#^Property PhpCsFixer\\\\Fixer\\\\Basic\\\\EncodingFixer\\:\\:\\$BOM has no typehint specified\\.$#"
-			count: 1
-			path: src/Fixer/Basic/EncodingFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Basic/EncodingFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Basic/EncodingFixer.php
 
@@ -1746,16 +1441,6 @@ parameters:
 			path: src/Fixer/Basic/NonPrintableCharacterFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Basic/NonPrintableCharacterFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Basic/NonPrintableCharacterFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$str of function strtr expects string, array\\|string given\\.$#"
 			count: 1
 			path: src/Fixer/Basic/NonPrintableCharacterFixer.php
@@ -1767,16 +1452,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$start of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:generatePartialCode\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Basic/Psr0Fixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Basic/Psr0Fixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Basic/Psr0Fixer.php
 
@@ -1811,16 +1486,6 @@ parameters:
 			path: src/Fixer/Basic/Psr0Fixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Basic/Psr4Fixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Basic/Psr4Fixer.php
-
-		-
 			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
 			count: 2
 			path: src/Fixer/Basic/Psr4Fixer.php
@@ -1836,24 +1501,9 @@ parameters:
 			path: src/Fixer/Casing/LowercaseConstantsFixer.php
 
 		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Casing/LowercaseConstantsFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Casing/LowercaseConstantsFixer.php
-
-		-
 			message: "#^Property PhpCsFixer\\\\Fixer\\\\Casing\\\\LowercaseKeywordsFixer\\:\\:\\$excludedTokens has no typehint specified\\.$#"
 			count: 1
 			path: src/Fixer/Casing/LowercaseKeywordsFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Casing/LowercaseStaticReferenceFixer.php
 
 		-
 			message: "#^Property PhpCsFixer\\\\Fixer\\\\Casing\\\\MagicMethodCasingFixer\\:\\:\\$magicNames has no typehint specified\\.$#"
@@ -1866,37 +1516,7 @@ parameters:
 			path: src/Fixer/Casing/MagicMethodCasingFixer.php
 
 		-
-			message: "#^Cannot call method isClassy\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Casing/MagicMethodCasingFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/Casing/MagicMethodCasingFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Casing/MagicMethodCasingFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Casing/MagicMethodCasingFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Casing/NativeFunctionCasingFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/Casing/NativeFunctionCasingFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Casing/NativeFunctionCasingFixer.php
 
@@ -1906,52 +1526,12 @@ parameters:
 			path: src/Fixer/Casing/NativeFunctionCasingFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Casing/NativeFunctionCasingFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
-
-		-
 			message: "#^Offset 'space' does not exist on array\\<string, mixed\\>\\|null\\.$#"
 			count: 1
 			path: src/Fixer/CastNotation/CastSpacesFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/CastNotation/CastSpacesFixer.php
-
-		-
-			message: "#^Cannot call method isCast\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/CastNotation/LowercaseCastFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/CastNotation/LowercaseCastFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/CastNotation/LowercaseCastFixer.php
-
-		-
 			message: "#^Strict comparison using \\!\\=\\= between null and int will always evaluate to true\\.$#"
-			count: 1
-			path: src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
 
@@ -1961,69 +1541,9 @@ parameters:
 			path: src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/CastNotation/NoShortBoolCastFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/CastNotation/NoShortBoolCastFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/CastNotation/NoShortBoolCastFixer.php
-
-		-
 			message: "#^Variable \\$i might not be defined\\.$#"
 			count: 1
 			path: src/Fixer/CastNotation/NoShortBoolCastFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/CastNotation/NoUnsetCastFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/CastNotation/NoUnsetCastFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/CastNotation/NoUnsetCastFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/CastNotation/NoUnsetCastFixer.php
-
-		-
-			message: "#^Cannot call method isCast\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/CastNotation/ShortScalarCastFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/CastNotation/ShortScalarCastFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/CastNotation/ShortScalarCastFixer.php
 
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassAttributesSeparationFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
@@ -2038,11 +1558,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
-			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
 			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
 
 		-
@@ -2068,21 +1583,6 @@ parameters:
 		-
 			message: "#^Parameter \\#3 \\$elementEndIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassAttributesSeparationFixer\\:\\:fixSpaceBelowClassElement\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 8
-			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
 			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
 
 		-
@@ -2124,11 +1624,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNonWhitespaceSibling\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
-
-		-
-			message: "#^Cannot call method isClassy\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
 
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixer\\:\\:fixClassyDefinitionExtends\\(\\) has parameter \\$classExtendsInfo with no value type specified in iterable type array\\.$#"
@@ -2191,11 +1686,6 @@ parameters:
 			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
 			count: 6
 			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
@@ -2203,16 +1693,6 @@ parameters:
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixer\\:\\:fixClassyDefinitionOpenSpacing\\(\\) should return int but returns int\\|null\\.$#"
 			count: 2
-			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
 			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
 
 		-
@@ -2231,11 +1711,6 @@ parameters:
 			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
-
-		-
 			message: "#^Only booleans are allowed in a ternary operator condition, int given\\.$#"
 			count: 2
 			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
@@ -2251,11 +1726,6 @@ parameters:
 			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
@@ -2267,11 +1737,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, bool\\|int given\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
 
@@ -2311,11 +1776,6 @@ parameters:
 			path: src/Fixer/ClassNotation/FinalInternalClassFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/ClassNotation/FinalInternalClassFixer.php
-
-		-
 			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/FinalInternalClassFixer.php
@@ -2331,23 +1791,8 @@ parameters:
 			path: src/Fixer/ClassNotation/FinalInternalClassFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/FinalInternalClassFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
 			count: 2
-			path: src/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
 			path: src/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixer.php
 
 		-
@@ -2361,44 +1806,14 @@ parameters:
 			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 4
-			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
 			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
 
 		-
 			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
 
 		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
@@ -2408,11 +1823,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
-			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
 			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
 
 		-
@@ -2431,11 +1841,6 @@ parameters:
 			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
 
 		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\NoPhp4ConstructorFixer\\:\\:getWrapperMethodSequence\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
@@ -2446,37 +1851,12 @@ parameters:
 			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$classOpenIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\NoUnneededFinalMethodFixer\\:\\:fixClass\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
 
@@ -2516,11 +1896,6 @@ parameters:
 			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
 
 		-
-			message: "#^Cannot call method isClassy\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, float\\|int given\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -2536,21 +1911,6 @@ parameters:
 			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
-
-		-
 			message: "#^Offset 'end' does not exist on array\\('start' \\=\\> int, 'visibility' \\=\\> string, 'static' \\=\\> bool, \\?'type' \\=\\> mixed, \\?'end' \\=\\> int, \\?'name' \\=\\> mixed\\)\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -2561,23 +1921,8 @@ parameters:
 			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
 
 		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
 
 		-
@@ -2606,22 +1951,7 @@ parameters:
 			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
 
 		-
-			message: "#^Cannot clone PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
-
-		-
-			message: "#^Parameter \\#3 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideRange\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
 
@@ -2631,18 +1961,8 @@ parameters:
 			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
-
-		-
 			message: "#^Foreach overwrites \\$interfaceIndex with its key variable\\.$#"
 			count: 2
-			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$array of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:fromArray\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
-			count: 1
 			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
 
 		-
@@ -2671,12 +1991,12 @@ parameters:
 			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
 
 		-
-			message: "#^Offset 'originalIndex' does not exist on array\\('tokens' \\=\\> array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\>, \\?'normalized' \\=\\> string, \\?'originalIndex' \\=\\> int\\)\\.$#"
+			message: "#^Offset 'originalIndex' does not exist on array\\('tokens' \\=\\> array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\>, \\?'normalized' \\=\\> string, \\?'originalIndex' \\=\\> int\\)\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
 
 		-
-			message: "#^Offset 'tokens' does not exist on null\\|array\\('tokens' \\=\\> array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\>, \\?'normalized' \\=\\> string, \\?'originalIndex' \\=\\> int\\)\\.$#"
+			message: "#^Offset 'tokens' does not exist on null\\|array\\('tokens' \\=\\> array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\>, \\?'normalized' \\=\\> string, \\?'originalIndex' \\=\\> int\\)\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
 
@@ -2684,16 +2004,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$indexEnd of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideRange\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
-
-		-
-			message: "#^Parameter \\#3 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideRange\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
 
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
@@ -2711,19 +2021,9 @@ parameters:
 			path: src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
-
-		-
 			message: "#^Only booleans are allowed in &&, int\\|null given on the left side\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 9
-			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
 
 		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
@@ -2736,27 +2036,12 @@ parameters:
 			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
-
-		-
 			message: "#^Parameter \\#4 \\$startIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\SelfAccessorFixer\\:\\:replaceNameOccurrences\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
 
 		-
 			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
 
@@ -2786,11 +2071,6 @@ parameters:
 			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
@@ -2798,11 +2078,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
-			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
 			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
 
 		-
@@ -2816,44 +2091,9 @@ parameters:
 			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
-
-		-
-			message: "#^Cannot clone PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
-
-		-
-			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\SingleClassElementPerStatementFixer\\:\\:getModifiersSequences\\(\\) should return array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\> but returns array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\>\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
 
 		-
 			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
@@ -2861,28 +2101,8 @@ parameters:
 			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
-
-		-
-			message: "#^Cannot clone PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
-
-		-
-			message: "#^Parameter \\#2 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
 
 		-
@@ -2901,32 +2121,7 @@ parameters:
 			path: src/Fixer/ClassNotation/VisibilityRequiredFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/ClassNotation/VisibilityRequiredFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/VisibilityRequiredFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/VisibilityRequiredFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/VisibilityRequiredFixer.php
-
-		-
-			message: "#^Parameter \\#2 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
-			count: 1
-			path: src/Fixer/ClassNotation/VisibilityRequiredFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ClassNotation/VisibilityRequiredFixer.php
 
@@ -2936,34 +2131,14 @@ parameters:
 			path: src/Fixer/ClassUsage/DateTimeImmutableFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 11
-			path: src/Fixer/ClassUsage/DateTimeImmutableFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ClassUsage/DateTimeImmutableFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 3
-			path: src/Fixer/ClassUsage/DateTimeImmutableFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Fixer/ClassUsage/DateTimeImmutableFixer.php
 
 		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
 			path: src/Fixer/ClassUsage/DateTimeImmutableFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Comment/CommentToPhpdocFixer.php
 
 		-
 			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\CommentsAnalyzer\\:\\:isHeaderComment\\(\\) expects int, float\\|int given\\.$#"
@@ -3001,11 +2176,6 @@ parameters:
 			path: src/Fixer/Comment/CommentToPhpdocFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/Comment/CommentToPhpdocFixer.php
-
-		-
 			message: "#^Only booleans are allowed in \\|\\|, mixed given on the left side\\.$#"
 			count: 1
 			path: src/Fixer/Comment/CommentToPhpdocFixer.php
@@ -3016,18 +2186,8 @@ parameters:
 			path: src/Fixer/Comment/CommentToPhpdocFixer.php
 
 		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Utils\\:\\:calculateTrailingWhitespaceIndent\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Comment/CommentToPhpdocFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in pre\\-increment, int\\|false given\\.$#"
 			count: 2
-			path: src/Fixer/Comment/CommentToPhpdocFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
 			path: src/Fixer/Comment/CommentToPhpdocFixer.php
 
 		-
@@ -3051,23 +2211,8 @@ parameters:
 			path: src/Fixer/Comment/HeaderCommentFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 7
-			path: src/Fixer/Comment/HeaderCommentFixer.php
-
-		-
 			message: "#^Offset 'comment_type' does not exist on array\\<string, mixed\\>\\|null\\.$#"
 			count: 2
-			path: src/Fixer/Comment/HeaderCommentFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Comment/HeaderCommentFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
 			path: src/Fixer/Comment/HeaderCommentFixer.php
 
 		-
@@ -3078,16 +2223,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
 			count: 1
-			path: src/Fixer/Comment/HeaderCommentFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/Comment/HeaderCommentFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
 			path: src/Fixer/Comment/HeaderCommentFixer.php
 
 		-
@@ -3116,32 +2251,12 @@ parameters:
 			path: src/Fixer/Comment/HeaderCommentFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Comment/NoEmptyCommentFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Comment\\\\NoEmptyCommentFixer\\:\\:getCommentBlock\\(\\) expects int, float\\|int given\\.$#"
 			count: 1
 			path: src/Fixer/Comment/NoEmptyCommentFixer.php
 
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\Comment\\\\NoEmptyCommentFixer\\:\\:getCommentBlock\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Fixer/Comment/NoEmptyCommentFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/Comment/NoEmptyCommentFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Comment/NoEmptyCommentFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Comment/NoEmptyCommentFixer.php
 
@@ -3206,21 +2321,6 @@ parameters:
 			path: src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/ElseifFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/ControlStructure/ElseifFixer.php
@@ -3231,22 +2331,7 @@ parameters:
 			path: src/Fixer/ControlStructure/ElseifFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/ElseifFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/ElseifFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/ElseifFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ControlStructure/ElseifFixer.php
 
@@ -3261,32 +2346,7 @@ parameters:
 			path: src/Fixer/ControlStructure/IncludeFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ControlStructure/IncludeFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/ControlStructure/IncludeFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/IncludeFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/IncludeFixer.php
-
-		-
 			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/IncludeFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ControlStructure/IncludeFixer.php
 
@@ -3294,21 +2354,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/ControlStructure/IncludeFixer.php
-
-		-
-			message: "#^Parameter \\#2 \\$token of method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\NoAlternativeSyntaxFixer\\:\\:fixElseif\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
-
-		-
-			message: "#^Parameter \\#2 \\$token of method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\NoAlternativeSyntaxFixer\\:\\:fixElse\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
-
-		-
-			message: "#^Parameter \\#2 \\$token of method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\NoAlternativeSyntaxFixer\\:\\:fixOpenCloseControls\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
 
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\NoAlternativeSyntaxFixer\\:\\:findParenthesisEnd\\(\\) has parameter \\$structureTokenIndex with no typehint specified\\.$#"
@@ -3316,18 +2361,8 @@ parameters:
 			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
-			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
 			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
 
 		-
@@ -3366,38 +2401,13 @@ parameters:
 			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 17
-			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\NoBreakCommentFixer\\:\\:isNoBreakComment\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
 
 		-
 			message: "#^Offset 'comment_text' does not exist on array\\<string, mixed\\>\\|null\\.$#"
 			count: 3
-			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 16
 			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
 
 		-
@@ -3426,21 +2436,6 @@ parameters:
 			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
-
-		-
 			message: "#^Only booleans are allowed in &&, int given on the right side\\.$#"
 			count: 1
 			path: src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
@@ -3451,17 +2446,7 @@ parameters:
 			path: src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoTrailingCommaInListCallFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoTrailingCommaInListCallFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ControlStructure/NoTrailingCommaInListCallFixer.php
 
@@ -3486,42 +2471,12 @@ parameters:
 			path: src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
-
-		-
 			message: "#^Offset 'namespaces' does not exist on array\\<string, mixed\\>\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
 
 		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
 
@@ -3536,11 +2491,6 @@ parameters:
 			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
@@ -3551,29 +2501,9 @@ parameters:
 			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
 			count: 3
 			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/NoUselessElseFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ControlStructure/NoUselessElseFixer.php
 
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
@@ -3596,43 +2526,13 @@ parameters:
 			path: src/Fixer/ControlStructure/NoUselessElseFixer.php
 
 		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
-
-		-
 			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php
-
-		-
 			message: "#^Variable \\$colonIndex might not be defined\\.$#"
 			count: 2
-			path: src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
 			path: src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php
 
 		-
@@ -3643,21 +2543,6 @@ parameters:
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: src/Fixer/ControlStructure/YodaStyleFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 24
-			path: src/Fixer/ControlStructure/YodaStyleFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixer\\:\\:isOfLowerPrecedence\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 2
-			path: src/Fixer/ControlStructure/YodaStyleFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 2
 			path: src/Fixer/ControlStructure/YodaStyleFixer.php
 
 		-
@@ -3676,18 +2561,8 @@ parameters:
 			path: src/Fixer/ControlStructure/YodaStyleFixer.php
 
 		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ControlStructure/YodaStyleFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 9
-			path: src/Fixer/ControlStructure/YodaStyleFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
+			message: "#^Parameter \\#1 \\$possibleKind of method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:isGivenKind\\(\\) expects array\\<int\\>\\|int, array\\<int\\|string\\> given\\.$#"
+			count: 1
 			path: src/Fixer/ControlStructure/YodaStyleFixer.php
 
 		-
@@ -3726,11 +2601,6 @@ parameters:
 			path: src/Fixer/ControlStructure/YodaStyleFixer.php
 
 		-
-			message: "#^Cannot call method isCast\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ControlStructure/YodaStyleFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 3
 			path: src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -3741,16 +2611,6 @@ parameters:
 			path: src/Fixer/ControlStructure/YodaStyleFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ControlStructure/YodaStyleFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ControlStructure/YodaStyleFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:isEmptyAt\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -3758,11 +2618,6 @@ parameters:
 		-
 			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/ControlStructure/YodaStyleFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
 			path: src/Fixer/ControlStructure/YodaStyleFixer.php
 
 		-
@@ -3966,11 +2821,6 @@ parameters:
 			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 9
-			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
 			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
@@ -3996,23 +2846,8 @@ parameters:
 			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 5
-			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
 			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
 
 		-
@@ -4022,11 +2857,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
 
@@ -4046,32 +2876,12 @@ parameters:
 			path: src/Fixer/FunctionNotation/FopenFlagOrderFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/FunctionNotation/FopenFlagOrderFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/FopenFlagOrderFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$argumentStartIndex \\(int\\) of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\FopenFlagsFixer\\:\\:fixFopenFlagToken\\(\\) should be contravariant with parameter \\$argumentStartIndex \\(mixed\\) of method PhpCsFixer\\\\AbstractFopenFlagFixer\\:\\:fixFopenFlagToken\\(\\)$#"
 			count: 1
 			path: src/Fixer/FunctionNotation/FopenFlagsFixer.php
 
 		-
 			message: "#^Parameter \\#3 \\$argumentEndIndex \\(int\\) of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\FopenFlagsFixer\\:\\:fixFopenFlagToken\\(\\) should be contravariant with parameter \\$argumentEndIndex \\(mixed\\) of method PhpCsFixer\\\\AbstractFopenFlagFixer\\:\\:fixFopenFlagToken\\(\\)$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/FopenFlagsFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/FunctionNotation/FopenFlagsFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/FunctionNotation/FopenFlagsFixer.php
 
@@ -4096,28 +2906,8 @@ parameters:
 			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
-			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
 			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
 
 		-
@@ -4136,11 +2926,6 @@ parameters:
 			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
-
-		-
 			message: "#^Offset 'closure_function…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
 			count: 1
 			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
@@ -4154,46 +2939,6 @@ parameters:
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\FunctionDeclarationFixer\\:\\:fixParenthesisInnerEdge\\(\\) has parameter \\$start with no typehint specified\\.$#"
 			count: 1
 			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/FunctionNotation/FunctionTypehintSpaceFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/FunctionTypehintSpaceFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/FunctionTypehintSpaceFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/ImplodeCallFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/FunctionNotation/ImplodeCallFixer.php
-
-		-
-			message: "#^Cannot clone PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/FunctionNotation/ImplodeCallFixer.php
-
-		-
-			message: "#^Parameter \\#2 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/ImplodeCallFixer.php
-
-		-
-			message: "#^Parameter \\#2 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/ImplodeCallFixer.php
 
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
@@ -4231,43 +2976,8 @@ parameters:
 			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 10
-			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
-
-		-
-			message: "#^Cannot call method isKeyword\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 7
-			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
 			count: 1
-			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\MethodArgumentSpaceFixer\\:\\:isNewline\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 2
-			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
 			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
 
 		-
@@ -4336,11 +3046,6 @@ parameters:
 			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
-
-		-
 			message: "#^Offset 'strict' does not exist on array\\<string, mixed\\>\\|null\\.$#"
 			count: 1
 			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -4348,11 +3053,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
-			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
 
 		-
@@ -4381,27 +3081,7 @@ parameters:
 			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
 
@@ -4409,16 +3089,6 @@ parameters:
 			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
 			count: 4
 			path: src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 7
-			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
 
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
@@ -4433,11 +3103,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
 			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
 
 		-
@@ -4476,29 +3141,9 @@ parameters:
 			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
 
 		-
 			message: "#^Offset 'scalar_types' does not exist on array\\<string, mixed\\>\\|null\\.$#"
@@ -4531,34 +3176,9 @@ parameters:
 			path: src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
-
-		-
 			message: "#^Offset 'space_before' does not exist on array\\<string, mixed\\>\\|null\\.$#"
 			count: 1
 			path: src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/FunctionNotation/StaticLambdaFixer.php
 
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
@@ -4581,33 +3201,8 @@ parameters:
 			path: src/Fixer/FunctionNotation/StaticLambdaFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/StaticLambdaFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/StaticLambdaFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 8
-			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\VoidReturnFixer\\:\\:hasReturnTypeHint\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
 
 		-
@@ -4646,22 +3241,12 @@ parameters:
 			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
-
-		-
 			message: "#^Only booleans are allowed in \\|\\|, int given on the left side\\.$#"
 			count: 1
 			path: src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
 
 		-
 			message: "#^Only booleans are allowed in \\|\\|, int given on the right side\\.$#"
-			count: 1
-			path: src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
 
@@ -4681,22 +3266,12 @@ parameters:
 			path: src/Fixer/Import/NoLeadingImportSlashFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Import/NoLeadingImportSlashFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Import\\\\NoLeadingImportSlashFixer\\:\\:removeLeadingImportSlash\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
 			path: src/Fixer/Import/NoLeadingImportSlashFixer.php
 
 		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Import/NoLeadingImportSlashFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Import/NoLeadingImportSlashFixer.php
 
@@ -4711,37 +3286,12 @@ parameters:
 			path: src/Fixer/Import/NoUnusedImportsFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Import/NoUnusedImportsFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 8
-			path: src/Fixer/Import/NoUnusedImportsFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Import/NoUnusedImportsFixer.php
-
-		-
 			message: "#^Only booleans are allowed in &&, int given on the right side\\.$#"
 			count: 1
 			path: src/Fixer/Import/NoUnusedImportsFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/Import/NoUnusedImportsFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$start of function substr expects int, int\\|false given\\.$#"
-			count: 1
-			path: src/Fixer/Import/NoUnusedImportsFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Import/NoUnusedImportsFixer.php
 
@@ -4756,11 +3306,6 @@ parameters:
 			path: src/Fixer/Import/OrderedImportsFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Import/OrderedImportsFixer.php
-
-		-
 			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
 			count: 1
 			path: src/Fixer/Import/OrderedImportsFixer.php
@@ -4768,11 +3313,6 @@ parameters:
 		-
 			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
 			count: 3
-			path: src/Fixer/Import/OrderedImportsFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Fixer/Import/OrderedImportsFixer.php
 
 		-
@@ -4811,11 +3351,6 @@ parameters:
 			path: src/Fixer/Import/OrderedImportsFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/Import/OrderedImportsFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
 			path: src/Fixer/Import/OrderedImportsFixer.php
@@ -4823,11 +3358,6 @@ parameters:
 		-
 			message: "#^Offset 'sort_algorithm' does not exist on array\\<string, mixed\\>\\|null\\.$#"
 			count: 3
-			path: src/Fixer/Import/OrderedImportsFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
 			path: src/Fixer/Import/OrderedImportsFixer.php
 
 		-
@@ -4841,23 +3371,8 @@ parameters:
 			path: src/Fixer/Import/OrderedImportsFixer.php
 
 		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Import/OrderedImportsFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Import/OrderedImportsFixer.php
-
-		-
 			message: "#^Variable \\$k2 might not be defined\\.$#"
 			count: 1
-			path: src/Fixer/Import/OrderedImportsFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$array of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:fromArray\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
-			count: 2
 			path: src/Fixer/Import/OrderedImportsFixer.php
 
 		-
@@ -4906,11 +3421,6 @@ parameters:
 			path: src/Fixer/Import/SingleImportPerStatementFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Import/SingleImportPerStatementFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Import\\\\SingleImportPerStatementFixer\\:\\:fixGroupUse\\(\\) expects int, array\\<int\\>\\|int given\\.$#"
 			count: 1
 			path: src/Fixer/Import/SingleImportPerStatementFixer.php
@@ -4931,16 +3441,6 @@ parameters:
 			path: src/Fixer/Import/SingleImportPerStatementFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 7
-			path: src/Fixer/Import/SingleImportPerStatementFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/Import/SingleImportPerStatementFixer.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\Import\\\\SingleImportPerStatementFixer\\:\\:detectIndent\\(\\) should return string but returns string\\|false\\.$#"
 			count: 1
 			path: src/Fixer/Import/SingleImportPerStatementFixer.php
@@ -4951,22 +3451,7 @@ parameters:
 			path: src/Fixer/Import/SingleImportPerStatementFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Import/SingleImportPerStatementFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Import/SingleImportPerStatementFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 7
-			path: src/Fixer/Import/SingleImportPerStatementFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Import/SingleImportPerStatementFixer.php
 
@@ -4996,26 +3481,6 @@ parameters:
 			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Utils\\:\\:calculateTrailingWhitespaceIndent\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
 			count: 1
 			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
@@ -5041,29 +3506,9 @@ parameters:
 			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
 
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
@@ -5106,16 +3551,6 @@ parameters:
 			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
@@ -5123,16 +3558,6 @@ parameters:
 		-
 			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
 
 		-
@@ -5161,39 +3586,9 @@ parameters:
 			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\CombineConsecutiveIssetsFixer\\:\\:getIssetInfo\\(\\) should return array\\<int\\> but returns array\\<int, int\\|null\\>\\.$#"
 			count: 1
 			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
-
-		-
-			message: "#^Cannot clone PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
-
-		-
-			message: "#^Method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\CombineConsecutiveIssetsFixer\\:\\:getTokenClones\\(\\) should return array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\> but returns array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\>\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
 
 		-
 			message: "#^Parameter \\#2 \\$start of method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\CombineConsecutiveUnsetsFixer\\:\\:moveTokens\\(\\) expects int, int\\|null given\\.$#"
@@ -5206,32 +3601,7 @@ parameters:
 			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
-
-		-
 			message: "#^Parameter \\#3 \\$indices of method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\CombineConsecutiveUnsetsFixer\\:\\:clearOffsetTokens\\(\\) expects array\\<int\\>, array\\<int, int\\|null\\> given\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
-
-		-
-			message: "#^Cannot clone PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
-
-		-
-			message: "#^Parameter \\#2 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
 
@@ -5246,42 +3616,12 @@ parameters:
 			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
-
-		-
 			message: "#^Variable method call on \\$this\\(PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\DeclareEqualNormalizeFixer\\)\\.$#"
 			count: 1
 			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
-
-		-
 			message: "#^Strict comparison using \\!\\=\\= between null and int will always evaluate to true\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/DirConstantFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/LanguageConstruct/DirConstantFixer.php
 
@@ -5291,18 +3631,8 @@ parameters:
 			path: src/Fixer/LanguageConstruct/DirConstantFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/LanguageConstruct/DirConstantFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:removeTrailingWhitespace\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/LanguageConstruct/DirConstantFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
 			path: src/Fixer/LanguageConstruct/DirConstantFixer.php
 
 		-
@@ -5326,18 +3656,8 @@ parameters:
 			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
-
-		-
 			message: "#^Only booleans are allowed in &&, mixed given on the left side\\.$#"
 			count: 2
-			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
 			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
 
 		-
@@ -5361,29 +3681,9 @@ parameters:
 			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
 
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\FunctionToConstantFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
@@ -5396,28 +3696,8 @@ parameters:
 			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
 
 		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\FunctionToConstantFixer\\:\\:getReplaceCandidate\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
 			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
 
 		-
@@ -5461,27 +3741,12 @@ parameters:
 			path: src/Fixer/LanguageConstruct/IsNullFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/LanguageConstruct/IsNullFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/LanguageConstruct/IsNullFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:removeTrailingWhitespace\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
 			path: src/Fixer/LanguageConstruct/IsNullFixer.php
 
 		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/IsNullFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/LanguageConstruct/IsNullFixer.php
 
@@ -5494,11 +3759,6 @@ parameters:
 			message: "#^Offset 'use_yoda_style' does not exist on array\\<string, mixed\\>\\|null\\.$#"
 			count: 1
 			path: src/Fixer/LanguageConstruct/IsNullFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
 
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
@@ -5571,11 +3831,6 @@ parameters:
 			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
-
-		-
 			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
 			count: 1
 			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
@@ -5616,11 +3871,6 @@ parameters:
 			path: src/Fixer/ListNotation/ListSyntaxFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ListNotation/ListSyntaxFixer.php
-
-		-
 			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
 			count: 2
 			path: src/Fixer/ListNotation/ListSyntaxFixer.php
@@ -5631,54 +3881,9 @@ parameters:
 			path: src/Fixer/ListNotation/ListSyntaxFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\NamespaceNotation\\\\BlankLineAfterNamespaceFixer\\:\\:getIndexToEnsureBlankLineAfter\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixer.php
 
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\NamespaceNotation\\\\NoLeadingNamespaceWhitespaceFixer\\:\\:endsWithWhitespace\\(\\) has parameter \\$str with no typehint specified\\.$#"
@@ -5686,19 +3891,9 @@ parameters:
 			path: src/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixer.php
-
-		-
 			message: "#^Property PhpCsFixer\\\\Fixer\\\\Naming\\\\NoHomoglyphNamesFixer\\:\\:\\$replacements type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Fixer/Naming/NoHomoglyphNamesFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 7
-			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
 
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
@@ -5707,26 +3902,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$from of method PhpCsFixer\\\\Fixer\\\\Operator\\\\AlignDoubleArrowFixerHelper\\:\\:injectArrayAlignmentPlaceholders\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
 
@@ -5741,21 +3916,6 @@ parameters:
 			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Operator/AlignEqualsFixerHelper.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Operator/AlignEqualsFixerHelper.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/AlignEqualsFixerHelper.php
-
-		-
 			message: "#^Property PhpCsFixer\\\\Fixer\\\\Operator\\\\BinaryOperatorSpacesFixer\\:\\:\\$allowedValues has no typehint specified\\.$#"
 			count: 1
 			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -5763,11 +3923,6 @@ parameters:
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\Operator\\\\BinaryOperatorSpacesFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 12
 			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
 
 		-
@@ -5781,28 +3936,8 @@ parameters:
 			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 8
-			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 11
-			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
-			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
 			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
 
 		-
@@ -5856,11 +3991,6 @@ parameters:
 			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
 
 		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
-
-		-
 			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -5906,27 +4036,7 @@ parameters:
 			path: src/Fixer/Operator/ConcatSpaceFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Operator/ConcatSpaceFixer.php
-
-		-
 			message: "#^Variable method call on \\$this\\(PhpCsFixer\\\\Fixer\\\\Operator\\\\ConcatSpaceFixer\\)\\.$#"
-			count: 1
-			path: src/Fixer/Operator/ConcatSpaceFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/ConcatSpaceFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/ConcatSpaceFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Operator/ConcatSpaceFixer.php
 
@@ -5941,43 +4051,13 @@ parameters:
 			path: src/Fixer/Operator/ConcatSpaceFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Operator/ConcatSpaceFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/Operator/IncrementStyleFixer.php
-
-		-
 			message: "#^Offset 'style' does not exist on array\\<string, mixed\\>\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/IncrementStyleFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/Operator/IncrementStyleFixer.php
-
-		-
-			message: "#^Cannot clone non\\-object variable \\$token of type PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/IncrementStyleFixer.php
-
-		-
-			message: "#^Parameter \\#2 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
 			count: 2
 			path: src/Fixer/Operator/IncrementStyleFixer.php
 
 		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/Operator/IncrementStyleFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 2
 			path: src/Fixer/Operator/IncrementStyleFixer.php
 
 		-
@@ -6011,11 +4091,6 @@ parameters:
 			path: src/Fixer/Operator/IncrementStyleFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Operator/IncrementStyleFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Operator\\\\IncrementStyleFixer\\:\\:findStart\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
 			path: src/Fixer/Operator/IncrementStyleFixer.php
@@ -6029,16 +4104,6 @@ parameters:
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\Operator\\\\IncrementStyleFixer\\:\\:findStart\\(\\) should return int but returns int\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Operator/IncrementStyleFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/Operator/NewWithBracesFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Operator/NewWithBracesFixer.php
 
 		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
@@ -6061,17 +4126,7 @@ parameters:
 			path: src/Fixer/Operator/NewWithBracesFixer.php
 
 		-
-			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Operator/NewWithBracesFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Operator/NewWithBracesFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Operator/NewWithBracesFixer.php
 
@@ -6084,51 +4139,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/Operator/NewWithBracesFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Operator/NotOperatorWithSpaceFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/NotOperatorWithSpaceFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Operator/NotOperatorWithSuccessorSpaceFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Operator/NotOperatorWithSuccessorSpaceFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/StandardizeIncrementFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Operator/StandardizeIncrementFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 7
-			path: src/Fixer/Operator/StandardizeIncrementFixer.php
 
 		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
@@ -6151,11 +4161,6 @@ parameters:
 			path: src/Fixer/Operator/StandardizeIncrementFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/StandardizeIncrementFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, int\\|null given\\.$#"
 			count: 4
 			path: src/Fixer/Operator/StandardizeIncrementFixer.php
@@ -6166,37 +4171,7 @@ parameters:
 			path: src/Fixer/Operator/StandardizeIncrementFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Operator/StandardizeIncrementFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Operator/StandardizeIncrementFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/TernaryOperatorSpacesFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Operator/TernaryOperatorSpacesFixer.php
-
-		-
 			message: "#^Only booleans are allowed in &&, int given on the left side\\.$#"
-			count: 1
-			path: src/Fixer/Operator/TernaryOperatorSpacesFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Operator/TernaryOperatorSpacesFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Operator/TernaryOperatorSpacesFixer.php
 
@@ -6206,17 +4181,7 @@ parameters:
 			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
 
 		-
-			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Fixer\\\\Operator\\\\TernaryToNullCoalescingFixer\\:\\:isHigherPrecedenceAssociativityOperator\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
 
@@ -6241,16 +4206,6 @@ parameters:
 			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
-
-		-
 			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
 			count: 1
 			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
@@ -6261,64 +4216,9 @@ parameters:
 			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
 
 		-
-			message: "#^Parameter \\#3 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideRange\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
-			count: 1
-			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$array of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:fromArray\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
-			count: 1
-			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Operator/UnaryOperatorSpacesFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$code of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:fromCode\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
 			count: 1
 			path: src/Fixer/PhpTag/FullOpeningTagFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpTag/FullOpeningTagFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpTag/LinebreakAfterOpeningTagFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpTag/LinebreakAfterOpeningTagFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpTag/LinebreakAfterOpeningTagFixer.php
 
 		-
 			message: "#^Binary operation \"\\-\" between int\\|string\\|null and 1 results in an error\\.$#"
@@ -6331,24 +4231,9 @@ parameters:
 			path: src/Fixer/PhpTag/NoClosingTagFixer.php
 
 		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpTag/NoClosingTagFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
 			count: 1
 			path: src/Fixer/PhpTag/NoClosingTagFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpTag/NoShortEchoTagFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpTag/NoShortEchoTagFixer.php
 
 		-
 			message: "#^Property PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitConstructFixer\\:\\:\\$assertionFixers has no typehint specified\\.$#"
@@ -6366,27 +4251,12 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
 
 		-
-			message: "#^Cannot call method isNativeConstant\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
-
-		-
 			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
 
@@ -6426,32 +4296,12 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 6
 			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
-			count: 3
-			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 3
 			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
 
@@ -6481,11 +4331,6 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
 			count: 2
 			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
@@ -6506,28 +4351,8 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
 
 		-
-			message: "#^Cannot call method isClassy\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
 			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
 
 		-
@@ -6561,18 +4386,8 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
 			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
 
 		-
@@ -6588,11 +4403,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
-			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
 			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
 
 		-
@@ -6621,16 +4431,6 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$i of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitInternalClassFixer\\:\\:isAllowedByConfiguration\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
@@ -6643,11 +4443,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitInternalClassFixer\\:\\:hasDocBlock\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
 			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
 
 		-
@@ -6676,11 +4471,6 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
 			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
@@ -6696,11 +4486,6 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$array_arg of function end expects array\\|object, array\\<int, string\\>\\|false given\\.$#"
 			count: 1
 			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
@@ -6711,11 +4496,6 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
-
-		-
 			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
 			count: 1
 			path: src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
@@ -6723,11 +4503,6 @@ parameters:
 		-
 			message: "#^Offset 'case' does not exist on array\\<string, mixed\\>\\|null\\.$#"
 			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
 			path: src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
 
 		-
@@ -6761,16 +4536,6 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitMockFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitMockFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/PhpUnit/PhpUnitMockFixer.php
-
-		-
 			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
 			count: 3
 			path: src/Fixer/PhpUnit/PhpUnitMockFixer.php
@@ -6791,23 +4556,8 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitMockFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 9
-			path: src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 5
-			path: src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php
 
 		-
@@ -6841,21 +4591,6 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
-
-		-
-			message: "#^Parameter \\#2 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
@@ -6876,32 +4611,12 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitNoExpectationAnnotationFixer\\:\\:detectIndent\\(\\) should return string but returns string\\|false\\.$#"
 			count: 1
 			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
 
 		-
 			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
 
@@ -6946,16 +4661,6 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
-
-		-
 			message: "#^Possibly invalid array key type array\\<string\\>\\|string\\.$#"
 			count: 1
 			path: src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
@@ -6967,16 +4672,6 @@ parameters:
 
 		-
 			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
 
@@ -6993,11 +4688,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitSizeClassFixer\\:\\:hasDocBlock\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
 			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
 
 		-
@@ -7026,11 +4716,6 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
-
-		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 2
 			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
@@ -7042,11 +4727,6 @@ parameters:
 
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitSizeClassFixer\\:\\:getDocBlockIndex\\(\\) should return int but returns int\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
 
@@ -7086,18 +4766,8 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 8
-			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
-
-		-
 			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
 			count: 2
-			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
 			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
 
 		-
@@ -7117,11 +4787,6 @@ parameters:
 
 		-
 			message: "#^Offset 'case' does not exist on array\\<string, mixed\\>\\|null\\.$#"
-			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
 
@@ -7181,23 +4846,8 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
-
-		-
 			message: "#^Offset 'call_type' does not exist on array\\<string, mixed\\>\\|null\\.$#"
 			count: 1
-			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
 
 		-
@@ -7236,18 +4886,8 @@ parameters:
 			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
 			count: 4
-			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
 			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
 
 		-
@@ -7306,21 +4946,6 @@ parameters:
 			path: src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
-
-		-
 			message: "#^Binary operation \"\\.\" between array\\<string\\>\\|string and string results in an error\\.$#"
 			count: 1
 			path: src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
@@ -7341,16 +4966,6 @@ parameters:
 			path: src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$start of function substr expects int, int\\|false given\\.$#"
 			count: 1
 			path: src/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixer.php
@@ -7359,11 +4974,6 @@ parameters:
 			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
 			count: 1
 			path: src/Fixer/Phpdoc/NoEmptyPhpdocFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 13
-			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
 
 		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
@@ -7397,16 +5007,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\NoSuperfluousPhpdocTagsFixer\\:\\:parseTypeHint\\(\\) expects int, int\\|null given\\.$#"
-			count: 2
-			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 2
 			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
 
@@ -7461,16 +5061,6 @@ parameters:
 			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -7517,21 +5107,6 @@ parameters:
 
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocAddMissingParamAnnotationFixer\\:\\:prepareArgumentInformation\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
 
@@ -7636,47 +5211,7 @@ parameters:
 			path: src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Utils\\:\\:calculateTrailingWhitespaceIndent\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
-
-		-
-			message: "#^Cannot call method isArray\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
 
@@ -7716,11 +5251,6 @@ parameters:
 			path: src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
@@ -7747,11 +5277,6 @@ parameters:
 
 		-
 			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
 
@@ -7786,17 +5311,7 @@ parameters:
 			path: src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
 
@@ -7971,19 +5486,9 @@ parameters:
 			path: src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
 			count: 2
 			path: src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ReturnNotation/NoUselessReturnFixer.php
 
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
@@ -7996,17 +5501,7 @@ parameters:
 			path: src/Fixer/ReturnNotation/NoUselessReturnFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ReturnNotation/NoUselessReturnFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ReturnNotation/NoUselessReturnFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/ReturnNotation/NoUselessReturnFixer.php
 
@@ -8014,16 +5509,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:clearTokenAndMergeSurroundingWhitespace\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/ReturnNotation/NoUselessReturnFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 10
-			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
 
 		-
 			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
@@ -8041,18 +5526,8 @@ parameters:
 			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
 
 		-
-			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Fixer\\\\ReturnNotation\\\\ReturnAssignmentFixer\\:\\:isSuperGlobal\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
 
 		-
@@ -8081,16 +5556,6 @@ parameters:
 			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -8101,23 +5566,8 @@ parameters:
 			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
 
 		-
@@ -8131,68 +5581,13 @@ parameters:
 			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
-
-		-
 			message: "#^Offset 'strategy' does not exist on array\\<string, mixed\\>\\|null\\.$#"
 			count: 2
 			path: src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 7
-			path: src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 8
-			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
 
 		-
@@ -8206,11 +5601,6 @@ parameters:
 			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
 
 		-
-			message: "#^Cannot call method isClassy\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\TokensAnalyzer\\:\\:isAnonymousClass\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
@@ -8219,31 +5609,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Semicolon/SemicolonAfterInstructionFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Semicolon/SemicolonAfterInstructionFixer.php
 
 		-
 			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
@@ -8266,27 +5631,7 @@ parameters:
 			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
 
@@ -8296,44 +5641,9 @@ parameters:
 			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
 			count: 1
 			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Strict/DeclareStrictTypesFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Strict/DeclareStrictTypesFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Strict/DeclareStrictTypesFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Strict/StrictParamFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Strict/StrictParamFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Strict/StrictParamFixer.php
 
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\Strict\\\\StrictParamFixer\\:\\:fixFunction\\(\\) has parameter \\$functionIndex with no typehint specified\\.$#"
@@ -8356,21 +5666,6 @@ parameters:
 			path: src/Fixer/Strict/StrictParamFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Strict/StrictParamFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Strict/StrictParamFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/StringNotation/EscapeImplicitBackslashesFixer.php
-
-		-
 			message: "#^Offset 'single_quoted' does not exist on array\\<string, mixed\\>\\|null\\.$#"
 			count: 1
 			path: src/Fixer/StringNotation/EscapeImplicitBackslashesFixer.php
@@ -8386,69 +5681,14 @@ parameters:
 			path: src/Fixer/StringNotation/EscapeImplicitBackslashesFixer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/StringNotation/ExplicitStringVariableFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/StringNotation/ExplicitStringVariableFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Fixer\\\\StringNotation\\\\ExplicitStringVariableFixer\\:\\:isStringPartToken\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 2
-			path: src/Fixer/StringNotation/ExplicitStringVariableFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/StringNotation/ExplicitStringVariableFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/StringNotation/ExplicitStringVariableFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/StringNotation/ExplicitStringVariableFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/StringNotation/HeredocToNowdocFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/StringNotation/HeredocToNowdocFixer.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
 			count: 1
 			path: src/Fixer/StringNotation/HeredocToNowdocFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/StringNotation/HeredocToNowdocFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
-
-		-
-			message: "#^Parameter \\#3 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideRange\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
-			count: 1
-			path: src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
 
 		-
 			message: "#^Offset 'strings_containing…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
@@ -8461,37 +5701,12 @@ parameters:
 			path: src/Fixer/StringNotation/SingleQuoteFixer.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:findArrayTokenRanges\\(\\) has parameter \\$from with no typehint specified\\.$#"
 			count: 1
 			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
 
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:findArrayTokenRanges\\(\\) has parameter \\$to with no typehint specified\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 7
-			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
 
@@ -8523,11 +5738,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, float\\|int given\\.$#"
 			count: 1
-			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 7
 			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
 
 		-
@@ -8616,49 +5826,9 @@ parameters:
 			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$prevNonWhitespace of method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixer\\:\\:shouldAddBlankLine\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Whitespace/CompactNullableTypehintFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/CompactNullableTypehintFixer.php
 
 		-
 			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
@@ -8666,22 +5836,7 @@ parameters:
 			path: src/Fixer/Whitespace/HeredocIndentationFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/Whitespace/HeredocIndentationFixer.php
-
-		-
 			message: "#^Parameter \\#2 \\$start of method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\HeredocIndentationFixer\\:\\:fixIndentation\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/HeredocIndentationFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 6
-			path: src/Fixer/Whitespace/HeredocIndentationFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Whitespace/HeredocIndentationFixer.php
 
@@ -8691,23 +5846,8 @@ parameters:
 			path: src/Fixer/Whitespace/HeredocIndentationFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/HeredocIndentationFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Whitespace/IndentationTypeFixer.php
-
-		-
 			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
 			count: 2
-			path: src/Fixer/Whitespace/IndentationTypeFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
 			path: src/Fixer/Whitespace/IndentationTypeFixer.php
 
 		-
@@ -8721,38 +5861,8 @@ parameters:
 			path: src/Fixer/Whitespace/IndentationTypeFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Whitespace/LineEndingFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Whitespace/LineEndingFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Whitespace/LineEndingFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
-
-		-
 			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
 			count: 1
-			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
 
 		-
@@ -8776,16 +5886,6 @@ parameters:
 			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
 
 		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\MethodChainingIndentationFixer\\:\\:getIndentContentAt\\(\\) has parameter \\$index with no typehint specified\\.$#"
 			count: 1
 			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
@@ -8802,11 +5902,6 @@ parameters:
 
 		-
 			message: "#^Offset 'tokens' does not exist on array\\<string, mixed\\>\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixer\\:\\:fixByToken\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
 
@@ -8831,23 +5926,13 @@ parameters:
 			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			message: "#^Parameter \\#1 \\$possibleKind of method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:isGivenKind\\(\\) expects array\\<int\\>\\|int, int\\|null given\\.$#"
 			count: 1
 			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
 
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixer\\:\\:removeMultipleBlankLines\\(\\) has parameter \\$index with no typehint specified\\.$#"
 			count: 1
-			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 7
 			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
 
 		-
@@ -8866,27 +5951,12 @@ parameters:
 			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
-
-		-
 			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
 
 		-
 			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixer\\:\\:removeEmptyLinesAfterLineWithTokenAt\\(\\) has parameter \\$index with no typehint specified\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
 
@@ -8924,81 +5994,6 @@ parameters:
 			message: "#^Offset 'positions' does not exist on array\\<string, mixed\\>\\|null\\.$#"
 			count: 2
 			path: src/Fixer/Whitespace/NoSpacesAroundOffsetFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Whitespace/NoSpacesAroundOffsetFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/NoSpacesAroundOffsetFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Fixer/Whitespace/SingleBlankLineAtEofFixer.php
 
 		-
 			message: "#^Only booleans are allowed in &&, int given on the left side\\.$#"
@@ -9216,27 +6211,7 @@ parameters:
 			path: src/Indicator/PhpUnitTestCaseIndicator.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Indicator/PhpUnitTestCaseIndicator.php
-
-		-
-			message: "#^Cannot call method getName\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Indicator/PhpUnitTestCaseIndicator.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Indicator/PhpUnitTestCaseIndicator.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Indicator/PhpUnitTestCaseIndicator.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Indicator/PhpUnitTestCaseIndicator.php
 
@@ -9936,36 +6911,6 @@ parameters:
 			path: src/Tokenizer/Analyzer/Analysis/TypeAnalysis.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
-
-		-
 			message: "#^Parameter \\#1 \\$name of class PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\ArgumentAnalysis constructor expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
@@ -9991,21 +6936,6 @@ parameters:
 			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
 
 		-
-			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\BlocksAnalyzer\\:\\:getBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/BlocksAnalyzer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 11
-			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
@@ -10021,37 +6951,7 @@ parameters:
 			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
 
 		-
-			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\CommentsAnalyzer\\:\\:isStructuralElement\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
-
-		-
-			message: "#^Parameter \\#2 \\$docsToken of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\CommentsAnalyzer\\:\\:isValidControl\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
-
-		-
-			message: "#^Parameter \\#2 \\$docsToken of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\CommentsAnalyzer\\:\\:isValidLanguageConstruct\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\CommentsAnalyzer\\:\\:getCommentBlockIndices\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
 
@@ -10071,23 +6971,8 @@ parameters:
 			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 7
-			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 8
-			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
-			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
 			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
 
 		-
@@ -10113,16 +6998,6 @@ parameters:
 		-
 			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
 			count: 2
-			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
 			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
 
 		-
@@ -10156,42 +7031,7 @@ parameters:
 			path: src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 7
-			path: src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/NamespacesAnalyzer.php
-
-		-
 			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
-			count: 1
-			path: src/Tokenizer/Analyzer/NamespacesAnalyzer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Tokenizer/Analyzer/NamespacesAnalyzer.php
 
@@ -10316,11 +7156,6 @@ parameters:
 			path: src/Tokenizer/Tokens.php
 
 		-
-			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:unregisterFoundToken\\(\\) expects array\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|string, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Tokenizer/Tokens.php
-
-		-
 			message: "#^Parameter \\#1 \\$index \\(int\\) of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:offsetSet\\(\\) should be contravariant with parameter \\$index \\(int\\|null\\) of method SplFixedArray\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\:\\:offsetSet\\(\\)$#"
 			count: 1
 			path: src/Tokenizer/Tokens.php
@@ -10333,21 +7168,6 @@ parameters:
 		-
 			message: "#^Variable \\$count might not be defined\\.$#"
 			count: 1
-			path: src/Tokenizer/Tokens.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Tokenizer/Tokens.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 9
-			path: src/Tokenizer/Tokens.php
-
-		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
 			path: src/Tokenizer/Tokens.php
 
 		-
@@ -10371,8 +7191,8 @@ parameters:
 			path: src/Tokenizer/Tokens.php
 
 		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
+			message: "#^Parameter \\#1 \\$possibleKind of method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:isGivenKind\\(\\) expects array\\<int\\>\\|int, array given\\.$#"
+			count: 1
 			path: src/Tokenizer/Tokens.php
 
 		-
@@ -10393,11 +7213,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
 			count: 1
-			path: src/Tokenizer/Tokens.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Tokenizer/Tokens.php
 
 		-
@@ -10426,32 +7241,12 @@ parameters:
 			path: src/Tokenizer/Tokens.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Tokenizer/Tokens.php
-
-		-
-			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findSequence\\(\\) should return array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|null but returns array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\>\\.$#"
-			count: 1
-			path: src/Tokenizer/Tokens.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:registerFoundToken\\(\\) expects array\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|string, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Tokenizer/Tokens.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:clearAt\\(\\) has parameter \\$index with no typehint specified\\.$#"
 			count: 1
 			path: src/Tokenizer/Tokens.php
 
 		-
 			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideAt\\(\\) has parameter \\$token with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Tokenizer/Tokens.php
-
-		-
-			message: "#^Cannot call method override\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Tokenizer/Tokens.php
 
@@ -10521,11 +7316,6 @@ parameters:
 			path: src/Tokenizer/Tokens.php
 
 		-
-			message: "#^Cannot call method isClassy\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Tokenizer/TokensAnalyzer.php
-
-		-
 			message: "#^Parameter \\#1 \\$classIndex of method PhpCsFixer\\\\Tokenizer\\\\TokensAnalyzer\\:\\:findClassyElements\\(\\) expects int, float\\|int given\\.$#"
 			count: 4
 			path: src/Tokenizer/TokensAnalyzer.php
@@ -10541,23 +7331,8 @@ parameters:
 			path: src/Tokenizer/TokensAnalyzer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 36
-			path: src/Tokenizer/TokensAnalyzer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 18
-			path: src/Tokenizer/TokensAnalyzer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
-			path: src/Tokenizer/TokensAnalyzer.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
 			path: src/Tokenizer/TokensAnalyzer.php
 
 		-
@@ -10566,23 +7341,8 @@ parameters:
 			path: src/Tokenizer/TokensAnalyzer.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/TokensAnalyzer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
-			path: src/Tokenizer/TokensAnalyzer.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\TokensAnalyzer\\:\\:getMethodAttributes\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: src/Tokenizer/TokensAnalyzer.php
-
-		-
-			message: "#^Cannot call method getName\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
 			path: src/Tokenizer/TokensAnalyzer.php
 
 		-
@@ -10596,27 +7356,12 @@ parameters:
 			path: src/Tokenizer/TokensAnalyzer.php
 
 		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 7
-			path: src/Tokenizer/TokensAnalyzer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
 			path: src/Tokenizer/TokensAnalyzer.php
 
 		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Tokenizer/TokensAnalyzer.php
-
-		-
-			message: "#^Cannot call method isArray\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Tokenizer/TokensAnalyzer.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Tokenizer/TokensAnalyzer.php
 
@@ -10641,22 +7386,7 @@ parameters:
 			path: src/Tokenizer/Transformer/ArrayTypehintTransformer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/Transformer/ArrayTypehintTransformer.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\BraceClassInstantiationTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
 
@@ -10666,18 +7396,8 @@ parameters:
 			path: src/Tokenizer/Transformer/ClassConstantTransformer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/Transformer/ClassConstantTransformer.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\CurlyBraceTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
 			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
 
 		-
@@ -10711,16 +7431,6 @@ parameters:
 			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
 
 		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
@@ -10741,17 +7451,7 @@ parameters:
 			path: src/Tokenizer/Transformer/ImportTransformer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/Transformer/ImportTransformer.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\NamespaceOperatorTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Tokenizer/Transformer/NamespaceOperatorTransformer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Tokenizer/Transformer/NamespaceOperatorTransformer.php
 
@@ -10761,33 +7461,13 @@ parameters:
 			path: src/Tokenizer/Transformer/NullableTypeTransformer.php
 
 		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/Transformer/NullableTypeTransformer.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\ReturnRefTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Tokenizer/Transformer/ReturnRefTransformer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Tokenizer/Transformer/ReturnRefTransformer.php
 
 		-
 			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\SquareBraceTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: src/Tokenizer/Transformer/SquareBraceTransformer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 5
-			path: src/Tokenizer/Transformer/SquareBraceTransformer.php
-
-		-
-			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 3
 			path: src/Tokenizer/Transformer/SquareBraceTransformer.php
 
 		-
@@ -10806,11 +7486,6 @@ parameters:
 			path: src/Tokenizer/Transformer/SquareBraceTransformer.php
 
 		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: src/Tokenizer/Transformer/SquareBraceTransformer.php
-
-		-
 			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
 			count: 1
 			path: src/Tokenizer/Transformer/SquareBraceTransformer.php
@@ -10821,17 +7496,7 @@ parameters:
 			path: src/Tokenizer/Transformer/TypeAlternationTransformer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 4
-			path: src/Tokenizer/Transformer/TypeAlternationTransformer.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Tokenizer/Transformer/TypeAlternationTransformer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Tokenizer/Transformer/TypeAlternationTransformer.php
 
@@ -10841,18 +7506,8 @@ parameters:
 			path: src/Tokenizer/Transformer/TypeColonTransformer.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: src/Tokenizer/Transformer/TypeColonTransformer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: src/Tokenizer/Transformer/TypeColonTransformer.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
 			path: src/Tokenizer/Transformer/TypeColonTransformer.php
 
 		-
@@ -10866,27 +7521,12 @@ parameters:
 			path: src/Tokenizer/Transformer/UseTransformer.php
 
 		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Tokenizer/Transformer/UseTransformer.php
-
-		-
 			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
 			path: src/Tokenizer/Transformer/UseTransformer.php
 
 		-
 			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
-			count: 1
-			path: src/Tokenizer/Transformer/UseTransformer.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: src/Tokenizer/Transformer/UseTransformer.php
-
-		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: src/Tokenizer/Transformer/UseTransformer.php
 
@@ -11836,11 +8476,6 @@ parameters:
 			path: tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
 
 		-
-			message: "#^Cannot call method toJson\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
-
-		-
 			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
 			count: 1
 			path: tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -11897,16 +8532,6 @@ parameters:
 
 		-
 			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixerTest\\:\\:doTestClassyInheritanceInfo\\(\\) has parameter \\$source with no typehint specified\\.$#"
-			count: 1
-			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
-
-		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
 
@@ -12049,11 +8674,6 @@ parameters:
 			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
 			count: 3
 			path: tests/Fixer/Comment/HeaderCommentFixerTest.php
-
-		-
-			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: tests/Fixer/Comment/NoEmptyCommentFixerTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$class of class ReflectionMethod constructor expects object\\|string, PhpCsFixer\\\\AbstractFixer\\|null given\\.$#"
@@ -13736,16 +10356,6 @@ parameters:
 			path: tests/Test/AbstractFixerTestCase.php
 
 		-
-			message: "#^Parameter \\#1 \\$other of method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:equals\\(\\) expects array\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|string, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: tests/Test/AbstractFixerTestCase.php
-
-		-
-			message: "#^Cannot call method toJson\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: tests/Test/AbstractFixerTestCase.php
-
-		-
 			message: "#^Parameter \\#1 \\$tokenKind of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:isTokenKindFound\\(\\) expects int\\|string, int\\|string\\|null given\\.$#"
 			count: 1
 			path: tests/Test/AbstractFixerTestCase.php
@@ -13866,39 +10476,9 @@ parameters:
 			path: tests/Test/AbstractTransformerTestCase.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: tests/Test/AbstractTransformerTestCase.php
-
-		-
-			message: "#^Cannot call method getName\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: tests/Test/AbstractTransformerTestCase.php
-
-		-
-			message: "#^Cannot call method toJson\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: tests/Test/AbstractTransformerTestCase.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: tests/Test/AbstractTransformerTestCase.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractTransformerTestCase\\:\\:countTokenPrototypes\\(\\) has parameter \\$prototypes with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Test/AbstractTransformerTestCase.php
-
-		-
-			message: "#^Parameter \\#1 \\$other of method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:equals\\(\\) expects array\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|string, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 1
-			path: tests/Tokenizer/TokensTest.php
-
-		-
-			message: "#^Cannot call method toJson\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: tests/Tokenizer/TokensTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$tokenKind of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:isTokenKindFound\\(\\) expects int\\|string, int\\|string\\|null given\\.$#"
@@ -13926,11 +10506,6 @@ parameters:
 			path: tests/Tokenizer/TokensTest.php
 
 		-
-			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: tests/Tokenizer/TokensTest.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
 			count: 1
 			path: tests/Tokenizer/TokensTest.php
@@ -13951,18 +10526,8 @@ parameters:
 			path: tests/Tokenizer/TokensTest.php
 
 		-
-			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: tests/Tokenizer/TokensTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
 			count: 1
-			path: tests/Tokenizer/TokensTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
-			count: 3
 			path: tests/Tokenizer/TokensTest.php
 
 		-
@@ -14286,16 +10851,6 @@ parameters:
 			path: tests/Tokenizer/Transformer/ReturnRefTransformerTest.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 2
-			path: tests/Tokenizer/Transformer/SquareBraceTransformerTest.php
-
-		-
-			message: "#^Cannot call method toJson\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: tests/Tokenizer/Transformer/SquareBraceTransformerTest.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\SquareBraceTransformerTest\\:\\:testProcess\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Tokenizer/Transformer/SquareBraceTransformerTest.php
@@ -14321,22 +10876,7 @@ parameters:
 			path: tests/Tokenizer/Transformer/WhitespacyCommentTransformerTest.php
 
 		-
-			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: tests/Tokenizer/Transformer/WhitespacyCommentTransformerTest.php
-
-		-
-			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
-			count: 1
-			path: tests/Tokenizer/Transformer/WhitespacyCommentTransformerTest.php
-
-		-
 			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TransformersTest\\:\\:testTransform\\(\\) has parameter \\$expectedTokenKinds with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/Tokenizer/TransformersTest.php
-
-		-
-			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
 			count: 1
 			path: tests/Tokenizer/TransformersTest.php
 

--- a/src/AbstractLinesBeforeNamespaceFixer.php
+++ b/src/AbstractLinesBeforeNamespaceFixer.php
@@ -74,7 +74,7 @@ abstract class AbstractLinesBeforeNamespaceFixer extends AbstractFixer implement
                 $tokens->clearAt($previousIndex);
             }
             // Remove new lines in opening token
-            if ($newlineInOpening) {
+            if ($newlineInOpening && null !== $openingToken) {
                 $tokens[$openingTokenIndex] = new Token([T_OPEN_TAG, rtrim($openingToken->getContent()).' ']);
             }
 

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -756,10 +756,6 @@ class Foo
         $nextIndex = $tokens->getNextMeaningfulToken($parenthesisEndIndex);
         $nextToken = $tokens[$nextIndex];
 
-        if (!$nextToken) {
-            return $parenthesisEndIndex;
-        }
-
         if ($nextToken->equals('{')) {
             return $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $nextIndex);
         }

--- a/src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+++ b/src/Fixer/ClassNotation/OrderedInterfacesFixer.php
@@ -164,7 +164,7 @@ final class OrderedInterfacesFixer extends AbstractFixer implements Configuratio
                 while ($interfaceTokens->offsetExists($actualInterfaceIndex)) {
                     $token = $interfaceTokens[$actualInterfaceIndex];
 
-                    if (null === $token || $token->isComment() || $token->isWhitespace()) {
+                    if ($token->isComment() || $token->isWhitespace()) {
                         break;
                     }
 

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -289,6 +289,36 @@ class Tokens extends \SplFixedArray
     }
 
     /**
+     * @param int $index
+     *
+     * @return Token
+     */
+    public function offsetGet($index)
+    {
+        $token = parent::offsetGet($index);
+
+        if (null === $token) {
+            return new Token('');
+        }
+
+        return $token;
+    }
+
+    /**
+     * @return Token
+     */
+    public function current()
+    {
+        $token = parent::current();
+
+        if (null === $token) {
+            return new Token('');
+        }
+
+        return $token;
+    }
+
+    /**
      * Unset collection item.
      *
      * @param int $index

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -791,6 +791,27 @@ PHP;
         static::assertSame(4, $tokens->findBlockEnd(Tokens::BLOCK_TYPE_DYNAMIC_VAR_BRACE, 2, true));
     }
 
+    public function testReturnsEmptyTokenOnUninitializedIndex()
+    {
+        $tokens = new Tokens(1);
+
+        $token = $tokens[0];
+
+        static::assertNull($token->getId());
+        static::assertSame('', $token->getContent());
+    }
+
+    public function testReturnsEmptyTokenOnUnsetIndex()
+    {
+        $tokens = Tokens::fromCode('<?php $foo = 1;');
+
+        unset($tokens[0]);
+        $token = $tokens[0];
+
+        static::assertNull($token->getId());
+        static::assertSame('', $token->getContent());
+    }
+
     public function testEmptyTokens()
     {
         $code = '';


### PR DESCRIPTION
This PR depends on #4964.

Technically, changes in `Tokens` are BC breaks but this has been the documented behavior for a while ([until recently when I removed some PHPDocs](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4849/files#diff-b853b43b9aa6d26771db195ab8a079c8L29)).

Also 6 new errors that don't seem related have been reported by PHPStan. I think they should have been reported earlier but for some reason they were not, so I added them to baseline for now.