### PR TITLE
feat: Introduce `variable_case` fixer

### DIFF
--- a/doc/rules/casing/variable_case.rst
+++ b/doc/rules/casing/variable_case.rst
@@ -1,0 +1,62 @@
+======================
+Rule ``variable_case``
+======================
+
+Enforce camel or snake case for variables, following configuration.
+
+Description
+-----------
+
+Keeps variables' names consistent across the project.
+
+Warning
+-------
+
+Using this rule is risky
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Fixer could be risky if renamed variables are defined outside of the modified
+file.
+
+Configuration
+-------------
+
+``case``
+~~~~~~~~
+
+Apply ``camel_case`` or ``snake_case`` to variables.
+
+Allowed values: ``'camel_case'`` and ``'snake_case'``
+
+Default value: ``'camel_case'``
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+*Default* configuration.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+   -<?php $my_variable = 2;
+   +<?php $myVariable = 2;
+
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['case' => 'snake_case']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+   -<?php $myVariable = 2;
+   +<?php $my_variable = 2;
+Source class
+------------
+
+`PhpCsFixer\\Fixer\\Casing\\VariableCaseFixer <./../../../src/Fixer/Casing/VariableCaseFixer.php>`_

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -144,6 +144,9 @@ Casing
 - `native_type_declaration_casing <./casing/native_type_declaration_casing.rst>`_
 
   Native type declarations should be used in the correct case.
+- `variable_case <./casing/variable_case.rst>`_ *(risky)*
+
+  Enforce camel or snake case for variables, following configuration.
 
 Cast Notation
 -------------

--- a/src/Fixer/Casing/VariableCaseFixer.php
+++ b/src/Fixer/Casing/VariableCaseFixer.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Casing;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * Fixer for variables case.
+ *
+ * @author Jennifer Konikowski <jennifer@testdouble.com>
+ */
+final class VariableCaseFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
+{
+    /**
+     * @internal
+     */
+    const CAMEL_CASE = 'camel_case';
+
+    /**
+     * @internal
+     */
+    const SNAKE_CASE = 'snake_case';
+
+    /**
+     * Hold the function that will be used to convert the constants.
+     *
+     * @var callable
+     */
+    private $fixFunction;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(array $configuration = null)
+    {
+        parent::configure($configuration);
+
+        if (self::CAMEL_CASE === $this->configuration['case']) {
+            $this->fixFunction = static function ($token) {
+                // TODO: use camel case function
+                return VariableCaseFixer::camelCase($token);
+            };
+        }
+
+        if (self::SNAKE_CASE === $this->configuration['case']) {
+            $this->fixFunction = static function ($token) {
+                // TODO: use snake case function (yet to be defined)
+                return strtolower($token);
+            };
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'The PHP constants `true`, `false`, and `null` MUST be written using the correct casing.',
+            [new CodeSample("<?php\n\$a = FALSE;\n\$b = True;\n\$c = nuLL;\n")]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_VARIABLE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('case', 'Apply `camel_case` or `snake_case` to variables.'))
+            ->setAllowedValues([self::CAMEL_CASE, self::SNAKE_CASE])
+            ->setDefault(self::CAMEL_CASE)
+                ->getOption(),
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach ($tokens as $index => $token) {
+            if (T_VARIABLE == $token->getId()) {
+                $tokens[$index] = new Token([$token->getId(), $this->updateVariableCasing($token->getContent())]);
+            }
+        }
+    }
+
+    private function updateVariableCasing($variableName)
+    {
+        if (self::CAMEL_CASE === $this->configuration['case']) {
+            return $this->camelCase($variableName);
+        } else {
+            return $this->snakeCase($variableName);
+        }
+    }
+
+    private function camelCase($string)
+    {
+        $string = preg_replace('/_/i', ' ', $string);
+        $string = trim($string);
+        // uppercase the first character of each word
+        $string = ucwords($string);
+        $string = str_replace(" ", "", $string);
+        $string = lcfirst($string);
+
+        return $string;
+    }
+
+    private function snakeCase($string, $separator = "_")
+    {
+        // insert hyphen between any letter and the beginning of a numeric chain
+        $string = preg_replace('/([a-z]+)([0-9]+)/i', '$1'.$separator.'$2', $string);
+        // insert hyphen between any lower-to-upper-case letter chain
+        $string = preg_replace('/([a-z]+)([A-Z]+)/', '$1'.$separator.'$2', $string);
+        // insert hyphen between the end of a numeric chain and the beginning of an alpha chain
+        $string = preg_replace('/([0-9]+)([a-z]+)/i', '$1'.$separator.'$2', $string);
+
+        // Lowercase
+        $string = strtolower($string);
+
+        return $string;
+    }
+}

--- a/src/Fixer/Casing/VariableCaseFixer.php
+++ b/src/Fixer/Casing/VariableCaseFixer.php
@@ -18,6 +18,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -48,8 +49,18 @@ final class VariableCaseFixer extends AbstractFixer implements ConfigurationDefi
             [
                 new CodeSample("<?php \$my_variable = 2;\n"),
                 new CodeSample("<?php \$myVariable = 2;\n", ['case' => self::SNAKE_CASE]),
-            ]
+            ],
+            null,
+            'Risky because it cannot detect a change that will have an impact in other files.'
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky()
+    {
+        return true;
     }
 
     /**
@@ -96,7 +107,7 @@ final class VariableCaseFixer extends AbstractFixer implements ConfigurationDefi
 
     private function camelCase($string)
     {
-        $string = preg_replace('/_/i', ' ', $string);
+        $string = Preg::replace('/_/i', ' ', $string);
         $string = trim($string);
         // uppercase the first character of each word
         $string = ucwords($string);
@@ -108,11 +119,11 @@ final class VariableCaseFixer extends AbstractFixer implements ConfigurationDefi
     private function snakeCase($string, $separator = '_')
     {
         // insert separator between any letter and the beginning of a numeric chain
-        $string = preg_replace('/([a-z]+)([0-9]+)/i', '$1'.$separator.'$2', $string);
+        $string = Preg::replace('/([a-z]+)([0-9]+)/i', '$1'.$separator.'$2', $string);
         // insert separator between any lower-to-upper-case letter chain
-        $string = preg_replace('/([a-z]+)([A-Z]+)/', '$1'.$separator.'$2', $string);
+        $string = Preg::replace('/([a-z]+)([A-Z]+)/', '$1'.$separator.'$2', $string);
         // insert separator between the end of a numeric chain and the beginning of an alpha chain
-        $string = preg_replace('/([0-9]+)([a-z]+)/i', '$1'.$separator.'$2', $string);
+        $string = Preg::replace('/([0-9]+)([a-z]+)/i', '$1'.$separator.'$2', $string);
 
         // Lowercase
         return strtolower($string);

--- a/src/Fixer/Casing/VariableCaseFixer.php
+++ b/src/Fixer/Casing/VariableCaseFixer.php
@@ -57,7 +57,7 @@ final class VariableCaseFixer extends AbstractFixer implements ConfigurationDefi
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isTokenKindFound(T_VARIABLE);
+        return $tokens->isAnyTokenKindsFound([T_VARIABLE, T_STRING_VARNAME]);
     }
 
     /**
@@ -79,7 +79,7 @@ final class VariableCaseFixer extends AbstractFixer implements ConfigurationDefi
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
         foreach ($tokens as $index => $token) {
-            if (T_VARIABLE === $token->getId()) {
+            if ((T_VARIABLE === $token->getId()) || (T_STRING_VARNAME === $token->getId())) {
                 $tokens[$index] = new Token([$token->getId(), $this->updateVariableCasing($token->getContent())]);
             }
         }

--- a/src/Fixer/Casing/VariableCaseFixer.php
+++ b/src/Fixer/Casing/VariableCaseFixer.php
@@ -44,10 +44,10 @@ final class VariableCaseFixer extends AbstractFixer implements ConfigurationDefi
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Enforce camel (or snake) case for variable names, following configuration',
+            'Enforce camel (or snake) case for variable names, following configuration.',
             [
-                new CodeSample('<?php $myVariable = 2;'),
-                new CodeSample('<?php $my_variable = 2;', ['case' => self::SNAKE_CASE]),
+                new CodeSample("<?php \$my_variable = 2;\n"),
+                new CodeSample("<?php \$myVariable = 2;\n", ['case' => self::SNAKE_CASE]),
             ]
         );
     }

--- a/tests/Fixer/Casing/VariableCaseFixerTest.php
+++ b/tests/Fixer/Casing/VariableCaseFixerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Casing;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Jennifer Konikowski <jennifer@testdouble.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Casing\VariableCaseFixer
+ */
+final class VariableCaseFixerTest extends AbstractFixerTestCase
+{
+     /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideCamelCaseFixCases
+     */
+    public function testCamelCaseFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideCamelCaseFixCases()
+    {
+        return [
+            [
+                '<?php $testVariable = 2;',
+                '<?php $test_variable = 2;',
+            ],
+            [
+                '<?php function foo_bar() { $testVariable = 2;}',
+                '<?php function foo_bar() { $test__variable = 2;}'
+            ],
+            [
+                '<?php echo $testModel->this_field;',
+                '<?php echo $test_model->this_field;'
+            ]
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideSnakeCaseFixCases
+     */
+    public function testSnakeCaseFix($expected, $input = null)
+    {
+        $this->fixer->configure(['case' => 'snake_case']);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideSnakeCaseFixCases()
+    {
+        return [
+            [
+                '<?php $test_variable = 2;',
+                '<?php $testVariable = 2;',
+            ],
+            [
+                '<?php function fooBar() { $test_variable = 2;}',
+                '<?php function fooBar() { $testVariable = 2;}'
+            ],
+            [
+                '<?php echo $test_model->thisField;',
+                '<?php echo $testModel->thisField;'
+            ]
+        ];
+    }
+}

--- a/tests/Fixer/Casing/VariableCaseFixerTest.php
+++ b/tests/Fixer/Casing/VariableCaseFixerTest.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Tests\Fixer\Casing;
 
+use PhpCsFixer\Fixer\Casing\VariableCaseFixer;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
 /**
@@ -23,7 +24,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  */
 final class VariableCaseFixerTest extends AbstractFixerTestCase
 {
-     /**
+    /**
      * @param string      $expected
      * @param null|string $input
      *
@@ -43,12 +44,12 @@ final class VariableCaseFixerTest extends AbstractFixerTestCase
             ],
             [
                 '<?php function foo_bar() { $testVariable = 2;}',
-                '<?php function foo_bar() { $test__variable = 2;}'
+                '<?php function foo_bar() { $test__variable = 2;}',
             ],
             [
                 '<?php echo $testModel->this_field;',
-                '<?php echo $test_model->this_field;'
-            ]
+                '<?php echo $test_model->this_field;',
+            ],
         ];
     }
 
@@ -60,7 +61,7 @@ final class VariableCaseFixerTest extends AbstractFixerTestCase
      */
     public function testSnakeCaseFix($expected, $input = null)
     {
-        $this->fixer->configure(['case' => 'snake_case']);
+        $this->fixer->configure(['case' => VariableCaseFixer::SNAKE_CASE]);
         $this->doTest($expected, $input);
     }
 
@@ -72,13 +73,21 @@ final class VariableCaseFixerTest extends AbstractFixerTestCase
                 '<?php $testVariable = 2;',
             ],
             [
+                '<?php $abc_12_variable = 2;',
+                '<?php $abc12Variable = 2;',
+            ],
+            [
+                '<?php $abc_123_a_variable = 2;',
+                '<?php $abc123aVariable = 2;',
+            ],
+            [
                 '<?php function fooBar() { $test_variable = 2;}',
-                '<?php function fooBar() { $testVariable = 2;}'
+                '<?php function fooBar() { $testVariable = 2;}',
             ],
             [
                 '<?php echo $test_model->thisField;',
-                '<?php echo $testModel->thisField;'
-            ]
+                '<?php echo $testModel->thisField;',
+            ],
         ];
     }
 }

--- a/tests/Fixer/Casing/VariableCaseFixerTest.php
+++ b/tests/Fixer/Casing/VariableCaseFixerTest.php
@@ -62,6 +62,10 @@ final class VariableCaseFixerTest extends AbstractFixerTestCase
                 '<?php echo $testModel->this_field;',
                 '<?php echo $test_model->this_field;',
             ],
+            [
+                '<?php function f($barBaz, $file) { require $file;}',
+                '<?php function f($bar_baz, $file) { require $file;}',
+            ],
         ];
     }
 
@@ -97,8 +101,24 @@ final class VariableCaseFixerTest extends AbstractFixerTestCase
                 '<?php function fooBar() { $testVariable = 2;}',
             ],
             [
-                '<?php echo $test_model->thisField;',
-                '<?php echo $testModel->thisField;',
+                '<?php $test_variable = 2; echo "hi $test_variable!";',
+                '<?php $testVariable = 2; echo "hi $testVariable!";',
+            ],
+            [
+                '<?php $test_variable = 2; echo "hi ${test_variable}!";',
+                '<?php $testVariable = 2; echo "hi ${testVariable}!";',
+            ],
+            [
+                '<?php $test_variable = 2; echo "hi {$test_variable}!";',
+                '<?php $testVariable = 2; echo "hi {$testVariable}!";',
+            ],
+            [
+                '<?php echo $test_model->this_field;',
+                '<?php echo $testModel->this_field;',
+            ],
+            [
+                '<?php function f($bar_baz, $file) { require $file;}',
+                '<?php function f($barBaz, $file) { require $file;}',
             ],
         ];
     }

--- a/tests/Fixer/Casing/VariableCaseFixerTest.php
+++ b/tests/Fixer/Casing/VariableCaseFixerTest.php
@@ -43,6 +43,18 @@ final class VariableCaseFixerTest extends AbstractFixerTestCase
                 '<?php $test_variable = 2;',
             ],
             [
+                '<?php $testVariable = 2; echo "hi $testVariable!";',
+                '<?php $test_variable = 2; echo "hi $test_variable!";',
+            ],
+            [
+                '<?php $testVariable = 2; echo "hi ${testVariable}!";',
+                '<?php $test_variable = 2; echo "hi ${test_variable}!";',
+            ],
+            [
+                '<?php $testVariable = 2; echo "hi {$testVariable}!";',
+                '<?php $test_variable = 2; echo "hi {$test_variable}!";',
+            ],
+            [
                 '<?php function foo_bar() { $testVariable = 2;}',
                 '<?php function foo_bar() { $test__variable = 2;}',
             ],

--- a/tests/Fixer/Casing/VariableCaseFixerTest.php
+++ b/tests/Fixer/Casing/VariableCaseFixerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of PHP CS Fixer.
  *
@@ -25,17 +27,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class VariableCaseFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @param string      $expected
-     * @param null|string $input
-     *
      * @dataProvider provideCamelCaseFixCases
      */
-    public function testCamelCaseFix($expected, $input = null)
+    public function testCamelCaseFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCamelCaseFixCases()
+    public static function provideCamelCaseFixCases(): iterable
     {
         return [
             [
@@ -70,18 +69,15 @@ final class VariableCaseFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @param string      $expected
-     * @param null|string $input
-     *
      * @dataProvider provideSnakeCaseFixCases
      */
-    public function testSnakeCaseFix($expected, $input = null)
+    public function testSnakeCaseFix(string $expected, ?string $input = null): void
     {
         $this->fixer->configure(['case' => VariableCaseFixer::SNAKE_CASE]);
         $this->doTest($expected, $input);
     }
 
-    public function provideSnakeCaseFixCases()
+    public static function provideSnakeCaseFixCases(): iterable
     {
         return [
             [

--- a/tests/Fixer/Casing/VariableCaseFixerTest.php
+++ b/tests/Fixer/Casing/VariableCaseFixerTest.php
@@ -28,6 +28,8 @@ final class VariableCaseFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideIgnoreCases
+     *
+     * @param array<string, mixed> $config
      */
     public function testIgnore(string $input, array $config = []): void
     {
@@ -35,6 +37,9 @@ final class VariableCaseFixerTest extends AbstractFixerTestCase
         $this->doTest($input);
     }
 
+    /**
+     * @return iterable<string, array{0: string, 1?: array<string, mixed>}>
+     */
     public static function provideIgnoreCases(): iterable
     {
         foreach (['public', 'protected', 'private'] as $visibility) {
@@ -63,40 +68,44 @@ final class VariableCaseFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @return iterable<string, array{0: string, 1?: string}>
+     */
     public static function provideCamelCaseFixCases(): iterable
     {
-        return [
-            [
-                '<?php $testVariable = 2;',
-                '<?php $test_variable = 2;',
-            ],
-            [
-                '<?php $testVariable = 2; echo "hi $testVariable!";',
-                '<?php $test_variable = 2; echo "hi $test_variable!";',
-            ],
-            [
-                '<?php $testVariable = 2; echo "hi ${testVariable}!";',
-                '<?php $test_variable = 2; echo "hi ${test_variable}!";',
-            ],
-            [
-                '<?php $testVariable = 2; echo "hi {$testVariable}!";',
-                '<?php $test_variable = 2; echo "hi {$test_variable}!";',
-            ],
-            [
-                '<?php function foo_bar() { $testVariable = 2;}',
-                '<?php function foo_bar() { $test__variable = 2;}',
-            ],
-            [
-                '<?php echo $testModel->this_field;',
-                '<?php echo $test_model->this_field;',
-            ],
-            [
-                '<?php function f($barBaz, $file) { require $file;}',
-                '<?php function f($bar_baz, $file) { require $file;}',
-            ],
-            [
-                '<?php function f($bar_baz, $file) { require $file;}',
-            ],
+        yield 'variable assignment' => [
+            '<?php $testVariable = 2;',
+            '<?php $test_variable = 2;',
+        ];
+
+        yield 'variable assignment and string interpolation' => [
+            '<?php $testVariable = 2; echo "hi $testVariable!";',
+            '<?php $test_variable = 2; echo "hi $test_variable!";',
+        ];
+
+        yield 'variable assignment and deprecated string interpolation' => [
+            '<?php $testVariable = 2; echo "hi ${testVariable}!";',
+            '<?php $test_variable = 2; echo "hi ${test_variable}!";',
+        ];
+
+        yield 'variable assignment and braces string interpolation' => [
+            '<?php $testVariable = 2; echo "hi {$testVariable}!";',
+            '<?php $test_variable = 2; echo "hi {$test_variable}!";',
+        ];
+
+        yield 'local variable in function' => [
+            '<?php function foo_bar() { $testVariable = 2;}',
+            '<?php function foo_bar() { $test__variable = 2;}',
+        ];
+
+        yield 'property fetch on variable' => [
+            '<?php echo $testModel->this_field;',
+            '<?php echo $test_model->this_field;',
+        ];
+
+        yield 'function arguments' => [
+            '<?php function f($barBaz, $file) { require $file;}',
+            '<?php function f($bar_baz, $file) { require $file;}',
         ];
     }
 
@@ -109,45 +118,54 @@ final class VariableCaseFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @return iterable<string, array{0: string, 1?: string}>
+     */
     public static function provideSnakeCaseFixCases(): iterable
     {
-        return [
-            [
-                '<?php $test_variable = 2;',
-                '<?php $testVariable = 2;',
-            ],
-            [
-                '<?php $abc_12_variable = 2;',
-                '<?php $abc12Variable = 2;',
-            ],
-            [
-                '<?php $abc_123_a_variable = 2;',
-                '<?php $abc123aVariable = 2;',
-            ],
-            [
-                '<?php function fooBar() { $test_variable = 2;}',
-                '<?php function fooBar() { $testVariable = 2;}',
-            ],
-            [
-                '<?php $test_variable = 2; echo "hi $test_variable!";',
-                '<?php $testVariable = 2; echo "hi $testVariable!";',
-            ],
-            [
-                '<?php $test_variable = 2; echo "hi ${test_variable}!";',
-                '<?php $testVariable = 2; echo "hi ${testVariable}!";',
-            ],
-            [
-                '<?php $test_variable = 2; echo "hi {$test_variable}!";',
-                '<?php $testVariable = 2; echo "hi {$testVariable}!";',
-            ],
-            [
-                '<?php echo $test_model->this_field;',
-                '<?php echo $testModel->this_field;',
-            ],
-            [
-                '<?php function f($bar_baz, $file) { require $file;}',
-                '<?php function f($barBaz, $file) { require $file;}',
-            ],
+        yield 'variable assignment' => [
+            '<?php $test_variable = 2;',
+            '<?php $testVariable = 2;',
+        ];
+
+        yield 'variable assignment with numbers in name' => [
+            '<?php $abc_12_variable = 2;',
+            '<?php $abc12Variable = 2;',
+        ];
+
+        yield 'variable assignment with numbers in name and mixed casing' => [
+            '<?php $abc_123_a_variable = 2;',
+            '<?php $abc123aVariable = 2;',
+        ];
+
+        yield 'local variable in function' => [
+            '<?php function fooBar() { $test_variable = 2;}',
+            '<?php function fooBar() { $testVariable = 2;}',
+        ];
+
+        yield 'variable assignment and string interpolation' => [
+            '<?php $test_variable = 2; echo "hi $test_variable!";',
+            '<?php $testVariable = 2; echo "hi $testVariable!";',
+        ];
+
+        yield 'variable assignment and deprecated string interpolation' => [
+            '<?php $test_variable = 2; echo "hi ${test_variable}!";',
+            '<?php $testVariable = 2; echo "hi ${testVariable}!";',
+        ];
+
+        yield 'variable assignment and braces string interpolation' => [
+            '<?php $test_variable = 2; echo "hi {$test_variable}!";',
+            '<?php $testVariable = 2; echo "hi {$testVariable}!";',
+        ];
+
+        yield 'property fetch on variable' => [
+            '<?php echo $test_model->this_field;',
+            '<?php echo $testModel->this_field;',
+        ];
+
+        yield 'function arguments' => [
+            '<?php function f($bar_baz, $file) { require $file;}',
+            '<?php function f($barBaz, $file) { require $file;}',
         ];
     }
 }

--- a/tests/Fixer/Casing/VariableCaseFixerTest.php
+++ b/tests/Fixer/Casing/VariableCaseFixerTest.php
@@ -27,6 +27,35 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class VariableCaseFixerTest extends AbstractFixerTestCase
 {
     /**
+     * @dataProvider provideIgnoreCases
+     */
+    public function testIgnore(string $input, array $config = []): void
+    {
+        $this->fixer->configure($config);
+        $this->doTest($input);
+    }
+
+    public static function provideIgnoreCases(): iterable
+    {
+        foreach (['public', 'protected', 'private'] as $visibility) {
+            $modifiers = ['', 'static'];
+
+            if (\defined('T_READONLY')) { // @TODO: drop condition when PHP 8.1+ is required
+                $modifiers[] = 'readonly';
+            }
+
+            foreach ($modifiers as $modifier) {
+                yield "{$visibility} {$modifier} property snake_case" => ["<?php class Foo { {$visibility} {$modifier} \$bar_baz; }"];
+
+                yield "{$visibility} {$modifier} property camelCase" => [
+                    "<?php class Foo { {$visibility} {$modifier} \$barBaz; }",
+                    ['case' => VariableCaseFixer::SNAKE_CASE],
+                ];
+            }
+        }
+    }
+
+    /**
      * @dataProvider provideCamelCaseFixCases
      */
     public function testCamelCaseFix(string $expected, ?string $input = null): void
@@ -63,6 +92,9 @@ final class VariableCaseFixerTest extends AbstractFixerTestCase
             ],
             [
                 '<?php function f($barBaz, $file) { require $file;}',
+                '<?php function f($bar_baz, $file) { require $file;}',
+            ],
+            [
                 '<?php function f($bar_baz, $file) { require $file;}',
             ],
         ];


### PR DESCRIPTION
The project that I am working in has a rule that variables should all be in camelCase. However, we don't have any way to currently lint or automatically fix. Since we are using PHPCSFixer, I wanted to add a fixer that would automatically make that change.