### PR TITLE
allow @var phpdocs before return statements

### DIFF
--- a/src/Tokenizer/Analyzer/CommentsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/CommentsAnalyzer.php
@@ -190,6 +190,10 @@ final class CommentsAnalyzer
      */
     private function isValidControl(Tokens $tokens, Token $docsToken, $controlIndex)
     {
+        if ($tokens[$controlIndex]->isGivenKind(T_RETURN) && false !== stripos($docsToken->getContent(), '@var')) {
+            return true;
+        }
+
         static $controlStructures = [
             T_FOR,
             T_FOREACH,

--- a/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
@@ -552,6 +552,19 @@ $loader = require __DIR__.\'/../vendor/autoload.php\';
 ',
         ];
 
+        $cases[] = [
+            '<?php
+class A
+{
+    public function b()
+    {
+        /** @var string */
+        return \'foo\';
+    }
+}
+',
+        ];
+
         return $cases;
     }
 

--- a/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
@@ -270,6 +270,7 @@ $bar;',
             ['<?php /* @var string $s */ echo($s);'],
             ['<?php /* @var User $bar */ ($baz = tmp())->doSomething();'],
             ['<?php /* @var User $bar */ list($bar) = a();'],
+            ['<?php /* @var string */ return \'foo\';'],
         ];
     }
 


### PR DESCRIPTION
This PR stops phpdocs before return statements from being converted to comments, if they are a `@var` definition.

This is a common requirement with SA tooling to assist the tool with the return type. 
e.g:
https://psalm.dev/r/0de99e28de
```php
<?php

interface EncoderInterface
{
    /**
     * @return bool|float|int|string
     */
    public function encode(array $data);
}

function returnsString(EncoderInterface $encoder): string
{
    /** @var string */
    return $encoder->encode(
        ['invoice_number' => 1],
    );
}
```

We don't want `/** @var string */` converted to `// @var string` in this instance.

Thanks.
