### PR TITLE
bug: Fix MultilineWhitespaceBeforeSemicolonsFixer

### DIFF
--- a/src/AbstractPhpdocTypesFixer.php
+++ b/src/AbstractPhpdocTypesFixer.php
@@ -122,7 +122,6 @@ abstract class AbstractPhpdocTypesFixer extends AbstractFixer
     {
         return str_ends_with($type, '[]')
             ? $this->normalizeType(substr($type, 0, -2)).'[]'
-            : $this->normalize($type)
-        ;
+            : $this->normalize($type);
     }
 }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -74,8 +74,7 @@ final class Application extends BaseApplication
     {
         $stdErr = $output instanceof ConsoleOutputInterface
             ? $output->getErrorOutput()
-            : ($input->hasParameterOption('--format', true) && 'txt' !== $input->getParameterOption('--format', null, true) ? null : $output)
-        ;
+            : ($input->hasParameterOption('--format', true) && 'txt' !== $input->getParameterOption('--format', null, true) ? null : $output);
 
         if (null !== $stdErr) {
             $warningsDetector = new WarningsDetector($this->toolInfo);

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -182,8 +182,7 @@ Exit code of the fix command is built using following bit flags:
 * 32 - Configuration error of a Fixer.
 * 64 - Exception raised within the application.
 
-EOF
-        ;
+EOF;
     }
 
     /**
@@ -251,8 +250,7 @@ EOF
 
         $stdErr = $output instanceof ConsoleOutputInterface
             ? $output->getErrorOutput()
-            : ('txt' === $reporter->getFormat() ? $output : null)
-        ;
+            : ('txt' === $reporter->getFormat() ? $output : null);
 
         if (null !== $stdErr) {
             if (OutputInterface::VERBOSITY_VERBOSE <= $verbosity) {
@@ -324,8 +322,7 @@ EOF
 
         $output->isDecorated()
             ? $output->write($reporter->generate($reportSummary))
-            : $output->write($reporter->generate($reportSummary), false, OutputInterface::OUTPUT_RAW)
-        ;
+            : $output->write($reporter->generate($reportSummary), false, OutputInterface::OUTPUT_RAW);
 
         $invalidErrors = $this->errorsManager->getInvalidErrors();
         $exceptionErrors = $this->errorsManager->getExceptionErrors();

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -44,8 +44,7 @@ final class HelpCommand extends BaseHelpCommand
     {
         return \is_array($value)
             ? static::arrayToString($value)
-            : static::scalarToString($value)
-        ;
+            : static::scalarToString($value);
     }
 
     /**
@@ -122,8 +121,7 @@ final class HelpCommand extends BaseHelpCommand
 
             $str .= \is_array($v)
                 ? static::arrayToString($v).', '
-                : static::scalarToString($v).', '
-            ;
+                : static::scalarToString($v).', ';
         }
 
         return substr($str, 0, -2).']';

--- a/src/Console/Command/ListSetsCommand.php
+++ b/src/Console/Command/ListSetsCommand.php
@@ -70,8 +70,7 @@ final class ListSetsCommand extends Command
 
         $output->isDecorated()
             ? $output->write(OutputFormatter::escape($report))
-            : $output->write($report, false, OutputInterface::OUTPUT_RAW)
-        ;
+            : $output->write($report, false, OutputInterface::OUTPUT_RAW);
 
         return 0;
     }

--- a/src/Console/Output/ErrorOutput.php
+++ b/src/Console/Output/ErrorOutput.php
@@ -150,7 +150,6 @@ final class ErrorOutput
     {
         return $this->isDecorated
             ? OutputFormatter::escape($string)
-            : $string
-        ;
+            : $string;
     }
 }

--- a/src/Differ/DiffConsoleFormatter.php
+++ b/src/Differ/DiffConsoleFormatter.php
@@ -40,8 +40,7 @@ final class DiffConsoleFormatter
 
         $template = $isDecorated
             ? $this->template
-            : Preg::replace('/<[^<>]+>/', '', $this->template)
-        ;
+            : Preg::replace('/<[^<>]+>/', '', $this->template);
 
         return sprintf(
             $template,

--- a/src/Documentation/FixerDocumentGenerator.php
+++ b/src/Documentation/FixerDocumentGenerator.php
@@ -298,8 +298,7 @@ RST;
 
             $attributes = 0 === \count($attributes)
                 ? ''
-                : ' *('.implode(', ', $attributes).')*'
-            ;
+                : ' *('.implode(', ', $attributes).')*';
 
             $summary = str_replace('`', '``', $fixer->getDefinition()->getSummary());
 
@@ -342,8 +341,7 @@ RST;
         $tokens = Tokens::fromCode($old);
         $file = $sample instanceof FileSpecificCodeSampleInterface
             ? $sample->getSplFileInfo()
-            : new StdinFileInfo()
-        ;
+            : new StdinFileInfo();
 
         if ($fixer instanceof ConfigurableFixerInterface) {
             $fixer->configure($sample->getConfiguration() ?? []);

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -261,7 +261,6 @@ class Foo
     {
         return self::LINE_NEXT === $option
             ? CurlyBracesPositionFixer::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END
-            : CurlyBracesPositionFixer::SAME_LINE
-        ;
+            : CurlyBracesPositionFixer::SAME_LINE;
     }
 }

--- a/src/Fixer/Basic/NoTrailingCommaInSinglelineFixer.php
+++ b/src/Fixer/Basic/NoTrailingCommaInSinglelineFixer.php
@@ -50,8 +50,7 @@ final class NoTrailingCommaInSinglelineFixer extends AbstractFixer implements Co
     {
         return
             $tokens->isTokenKindFound(',')
-            && $tokens->isAnyTokenKindsFound([')', CT::T_ARRAY_SQUARE_BRACE_CLOSE, CT::T_DESTRUCTURING_SQUARE_BRACE_CLOSE, CT::T_GROUP_IMPORT_BRACE_CLOSE])
-        ;
+            && $tokens->isAnyTokenKindsFound([')', CT::T_ARRAY_SQUARE_BRACE_CLOSE, CT::T_DESTRUCTURING_SQUARE_BRACE_CLOSE, CT::T_GROUP_IMPORT_BRACE_CLOSE]);
     }
 
     /**
@@ -154,8 +153,7 @@ final class NoTrailingCommaInSinglelineFixer extends AbstractFixer implements Co
                     || Tokens::BLOCK_TYPE_DYNAMIC_VAR_BRACE === $block['type']
                     || Tokens::BLOCK_TYPE_INDEX_SQUARE_BRACE === $block['type']
                     || Tokens::BLOCK_TYPE_PARENTHESIS_BRACE === $block['type']
-                ) && \in_array('arguments', $elements, true)
-            ;
+                ) && \in_array('arguments', $elements, true);
         }
 
         return false;

--- a/src/Fixer/Basic/OctalNotationFixer.php
+++ b/src/Fixer/Basic/OctalNotationFixer.php
@@ -67,8 +67,7 @@ final class OctalNotationFixer extends AbstractFixer
 
             $tokens[$index] = 1 === Preg::match('#^0+$#', $content)
                 ? new Token([T_LNUMBER, '0'])
-                : new Token([T_LNUMBER, '0o'.('_' === $content[1] ? '0' : '').substr($content, 1)])
-            ;
+                : new Token([T_LNUMBER, '0o'.('_' === $content[1] ? '0' : '').substr($content, 1)]);
         }
     }
 }

--- a/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+++ b/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
@@ -133,8 +133,7 @@ class Sample
             $prevIndex = $tokens->getPrevMeaningfulToken($index);
             $expectedKinds = 'property' === $element['type']
                 ? $expectedKindsPropertyKinds
-                : $expectedKindsGeneric
-            ;
+                : $expectedKindsGeneric;
 
             while ($tokens[$prevIndex]->isGivenKind($expectedKinds)) {
                 if ($tokens[$prevIndex]->isGivenKind([T_ABSTRACT, T_FINAL])) {

--- a/src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+++ b/src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
@@ -100,8 +100,7 @@ final class NoAlternativeSyntaxFixer extends AbstractFixer implements Configurab
 
         return $nextToken->equals('(')
             ? $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $nextIndex)
-            : $structureTokenIndex // return if next token is not opening parenthesis
-        ;
+            : $structureTokenIndex; // return if next token is not opening parenthesis
     }
 
     /**

--- a/src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
+++ b/src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
@@ -72,8 +72,7 @@ final class NoSuperfluousElseifFixer extends AbstractNoUselessElseFixer
     {
         return
             $tokens[$index]->isGivenKind(T_ELSEIF)
-            || ($tokens[$index]->isGivenKind(T_ELSE) && $tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(T_IF))
-        ;
+            || ($tokens[$index]->isGivenKind(T_ELSE) && $tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(T_IF));
     }
 
     private function convertElseifToIf(Tokens $tokens, int $index): void

--- a/src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
+++ b/src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
@@ -286,8 +286,7 @@ while ($y) { continue (2); }
             || $this->isWrappedFnBody($tokens, $beforeOpenIndex, $afterCloseIndex)
             || $this->isWrappedForElement($tokens, $beforeOpenIndex, $afterCloseIndex)
             || $this->isWrappedLanguageConstructArgument($tokens, $beforeOpenIndex, $afterCloseIndex)
-            || $this->isWrappedSequenceElement($tokens, $beforeOpenIndex, $afterCloseIndex)
-        ;
+            || $this->isWrappedSequenceElement($tokens, $beforeOpenIndex, $afterCloseIndex);
     }
 
     private function isExitStatement(Tokens $tokens, int $beforeOpenIndex): bool
@@ -351,8 +350,7 @@ while ($y) { continue (2); }
             || $this->isSingleStatement($tokens, $beforeOpenIndex, $afterCloseIndex)
             || $this->isWrappedFnBody($tokens, $beforeOpenIndex, $afterCloseIndex)
             || $this->isWrappedForElement($tokens, $beforeOpenIndex, $afterCloseIndex)
-            || $this->isWrappedSequenceElement($tokens, $beforeOpenIndex, $afterCloseIndex)
-        ;
+            || $this->isWrappedSequenceElement($tokens, $beforeOpenIndex, $afterCloseIndex);
     }
 
     private function isWrappedPartOfOperation(Tokens $tokens, int $beforeOpenIndex, int $openIndex, int $closeIndex, int $afterCloseIndex): bool
@@ -419,8 +417,7 @@ while ($y) { continue (2); }
 
         return
             ($beforeIsStatementOpen && $afterIsBinaryOperation) // `<?php (X) +`
-            || ($beforeIsBinaryOperation && $afterIsStatementEnd) // `+ (X);`
-        ;
+            || ($beforeIsBinaryOperation && $afterIsStatementEnd); // `+ (X);`
     }
 
     // bounded `print|yield|yield from|require|require_once|include|include_once (X)`
@@ -473,8 +470,7 @@ while ($y) { continue (2); }
         return
             ($startIsComma && null !== $blockTypeEnd) // `,(X)]`
             || ($endIsComma && null !== $blockTypeStart) // `[(X),`
-            || (null !== $blockTypeEnd && null !== $blockTypeStart) // any type of `{(X)}`, `[(X)]` and `((X))`
-        ;
+            || (null !== $blockTypeEnd && null !== $blockTypeStart); // any type of `{(X)}`, `[(X)]` and `((X))`
     }
 
     // any of `for( (X); ;(X)) ;` note that the middle element is covered as 'single statement' as it is `; (X) ;`
@@ -700,14 +696,12 @@ while ($y) { continue (2); }
             !$this->isAccess($tokens, $afterCloseIndex)
             && !$tokens[$afterCloseIndex]->equalsAny([';', ',', [T_CLOSE_TAG]])
             && null === $this->getBlock($tokens, $afterCloseIndex, false)
-            && !($tokens[$afterCloseIndex]->equalsAny([':', ';']) && $tokens[$beforeOpenIndex]->isGivenKind(T_CASE))
-        ;
+            && !($tokens[$afterCloseIndex]->equalsAny([':', ';']) && $tokens[$beforeOpenIndex]->isGivenKind(T_CASE));
 
         $needsSpaceBefore =
             !$this->isPreUnaryOperation($tokens, $beforeOpenIndex)
             && !$tokens[$beforeOpenIndex]->equalsAny(['}', [T_EXIT], [T_OPEN_TAG]])
-            && null === $this->getBlock($tokens, $beforeOpenIndex, true)
-        ;
+            && null === $this->getBlock($tokens, $beforeOpenIndex, true);
 
         $this->removeBrace($tokens, $closeIndex, $needsSpaceAfter);
         $this->removeBrace($tokens, $openIndex, $needsSpaceBefore);

--- a/src/Fixer/ControlStructure/YodaStyleFixer.php
+++ b/src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -389,8 +389,7 @@ return $foo === count($bar);
 
         return ($yoda && !$leftSideIsVariable) || (!$yoda && !$rightSideIsVariable)
             ? null
-            : ['left' => $left, 'right' => $right]
-        ;
+            : ['left' => $left, 'right' => $right];
     }
 
     /**

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -315,8 +315,7 @@ SAMPLE
             $lastLineIndex = strrpos($existingIndentation, "\n");
             $existingIndentation = false === $lastLineIndex
                 ? $existingIndentation
-                : substr($existingIndentation, $lastLineIndex + 1)
-            ;
+                : substr($existingIndentation, $lastLineIndex + 1);
         }
 
         $indentation = $existingIndentation.$this->whitespacesConfig->getIndent();

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -771,8 +771,7 @@ $array = [
                     if ($tokens[$i + 1]->isGivenKind([T_ARRAY, CT::T_ARRAY_SQUARE_BRACE_OPEN])) {
                         $arrayStartIndex = $tokens[$i + 1]->isGivenKind(T_ARRAY)
                             ? $tokens->getNextMeaningfulToken($i + 1)
-                            : $i + 1
-                        ;
+                            : $i + 1;
                         $blockType = Tokens::detectBlockType($tokens[$arrayStartIndex]);
                         $arrayEndIndex = $tokens->findBlockEnd($blockType['type'], $arrayStartIndex);
 

--- a/src/Fixer/PhpTag/EchoTagSyntaxFixer.php
+++ b/src/Fixer/PhpTag/EchoTagSyntaxFixer.php
@@ -72,8 +72,7 @@ final class EchoTagSyntaxFixer extends AbstractFixer implements ConfigurableFixe
 <?php /* comment */ echo '2' . '3'; ?>
 <?php print '2' . '3'; someFunction(); ?>
 
-EOT
-        ;
+EOT;
 
         return new FixerDefinition(
             'Replaces short-echo `<?=` with long format `<?php echo`/`<?php print` syntax, or vice-versa.',

--- a/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
@@ -162,8 +162,7 @@ class MyTest extends \\PhpUnit\\FrameWork\\TestCase
 
         return
             $this->isPHPDoc($tokens, $docBlockIndex) // If the function doesn't have test in its name, and no doc block, it's not a test
-            && str_contains($tokens[$docBlockIndex]->getContent(), '@test')
-        ;
+            && str_contains($tokens[$docBlockIndex]->getContent(), '@test');
     }
 
     private function isMethod(Tokens $tokens, int $index): bool

--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -185,8 +185,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
         // If the function doesn't have test in its name, and no doc block, it is not a test
         return
             $this->isPHPDoc($tokens, $docBlockIndex)
-            && str_contains($tokens[$docBlockIndex]->getContent(), '@test')
-        ;
+            && str_contains($tokens[$docBlockIndex]->getContent(), '@test');
     }
 
     private function isMethod(Tokens $tokens, int $index): bool

--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -453,8 +453,7 @@ class Foo {
 
         return $tokens[$colonIndex]->isGivenKind(CT::T_TYPE_COLON)
             ? $this->parseTypeHint($tokens, $tokens->getNextMeaningfulToken($colonIndex))
-            : self::NO_TYPE_INFO
-        ;
+            : self::NO_TYPE_INFO;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -311,8 +311,7 @@ EOF;
                 $line =
                     $item['indent']
                     .' * @'
-                    .$item['tag']
-                ;
+                    .$item['tag'];
 
                 if ($hasStatic) {
                     $line .=
@@ -320,8 +319,7 @@ EOF;
                             $tagMax - \strlen($item['tag']) + 1,
                             $item['static'] ? 1 : 0
                         )
-                        .($item['static'] ?: $this->getIndent(6 /* \strlen('static') */, 0))
-                    ;
+                        .($item['static'] ?: $this->getIndent(6 /* \strlen('static') */, 0));
                     $hintVerticalAlignIndent = 1;
                 } else {
                     $hintVerticalAlignIndent = $tagMax - \strlen($item['tag']) + 1;
@@ -332,8 +330,7 @@ EOF;
                         $hintVerticalAlignIndent,
                         $item['hint'] ? 1 : 0
                     )
-                    .$item['hint']
-                ;
+                    .$item['hint'];
 
                 if (!empty($item['var'])) {
                     $line .=
@@ -343,8 +340,7 @@ EOF;
                             !empty($item['desc'])
                             ? $this->getIndent($varMax - \strlen($item['var']) + 1).$item['desc'].$lineEnding
                             : $lineEnding
-                        )
-                    ;
+                        );
                 } elseif (!empty($item['desc'])) {
                     $line .= $this->getIndent($hintMax - \strlen($item['hint']) + 1).$item['desc'].$lineEnding;
                 } else {

--- a/src/Fixer/Phpdoc/PhpdocTagTypeFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTagTypeFixer.php
@@ -202,8 +202,7 @@ final class PhpdocTagTypeFixer extends AbstractFixer implements ConfigurableFixe
     {
         return
             Preg::match('/(^|\R)\h*[^@\s]\N*/', $this->cleanComment($parts[$index - 1]))
-            || Preg::match('/^.*?\R\s*[^@\s]/', $this->cleanComment($parts[$index + 1]))
-        ;
+            || Preg::match('/^.*?\R\s*[^@\s]/', $this->cleanComment($parts[$index + 1]));
     }
 
     private function cleanComment(string $comment): string

--- a/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+++ b/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -313,8 +313,7 @@ final class ReturnAssignmentFixer extends AbstractFixer
         $inserted = 0;
         $originalIndent = $tokens[$assignVarIndex - 1]->isWhitespace()
             ? $tokens[$assignVarIndex - 1]->getContent()
-            : null
-        ;
+            : null;
 
         // remove the return statement
         if ($tokens[$returnVarEndIndex]->equals(';')) { // do not remove PHP close tags
@@ -331,8 +330,7 @@ final class ReturnAssignmentFixer extends AbstractFixer
             $fistLinebreakPos = strrpos($content, "\n");
             $content = false === $fistLinebreakPos
                 ? ' '
-                : substr($content, $fistLinebreakPos)
-            ;
+                : substr($content, $fistLinebreakPos);
 
             $tokens[$returnIndex - 1] = new Token([T_WHITESPACE, $content]);
         }

--- a/src/Fixer/StringNotation/EscapeImplicitBackslashesFixer.php
+++ b/src/Fixer/StringNotation/EscapeImplicitBackslashesFixer.php
@@ -123,8 +123,7 @@ EOF;
             $isSingleQuotedString = $token->isGivenKind(T_CONSTANT_ENCAPSED_STRING) && ('\'' === $content[0] || 'b\'' === $firstTwoCharacters);
             $isDoubleQuotedString =
                 ($token->isGivenKind(T_CONSTANT_ENCAPSED_STRING) && ('"' === $content[0] || 'b"' === $firstTwoCharacters))
-                || ($token->isGivenKind(T_ENCAPSED_AND_WHITESPACE) && $doubleQuoteOpened)
-            ;
+                || ($token->isGivenKind(T_ENCAPSED_AND_WHITESPACE) && $doubleQuoteOpened);
             $isHeredocSyntax = !$isSingleQuotedString && !$isDoubleQuotedString;
             if (
                 (false === $this->configuration['single_quoted'] && $isSingleQuotedString)

--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -169,7 +169,6 @@ EOT
         return $token->isGivenKind(T_ENCAPSED_AND_WHITESPACE)
             || $token->isGivenKind(T_START_HEREDOC)
             || '"' === $token->getContent()
-            || 'b"' === strtolower($token->getContent())
-        ;
+            || 'b"' === strtolower($token->getContent());
     }
 }

--- a/src/Fixer/StringNotation/StringLengthToEmptyFixer.php
+++ b/src/Fixer/StringNotation/StringLengthToEmptyFixer.php
@@ -256,8 +256,7 @@ final class StringLengthToEmptyFixer extends AbstractFunctionReferenceFixer
     {
         return
             $token->isGivenKind([T_IS_IDENTICAL, T_IS_NOT_IDENTICAL, T_IS_SMALLER_OR_EQUAL, T_IS_GREATER_OR_EQUAL])
-            || $token->equals('<') || $token->equals('>')
-        ;
+            || $token->equals('<') || $token->equals('>');
     }
 
     private function isOfHigherPrecedence(Token $token): bool

--- a/src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+++ b/src/Fixer/Whitespace/MethodChainingIndentationFixer.php
@@ -210,13 +210,11 @@ final class MethodChainingIndentationFixer extends AbstractFixer implements Whit
 
             return
                 $tokens[$thirdMeaningful]->equals('(')
-                && $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $thirdMeaningful) > $end
-            ;
+                && $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $thirdMeaningful) > $end;
         }
 
         return
             !$tokens[$end]->equals(')')
-            || $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $end) >= $start
-        ;
+            || $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $end) >= $start;
     }
 }

--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -261,8 +261,7 @@ else {
             ) {
                 $previousOpenTagContent = $tokens[$index - 1]->isGivenKind(T_OPEN_TAG)
                     ? Preg::replace('/\S/', '', $tokens[$index - 1]->getContent())
-                    : ''
-                ;
+                    : '';
 
                 $content = $previousOpenTagContent.($token->isWhitespace() ? $token->getContent() : '');
 

--- a/src/Tokenizer/Analyzer/ControlCaseStructuresAnalyzer.php
+++ b/src/Tokenizer/Analyzer/ControlCaseStructuresAnalyzer.php
@@ -197,8 +197,7 @@ final class ControlCaseStructuresAnalyzer
     {
         $default = null === $analysis['default']
             ? null
-            : new DefaultAnalysis($analysis['default']['index'], $analysis['default']['open'])
-        ;
+            : new DefaultAnalysis($analysis['default']['index'], $analysis['default']['open']);
 
         $cases = [];
 

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -379,16 +379,14 @@ class Tokens extends \SplFixedArray
 
                     return \strlen($whitespace) > 2 // @TODO: can be removed on PHP 8; https://php.net/manual/en/function.substr.php
                         ? substr($whitespace, 2)
-                        : ''
-                    ;
+                        : '';
                 }
 
                 $tokens[$index] = new Token([T_OPEN_TAG, rtrim($token->getContent()).$whitespace[0]]);
 
                 return \strlen($whitespace) > 1 // @TODO: can be removed on PHP 8; https://php.net/manual/en/function.substr.php
                     ? substr($whitespace, 1)
-                    : ''
-                ;
+                    : '';
             }
 
             return $whitespace;
@@ -1345,8 +1343,7 @@ class Tokens extends \SplFixedArray
         // inlined extractTokenKind() call on the hot path
         $tokenKind = $token instanceof Token
             ? ($token->isArray() ? $token->getId() : $token->getContent())
-            : (\is_array($token) ? $token[0] : $token)
-        ;
+            : (\is_array($token) ? $token[0] : $token);
 
         $this->foundTokenKinds[$tokenKind] ??= 0;
         ++$this->foundTokenKinds[$tokenKind];
@@ -1362,8 +1359,7 @@ class Tokens extends \SplFixedArray
         // inlined extractTokenKind() call on the hot path
         $tokenKind = $token instanceof Token
             ? ($token->isArray() ? $token->getId() : $token->getContent())
-            : (\is_array($token) ? $token[0] : $token)
-        ;
+            : (\is_array($token) ? $token[0] : $token);
 
         if (!isset($this->foundTokenKinds[$tokenKind])) {
             return;
@@ -1381,8 +1377,7 @@ class Tokens extends \SplFixedArray
     {
         return $token instanceof Token
             ? ($token->isArray() ? $token->getId() : $token->getContent())
-            : (\is_array($token) ? $token[0] : $token)
-        ;
+            : (\is_array($token) ? $token[0] : $token);
     }
 
     /**

--- a/tests/AutoReview/CommandTest.php
+++ b/tests/AutoReview/CommandTest.php
@@ -48,8 +48,7 @@ final class CommandTest extends TestCase
                 // is not an alias
                 !\in_array($name, $commands[$name]->getAliases(), true)
                 // and is our command
-                && str_starts_with(\get_class($commands[$name]), 'PhpCsFixer\\')
-            ;
+                && str_starts_with(\get_class($commands[$name]), 'PhpCsFixer\\');
         });
 
         return array_map(static function (string $name) use ($commands): array {

--- a/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
@@ -955,8 +955,7 @@ else?><?php echo 5;',
             else
                 $ret .= $value;
 
-            return $ret;'
-        ;
+            return $ret;';
 
         $ifElseIfTemplate = '<?php
             if ($a === false)
@@ -968,8 +967,7 @@ else?><?php echo 5;',
             else
                 $ret .= $value;
 
-            return $ret;'
-        ;
+            return $ret;';
 
         $ifElseTemplate = '<?php
             if ($a === false)
@@ -981,8 +979,7 @@ else?><?php echo 5;',
             else
                 $ret .= $value;
 
-            return $ret;'
-        ;
+            return $ret;';
 
         yield [sprintf($ifTemplate, $statement)];
 

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -444,8 +444,7 @@ EOF;
 <?php
 
 $c = 1;
-EOF
-        ;
+EOF;
 
         $this->doTest($expected);
     }
@@ -1728,8 +1727,7 @@ EOF;
 <?php
 
 $c = 1;
-EOF
-        ;
+EOF;
 
         $this->doTest($expected);
     }

--- a/tests/Fixer/Import/SingleImportPerStatementFixerTest.php
+++ b/tests/Fixer/Import/SingleImportPerStatementFixerTest.php
@@ -277,16 +277,14 @@ use G\{H,I/*1*/,/*2*/};
         $expected = '<?php
 use Space\Models\TestModelA;
 use Space\Models\TestModelB;
-use Space\Models\TestModel;'
-        ;
+use Space\Models\TestModel;';
 
         $input = '<?php
 use Space\Models\ {
     TestModelA,
     TestModelB,
     TestModel,
-};'
-        ;
+};';
 
         $this->doTest($expected, $input);
 

--- a/tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
@@ -433,8 +433,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             $this->setExpectedException(\'RuntimeException\', \'msg\'/*B*/, /*C*/123);
             zzz();
         }
-'
-        ;
+';
         $input = $expected = '<?php
     final class MyTest extends \PHPUnit_Framework_TestCase
     {

--- a/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
+++ b/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
@@ -44,21 +44,32 @@ final class MultilineWhitespaceBeforeSemicolonsFixerTest extends AbstractFixerTe
         return [
             [
                 '<?php
-                    $foo->bar() // test
-;',
+                    $foo->bar(); // test',
                 '<?php
                     $foo->bar() // test
                     ;',
             ],
             [
+                '<?php echo(1); // test',
                 "<?php echo(1) // test\n;",
             ],
             [
+                "<?php echo(1); // test\n",
+            ],
+            [
+                '<?php
+                    $foo->bar(); # test',
                 '<?php
                     $foo->bar() # test
-;',
+
+
+                ;',
+            ],
+            [
                 '<?php
-                    $foo->bar() # test
+                    $foo->bar();// test',
+                '<?php
+                    $foo->bar()// test
 
 
                 ;',
@@ -125,16 +136,14 @@ $this
             ],
             [
                 '<?php
-                    Foo::bar() // test
-;',
+                    Foo::bar(); // test',
                 '<?php
                     Foo::bar() // test
                     ;',
             ],
             [
                 '<?php
-                    Foo::bar() # test
-;',
+                    Foo::bar(); # test',
                 '<?php
                     Foo::bar() # test
 
@@ -198,6 +207,46 @@ self
 
     ;',
             ],
+            [
+                '<?php
+$seconds = $minutes
+    * 60; // seconds in a minute',
+                '<?php
+$seconds = $minutes
+    * 60 // seconds in a minute
+;',
+            ],
+            [
+                '<?php
+$seconds = $minutes
+    * (int) \'60\'; // seconds in a minute',
+                '<?php
+$seconds = $minutes
+    * (int) \'60\' // seconds in a minute
+;',
+            ],
+            [
+                '<?php
+$secondsPerMinute = 60;
+$seconds = $minutes
+    * $secondsPerMinute; // seconds in a minute',
+                '<?php
+$secondsPerMinute = 60;
+$seconds = $minutes
+    * $secondsPerMinute // seconds in a minute
+;',
+            ],
+            [
+                '<?php
+$secondsPerMinute = 60;
+$seconds = $minutes
+    * 60 * (int) true; // seconds in a minute',
+                '<?php
+$secondsPerMinute = 60;
+$seconds = $minutes
+    * 60 * (int) true // seconds in a minute
+;',
+            ],
         ];
     }
 
@@ -215,6 +264,7 @@ self
     {
         return [
             [
+                '<?php echo(1); // test',
                 "<?php echo(1) // test\r\n;",
             ],
         ];
@@ -844,6 +894,108 @@ Service
             [
                 "<?php\n\$this\n    ->one(1, )\n    ->two()\n;",
                 "<?php\n\$this\n    ->one(1, )\n    ->two();",
+            ],
+            [
+                '<?php
+
+                    $foo->bar();
+
+                    Service::method1()
+                        ->method2()
+                        ->method3()->method4()
+                    ;
+                ?>',
+                '<?php
+
+                    $foo->bar()
+                    ;
+
+                    Service::method1()
+                        ->method2()
+                        ->method3()->method4();
+                ?>',
+            ],
+            [
+                '<?php
+
+                    $foo->bar();
+
+                    \Service::method1()
+                        ->method2()
+                        ->method3()->method4()
+                    ;
+                ?>',
+                '<?php
+
+                    $foo->bar()
+                    ;
+
+                    \Service::method1()
+                        ->method2()
+                        ->method3()->method4();
+                ?>',
+            ],
+            [
+                '<?php
+
+                    $foo->bar();
+
+                    Ns\Service::method1()
+                        ->method2()
+                        ->method3()->method4()
+                    ;
+                ?>',
+                '<?php
+
+                    $foo->bar()
+                    ;
+
+                    Ns\Service::method1()
+                        ->method2()
+                        ->method3()->method4();
+                ?>',
+            ],
+            [
+                '<?php
+
+                    $foo->bar();
+
+                    \Ns\Service::method1()
+                        ->method2()
+                        ->method3()->method4()
+                    ;
+                ?>',
+                '<?php
+
+                    $foo->bar()
+                    ;
+
+                    \Ns\Service::method1()
+                        ->method2()
+                        ->method3()->method4();
+                ?>',
+            ],
+            [
+                '<?php
+$this
+    ->setName(\'readme2\')
+    ->setDescription(\'Generates the README\')
+;
+',
+                '<?php
+$this
+    ->setName(\'readme2\')
+    ->setDescription(\'Generates the README\')
+    ;
+',
+            ],
+            [
+                '<?php
+$this
+    ->foo()
+    ->{$bar ? \'bar\' : \'baz\'}()
+;
+',
             ],
         ];
     }

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -1218,8 +1218,7 @@ enum Foo
     case CASE_1;
 
     %s
-}'
-        ;
+}';
 
         $enumAttributes = [
             'case CASE_2;',

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -269,7 +269,8 @@ final class FixerFactoryTest extends TestCase
         $this->expectExceptionMessageMatches('#^Rule contains conflicting fixers:\n#');
 
         (new FixerFactory())
-            ->registerBuiltInFixers()->useRuleSet($ruleSet);
+            ->registerBuiltInFixers()->useRuleSet($ruleSet)
+        ;
     }
 
     public static function provideConflictingFixersCases(): array

--- a/tests/Test/TokensWithObservedTransformers.php
+++ b/tests/Test/TokensWithObservedTransformers.php
@@ -69,7 +69,6 @@ class TokensWithObservedTransformers extends Tokens
     {
         return $token instanceof Token
             ? ($token->isArray() ? $token->getId() : $token->getContent())
-            : (\is_array($token) ? $token[0] : $token)
-        ;
+            : (\is_array($token) ? $token[0] : $token);
     }
 }

--- a/tests/Tokenizer/Analyzer/ControlCaseStructuresAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ControlCaseStructuresAnalyzerTest.php
@@ -363,8 +363,7 @@ $expressionResult = match ($condition) {
     3, 4 => bar(),
     default => baz(),
 };
-'
-        ;
+';
 
         yield [
             [

--- a/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php
@@ -42,8 +42,7 @@ final class NameQualifiedTransformerTest extends AbstractTransformerTestCase
         $expectedTokens = Tokens::fromArray($expected);
         $tokens = null === $input
             ? Tokens::fromArray($expected)
-            : Tokens::fromArray($input)
-        ;
+            : Tokens::fromArray($input);
 
         $tokenCount = \count($tokens);
 


### PR DESCRIPTION
Closes #4896

Now `new_line_for_chained_calls` do the same fixes as `no_multi_line` except chaining calls.

Also it fixes wrong idententions in chainig calls:
```php
// before
$foo
    ->bar()
    ;

// after
$foo
    ->bar()
;
```

It also seemed to me that `no_multi_line` fixes with comments were not working correctly. I fixed it, but if the reviewers decide that it should be returned, I will:
```php
//before
    $foo->bar() // test
;
                    
//after
    $foo->bar(); // test
```