### PR TITLE
feat: add phpDoc support for `fully_qualified_strict_types` fixer

### DIFF
--- a/doc/rules/import/fully_qualified_strict_types.rst
+++ b/doc/rules/import/fully_qualified_strict_types.rst
@@ -34,7 +34,14 @@ Example #1
 
     use Foo\Bar;
     use Foo\Bar\Baz;
+    use Foo\Bar\Bam;
 
+    /**
+   - * @see \Foo\Bar\Baz
+   - * @see \Foo\Bar\Bam
+   + * @see Baz
+   + * @see Bam
+     */
     class SomeClass
     {
    -    public function doX(\Foo\Bar $foo): \Foo\Bar\Baz

--- a/doc/rules/import/fully_qualified_strict_types.rst
+++ b/doc/rules/import/fully_qualified_strict_types.rst
@@ -34,24 +34,33 @@ Example #1
 
     use Foo\Bar;
     use Foo\Bar\Baz;
-    use Foo\Bar\Bam;
 
     /**
    - * @see \Foo\Bar\Baz
-   - * @see \Foo\Bar\Bam
    + * @see Baz
-   + * @see Bam
      */
     class SomeClass
     {
-   -    public function doX(\Foo\Bar $foo): \Foo\Bar\Baz
-   +    public function doX(Bar $foo): Baz
-        {
+        /**
+   -     * @var \Foo\Bar\Baz
+   +     * @var Baz
+         */
+        public $baz;
+
+        /**
+   -     * @param \Foo\Bar\Baz $baz
+   +     * @param Baz $baz
+         */
+        public function __construct($baz) {
+            $this->baz = $baz;
         }
 
-   -    public function doY(Foo\NotImported $u, \Foo\NotImported $v)
-   +    public function doY(Foo\NotImported $u, Foo\NotImported $v)
-        {
+        /**
+   -     * @return \Foo\Bar\Baz
+   +     * @return Baz
+         */
+        public function getBaz() {
+            return $this->baz;
         }
     }
 

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -21,7 +21,7 @@ parameters:
         -
             message: '#^Method PhpCsFixer\\Tests\\.+::provide.+Cases\(\) return type has no value type specified in iterable type iterable\.$#'
             path: tests
-            count: 1120
+            count: 1113
 
         -
             message: '#Call to static method .+ with .+ will always evaluate to true.$#'

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -177,16 +177,17 @@ class SomeClass
 
         if ([] !== $matches) {
             foreach ($matches[2] as $i => $typeName) {
-                if (!\in_array($matches[1][$i], ['param', 'return', 'see', 'var'], true)) {
+                if (!\in_array($matches[1][$i], ['param', 'return', 'see', 'throws', 'var'], true)) {
                     continue;
                 }
 
                 $shortTokens = $this->determineShortType($typeName, $uses, $namespaceName);
 
                 if (null !== $shortTokens) {
+                    // Replace tag+type in order to avoid replacing type multiple times (when same type is used in multiple places)
                     $phpDocContent = str_replace(
-                        $typeName,
-                        implode('', array_map(
+                        $matches[0][$i],
+                        '@'.$matches[1][$i].' '.implode('', array_map(
                             static fn (Token $token) => $token->getContent(),
                             $shortTokens
                         )),

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -47,20 +47,29 @@ final class FullyQualifiedStrictTypesFixer extends AbstractFixer implements Conf
 
 use Foo\Bar;
 use Foo\Bar\Baz;
-use Foo\Bar\Bam;
 
 /**
  * @see \Foo\Bar\Baz
- * @see \Foo\Bar\Bam
  */
 class SomeClass
 {
-    public function doX(\Foo\Bar $foo): \Foo\Bar\Baz
-    {
+    /**
+     * @var \Foo\Bar\Baz
+     */
+    public $baz;
+
+    /**
+     * @param \Foo\Bar\Baz $baz
+     */
+    public function __construct($baz) {
+        $this->baz = $baz;
     }
 
-    public function doY(Foo\NotImported $u, \Foo\NotImported $v)
-    {
+    /**
+     * @return \Foo\Bar\Baz
+     */
+    public function getBaz() {
+        return $this->baz;
     }
 }
 '

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -167,11 +167,22 @@ class SomeClass
         Preg::matchAll('#@([^\s]+)\s+([^\s]+)#', $phpDocContent, $matches);
 
         if ([] !== $matches) {
-            foreach ($matches[2] as $typeName) {
+            foreach ($matches[2] as $i => $typeName) {
+                if (!\in_array($matches[1][$i], ['param', 'return', 'see', 'var'], true)) {
+                    continue;
+                }
+
                 $shortTokens = $this->determineShortType($typeName, $uses, $namespaceName);
 
                 if (null !== $shortTokens) {
-                    $phpDocContent = str_replace($typeName, $shortTokens[0]->getContent(), $phpDocContent);
+                    $phpDocContent = str_replace(
+                        $typeName,
+                        implode('', array_map(
+                            static fn (Token $token) => $token->getContent(),
+                            $shortTokens
+                        )),
+                        $phpDocContent
+                    );
                 }
             }
 

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -696,88 +696,112 @@ class Two
     }
 
     /**
-     * @return iterable<string, array{string, ?string}>
+     * @return iterable<string, array{0: string, 1?: string}>
      */
     public static function provideCodeWithPhpDocCases(): iterable
     {
         yield 'Test class PHPDoc fixes' => [
             '<?php
+
 namespace Foo\Bar;
+
 use Foo\Bar\Baz;
 use Foo\Bar\Bam;
+
 /**
  * @see Baz
  * @see Bam
  */
 class SomeClass
 {
+    /**
+     * @var Baz
+     */
+    public $baz;
 
+    /** @var Bam */
+    public $bam;
 }',
             '<?php
+
 namespace Foo\Bar;
+
 use Foo\Bar\Baz;
 use Foo\Bar\Bam;
+
 /**
  * @see \Foo\Bar\Baz
  * @see \Foo\Bar\Bam
  */
 class SomeClass
 {
+    /**
+     * @var \Foo\Bar\Baz
+     */
+    public $baz;
 
+    /** @var \Foo\Bar\Bam */
+    public $bam;
 }',
         ];
 
         yield 'Test PHPDoc nullable fixes' => [
             '<?php
+
 namespace Foo\Bar;
+
 use Foo\Bar\Baz;
 use Foo\Bar\Bam;
+
 /**
  * @see Baz|null
  * @see Bam|null
  */
-class SomeClass
-{
-
-}',
+class SomeClass {}',
             '<?php
+
 namespace Foo\Bar;
+
 use Foo\Bar\Baz;
 use Foo\Bar\Bam;
+
 /**
  * @see \Foo\Bar\Baz|null
  * @see \Foo\Bar\Bam|null
  */
-class SomeClass
-{
-
-}',
+class SomeClass {}',
         ];
 
         yield 'Test PHPDoc in interface' => [
             '<?php
+
 namespace Foo\Bar;
+
 use Foo\Bar\Baz;
 
 interface SomeClass
 {
    /**
-    * @var SomeClass $foo
-    * @var Buz $buz
+    * @param SomeClass $foo
+    * @param Buz $buz
+    * @param Zoof\Buz $barbuz
     *
     * @return Baz
     */
     public function doSomething(SomeClass $foo, Buz $buz, Zoof\Buz $barbuz): Baz;
 }',
             '<?php
+
 namespace Foo\Bar;
+
 use Foo\Bar\Baz;
 
 interface SomeClass
 {
    /**
-    * @var \Foo\Bar\SomeClass $foo
-    * @var \Foo\Bar\Buz $buz
+    * @param \Foo\Bar\SomeClass $foo
+    * @param \Foo\Bar\Buz $buz
+    * @param \Foo\Bar\Zoof\Buz $barbuz
     *
     * @return \Foo\Bar\Baz
     */
@@ -787,26 +811,30 @@ interface SomeClass
 
         yield 'Test PHPDoc in interface with no imports' => [
             '<?php
+
 namespace Foo\Bar;
 
 interface SomeClass
 {
    /**
-    * @var SomeClass $foo
-    * @var Buz $buz
+    * @param SomeClass $foo
+    * @param Buz $buz
+    * @param Zoof\Buz $barbuz
     *
     * @return Baz
     */
     public function doSomething(SomeClass $foo, Buz $buz, Zoof\Buz $barbuz): Baz;
 }',
             '<?php
+
 namespace Foo\Bar;
 
 interface SomeClass
 {
    /**
-    * @var \Foo\Bar\SomeClass $foo
-    * @var \Foo\Bar\Buz $buz
+    * @param \Foo\Bar\SomeClass $foo
+    * @param \Foo\Bar\Buz $buz
+    * @param \Foo\Bar\Zoof\Buz $barbuz
     *
     * @return \Foo\Bar\Baz
     */
@@ -816,31 +844,28 @@ interface SomeClass
 
         yield 'Test not imported PHPDoc fixes' => [
             '<?php
+
 namespace Foo\Bar;
 
 /**
  * @see Baz
  * @see Bam
  */
-final class SomeClass
-{
-
-}',
+final class SomeClass {}',
             '<?php
+
 namespace Foo\Bar;
 
 /**
  * @see \Foo\Bar\Baz
  * @see \Foo\Bar\Bam
  */
-final class SomeClass
-{
-
-}',
+final class SomeClass {}',
         ];
 
         yield 'Test multiple PHPDoc blocks' => [
             '<?php
+
 namespace Foo\Bar;
 
 use Foo\Bar\Buz;
@@ -854,14 +879,15 @@ use Foo\Bar\SomeClass;
 interface SomeClass
 {
     /**
-    * @var SomeClass $foo
-    * @var Buz $buz
+    * @param SomeClass $foo
+    * @param Buz $buz
     *
     * @return Baz
     */
-    public function doSomething(SomeClass $foo, Buz $buz, Zoof\Buz $barbuz): Baz;
+    public function doSomething(SomeClass $foo, Buz $buz): Baz;
 }',
             '<?php
+
 namespace Foo\Bar;
 
 use Foo\Bar\Buz;
@@ -875,13 +901,26 @@ use Foo\Bar\SomeClass;
 interface SomeClass
 {
     /**
-    * @var \Foo\Bar\SomeClass $foo
-    * @var \Foo\Bar\Buz $buz
+    * @param \Foo\Bar\SomeClass $foo
+    * @param \Foo\Bar\Buz $buz
     *
     * @return \Foo\Bar\Baz
     */
-    public function doSomething(\Foo\Bar\SomeClass $foo, \Foo\Bar\Buz $buz, \Foo\Bar\Zoof\Buz $barbuz): \Foo\Bar\Baz;
+    public function doSomething(\Foo\Bar\SomeClass $foo, \Foo\Bar\Buz $buz): \Foo\Bar\Baz;
 }',
+        ];
+
+        yield 'Skip @covers in tests (they require FQCN)' => [
+            '<?php
+
+namespace Tests\Foo\Bar;
+
+use Foo\Bar\SomeClass;
+
+/**
+ * @covers \Foo\Bar\SomeClass
+ */
+class SomeClassTest {}',
         ];
     }
 

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -922,6 +922,97 @@ use Foo\Bar\SomeClass;
  */
 class SomeClassTest {}',
         ];
+
+        yield 'Imports with aliases' => [
+            '<?php
+
+namespace Foo\Bar;
+
+use Foo\Bar\Baz as Buzz;
+use Foo\Bar\Bam as Boom;
+
+/**
+ * @see Buzz
+ * @see Boom
+ */
+class SomeClass
+{
+    /**
+     * @var Buzz
+     */
+    public $baz;
+
+    /** @var Boom */
+    public $bam;
+
+    /**
+     * @param Buzz $baz
+     * @param Boom $bam
+     */
+    public function __construct($baz, $bam) {
+        $this->baz = $baz;
+        $this->bam = $bam;
+    }
+
+    /**
+     * @return Buzz
+     */
+    public function getBaz() {
+        return $this->baz;
+    }
+
+    /**
+     * @return Boom
+     */
+    public function getBam() {
+        return $this->bam;
+    }
+}',
+            '<?php
+
+namespace Foo\Bar;
+
+use Foo\Bar\Baz as Buzz;
+use Foo\Bar\Bam as Boom;
+
+/**
+ * @see \Foo\Bar\Baz
+ * @see \Foo\Bar\Bam
+ */
+class SomeClass
+{
+    /**
+     * @var \Foo\Bar\Baz
+     */
+    public $baz;
+
+    /** @var \Foo\Bar\Bam */
+    public $bam;
+
+    /**
+     * @param \Foo\Bar\Baz $baz
+     * @param \Foo\Bar\Bam $bam
+     */
+    public function __construct($baz, $bam) {
+        $this->baz = $baz;
+        $this->bam = $bam;
+    }
+
+    /**
+     * @return \Foo\Bar\Baz
+     */
+    public function getBaz() {
+        return $this->baz;
+    }
+
+    /**
+     * @return \Foo\Bar\Bam
+     */
+    public function getBam() {
+        return $this->bam;
+    }
+}',
+        ];
     }
 
     /**

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -688,6 +688,204 @@ class Two
     }
 
     /**
+     * @dataProvider provideCodeWithPhpDocCases
+     */
+    public function testCodeWithPhpDoc(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string, array{string, ?string}>
+     */
+    public static function provideCodeWithPhpDocCases(): iterable
+    {
+        yield 'Test class PHPDoc fixes' => [
+            '<?php
+namespace Foo\Bar;
+use Foo\Bar\Baz;
+use Foo\Bar\Bam;
+/**
+ * @see Baz
+ * @see Bam
+ */
+class SomeClass
+{
+
+}',
+            '<?php
+namespace Foo\Bar;
+use Foo\Bar\Baz;
+use Foo\Bar\Bam;
+/**
+ * @see \Foo\Bar\Baz
+ * @see \Foo\Bar\Bam
+ */
+class SomeClass
+{
+
+}',
+        ];
+
+        yield 'Test PHPDoc nullable fixes' => [
+            '<?php
+namespace Foo\Bar;
+use Foo\Bar\Baz;
+use Foo\Bar\Bam;
+/**
+ * @see Baz|null
+ * @see Bam|null
+ */
+class SomeClass
+{
+
+}',
+            '<?php
+namespace Foo\Bar;
+use Foo\Bar\Baz;
+use Foo\Bar\Bam;
+/**
+ * @see \Foo\Bar\Baz|null
+ * @see \Foo\Bar\Bam|null
+ */
+class SomeClass
+{
+
+}',
+        ];
+
+        yield 'Test PHPDoc in interface' => [
+            '<?php
+namespace Foo\Bar;
+use Foo\Bar\Baz;
+
+interface SomeClass
+{
+   /**
+    * @var SomeClass $foo
+    * @var Buz $buz
+    *
+    * @return Baz
+    */
+    public function doSomething(SomeClass $foo, Buz $buz, Zoof\Buz $barbuz): Baz;
+}',
+            '<?php
+namespace Foo\Bar;
+use Foo\Bar\Baz;
+
+interface SomeClass
+{
+   /**
+    * @var \Foo\Bar\SomeClass $foo
+    * @var \Foo\Bar\Buz $buz
+    *
+    * @return \Foo\Bar\Baz
+    */
+    public function doSomething(\Foo\Bar\SomeClass $foo, \Foo\Bar\Buz $buz, \Foo\Bar\Zoof\Buz $barbuz): \Foo\Bar\Baz;
+}',
+        ];
+
+        yield 'Test PHPDoc in interface with no imports' => [
+            '<?php
+namespace Foo\Bar;
+
+interface SomeClass
+{
+   /**
+    * @var SomeClass $foo
+    * @var Buz $buz
+    *
+    * @return Baz
+    */
+    public function doSomething(SomeClass $foo, Buz $buz, Zoof\Buz $barbuz): Baz;
+}',
+            '<?php
+namespace Foo\Bar;
+
+interface SomeClass
+{
+   /**
+    * @var \Foo\Bar\SomeClass $foo
+    * @var \Foo\Bar\Buz $buz
+    *
+    * @return \Foo\Bar\Baz
+    */
+    public function doSomething(\Foo\Bar\SomeClass $foo, \Foo\Bar\Buz $buz, \Foo\Bar\Zoof\Buz $barbuz): \Foo\Bar\Baz;
+}',
+        ];
+
+        yield 'Test not imported PHPDoc fixes' => [
+            '<?php
+namespace Foo\Bar;
+
+/**
+ * @see Baz
+ * @see Bam
+ */
+final class SomeClass
+{
+
+}',
+            '<?php
+namespace Foo\Bar;
+
+/**
+ * @see \Foo\Bar\Baz
+ * @see \Foo\Bar\Bam
+ */
+final class SomeClass
+{
+
+}',
+        ];
+
+        yield 'Test multiple PHPDoc blocks' => [
+            '<?php
+namespace Foo\Bar;
+
+use Foo\Bar\Buz;
+use Foo\Bar\Baz;
+use Foo\Bar\SomeClass;
+
+/**
+ * @see Baz
+ * @see Bam
+ */
+interface SomeClass
+{
+    /**
+    * @var SomeClass $foo
+    * @var Buz $buz
+    *
+    * @return Baz
+    */
+    public function doSomething(SomeClass $foo, Buz $buz, Zoof\Buz $barbuz): Baz;
+}',
+            '<?php
+namespace Foo\Bar;
+
+use Foo\Bar\Buz;
+use Foo\Bar\Baz;
+use Foo\Bar\SomeClass;
+
+/**
+ * @see \Foo\Bar\Baz
+ * @see \Foo\Bar\Bam
+ */
+interface SomeClass
+{
+    /**
+    * @var \Foo\Bar\SomeClass $foo
+    * @var \Foo\Bar\Buz $buz
+    *
+    * @return \Foo\Bar\Baz
+    */
+    public function doSomething(\Foo\Bar\SomeClass $foo, \Foo\Bar\Buz $buz, \Foo\Bar\Zoof\Buz $barbuz): \Foo\Bar\Baz;
+}',
+        ];
+    }
+
+    /**
      * @requires PHP 8.0
      *
      * @dataProvider provideFix80Cases

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -36,6 +36,9 @@ final class FullyQualifiedStrictTypesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @return iterable<array{0: string, 1?: null|string, 2?: array<string, mixed>}>
+     */
     public static function provideNewLogicCases(): iterable
     {
         yield 'namespace === type name' => [
@@ -164,6 +167,9 @@ class A {
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @return iterable<array{0: string, 1?: null|string}>
+     */
     public static function provideCodeWithReturnTypesCases(): iterable
     {
         yield 'Import common strict types' => [
@@ -376,6 +382,9 @@ class SomeClass
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @return iterable<array{0: string, 1?: null|string}>
+     */
     public static function provideCodeWithoutReturnTypesCases(): iterable
     {
         yield 'import from namespace and global' => [
@@ -635,6 +644,9 @@ namespace {
         ];
     }
 
+    /**
+     * @return iterable<array{0: string, 1?: null|string}>
+     */
     public static function provideCodeWithReturnTypesCasesWithNullableCases(): iterable
     {
         yield 'Test namespace fixes with nullable types' => [
@@ -1025,6 +1037,9 @@ class SomeClass
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @return iterable<array{0: string, 1?: null|string}>
+     */
     public static function provideFix80Cases(): iterable
     {
         yield [
@@ -1069,6 +1084,9 @@ class SomeClass
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @return iterable<array{0: string, 1?: null|string, 2?: array<string, mixed>}>
+     */
     public static function provideFix81Cases(): iterable
     {
         yield [
@@ -1123,6 +1141,9 @@ class SomeClass
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @return iterable<array{0: string, 1?: null|string, 2?: array<string, mixed>}>
+     */
     public static function provideFix82Cases(): iterable
     {
         yield 'simple param in global namespace without use' => [

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -700,15 +700,18 @@ class Two
     }
 
     /**
+     * @param array<string, mixed> $config
+     *
      * @dataProvider provideCodeWithPhpDocCases
      */
-    public function testCodeWithPhpDoc(string $expected, ?string $input = null): void
+    public function testCodeWithPhpDoc(string $expected, ?string $input = null, array $config = []): void
     {
+        $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
 
     /**
-     * @return iterable<string, array{0: string, 1?: string}>
+     * @return iterable<string, array{0: string, 1?: string, 2?: array<string, mixed>}>
      */
     public static function provideCodeWithPhpDocCases(): iterable
     {
@@ -1024,6 +1027,28 @@ class SomeClass
         return $this->bam;
     }
 }',
+        ];
+
+        yield 'Leading backslash in global namespace' => [
+            '<?php
+
+/**
+ * @param \DateTimeInterface $dateTime
+ * @return \DateTimeInterface
+ * @see \DateTimeImmutable
+ * @throws \Exception
+ */
+function foo($dateTime) {}',
+            '<?php
+
+/**
+ * @param DateTimeInterface $dateTime
+ * @return DateTimeInterface
+ * @see DateTimeImmutable
+ * @throws Exception
+ */
+function foo($dateTime) {}',
+            ['leading_backslash_in_global_namespace' => true],
         ];
     }
 

--- a/tests/Fixtures/Integration/priority/phpdoc_to_return_type,fully_qualified_strict_types.test
+++ b/tests/Fixtures/Integration/priority/phpdoc_to_return_type,fully_qualified_strict_types.test
@@ -5,7 +5,7 @@ Integration of fixers: phpdoc_to_return_type,fully_qualified_strict_types.
 --EXPECT--
 <?php
 use \Foo\Bar\Baz;
-/** @return \Foo\Bar\Baz */
+/** @return Baz */
 function my_foo(): Baz
 {}
 


### PR DESCRIPTION
Fixes #3958.

I added support to `fully_qualified_strict_types` fixer to be able to work with PHPDoc, as discussed it https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3958. This is my first PR to PHP-CS-Fixer, I tried to adhere to the contributing rules, hopefully I didn't miss anything important.

There is one small issue probably with integration of some other fixer, I hope we can resolve it.

