### PR TITLE
Allow single line braces for empty function body

### DIFF
--- a/doc/ruleSets/PSR12.rst
+++ b/doc/ruleSets/PSR12.rst
@@ -11,7 +11,7 @@ Rules
 - `blank_line_after_opening_tag <./../rules/php_tag/blank_line_after_opening_tag.rst>`_
 - `braces <./../rules/basic/braces.rst>`_
   config:
-  ``['allow_single_line_anonymous_class_with_empty_body' => true]``
+  ``['allow_single_line_empty_body' => true]``
 - `compact_nullable_typehint <./../rules/whitespace/compact_nullable_typehint.rst>`_
 - `declare_equal_normalize <./../rules/language_construct/declare_equal_normalize.rst>`_
 - `lowercase_cast <./../rules/cast_notation/lowercase_cast.rst>`_

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -16,7 +16,7 @@ Rules
   ``['statements' => ['return']]``
 - `braces <./../rules/basic/braces.rst>`_
   config:
-  ``['allow_single_line_anonymous_class_with_empty_body' => true, 'allow_single_line_closure' => true]``
+  ``['allow_single_line_closure' => true, 'allow_single_line_empty_body' => true]``
 - `cast_spaces <./../rules/cast_notation/cast_spaces.rst>`_
 - `class_attributes_separation <./../rules/class_notation/class_attributes_separation.rst>`_
   config:

--- a/doc/rules/basic/braces.rst
+++ b/doc/rules/basic/braces.rst
@@ -26,6 +26,15 @@ Allowed types: ``bool``
 
 Default value: ``false``
 
+``allow_single_line_empty_function_body``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whether the braces are allowed to be placed on the same line if the function body is empty.
+
+Allowed types: ``bool``
+
+Default value: ``false``
+
 ``position_after_functions_and_oop_constructs``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/rules/basic/braces.rst
+++ b/doc/rules/basic/braces.rst
@@ -11,6 +11,8 @@ Configuration
 ``allow_single_line_anonymous_class_with_empty_body``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. warning:: This option is deprecated and will be removed on next major version. Use option "allow_single_line_empty_body" instead.
+
 Whether single line anonymous class with empty body notation should be allowed.
 
 Allowed types: ``bool``
@@ -26,10 +28,10 @@ Allowed types: ``bool``
 
 Default value: ``false``
 
-``allow_single_line_empty_function_body``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``allow_single_line_empty_body``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Whether the braces are allowed to be placed on the same line if the function body is empty.
+Whether the braces are allowed to be placed on the same line if they are empty.
 
 Allowed types: ``bool``
 
@@ -191,7 +193,7 @@ The rule is part of the following rule sets:
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``braces`` rule with the config below:
 
-  ``['allow_single_line_anonymous_class_with_empty_body' => true]``
+  ``['allow_single_line_empty_body' => true]``
 
 @PSR2
   Using the `@PSR2 <./../../ruleSets/PSR2.rst>`_ rule set will enable the ``braces`` rule with the default config.
@@ -199,9 +201,9 @@ The rule is part of the following rule sets:
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``braces`` rule with the config below:
 
-  ``['allow_single_line_anonymous_class_with_empty_body' => true, 'allow_single_line_closure' => true]``
+  ``['allow_single_line_closure' => true, 'allow_single_line_empty_body' => true]``
 
 @Symfony
   Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``braces`` rule with the config below:
 
-  ``['allow_single_line_anonymous_class_with_empty_body' => true, 'allow_single_line_closure' => true]``
+  ``['allow_single_line_closure' => true, 'allow_single_line_empty_body' => true]``

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -172,6 +172,10 @@ class Foo
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)
                 ->getOption(),
+            (new FixerOptionBuilder('allow_single_line_empty_function_body', 'Whether the braces are allowed to be placed on the same line if the function body is empty.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(false)
+                ->getOption(),
             (new FixerOptionBuilder('position_after_functions_and_oop_constructs', 'whether the opening brace should be placed on "next" or "same" line after classy constructs (non-anonymous classes, interfaces, traits, methods and non-lambda functions).'))
                 ->setAllowedValues([self::LINE_NEXT, self::LINE_SAME])
                 ->setDefault(self::LINE_NEXT)
@@ -353,6 +357,20 @@ class Foo
                 );
 
                 if (!$this->isMultilined($tokens, $index, $braceEndIndex)) {
+                    $index = $braceEndIndex;
+
+                    continue;
+                }
+            }
+
+            if (
+                $this->configuration['allow_single_line_empty_function_body']
+                && $token->isGivenKind(T_FUNCTION)
+            ) {
+                $braceStartIndex = $tokens->getNextTokenOfKind($index, ['{']);
+                $braceEndIndex = $tokens->getNextMeaningfulToken($braceStartIndex);
+
+                if ('}' === $tokens[$braceEndIndex]->getContent() && !$this->isMultilined($tokens, $braceStartIndex, $braceEndIndex)) {
                     $index = $braceEndIndex;
 
                     continue;

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -165,6 +165,7 @@ class Foo
     {
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('allow_single_line_anonymous_class_with_empty_body', 'Whether single line anonymous class with empty body notation should be allowed.'))
+                ->setDeprecationMessage('Use option "allow_single_line_empty_body" instead.')
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)
                 ->getOption(),
@@ -172,7 +173,7 @@ class Foo
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)
                 ->getOption(),
-            (new FixerOptionBuilder('allow_single_line_empty_function_body', 'Whether the braces are allowed to be placed on the same line if the function body is empty.'))
+            (new FixerOptionBuilder('allow_single_line_empty_body', 'Whether the braces are allowed to be placed on the same line if they are empty.'))
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)
                 ->getOption(),
@@ -363,14 +364,15 @@ class Foo
                 }
             }
 
-            if (
-                $this->configuration['allow_single_line_empty_function_body']
-                && $token->isGivenKind(T_FUNCTION)
-            ) {
-                $braceStartIndex = $tokens->getNextTokenOfKind($index, ['{']);
+            if ($this->configuration['allow_single_line_empty_body']) {
+                $braceStartIndex = $tokens->getNextTokenOfKind($index, [';', '{']);
+                if (!$tokens[$braceStartIndex]->equals('{')) {
+                    continue;
+                }
+
                 $braceEndIndex = $tokens->getNextMeaningfulToken($braceStartIndex);
 
-                if ('}' === $tokens[$braceEndIndex]->getContent() && !$this->isMultilined($tokens, $braceStartIndex, $braceEndIndex)) {
+                if ('}' === $tokens[$braceEndIndex]->getContent() && !$this->isMultilined($tokens, $index, $braceEndIndex)) {
                     $index = $braceEndIndex;
 
                     continue;

--- a/src/RuleSet/Sets/PSR12Set.php
+++ b/src/RuleSet/Sets/PSR12Set.php
@@ -27,7 +27,7 @@ final class PSR12Set extends AbstractRuleSetDescription
             '@PSR2' => true,
             'blank_line_after_opening_tag' => true,
             'braces' => [
-                'allow_single_line_anonymous_class_with_empty_body' => true,
+                'allow_single_line_empty_body' => true,
             ],
             'compact_nullable_typehint' => true,
             'declare_equal_normalize' => true,

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -34,8 +34,8 @@ final class SymfonySet extends AbstractRuleSetDescription
                 ],
             ],
             'braces' => [
-                'allow_single_line_anonymous_class_with_empty_body' => true,
                 'allow_single_line_closure' => true,
+                'allow_single_line_empty_body' => true,
             ],
             'cast_spaces' => true,
             'class_attributes_separation' => [

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -4691,6 +4691,26 @@ $foo = new class () extends \Exception {
 $foo = new class () extends \Exception {};
 ',
             ],
+        ];
+    }
+
+    /**
+     * @group legacy
+     * @dataProvider provideFixDeprecated70Cases
+     * @requires PHP 7.0
+     */
+    public function testFix70Deprecated(string $expected, ?string $input = null, array $configuration = []): void
+    {
+        $this->expectDeprecation('Option "allow_single_line_anonymous_class_with_empty_body" for rule "braces" is deprecated and will be removed in version 4.0. Use option "allow_single_line_empty_body" instead.');
+
+        $this->fixer->configure($configuration);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixDeprecated70Cases(): array
+    {
+        return [
             [
                 '<?php
 $foo = new class () extends \Exception {};
@@ -4889,18 +4909,18 @@ if (true) {
     }
 
     /**
-     * @dataProvider provideFixWithAllowSingleLineEmptyFunctionBody
+     * @dataProvider provideFixWithAllowSingleLineEmptyBodyCases
      */
-    public function testFixWithAllowSingleLineEmptyFunctionBody(string $expected, ?string $input = null): void
+    public function testFixWithAllowSingleLineEmptyBody(string $expected, ?string $input = null): void
     {
         $this->fixer->configure([
-            'allow_single_line_empty_function_body' => true,
+            'allow_single_line_empty_body' => true,
         ]);
 
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithAllowSingleLineEmptyFunctionBody()
+    public function provideFixWithAllowSingleLineEmptyBodyCases()
     {
         return [
             [
@@ -4930,6 +4950,12 @@ if (true) {
             ],
             [
                 '<?php
+    function foo()
+    {
+    }',
+            ],
+            [
+                '<?php
     class A
     {
         public function emptyBody(): void {}
@@ -4949,6 +4975,85 @@ if (true) {
     {
         public function nonEmptyBody(): void { 0; }
     }',
+            ],
+            [
+                '<?php
+    $x = new class () {
+        public function x(): void
+        {
+            0;
+        }
+    };',
+                '<?php
+    $x = new class () { public function x(): void {
+        0;
+    } };',
+            ],
+            [
+                '<?php
+    $x = new class () {};',
+            ],
+            [
+                '<?php
+    class Foo {}',
+            ],
+            [
+                '<?php
+    class Foo
+    {
+        public function bar(): void
+        {
+            0;
+        }
+    }',
+                '<?php
+    class Foo { public function bar(): void {
+        0;
+    }}',
+            ],
+            [
+                '<?php
+    interface Foo {}',
+            ],
+            [
+                '<?php
+    trait Foo {}',
+            ],
+            [
+                '<?php
+    if (true) {} else {}',
+            ],
+            [
+                '<?php
+    if (true) {
+        0;
+    } else {}',
+                '<?php
+    if (true) { 0; } else {}',
+            ],
+            [
+                '<?php
+    while (false) {
+        0;
+    }',
+                '<?php
+    while (false) { 0; }',
+            ],
+            [
+                '<?php
+    while (false) {}',
+            ],
+            [
+                '<?php
+    try {
+        0;
+    } catch (\Throwable $t) {}',
+                '<?php
+    try { 0; } catch (\Throwable $t) {}',
+            ],
+            [
+                '<?php
+    try {} catch (\Throwable $t) {}',
             ],
         ];
     }

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -4889,6 +4889,71 @@ if (true) {
     }
 
     /**
+     * @dataProvider provideFixWithAllowSingleLineEmptyFunctionBody
+     */
+    public function testFixWithAllowSingleLineEmptyFunctionBody(string $expected, ?string $input = null): void
+    {
+        $this->fixer->configure([
+            'allow_single_line_empty_function_body' => true,
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithAllowSingleLineEmptyFunctionBody()
+    {
+        return [
+            [
+                '<?php
+    $emptyBody = function () {};',
+            ],
+            [
+                '<?php
+    $nonEmptyBody = function () {
+        0;
+    };',
+                '<?php
+    $nonEmptyBody = function () { 0; };',
+            ],
+            [
+                '<?php
+    function empty_body(): void {}',
+            ],
+            [
+                '<?php
+    function non_empty_body(): void
+    {
+        0;
+    }',
+                '<?php
+    function non_empty_body(): void { 0; }',
+            ],
+            [
+                '<?php
+    class A
+    {
+        public function emptyBody(): void {}
+    }',
+            ],
+            [
+                '<?php
+    class A
+    {
+        public function nonEmptyBody(): void
+        {
+            0;
+        }
+    }',
+                '<?php
+    class A
+    {
+        public function nonEmptyBody(): void { 0; }
+    }',
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider provideDoWhileLoopInsideAnIfWithoutBracketsCases
      */
     public function testDoWhileLoopInsideAnIfWithoutBrackets(string $expected, ?string $input = null): void

--- a/tests/Fixtures/Integration/misc/PHP7_0.test
+++ b/tests/Fixtures/Integration/misc/PHP7_0.test
@@ -75,14 +75,10 @@ class Foo implements FooInterface
     }
 
     // scalar typehinting
-    public function bar1(int $a): string
-    {
-    }
+    public function bar1(int $a): string {}
 
     // scalar typehinting
-    public function bar2(int $a): string
-    {
-    }
+    public function bar2(int $a): string {}
 
     public function getFnc1()
     {

--- a/tests/Fixtures/Integration/misc/PHP7_2.test
+++ b/tests/Fixtures/Integration/misc/PHP7_2.test
@@ -35,23 +35,17 @@ abstract class XB extends XA
 }
 class XC extends XB
 {
-    public function bar($x): stdClass
-    {
-    }
+    public function bar($x): stdClass {}
 }
 
 // Parameter Type Widening
 class ArrayClass
 {
-    public function foo(array $foo)
-    { /* ... */
-    }
+    public function foo(array $foo) { /* ... */ }
 }
 class EverythingClass extends ArrayClass
 {
-    public function foo($foo)
-    { /* ... */
-    }
+    public function foo($foo) { /* ... */ }
 }
 
 --INPUT--

--- a/tests/Fixtures/Integration/misc/PHP8_0.test
+++ b/tests/Fixtures/Integration/misc/PHP8_0.test
@@ -90,9 +90,7 @@ class T
 // nothing we can do
 
 // https://wiki.php.net/rfc/trailing_comma_in_parameter_list
-function foo(string $param = null, ): void
-{
-}
+function foo(string $param = null, ): void {}
 call_user_func('foo', 1, );
 
 // https://wiki.php.net/rfc/trailing_comma_in_closure_use_list

--- a/tests/Fixtures/Integration/set/@Symfony.test-out.php
+++ b/tests/Fixtures/Integration/set/@Symfony.test-out.php
@@ -109,9 +109,7 @@ class FooBarTest extends \PHPUnit_Framework_TestCase implements Test1Interface, 
 
 final class FinalClass
 {
-    final public function finalMethod()
-    {
-    }
+    final public function finalMethod() {}
 }
 
 echo 1;

--- a/tests/Fixtures/Integration/set/@Symfony_whitespaces.test-out.php
+++ b/tests/Fixtures/Integration/set/@Symfony_whitespaces.test-out.php
@@ -109,9 +109,7 @@ class FooBarTest extends \PHPUnit_Framework_TestCase implements Test1Interface, 
 
 final class FinalClass
 {
-	final public function finalMethod()
-	{
-	}
+	final public function finalMethod() {}
 }
 
 echo 1;


### PR DESCRIPTION
Closes #5475.

This option allows placing braces on a single line for empty function bodies:

```php
class X 
{
     public function __construct(
              public int $x,
              //...
     ) {}
}
```

Since the introduction of property promotion this kind of constructors are quite widespread. This option also enables this behaviour for other empty functions as well, e.g. 
```php
public function x(): void {}
```