### PR TITLE
feat: Make `ModernizeStrposFixer` support using function `str_starts_with()` or `str_ends_with()` to replace `substr()`

### DIFF
--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -309,7 +309,7 @@ Custom values:
                                 return true;
                             }
 
-                            if ('method:' === substr($value, 0, 7)) {
+                            if (str_starts_with($value, 'method:')) {
                                 return true;
                             }
                         }

--- a/tests/Fixer/Alias/ModernizeStrposFixerTest.php
+++ b/tests/Fixer/Alias/ModernizeStrposFixerTest.php
@@ -125,6 +125,46 @@ final class ModernizeStrposFixerTest extends AbstractFixerTestCase
             '<?php $a = $input &&   strpos($input, $method) !== FALSE ? $input : null;',
         ];
 
+        yield 'yoda substr third argument is positive ===' => [
+            '<?php if (  str_starts_with($haystack, $needle)) {}',
+            '<?php if ($needle === substr($haystack, 0, 5)) {}',
+        ];
+
+        yield 'substr third argument is positive ===' => [
+            '<?php if (str_starts_with($haystack, $needle)  ) {}',
+            '<?php if (substr($haystack, 0, 5) === $needle) {}',
+        ];
+
+        yield 'yoda substr third argument is positive !==' => [
+            '<?php if (  !str_starts_with($haystack, $needle)) {}',
+            '<?php if ($needle !== substr($haystack, 0, 5)) {}',
+        ];
+
+        yield 'substr third argument is positive !==' => [
+            '<?php if (!str_starts_with($haystack, $needle)  ) {}',
+            '<?php if (substr($haystack, 0, 5) !== $needle) {}',
+        ];
+
+        yield 'yoda substr third argument is negative ===' => [
+            '<?php if (  str_ends_with($haystack, $needle)) {}',
+            '<?php if ($needle === substr($haystack, 0, -5)) {}',
+        ];
+
+        yield 'substr third argument is negative ===' => [
+            '<?php if (str_ends_with($haystack, $needle)  ) {}',
+            '<?php if (substr($haystack, 0, -5) === $needle) {}',
+        ];
+
+        yield 'yoda substr third argument is negative !==' => [
+            '<?php if (  !str_ends_with($haystack, $needle)) {}',
+            '<?php if ($needle !== substr($haystack, 0, -5)) {}',
+        ];
+
+        yield 'substr third argument is negative !==' => [
+            '<?php if (!str_ends_with($haystack, $needle)  ) {}',
+            '<?php if (substr($haystack, 0, -5) !== $needle) {}',
+        ];
+
         // do not fix
 
         yield [
@@ -190,6 +230,10 @@ final class ModernizeStrposFixerTest extends AbstractFixerTestCase
 
         yield 'higher precedence 4' => [
             '<?php $a = strpos($haystack, $needle) === 0 > $b;',
+        ];
+
+        yield 'substr third argument is not 0' => [
+            '<?php if (substr($haystack, 1, -5) === $needle) {}',
         ];
     }
 }


### PR DESCRIPTION
Closes #5974 