### PR TITLE
Adds new tags to PhpdocAlignFixer

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1799,7 +1799,7 @@ List of Available Rules
 
    - | ``tags``
      | The tags that should be aligned.
-     | Allowed values: a subset of ``['param', 'property', 'property-read', 'property-write', 'return', 'throws', 'type', 'var', 'method']``
+     | Allowed values: a subset of ``['param', 'property', 'property-read', 'property-write', 'return', 'throws', 'type', 'var', 'method', 'param-out', 'template', 'template-covariant', 'extends', 'implements', 'deprecated', 'internal', 'readonly', 'no-named-arguments', 'psalm-allow-private-mutation', 'psalm-assert', 'psalm-assert-if-false', 'psalm-if-this-is', 'psalm-assert-if-true', 'psalm-consistent-constructor', 'psalm-consistent-templates', 'psalm-external-mutation-free', 'psalm-ignore-falsable-return', 'psalm-ignore-nullable-return', 'psalm-ignore-var', 'psalm-immutable', 'psalm-import-type', 'psalm-internal', 'psalm-method', 'psalm-mutation-free', 'psalm-param', 'psalm-param-out', 'psalm-property', 'psalm-property-read', 'psalm-property-write', 'psalm-pure', 'psalm-readonly', 'psalm-readonly-allow-private-mutation', 'psalm-require-extends', 'psalm-require-implements', 'psalm-return', 'psalm-seal-properties', 'psalm-suppress SomeIssueName', 'psalm-taint-*', 'psalm-trace', 'psalm-type', 'psalm-var', 'phpstan-var', 'phpstan-param', 'phpstan-return', 'phpstan-template', 'phpstan-template-covariant', 'phpstan-extends', 'phpstan-implements']``
      | Default value: ``['method', 'param', 'property', 'return', 'throws', 'type', 'var']``
    - | ``align``
      | Align comments

--- a/doc/rules/phpdoc/phpdoc_align.rst
+++ b/doc/rules/phpdoc/phpdoc_align.rst
@@ -13,7 +13,7 @@ Configuration
 
 The tags that should be aligned.
 
-Allowed values: a subset of ``['param', 'property', 'property-read', 'property-write', 'return', 'throws', 'type', 'var', 'method']``
+Allowed values: a subset of ``['param', 'property', 'property-read', 'property-write', 'return', 'throws', 'type', 'var', 'method', 'param-out', 'template', 'template-covariant', 'extends', 'implements', 'deprecated', 'internal', 'readonly', 'no-named-arguments', 'psalm-allow-private-mutation', 'psalm-assert', 'psalm-assert-if-false', 'psalm-if-this-is', 'psalm-assert-if-true', 'psalm-consistent-constructor', 'psalm-consistent-templates', 'psalm-external-mutation-free', 'psalm-ignore-falsable-return', 'psalm-ignore-nullable-return', 'psalm-ignore-var', 'psalm-immutable', 'psalm-import-type', 'psalm-internal', 'psalm-method', 'psalm-mutation-free', 'psalm-param', 'psalm-param-out', 'psalm-property', 'psalm-property-read', 'psalm-property-write', 'psalm-pure', 'psalm-readonly', 'psalm-readonly-allow-private-mutation', 'psalm-require-extends', 'psalm-require-implements', 'psalm-return', 'psalm-seal-properties', 'psalm-suppress SomeIssueName', 'psalm-taint-*', 'psalm-trace', 'psalm-type', 'psalm-var', 'phpstan-var', 'phpstan-param', 'phpstan-return', 'phpstan-template', 'phpstan-template-covariant', 'phpstan-extends', 'phpstan-implements']``
 
 Default value: ``['method', 'param', 'property', 'return', 'throws', 'type', 'var']``
 

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -170,7 +170,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
 
         // e.g. @deprecated
         if ([] !== $simpleTags) {
-            $types[] = '(?P<tag>'.implode('|', $simpleTags).')';
+            $types[] = '(?P<simpleTag>'.implode('|', $simpleTags).')';
         }
 
         // e.g. @param <hint> <$var>
@@ -429,6 +429,12 @@ EOF;
     private function getMatches(string $line, bool $matchCommentOnly = false): ?array
     {
         if (Preg::match($this->regex, $line, $matches)) {
+            if (!empty($matches['simpleTag'])) {
+                $matches['tag'] = $matches['simpleTag'];
+                $matches['hint'] = '';
+                $matches['var'] = '';
+            }
+
             if (!empty($matches['tag2'])) {
                 $matches['tag'] = $matches['tag2'];
                 $matches['hint'] = $matches['hint2'];

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -1103,6 +1103,110 @@ EOF;
         $this->doTest($expected, $input);
     }
 
+    public function testAlignsSimpleTags(): void
+    {
+        $this->fixer->configure(['tags' => ['deprecated', 'internal']]);
+
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @deprecated I'm deprecated
+     * @internal   I just happen to be
+     */
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @deprecated   I'm deprecated
+     * @internal           I just happen to be
+     */
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testAlignsSimpleTagsWithName(): void
+    {
+        $this->fixer->configure(['tags' => ['deprecated', 'internal', 'param']]);
+
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @deprecated        Foobar
+     * @internal          I just happen to be
+     * @param      string $source source package name
+     */
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @deprecated  Foobar
+     * @internal           I just happen to be
+     * @param string $source source package name
+     */
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testAlignsSimpleTagsWithMethod(): void
+    {
+        $this->fixer->configure(['tags' => ['deprecated', 'internal', 'method', 'property']]);
+
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @deprecated        Foobar
+     * @internal          I just happen to be
+     * @property   string $source source package name
+     * @method     int    bar()   Description
+     */
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @deprecated  Foobar
+     * @internal           I just happen to be
+     * @property string $source source package name
+     * @method    int    bar() Description
+     */
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testAlignsSimpleTagsWithReturn(): void
+    {
+        $this->fixer->configure(['tags' => ['deprecated', 'internal', 'method', 'property', 'return']]);
+
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @deprecated        Foobar
+     * @internal          I just happen to be
+     * @property   string $source source package name
+     * @method     int    bar()   Description
+     * @return     int    Example
+     */
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @deprecated  Foobar
+     * @internal           I just happen to be
+     * @property string $source source package name
+     * @method    int    bar() Description
+     * @return        int Example
+     */
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
     public function testDoesNotAlignWithEmptyConfig(): void
     {
         $this->fixer->configure(['tags' => []]);


### PR DESCRIPTION
New PHPDoc tags

  - @param-out
  - @template
  - @template-covariant
  - @extends
  - @implements
  - @deprecated
  - @internal
  - @readonly
  - @no-named-arguments
  - @psalm-allow-private-mutation
  - @psalm-assert
  - @psalm-assert-if-false
  - @psalm-if-this-is
  - @psalm-assert-if-true
  - @psalm-consistent-constructor
  - @psalm-consistent-templates
  - @psalm-external-mutation-free
  - @psalm-ignore-falsable-return
  - @psalm-ignore-nullable-return
  - @psalm-ignore-var
  - @psalm-immutable
  - @psalm-import-type
  - @psalm-internal
  - @psalm-method
  - @psalm-mutation-free
  - @psalm-param
  - @psalm-param-out
  - @psalm-property
  - @psalm-property-read
  - @psalm-property-write
  - @psalm-pure
  - @psalm-readonly
  - @psalm-readonly-allow-private-mutation
  - @psalm-require-extends
  - @psalm-require-implements
  - @psalm-return
  - @psalm-seal-properties
  - @psalm-suppress SomeIssueName
  - @psalm-taint-*
  - @psalm-trace
  - @psalm-type
  - @psalm-var
  - @phpstan-var
  - @phpstan-param
  - @phpstan-return
  - @phpstan-template
  - @phpstan-template-covariant
  - @phpstan-extends
  - @phpstan-implements

Closes #5290