### PR TITLE
Fixed the name attribute of file tag when using checkstyle format and no cache (2nd attempt)

### DIFF
--- a/src/Cache/Directory.php
+++ b/src/Cache/Directory.php
@@ -50,6 +50,12 @@ final class Directory implements DirectoryInterface
 
     private function normalizePath(string $path): string
     {
-        return str_replace(['\\', '/'], \DIRECTORY_SEPARATOR, $path);
+        $path = str_replace(['\\', '/'], \DIRECTORY_SEPARATOR, $path);
+
+        if (0 === stripos($path, '.'.\DIRECTORY_SEPARATOR)) {
+            $path = str_replace('.'.\DIRECTORY_SEPARATOR, '', $path);
+        }
+
+        return $path;
     }
 }

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -305,16 +305,16 @@ final class ConfigurationResolver
         if (null === $this->directory) {
             $path = $this->getCacheFile();
             if (null === $path) {
-                $absolutePath = $this->cwd;
+                $this->directory = new Directory($this->cwd);
             } else {
                 $filesystem = new Filesystem();
 
                 $absolutePath = $filesystem->isAbsolutePath($path)
                     ? $path
                     : $this->cwd.\DIRECTORY_SEPARATOR.$path;
-            }
 
-            $this->directory = new Directory(\dirname($absolutePath));
+                $this->directory = new Directory(\dirname($absolutePath));
+            }
         }
 
         return $this->directory;

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1170,9 +1170,15 @@ For more info about updating see: https://github.com/FriendsOfPHP/PHP-CS-Fixer/b
     public function provideGetDirectoryCases(): array
     {
         return [
-            [null, '/my/path/my/file', 'path/my/file'],
+            [null, '/my/path/my/file', 'my/file'],
+            [null, './my/file', 'my/file'],
+            [null, 'my/file', 'my/file'],
             ['/my/path2/dir/.php-cs-fixer.cache', '/my/path2/dir/dir2/file', 'dir2/file'],
+            ['/my/path2/dir/.php-cs-fixer.cache', './dir2/file', 'dir2/file'],
+            ['/my/path2/dir/.php-cs-fixer.cache', 'dir2/file', 'dir2/file'],
             ['dir/.php-cs-fixer.cache', '/my/path/dir/dir3/file', 'dir3/file'],
+            ['dir/.php-cs-fixer.cache', './dir3/file', 'dir3/file'],
+            ['dir/.php-cs-fixer.cache', 'dir3/file', 'dir3/file'],
         ];
     }
 

--- a/tests/Smoke/StdinTest.php
+++ b/tests/Smoke/StdinTest.php
@@ -56,7 +56,7 @@ final class StdinTest extends AbstractSmokeTest
         $fileResult = str_replace("\n--- ".$path."\n", "\n--- php://stdin\n", $fileResult);
         $fileResult = str_replace("\n+++ ".$path."\n", "\n+++ php://stdin\n", $fileResult);
 
-        $path = str_replace('/', \DIRECTORY_SEPARATOR, basename(realpath($cwd)).'/'.$inputFile);
+        $path = str_replace('/', \DIRECTORY_SEPARATOR, $inputFile);
         $fileResult = Preg::replace(
             '#/?'.preg_quote($path, '#').'#',
             'php://stdin',


### PR DESCRIPTION
Closes #6097

Second attempt, this time targeting master rather than 2.19 branch