### PR TITLE
refactor: increase performance by ~7% thanks to Tokens::block*Cache hit increased by ~12%

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -314,7 +314,31 @@ class Tokens extends \SplFixedArray
      */
     public function offsetSet($index, $newval): void
     {
+        // # cache usage count with following variant: tests/Fixer/: 102_074
+        // $this->blockStartCache = [];
+        // $this->blockEndCache = [];
+
         if (!isset($this[$index]) || !$this[$index]->equals($newval)) {
+            // # cache usage count with following variant: tests/Fixer/: 108_464
+            // $this->blockStartCache = [];
+            // $this->blockEndCache = [];
+
+            if (isset($this[$index]) && self::isTokenBlockEdge($this[$index])) {
+                // # cache usage count with following variant: tests/Fixer/: 113_324
+                // $this->blockStartCache = [];
+                // $this->blockEndCache = [];
+            }
+
+            if (isset($this[$index])) {
+                // # cache usage count with following variant: tests/Fixer/: 114_574
+                if (isset($this->blockStartCache[$index])) {
+                    unset($this->blockEndCache[$this->blockStartCache[$index]], $this->blockStartCache[$index]);
+                }
+                if (isset($this->blockEndCache[$index])) {
+                    unset($this->blockStartCache[$this->blockEndCache[$index]], $this->blockEndCache[$index]);
+                }
+            }
+
             $this->changed = true;
             $this->namespaceDeclarations = null;
 

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -314,23 +314,8 @@ class Tokens extends \SplFixedArray
      */
     public function offsetSet($index, $newval): void
     {
-        // # cache usage count with following variant: tests/Fixer/: 102_074
-        // $this->blockStartCache = [];
-        // $this->blockEndCache = [];
-
         if (!isset($this[$index]) || !$this[$index]->equals($newval)) {
-            // # cache usage count with following variant: tests/Fixer/: 108_464
-            // $this->blockStartCache = [];
-            // $this->blockEndCache = [];
-
-            if (isset($this[$index]) && self::isTokenBlockEdge($this[$index])) {
-                // # cache usage count with following variant: tests/Fixer/: 113_324
-                // $this->blockStartCache = [];
-                // $this->blockEndCache = [];
-            }
-
             if (isset($this[$index])) {
-                // # cache usage count with following variant: tests/Fixer/: 114_574
                 if (isset($this->blockStartCache[$index])) {
                     unset($this->blockEndCache[$this->blockStartCache[$index]], $this->blockStartCache[$index]);
                 }

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -295,10 +295,18 @@ class Tokens extends \SplFixedArray
      */
     public function offsetUnset($index): void
     {
-        $this->changed = true;
-        $this->namespaceDeclarations = null;
         if (isset($this[$index])) {
+            if (isset($this->blockStartCache[$index])) {
+                unset($this->blockEndCache[$this->blockStartCache[$index]], $this->blockStartCache[$index]);
+            }
+            if (isset($this->blockEndCache[$index])) {
+                unset($this->blockStartCache[$this->blockEndCache[$index]], $this->blockEndCache[$index]);
+            }
+
             $this->unregisterFoundToken($this[$index]);
+
+            $this->changed = true;
+            $this->namespaceDeclarations = null;
         }
 
         parent::offsetUnset($index);

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -314,9 +314,6 @@ class Tokens extends \SplFixedArray
      */
     public function offsetSet($index, $newval): void
     {
-        $this->blockStartCache = [];
-        $this->blockEndCache = [];
-
         if (!isset($this[$index]) || !$this[$index]->equals($newval)) {
             $this->changed = true;
             $this->namespaceDeclarations = null;

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -322,14 +322,13 @@ class Tokens extends \SplFixedArray
                 if (isset($this->blockEndCache[$index])) {
                     unset($this->blockStartCache[$this->blockEndCache[$index]], $this->blockEndCache[$index]);
                 }
+
+                $this->unregisterFoundToken($this[$index]);
             }
 
             $this->changed = true;
             $this->namespaceDeclarations = null;
 
-            if (isset($this[$index])) {
-                $this->unregisterFoundToken($this[$index]);
-            }
             $this->registerFoundToken($newval);
         }
 


### PR DESCRIPTION
### meta

- attempts: ~5 (most of them merged as a partial victory)
- mental execution time: ~2yrs (with partial merges over time, and also 2nd author)
- actual coding: ~1h (for this approach), 1h for cleanups around (extracted to other PRs)

### results

- approx ~7% performance gain
- increase Tokens::block*Cache hit by ~12%

### approach

- no need to clear the blockCache for such changes

```php
// $tokens[5] = [T_DOC_COMMENT, "/** Foo */"
$tokens[5] = new Token([T_COMMENT, "/* Foo */");
```

### benchmark

```
# ./php-cs-fixer fix -vvv # on master
Fixed 0 of 1063 files in 66.990 seconds, 24.000 MB memory used
Fixed 0 of 1063 files in 67.361 seconds, 24.000 MB memory used
Fixed 0 of 1063 files in 66.848 seconds, 24.000 MB memory used
```

```
# ./php-cs-fixer fix -vvv # on PR
Fixed 0 of 1063 files in 62.640 seconds, 24.000 MB memory used
Fixed 0 of 1063 files in 62.527 seconds, 24.000 MB memory used
Fixed 0 of 1063 files in 62.846 seconds, 24.000 MB memory used
```
