### PR TITLE
feat: phpDoc to property/return/param Fixer - allow fixing mixed on PHP >= 8

### DIFF
--- a/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
@@ -39,7 +39,6 @@ final class PhpdocToParamTypeFixer extends AbstractPhpdocToTypeDeclarationFixer
      * @var array<string, true>
      */
     private const SKIPPED_TYPES = [
-        'mixed' => true,
         'resource' => true,
         'static' => true,
         'void' => true,

--- a/src/Fixer/FunctionNotation/PhpdocToPropertyTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToPropertyTypeFixer.php
@@ -28,7 +28,6 @@ final class PhpdocToPropertyTypeFixer extends AbstractPhpdocToTypeDeclarationFix
      * @var array<string, true>
      */
     private array $skippedTypes = [
-        'mixed' => true,
         'resource' => true,
         'null' => true,
     ];

--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -119,10 +119,6 @@ final class Foo {
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
-        if (\PHP_VERSION_ID >= 8_00_00) {
-            unset($this->skippedTypes['mixed']);
-        }
-
         for ($index = $tokens->count() - 1; 0 < $index; --$index) {
             if (!$tokens[$index]->isGivenKind([T_FUNCTION, T_FN])) {
                 continue;

--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -42,7 +42,6 @@ final class PhpdocToReturnTypeFixer extends AbstractPhpdocToTypeDeclarationFixer
      * @var array<string, true>
      */
     private array $skippedTypes = [
-        'mixed' => true,
         'resource' => true,
         'null' => true,
     ];

--- a/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
@@ -30,26 +30,18 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
      *
      * @dataProvider provideFixCases
      */
-    public function testFix(
-        string $expected,
-        ?string $input = null,
-        ?int $availableAboveVersion = null,
-        array $config = [],
-        ?int $skipFromVersion = null
-    ): void {
-        if (null !== $skipFromVersion && \PHP_VERSION_ID >= $skipFromVersion) {
-            static::markTestSkipped(sprintf('Only available up to version %d', $skipFromVersion));
-        }
-
+    public function testFix(string $expected, ?string $input = null, ?int $versionSpecificFix = null, array $config = []): void
+    {
         if (
             null !== $input
-            && (null !== $availableAboveVersion && \PHP_VERSION_ID < $availableAboveVersion)
+            && (null !== $versionSpecificFix && \PHP_VERSION_ID < $versionSpecificFix)
         ) {
             $expected = $input;
             $input = null;
         }
 
         $this->fixer->configure($config);
+
         $this->doTest($expected, $input);
     }
 
@@ -196,32 +188,6 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
                     * @param float $tab
                     */
                     function my_foo($bar, $baz, $tab) {}',
-        ];
-
-        yield 'non-root class with mixed type of param for php < 8' => [
-            '<?php
-                /**
-                * @param mixed $bar
-                */
-                function my_foo($bar) {}',
-            null,
-            null,
-            [],
-            80000,
-        ];
-
-        yield 'non-root class with mixed type of param for php >= 8' => [
-            '<?php
-                    /**
-                    * @param mixed $bar
-                    */
-                    function my_foo(mixed $bar) {}',
-            '<?php
-                    /**
-                    * @param mixed $bar
-                    */
-                    function my_foo($bar) {}',
-            80000,
         ];
 
         yield 'non-root namespaced class' => [
@@ -529,6 +495,53 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
                     /** @param Bar&Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz $x */
                     function bar($x) {}
                 ',
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixPre80Cases
+     *
+     * @requires PHP <8.0
+     */
+    public function testFixPre80(string $expected, string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixPre80Cases(): iterable
+    {
+        yield 'skip mixed type of param' => [
+            '<?php
+                    /**
+                    * @param mixed $bar
+                    */
+                    function my_foo($bar) {}',
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixPhp80Cases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFixPhp80(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixPhp80Cases(): iterable
+    {
+        yield 'non-root class with mixed type of param for php >= 8' => [
+            '<?php
+                    /**
+                    * @param mixed $bar
+                    */
+                    function my_foo(mixed $bar) {}',
+            '<?php
+                    /**
+                    * @param mixed $bar
+                    */
+                    function my_foo($bar) {}',
         ];
     }
 }

--- a/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
@@ -28,25 +28,8 @@ final class PhpdocToPropertyTypeFixerTest extends AbstractFixerTestCase
      *
      * @dataProvider provideFixCases
      */
-    public function testFix(
-        string $expected,
-        ?string $input = null,
-        ?int $availableAboveVersion = null,
-        array $config = [],
-        ?int $skipFromVersion = null
-    ): void {
-        if (null !== $skipFromVersion && \PHP_VERSION_ID >= $skipFromVersion) {
-            static::markTestSkipped(sprintf('Only available up to version %d', $skipFromVersion));
-        }
-
-        if (
-            null !== $input
-            && (null !== $availableAboveVersion && \PHP_VERSION_ID < $availableAboveVersion)
-        ) {
-            $expected = $input;
-            $input = null;
-        }
-
+    public function testFix(string $expected, ?string $input = null, array $config = []): void
+    {
         $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
@@ -147,7 +130,6 @@ final class PhpdocToPropertyTypeFixerTest extends AbstractFixerTestCase
         yield 'do not fix scalar types when configured as such' => [
             '<?php class Foo { /** @var int */ private $foo; }',
             null,
-            null,
             ['scalar_types' => false],
         ];
 
@@ -172,20 +154,6 @@ final class PhpdocToPropertyTypeFixerTest extends AbstractFixerTestCase
 
         yield 'skip resource special type' => [
             '<?php class Foo { /** @var resource */ private $foo; }',
-        ];
-
-        yield 'skip mixed special type' => [
-            '<?php class Foo { /** @var mixed */ private $foo; }',
-            null,
-            null,
-            [],
-            80000,
-        ];
-
-        yield 'fix mixed special type' => [
-            '<?php class Foo { /** @var mixed */ private mixed $foo; }',
-            '<?php class Foo { /** @var mixed */ private $foo; }',
-            80000,
         ];
 
         yield 'null alone cannot be a property type' => [
@@ -547,6 +515,41 @@ final class PhpdocToPropertyTypeFixerTest extends AbstractFixerTestCase
 
         yield 'very long class name after ampersand' => [
             '<?php class Foo { /** @var Bar&Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz */ private $x; }',
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixPre80Cases
+     *
+     * @requires PHP <8.0
+     */
+    public function testFixPre80(string $expected, string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixPre80Cases(): iterable
+    {
+        yield 'skip mixed type' => [
+            '<?php class Foo { /** @var mixed */ private $foo; }',
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixPhp80Cases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFixPhp80(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixPhp80Cases(): iterable
+    {
+        yield 'fix mixed type' => [
+            '<?php class Foo { /** @var mixed */ private mixed $foo; }',
+            '<?php class Foo { /** @var mixed */ private $foo; }',
         ];
     }
 

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -30,20 +30,11 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
      *
      * @dataProvider provideFixCases
      */
-    public function testFix(
-        string $expected,
-        ?string $input = null,
-        ?int $availableAboveVersion = null,
-        array $config = [],
-        ?int $skipFromVersion = null
-    ): void {
-        if (null !== $skipFromVersion && \PHP_VERSION_ID >= $skipFromVersion) {
-            static::markTestSkipped(sprintf('Only available up to version %d', $skipFromVersion));
-        }
-
+    public function testFix(string $expected, ?string $input = null, ?int $versionSpecificFix = null, array $config = []): void
+    {
         if (
             null !== $input
-            && (null !== $availableAboveVersion && \PHP_VERSION_ID < $availableAboveVersion)
+            && (null !== $versionSpecificFix && \PHP_VERSION_ID < $versionSpecificFix)
         ) {
             $expected = $input;
             $input = null;
@@ -235,7 +226,7 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
             '<?php /** @return null */ function my_foo() {}',
         ];
 
-        yield 'skip mixed types' => [
+        yield 'skip union types' => [
             '<?php /** @return Foo|Bar */ function my_foo() {}',
         ];
 
@@ -263,7 +254,7 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
             '<?php /** @return string|string[] */ function my_foo() {}',
         ];
 
-        yield 'skip mixed nullable types' => [
+        yield 'skip nullable union types' => [
             '<?php /** @return null|Foo|Bar */ function my_foo() {}',
         ];
 
@@ -397,29 +388,6 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
                     /** @return Bar&Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz */
                     function bar() {}
                 ',
-        ];
-
-        yield 'skip mixed type' => [
-            '<?php
-                    /** @return mixed */
-                    function bar() {}
-                ',
-            null,
-            null,
-            [],
-            80000,
-        ];
-
-        yield 'fix mixed type' => [
-            '<?php
-                    /** @return mixed */
-                    function bar(): mixed {}
-                ',
-            '<?php
-                    /** @return mixed */
-                    function bar() {}
-                ',
-            80000,
         ];
 
         yield 'arrow function' => [


### PR DESCRIPTION
Hello,

I'm trying to use `PhpdocTo Property/Return/Param Fixers` for fixing a `mixed` type from phpdocs on PHP >= 8.0 - which allows `mixed` as a declared scalar type. 

It seems to me, it should work. But it is actually skipped before even trying to check if the type is allowed for the version.

I removed the `mixed` from a skipped types and it is checked against a version specific types later, so it works fine.
I also unified test cases for all 3 fixers, so it lowers a brain damage for managing the tests.

PS:
I created the PR from `master` and marked it as a feature not as a bugfix, since I feel it as an improvement in the fixing - not fixing a bug, but I can change it if it should be a bugfix.