### PR TITLE
DX: Add shell completion commands

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -14,7 +14,8 @@
         {
             "name": [
                 "*.php",
-                "*.php8"
+                "*.php8",
+                "completion.*"
             ],
             "exclude": [
                 "Test",

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -26,6 +26,8 @@ use PhpCsFixer\PharChecker;
 use PhpCsFixer\ToolInfo;
 use PhpCsFixer\Utils;
 use Symfony\Component\Console\Application as BaseApplication;
+use Symfony\Component\Console\Command\CompleteCommand;
+use Symfony\Component\Console\Command\DumpCompletionCommand;
 use Symfony\Component\Console\Command\ListCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
@@ -127,6 +129,6 @@ final class Application extends BaseApplication
 
     protected function getDefaultCommands(): array
     {
-        return [new HelpCommand(), new ListCommand()];
+        return [new HelpCommand(), new ListCommand(), new CompleteCommand(), new DumpCompletionCommand()];
     }
 }


### PR DESCRIPTION
Symfony Console supports completion of command and option names out of the box ([doc](https://symfony.com/doc/current/console.html#console-completion)). 

Documentation:

The `completion` command dumps the shell completion script required to use shell autocompletion (currently, bash and fish completion is supported).
  
  Static installation
  -------------------
  
  Dump the script to a global completion file and restart your shell:
  
      ./php-cs-fixer.phar completion bash | sudo tee /etc/bash_completion.d/php-cs-fixer.phar
  
  Or dump the script to a local file and source it:
  
      ./php-cs-fixer.phar completion bash > completion.sh
  
      # source the file whenever you use the project
      source completion.sh
  
      # or add this line at the end of your "~/.bashrc" file:
      source /path/to/completion.sh
  
  Dynamic installation
  --------------------
  
  Add this to the end of your shell configuration file (e.g. "~/.bashrc"):
  
      eval "$(php-cs-fixer.phar completion bash)"
