### PR TITLE
feature: Support for `position_after_multiline_anonymous_class` in  `\PhpCsFixer\Fixer\Basic\BracesFixer`

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -139,6 +139,10 @@ List of Available Rules
      | whether the opening brace should be placed on "next" or "same" line after anonymous constructs (anonymous classes and lambda functions).
      | Allowed values: ``'next'``, ``'same'``
      | Default value: ``'same'``
+   - | ``position_after_multiline_anonymous_class``
+     | whether the opening brace should be placed on "next" or "same" line after multiline anonymous class definitions.
+     | Allowed values: ``'next'``, ``'same'``
+     | Default value: ``'next'``
 
 
    Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -204,6 +204,10 @@ class Foo
                 ->setAllowedValues([self::LINE_NEXT, self::LINE_SAME])
                 ->setDefault(self::LINE_SAME)
                 ->getOption(),
+            (new FixerOptionBuilder('position_after_multiline_anonymous_class', 'whether the opening brace should be placed on "next" or "same" line after multiline anonymous class definitions.'))
+                ->setAllowedValues([self::LINE_NEXT, self::LINE_SAME])
+                ->setDefault(self::LINE_NEXT)
+                ->getOption(),
         ]);
     }
 
@@ -583,10 +587,17 @@ class Foo
                 || (
                     self::LINE_NEXT === $this->configuration['position_after_control_structures'] && $token->isGivenKind($controlTokens)
                     || (
-                        self::LINE_NEXT === $this->configuration['position_after_anonymous_constructs']
-                        && (
+                        (
                             $token->isGivenKind(T_FUNCTION) && $tokensAnalyzer->isLambda($index)
                             || $token->isGivenKind(T_CLASS) && $tokensAnalyzer->isAnonymousClass($index)
+                        )
+                        && (
+                            self::LINE_NEXT === $this->configuration['position_after_anonymous_constructs']
+                            || (
+                                self::LINE_NEXT === $this->configuration['position_after_multiline_anonymous_class']
+                                && $token->isGivenKind(T_CLASS) && $tokensAnalyzer->isAnonymousClass($index)
+                                && $this->isMultilined($tokens, $index, $tokens->getNextTokenOfKind($index, ['{']) - 1)
+                            )
                         )
                     )
                 )

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -31,6 +31,7 @@ final class BracesFixerTest extends AbstractFixerTestCase
     private static $configurationOopPositionSameLine = ['position_after_functions_and_oop_constructs' => BracesFixer::LINE_SAME];
     private static $configurationCtrlStructPositionNextLine = ['position_after_control_structures' => BracesFixer::LINE_NEXT];
     private static $configurationAnonymousPositionNextLine = ['position_after_anonymous_constructs' => BracesFixer::LINE_NEXT];
+    private static $configurationMultilineAnonymousClassPositionSameLine = ['position_after_multiline_anonymous_class' => BracesFixer::LINE_SAME];
 
     public function testInvalidConfigurationClassyConstructs(): void
     {
@@ -246,6 +247,57 @@ final class BracesFixerTest extends AbstractFixerTestCase
         for ($i=0;$i<5;++$i);
     };',
                 self::$configurationAnonymousPositionNextLine,
+            ],
+// Currently unable to test since `\PhpCsFixer\Tokenizer\Tokens::generateCode` generates a different indentation than `\PhpCsFixer\AbstractFixer::fix()` (which marks \PhpCsFixer\Tokenizer\Tokens::$changed as `true`)
+//            [
+//                '<?php
+//    $a = new class extends \StdObject implements
+//        \Stringable {
+//        };',
+//                null,
+//                self::$configurationMultilineAnonymousClassPositionSameLine,
+//            ],
+            [
+                '<?php
+    $a = new class extends \StdObject { // Not affected by `position_after_multiline_anonymous_class` setting.
+    };',
+            ],
+            [
+                '<?php
+    $a = new class extends \StdObject { // Not affected by `position_after_multiline_anonymous_class` setting (moved to same line by default).
+    };',
+                '<?php
+    $a = new class extends \StdObject
+    { // Not affected by `position_after_multiline_anonymous_class` setting (moved to same line by default).
+    };',
+            ],
+            [
+                '<?php
+    $a = new class extends \StdObject implements
+        \Stringable
+    { // Moved to new line after fix run.
+        function __toString()
+        {
+            return function () use (
+                $b
+            ) { // Moved to same line after fix run (not affected by `position_after_multiline_anonymous_class` setting).
+                return "test";
+            };
+        }
+    };',
+                '<?php
+    $a = new class extends \StdObject implements
+        \Stringable { // Moved to new line after fix run.
+        function __toString()
+        {
+            return function () use (
+                $b
+            )
+            { // Moved to same line after fix run (not affected by `position_after_multiline_anonymous_class` setting).
+                return "test";
+            };
+        }
+    };',
             ],
             [
                 '<?php


### PR DESCRIPTION
Currently PHP CS Fixer can't distinguish between single and multiline anonymous class definitions. 
This causes the fixer to format the opening brace for multiline anonymous classes according to the `position_after_anonymous_constructs` setting:
```php
$model = new class extends BaseActiveRecord implements
    IdentifierInterface,
    RelationInterface { // 👈 opening brace moved to "same" line
    public function someImplementation() {
    }
}
```

With the introduction of the `position_after_multiline_anonymous_class` setting the position of the opening braces can be specified for multiline anonymous classes (default value "next" line).

```php
$model = new class extends BaseActiveRecord implements
    IdentifierInterface,
    RelationInterface
{ // 👈 opening brace remains on the "next" line
    public function someImplementation() {
    }
}
```