### PR TITLE
feat: Add `spacing` option to `PhpdocAlignFixer`

### DIFF
--- a/doc/rules/phpdoc/phpdoc_align.rst
+++ b/doc/rules/phpdoc/phpdoc_align.rst
@@ -23,7 +23,9 @@ Default value: ``'vertical'``
 Spacing between tag, hint, comment, signature, etc. You can set same spacing for
 all tags using a positive integer or different spacings for different tags using
 an associative array of positive integers ``['tagA' => spacingForA, 'tagB' =>
-spacingForB]``.
+spacingForB]``. If you want to define default spacing to more than 1 space use
+``_default`` key in config array, e.g.: ``['tagA' => spacingForA, 'tagB' =>
+spacingForB, '_default' => spacingForAllOthers]``.
 
 Allowed types: ``int`` and ``int[]``
 

--- a/doc/rules/phpdoc/phpdoc_align.rst
+++ b/doc/rules/phpdoc/phpdoc_align.rst
@@ -17,6 +17,18 @@ Allowed values: ``'left'`` and ``'vertical'``
 
 Default value: ``'vertical'``
 
+``spacing``
+~~~~~~~~~~~
+
+Spacing between tag, hint, comment, signature, etc. You can set same spacing for
+all tags using a positive integer or different spacings for different tags using
+an associative array of positive integers ``['tagA' => spacingForA, 'tagB' =>
+spacingForB]``.
+
+Allowed types: ``int`` and ``int[]``
+
+Default value: ``1``
+
 ``tags``
 ~~~~~~~~
 
@@ -58,6 +70,13 @@ Example #1
    + * @param int             $code       an HTTP response status code
    + * @param bool            $debug
    + * @param mixed           &$reference a parameter passed by reference
+     *
+     * @return Foo description foo
+     *
+   - * @throws Foo            description foo
+   + * @throws Foo description foo
+     *             description foo
+     *
      */
 
 Example #2
@@ -81,6 +100,13 @@ With configuration: ``['align' => 'vertical']``.
    + * @param int             $code       an HTTP response status code
    + * @param bool            $debug
    + * @param mixed           &$reference a parameter passed by reference
+     *
+     * @return Foo description foo
+     *
+   - * @throws Foo            description foo
+   + * @throws Foo description foo
+     *             description foo
+     *
      */
 
 Example #3
@@ -104,6 +130,75 @@ With configuration: ``['align' => 'left']``.
    + * @param int $code an HTTP response status code
    + * @param bool $debug
    + * @param mixed &$reference a parameter passed by reference
+     *
+     * @return Foo description foo
+     *
+   - * @throws Foo            description foo
+   + * @throws Foo description foo
+     *             description foo
+     *
+     */
+
+Example #4
+~~~~~~~~~~
+
+With configuration: ``['align' => 'left', 'spacing' => 2]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    /**
+   - * @param  EngineInterface $templating
+   - * @param string      $format
+   - * @param  int  $code       an HTTP response status code
+   - * @param    bool         $debug
+   - * @param  mixed    &$reference     a parameter passed by reference
+   + * @param  EngineInterface  $templating
+   + * @param  string  $format
+   + * @param  int  $code  an HTTP response status code
+   + * @param  bool  $debug
+   + * @param  mixed  &$reference  a parameter passed by reference
+     *
+   - * @return Foo description foo
+   + * @return  Foo  description foo
+     *
+   - * @throws Foo            description foo
+   - *             description foo
+   + * @throws  Foo  description foo
+   + *               description foo
+     *
+     */
+
+Example #5
+~~~~~~~~~~
+
+With configuration: ``['align' => 'left', 'spacing' => ['param' => 2]]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    /**
+   - * @param  EngineInterface $templating
+   - * @param string      $format
+   - * @param  int  $code       an HTTP response status code
+   - * @param    bool         $debug
+   - * @param  mixed    &$reference     a parameter passed by reference
+   + * @param  EngineInterface  $templating
+   + * @param  string  $format
+   + * @param  int  $code  an HTTP response status code
+   + * @param  bool  $debug
+   + * @param  mixed  &$reference  a parameter passed by reference
+     *
+     * @return Foo description foo
+     *
+   - * @throws Foo            description foo
+   + * @throws Foo description foo
+     *             description foo
+     *
      */
 
 Rule sets

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -90,6 +90,8 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
 
     private const DEFAULT_SPACING = 1;
 
+    private const DEFAULT_SPACING_KEY = '_default';
+
     private string $regex;
 
     private string $regexCommentLine;
@@ -102,6 +104,8 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
      * @var int|int[]
      */
     private $spacing = 1;
+
+    private int $defaultSpacing = 1;
 
     public function configure(array $configuration): void
     {
@@ -137,6 +141,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
         $this->regexCommentLine = '/'.$indentRegex.'\*(?!\h?+@)(?:\s+(?P<desc>\V+))(?<!\*\/)\r?$/';
         $this->align = $this->configuration['align'];
         $this->spacing = $this->configuration['spacing'];
+        $this->defaultSpacing = $this->configuration['spacing'][self::DEFAULT_SPACING_KEY] ?? self::DEFAULT_SPACING;
     }
 
     public function getDefinition(): FixerDefinitionInterface
@@ -241,7 +246,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
 
         $spacing = new FixerOptionBuilder(
             'spacing',
-            'Spacing between tag, hint, comment, signature, etc. You can set same spacing for all tags using a positive integer or different spacings for different tags using an associative array of positive integers `[\'tagA\' => spacingForA, \'tagB\' => spacingForB]`.'
+            'Spacing between tag, hint, comment, signature, etc. You can set same spacing for all tags using a positive integer or different spacings for different tags using an associative array of positive integers `[\'tagA\' => spacingForA, \'tagB\' => spacingForB]`. If you want to define default spacing to more than 1 space use `_default` key in config array, e.g.: `[\'tagA\' => spacingForA, \'tagB\' => spacingForB, \'_default\' => spacingForAllOthers]`.'
         );
         $spacing->setAllowedTypes(['int', 'int[]'])
             ->setAllowedValues([$allowPositiveIntegers])
@@ -387,7 +392,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
     {
         return (\is_int($this->spacing)) ?
             $this->spacing :
-            ($this->spacing[$tag] ?? self::DEFAULT_SPACING);
+            ($this->spacing[$tag] ?? $this->defaultSpacing);
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -212,24 +212,15 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
 
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
-        $allowPositiveInteger = static function ($value) {
-            if (\is_int($value) && $value <= 0) {
-                throw new InvalidOptionsException('The "spacing" option is invalid. It must be greater than zero.');
-            }
-
-            return \is_int($value);
-        };
-
-        $allowArrayOfPositiveIntegers = static function ($value) {
-            if (\is_array($value)) {
-                foreach ($value as $val) {
-                    if (\is_int($val) && $val <= 0) {
-                        throw new InvalidOptionsException('The option "spacing" is invalid. All spacings must be greater than zero.');
-                    }
+        $allowPositiveIntegers = static function ($value) {
+            $spacings = \is_array($value) ? $value : [$value];
+            foreach ($spacings as $val) {
+                if (\is_int($val) && $val <= 0) {
+                    throw new InvalidOptionsException('The option "spacing" is invalid. All spacings must be greater than zero.');
                 }
             }
 
-            return \is_array($value);
+            return true;
         };
 
         $tags = new FixerOptionBuilder(
@@ -250,12 +241,10 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
 
         $spacing = new FixerOptionBuilder(
             'spacing',
-            'Spacing between tag, hint, comment, signature, etc. You can set same spacing for all tags using a positive integer '.
-            'or different spacings for different tags using an associative array of positive integers '.
-            '`[\'tagA\' => spacingForA, \'tagB\' => spacingForB]`.'
+            'Spacing between tag, hint, comment, signature, etc. You can set same spacing for all tags using a positive integer or different spacings for different tags using an associative array of positive integers `[\'tagA\' => spacingForA, \'tagB\' => spacingForB]`.'
         );
         $spacing->setAllowedTypes(['int', 'int[]'])
-            ->setAllowedValues([$allowPositiveInteger, $allowArrayOfPositiveIntegers])
+            ->setAllowedValues([$allowPositiveIntegers])
             ->setDefault(self::DEFAULT_SPACING)
         ;
 

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -28,6 +28,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -35,6 +36,7 @@ use PhpCsFixer\Tokenizer\Tokens;
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  * @author Graham Campbell <hello@gjcampbell.co.uk>
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ * @author Jakub Kwaśniewski <jakub@zero-85.pl>
  */
 final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerInterface, WhitespacesAwareFixerInterface
 {
@@ -86,14 +88,20 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
         'psalm-method',
     ];
 
+    private const DEFAULT_SPACING = 1;
+
     private string $regex;
 
     private string $regexCommentLine;
 
+    private string $align;
+
     /**
-     * @var string
+     * same spacing for all or specific for different tags.
+     *
+     * @var int|int[]
      */
-    private $align;
+    private $spacing = 1;
 
     public function configure(array $configuration): void
     {
@@ -128,6 +136,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
         $this->regex = '/'.$indentRegex.'\*\h*@(?J)(?:'.implode('|', $types).')'.$desc.'\h*\r?$/';
         $this->regexCommentLine = '/'.$indentRegex.'\*(?!\h?+@)(?:\s+(?P<desc>\V+))(?<!\*\/)\r?$/';
         $this->align = $this->configuration['align'];
+        $this->spacing = $this->configuration['spacing'];
     }
 
     public function getDefinition(): FixerDefinitionInterface
@@ -140,6 +149,12 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
              * @param  int  $code       an HTTP response status code
              * @param    bool         $debug
              * @param  mixed    &$reference     a parameter passed by reference
+             *
+             * @return Foo description foo
+             *
+             * @throws Foo            description foo
+             *             description foo
+             *
              */
 
             EOF;
@@ -150,6 +165,8 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
                 new CodeSample($code),
                 new CodeSample($code, ['align' => self::ALIGN_VERTICAL]),
                 new CodeSample($code, ['align' => self::ALIGN_LEFT]),
+                new CodeSample($code, ['align' => self::ALIGN_LEFT, 'spacing' => 2]),
+                new CodeSample($code, ['align' => self::ALIGN_LEFT, 'spacing' => ['param' => 2]]),
             ],
         );
     }
@@ -195,6 +212,26 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
 
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
+        $allowPositiveInteger = static function ($value) {
+            if (\is_int($value) && $value <= 0) {
+                throw new InvalidOptionsException('The "spacing" option is invalid. It must be greater than zero.');
+            }
+
+            return \is_int($value);
+        };
+
+        $allowArrayOfPositiveIntegers = static function ($value) {
+            if (\is_array($value)) {
+                foreach ($value as $val) {
+                    if (\is_int($val) && $val <= 0) {
+                        throw new InvalidOptionsException('The option "spacing" is invalid. All spacings must be greater than zero.');
+                    }
+                }
+            }
+
+            return \is_array($value);
+        };
+
         $tags = new FixerOptionBuilder(
             'tags',
             'The tags that should be aligned. Allowed values are tags with name (`\''.implode('\', \'', self::TAGS_WITH_NAME).'\'`), tags with method signature (`\''.implode('\', \'', self::TAGS_WITH_METHOD_SIGNATURE).'\'`) and any custom tag with description (e.g. `@tag <desc>`).'
@@ -211,7 +248,18 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
             ->setDefault(self::ALIGN_VERTICAL)
         ;
 
-        return new FixerConfigurationResolver([$tags->getOption(), $align->getOption()]);
+        $spacing = new FixerOptionBuilder(
+            'spacing',
+            'Spacing between tag, hint, comment, signature, etc. You can set same spacing for all tags using a positive integer '.
+            'or different spacings for different tags using an associative array of positive integers '.
+            '`[\'tagA\' => spacingForA, \'tagB\' => spacingForB]`.'
+        );
+        $spacing->setAllowedTypes(['int', 'int[]'])
+            ->setAllowedValues([$allowPositiveInteger, $allowArrayOfPositiveIntegers])
+            ->setDefault(self::DEFAULT_SPACING)
+        ;
+
+        return new FixerConfigurationResolver([$tags->getOption(), $align->getOption(), $spacing->getOption()]);
     }
 
     private function fixDocBlock(DocBlock $docBlock): void
@@ -260,6 +308,9 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
 
             $itemOpeningLine = null;
 
+            $currTag = null;
+            $spacingForTag = $this->spacingForTag($currTag);
+
             // update
             foreach ($items as $j => $item) {
                 if (null === $item['tag']) {
@@ -270,10 +321,10 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
                         continue;
                     }
 
-                    $extraIndent = 2;
+                    $extraIndent = 2 * $spacingForTag;
 
                     if (\in_array($itemOpeningLine['tag'], self::TAGS_WITH_NAME, true) || \in_array($itemOpeningLine['tag'], self::TAGS_WITH_METHOD_SIGNATURE, true)) {
-                        $extraIndent += $varMax + 1;
+                        $extraIndent += $varMax + $spacingForTag;
                     }
 
                     if ($hasStatic) {
@@ -295,6 +346,10 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
                     continue;
                 }
 
+                $currTag = $item['tag'];
+
+                $spacingForTag = $this->spacingForTag($currTag);
+
                 $itemOpeningLine = $item;
 
                 $line =
@@ -305,38 +360,45 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
                 if ($hasStatic) {
                     $line .=
                         $this->getIndent(
-                            $tagMax - \strlen($item['tag']) + 1,
-                            '' !== $item['static'] ? 1 : 0
+                            $tagMax - \strlen($item['tag']) + $spacingForTag,
+                            '' !== $item['static'] ? $spacingForTag : 0
                         )
                         .('' !== $item['static'] ? $item['static'] : $this->getIndent(6 /* \strlen('static') */, 0));
-                    $hintVerticalAlignIndent = 1;
+                    $hintVerticalAlignIndent = $spacingForTag;
                 } else {
-                    $hintVerticalAlignIndent = $tagMax - \strlen($item['tag']) + 1;
+                    $hintVerticalAlignIndent = $tagMax - \strlen($item['tag']) + $spacingForTag;
                 }
 
                 $line .=
                     $this->getIndent(
                         $hintVerticalAlignIndent,
-                        '' !== $item['hint'] ? 1 : 0
+                        '' !== $item['hint'] ? $spacingForTag : 0
                     )
                     .$item['hint'];
 
                 if ('' !== $item['var']) {
                     $line .=
-                        $this->getIndent((0 !== $hintMax ? $hintMax : -1) - \strlen($item['hint']) + 1)
+                        $this->getIndent((0 !== $hintMax ? $hintMax : -1) - \strlen($item['hint']) + $spacingForTag, $spacingForTag)
                         .$item['var']
                         .(
                             '' !== $item['desc']
-                            ? $this->getIndent($varMax - \strlen($item['var']) + 1).$item['desc']
+                            ? $this->getIndent($varMax - \strlen($item['var']) + $spacingForTag, $spacingForTag).$item['desc']
                             : ''
                         );
                 } elseif ('' !== $item['desc']) {
-                    $line .= $this->getIndent($hintMax - \strlen($item['hint']) + 1).$item['desc'];
+                    $line .= $this->getIndent($hintMax - \strlen($item['hint']) + $spacingForTag, $spacingForTag).$item['desc'];
                 }
 
                 $docBlock->getLine($current + $j)->setContent($line.$lineEnding);
             }
         }
+    }
+
+    private function spacingForTag(?string $tag): int
+    {
+        return (\is_int($this->spacing)) ?
+            $this->spacing :
+            ($this->spacing[$tag] ?? self::DEFAULT_SPACING);
     }
 
     /**
@@ -419,18 +481,20 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
             return 0;
         }
 
+        $spacingForTag = $this->spacingForTag($item['tag']);
+
         // Indent according to existing values:
         return
-            $this->getSentenceIndent($item['static']) +
-            $this->getSentenceIndent($item['tag']) +
-            $this->getSentenceIndent($item['hint']) +
-            $this->getSentenceIndent($item['var']);
+            $this->getSentenceIndent($item['static'], $spacingForTag) +
+            $this->getSentenceIndent($item['tag'], $spacingForTag) +
+            $this->getSentenceIndent($item['hint'], $spacingForTag) +
+            $this->getSentenceIndent($item['var'], $spacingForTag);
     }
 
     /**
      * Get indent for sentence.
      */
-    private function getSentenceIndent(?string $sentence): int
+    private function getSentenceIndent(?string $sentence, int $spacingForTag = 1): int
     {
         if (null === $sentence) {
             return 0;
@@ -438,6 +502,6 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
 
         $length = \strlen($sentence);
 
-        return 0 === $length ? 0 : $length + 1;
+        return 0 === $length ? 0 : $length + $spacingForTag;
     }
 }

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -105,8 +105,6 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
      */
     private $spacing = 1;
 
-    private int $defaultSpacing = 1;
-
     public function configure(array $configuration): void
     {
         parent::configure($configuration);
@@ -141,7 +139,6 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
         $this->regexCommentLine = '/'.$indentRegex.'\*(?!\h?+@)(?:\s+(?P<desc>\V+))(?<!\*\/)\r?$/';
         $this->align = $this->configuration['align'];
         $this->spacing = $this->configuration['spacing'];
-        $this->defaultSpacing = $this->configuration['spacing'][self::DEFAULT_SPACING_KEY] ?? self::DEFAULT_SPACING;
     }
 
     public function getDefinition(): FixerDefinitionInterface
@@ -390,9 +387,9 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
 
     private function spacingForTag(?string $tag): int
     {
-        return (\is_int($this->spacing)) ?
-            $this->spacing :
-            ($this->spacing[$tag] ?? $this->defaultSpacing);
+        return (\is_int($this->spacing))
+            ? $this->spacing
+            : ($this->spacing[$tag] ?? $this->spacing[self::DEFAULT_SPACING_KEY] ?? self::DEFAULT_SPACING);
     }
 
     /**

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -1493,12 +1493,12 @@ function foo($typeless): void {}',
     {
         yield 'zero' => [
             ['spacing' => 0],
-            'The "spacing" option is invalid. It must be greater than zero.',
+            'The option "spacing" is invalid. All spacings must be greater than zero.',
         ];
 
         yield 'negative' => [
             ['spacing' => -2],
-            'The "spacing" option is invalid. It must be greater than zero.',
+            'The option "spacing" is invalid. All spacings must be greater than zero.',
         ];
 
         yield 'zeroInArray' => [

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Fixer\Phpdoc;
 
+use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 use PhpCsFixer\WhitespacesFixerConfig;
@@ -28,7 +29,7 @@ final class PhpdocAlignFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      *
-     * @param array{align: string, tags: array<string>} $configuration
+     * @param array{align: string, tags: array<string>, spacing: array<string,int>} $configuration
      */
     public function testFix(
         array $configuration,
@@ -1338,6 +1339,176 @@ function foo($typeless): void {}',
  *                     Bar.
  */
 function foo($typeless): void {}',
+        ];
+
+        yield 'left align and @param with 2 spaces' => [
+            [
+                'align' => PhpdocAlignFixer::ALIGN_LEFT,
+                'spacing' => ['param' => 2],
+            ],
+            '<?php
+    /**
+     * @param  EngineInterface  $templating
+     * @param  string  $format
+     * @param  int  $code  An HTTP response status code
+     *                     See constants
+     * @param  bool  $debug
+     * @param  bool  $debug  See constants
+     *                       See constants
+     * @param  mixed  &$reference  A parameter passed by reference
+     *
+     * @return Foo description foo
+     *
+     * @throws Foo description foo
+     *             description foo
+     *
+     */
+',
+            '<?php
+    /**
+     * @param  EngineInterface $templating
+     * @param string      $format
+     * @param  int  $code       An HTTP response status code
+     *                              See constants
+     * @param    bool         $debug
+     * @param    bool         $debug See constants
+     * See constants
+     * @param  mixed    &$reference     A parameter passed by reference
+     *
+     * @return Foo description foo
+     *
+     * @throws Foo             description foo
+     *             description foo
+     *
+     */
+',
+        ];
+
+        yield 'vertical align with various spacing' => [
+            [
+                'align' => PhpdocAlignFixer::ALIGN_VERTICAL,
+                'spacing' => ['param' => 2, 'return' => 4],
+            ],
+            '<?php
+    /**
+     * @param  EngineInterface  $templating
+     * @param  string           $format
+     * @param  int              $code        An HTTP response status code
+     *                                       See constants
+     * @param  bool             $debug
+     * @param  bool             $debug       See constants
+     *                                       See constants
+     * @param  mixed            &$reference  A parameter passed by reference
+     *
+     * @return    Foo    description foo bar hello world!
+     *                   return description continuation
+     *
+     * @throws Foo description foo
+     *             description foo
+     *
+     */
+',
+            '<?php
+    /**
+     * @param  EngineInterface $templating
+     * @param string      $format
+     * @param  int  $code       An HTTP response status code
+     *                              See constants
+     * @param    bool         $debug
+     * @param    bool         $debug See constants
+     * See constants
+     * @param  mixed    &$reference     A parameter passed by reference
+     *
+     * @return Foo description foo bar hello world!
+    *        return description continuation
+     *
+     * @throws Foo             description foo
+     *             description foo
+     *
+     */
+',
+        ];
+
+        yield 'left align with various spacing' => [
+            [
+                'align' => PhpdocAlignFixer::ALIGN_LEFT,
+                'spacing' => ['param' => 2, 'return' => 4],
+            ],
+            '<?php
+    /**
+     * @param  EngineInterface  $templating
+     * @param  string  $format
+     * @param  int  $code  An HTTP response status code
+     *                     See constants
+     * @param  bool  $debug
+     * @param  bool  $debug  See constants
+     *                       See constants
+     * @param  mixed  &$reference  A parameter passed by reference
+     *
+     * @return    Foo    description foo
+     *
+     * @throws Foo description foo
+     *             description foo
+     *
+     */
+',
+            '<?php
+    /**
+     * @param  EngineInterface $templating
+     * @param string      $format
+     * @param  int  $code       An HTTP response status code
+     *                              See constants
+     * @param    bool         $debug
+     * @param    bool         $debug See constants
+     * See constants
+     * @param  mixed    &$reference     A parameter passed by reference
+     *
+     * @return Foo description foo
+     *
+     * @throws Foo             description foo
+     *             description foo
+     *
+     */
+',
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidConfigurationCases
+     *
+     * @param array<string,mixed> $config
+     */
+    public function testInvalidConfiguration(array $config, string $expectedMessage): void
+    {
+        $this->expectException(InvalidFixerConfigurationException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $this->fixer->configure($config);
+    }
+
+    public static function provideInvalidConfigurationCases(): iterable
+    {
+        yield 'zero' => [
+            ['spacing' => 0],
+            'The "spacing" option is invalid. It must be greater than zero.',
+        ];
+
+        yield 'negative' => [
+            ['spacing' => -2],
+            'The "spacing" option is invalid. It must be greater than zero.',
+        ];
+
+        yield 'zeroInArray' => [
+            ['spacing' => ['param' => 1, 'return' => 0]],
+            'The option "spacing" is invalid. All spacings must be greater than zero.',
+        ];
+
+        yield 'negativeInArray' => [
+            [
+                'align' => PhpdocAlignFixer::ALIGN_LEFT,
+                'spacing' => ['return' => 2, 'param' => -1],
+            ],
+            'The option "spacing" is invalid. All spacings must be greater than zero.',
         ];
     }
 }

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -1487,7 +1487,7 @@ function foo($typeless): void {}',
     }
 
     /**
-     * @return  iterable<array{array<string,mixed>, string}>
+     * @return iterable<array{array<string,mixed>, string}>
      */
     public static function provideInvalidConfigurationCases(): iterable
     {

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -1486,6 +1486,9 @@ function foo($typeless): void {}',
         $this->fixer->configure($config);
     }
 
+    /**
+     * @return  iterable<array{array<string,mixed>, string}>
+     */
     public static function provideInvalidConfigurationCases(): iterable
     {
         yield 'zero' => [

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -1471,6 +1471,51 @@ function foo($typeless): void {}',
      */
 ',
         ];
+
+        yield 'left align with changed default spacing' => [
+            [
+                'align' => PhpdocAlignFixer::ALIGN_LEFT,
+                'spacing' => ['_default' => 2, 'return' => 4],
+            ],
+            '<?php
+    /**
+     * @property  string  $bar  Foo-Bar lorem ipsum
+     * @param  EngineInterface  $templating
+     * @param  string  $format
+     * @param  int  $code  An HTTP response status code
+     *                     See constants
+     * @param  bool  $debug
+     * @param  bool  $debug  See constants
+     *                       See constants
+     * @param  mixed  &$reference  A parameter passed by reference
+     *
+     * @return    Foo    description foo
+     *
+     * @throws  Foo  description foo
+     *               description foo
+     *
+     */
+',
+            '<?php
+    /**
+     * @property string $bar                    Foo-Bar lorem ipsum
+     * @param  EngineInterface $templating
+     * @param string      $format
+     * @param  int  $code       An HTTP response status code
+     *                              See constants
+     * @param    bool         $debug
+     * @param    bool         $debug See constants
+     * See constants
+     * @param  mixed    &$reference     A parameter passed by reference
+     *
+     * @return Foo description foo
+     *
+     * @throws Foo             description foo
+     *             description foo
+     *
+     */
+',
+        ];
     }
 
     /**


### PR DESCRIPTION
The ``spacing`` option controls spacing between tag, hint, variable, signature, comment, etc. 
It allows to set same spacing for all tags using a positive integer or different spacings for different tags using an associative array of positive integers ``['tagA' => spacingForA, 'tagB' =>spacingForB]``.

To meet Laravel phpdoc alignment code style criteria configure fixer with:
``['align' => 'left', 'spacing' => ['param' => 2]]`` 