### PR TITLE
minor: Update PER set to v1.1

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -950,14 +950,14 @@ List of Available Rules
      | Default value: ``'start_plus_one'``
 
 
-   Part of rule sets `@PHP73Migration <./ruleSets/PHP73Migration.rst>`_ `@PHP74Migration <./ruleSets/PHP74Migration.rst>`_ `@PHP80Migration <./ruleSets/PHP80Migration.rst>`_ `@PHP81Migration <./ruleSets/PHP81Migration.rst>`_ `@PHP82Migration <./ruleSets/PHP82Migration.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PHP73Migration <./ruleSets/PHP73Migration.rst>`_ `@PHP74Migration <./ruleSets/PHP74Migration.rst>`_ `@PHP80Migration <./ruleSets/PHP80Migration.rst>`_ `@PHP81Migration <./ruleSets/PHP81Migration.rst>`_ `@PHP82Migration <./ruleSets/PHP82Migration.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Whitespace\\HeredocIndentationFixer <./../src/Fixer/Whitespace/HeredocIndentationFixer.php>`_
 -  `heredoc_to_nowdoc <./rules/string_notation/heredoc_to_nowdoc.rst>`_
 
    Convert ``heredoc`` to ``nowdoc`` where possible.
 
-   Part of rule set `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
 
    `Source PhpCsFixer\\Fixer\\StringNotation\\HeredocToNowdocFixer <./../src/Fixer/StringNotation/HeredocToNowdocFixer.php>`_
 -  `implode_call <./rules/function_notation/implode_call.rst>`_
@@ -1130,7 +1130,7 @@ List of Available Rules
 
    Method chaining MUST be properly indented. Method chaining with different levels of indentation is not supported.
 
-   Part of rule set `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Whitespace\\MethodChainingIndentationFixer <./../src/Fixer/Whitespace/MethodChainingIndentationFixer.php>`_
 -  `modernize_strpos <./rules/alias/modernize_strpos.rst>`_
@@ -1528,7 +1528,7 @@ List of Available Rules
 
    Single-line whitespace before closing semicolon are prohibited.
 
-   Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Semicolon\\NoSinglelineWhitespaceBeforeSemicolonsFixer <./../src/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixer.php>`_
 -  `no_spaces_after_function_name <./rules/function_notation/no_spaces_after_function_name.rst>`_
@@ -1616,7 +1616,7 @@ List of Available Rules
      | Default value: ``['arguments', 'array_destructuring', 'array', 'group_import']``
 
 
-   Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Basic\\NoTrailingCommaInSinglelineFixer <./../src/Fixer/Basic/NoTrailingCommaInSinglelineFixer.php>`_
 -  `no_trailing_comma_in_singleline_array <./rules/array_notation/no_trailing_comma_in_singleline_array.rst>`_
@@ -2991,7 +2991,7 @@ List of Available Rules
      | Default value: ``['arrays']``
 
 
-   Part of rule sets `@PHP73Migration <./ruleSets/PHP73Migration.rst>`_ `@PHP74Migration <./ruleSets/PHP74Migration.rst>`_ `@PHP80Migration <./ruleSets/PHP80Migration.rst>`_ `@PHP81Migration <./ruleSets/PHP81Migration.rst>`_ `@PHP82Migration <./ruleSets/PHP82Migration.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PHP73Migration <./ruleSets/PHP73Migration.rst>`_ `@PHP74Migration <./ruleSets/PHP74Migration.rst>`_ `@PHP80Migration <./ruleSets/PHP80Migration.rst>`_ `@PHP81Migration <./ruleSets/PHP81Migration.rst>`_ `@PHP82Migration <./ruleSets/PHP82Migration.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ControlStructure\\TrailingCommaInMultilineFixer <./../src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php>`_
 -  `trim_array_spaces <./rules/array_notation/trim_array_spaces.rst>`_

--- a/doc/ruleSets/PER.rst
+++ b/doc/ruleSets/PER.rst
@@ -8,3 +8,11 @@ Rules
 -----
 
 - `@PSR12 <./PSR12.rst>`_
+- `heredoc_indentation <./../rules/whitespace/heredoc_indentation.rst>`_
+- `heredoc_to_nowdoc <./../rules/string_notation/heredoc_to_nowdoc.rst>`_
+- `method_chaining_indentation <./../rules/whitespace/method_chaining_indentation.rst>`_
+- `no_singleline_whitespace_before_semicolons <./../rules/semicolon/no_singleline_whitespace_before_semicolons.rst>`_
+- `no_trailing_comma_in_singleline <./../rules/basic/no_trailing_comma_in_singleline.rst>`_
+- `trailing_comma_in_multiline <./../rules/control_structure/trailing_comma_in_multiline.rst>`_
+  config:
+  ``['after_heredoc' => true, 'elements' => ['arguments', 'arrays', 'match', 'parameters']]``

--- a/doc/rules/basic/no_trailing_comma_in_singleline.rst
+++ b/doc/rules/basic/no_trailing_comma_in_singleline.rst
@@ -58,6 +58,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``no_trailing_comma_in_singleline`` rule with the default config.
+
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``no_trailing_comma_in_singleline`` rule with the default config.
 

--- a/doc/rules/control_structure/trailing_comma_in_multiline.rst
+++ b/doc/rules/control_structure/trailing_comma_in_multiline.rst
@@ -103,6 +103,11 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``trailing_comma_in_multiline`` rule with the config below:
+
+  ``['after_heredoc' => true, 'elements' => ['arguments', 'arrays', 'match', 'parameters']]``
+
 @PHP73Migration
   Using the `@PHP73Migration <./../../ruleSets/PHP73Migration.rst>`_ rule set will enable the ``trailing_comma_in_multiline`` rule with the config below:
 

--- a/doc/rules/semicolon/no_singleline_whitespace_before_semicolons.rst
+++ b/doc/rules/semicolon/no_singleline_whitespace_before_semicolons.rst
@@ -22,6 +22,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``no_singleline_whitespace_before_semicolons`` rule.
+
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``no_singleline_whitespace_before_semicolons`` rule.
 

--- a/doc/rules/string_notation/heredoc_to_nowdoc.rst
+++ b/doc/rules/string_notation/heredoc_to_nowdoc.rst
@@ -22,7 +22,10 @@ Example #1
 Rule sets
 ---------
 
-The rule is part of the following rule set:
+The rule is part of the following rule sets:
+
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``heredoc_to_nowdoc`` rule.
 
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``heredoc_to_nowdoc`` rule.

--- a/doc/rules/whitespace/heredoc_indentation.rst
+++ b/doc/rules/whitespace/heredoc_indentation.rst
@@ -79,6 +79,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``heredoc_indentation`` rule with the default config.
+
 @PHP73Migration
   Using the `@PHP73Migration <./../../ruleSets/PHP73Migration.rst>`_ rule set will enable the ``heredoc_indentation`` rule with the default config.
 
@@ -93,3 +96,6 @@ The rule is part of the following rule sets:
 
 @PHP82Migration
   Using the `@PHP82Migration <./../../ruleSets/PHP82Migration.rst>`_ rule set will enable the ``heredoc_indentation`` rule with the default config.
+
+@PhpCsFixer
+  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``heredoc_indentation`` rule with the default config.

--- a/doc/rules/whitespace/method_chaining_indentation.rst
+++ b/doc/rules/whitespace/method_chaining_indentation.rst
@@ -23,7 +23,10 @@ Example #1
 Rule sets
 ---------
 
-The rule is part of the following rule set:
+The rule is part of the following rule sets:
+
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``method_chaining_indentation`` rule.
 
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``method_chaining_indentation`` rule.

--- a/src/RuleSet/Sets/PERRiskySet.php
+++ b/src/RuleSet/Sets/PERRiskySet.php
@@ -19,7 +19,7 @@ use PhpCsFixer\RuleSet\AbstractRuleSetDescription;
 /**
  * @internal
  *
- * Last updated to PER Coding Style v1.0.0.
+ * Last updated to PER Coding Style v1.1.0.
  */
 final class PERRiskySet extends AbstractRuleSetDescription
 {

--- a/src/RuleSet/Sets/PERSet.php
+++ b/src/RuleSet/Sets/PERSet.php
@@ -19,7 +19,7 @@ use PhpCsFixer\RuleSet\AbstractRuleSetDescription;
 /**
  * @internal
  *
- * Last updated to PER Coding Style v1.0.0.
+ * Last updated to PER Coding Style v1.1.0.
  */
 final class PERSet extends AbstractRuleSetDescription
 {
@@ -27,6 +27,15 @@ final class PERSet extends AbstractRuleSetDescription
     {
         return [
             '@PSR12' => true,
+            'heredoc_indentation' => true,
+            'heredoc_to_nowdoc' => true,
+            'method_chaining_indentation' => true,
+            'no_singleline_whitespace_before_semicolons' => true,
+            'no_trailing_comma_in_singleline' => true,
+            'trailing_comma_in_multiline' => [
+                'after_heredoc' => true,
+                'elements' => ['arguments', 'arrays', 'match', 'parameters'],
+            ],
         ];
     }
 

--- a/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
+++ b/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
@@ -33,13 +33,13 @@ final class TrailingCommaInMultilineFixerTest extends AbstractFixerTestCase
      *
      * @dataProvider provideInvalidConfigurationCases
      *
-     * @param mixed $exceptionMessega
+     * @param mixed $exceptionMessage
      * @param mixed $configuration
      */
-    public function testInvalidConfiguration($exceptionMessega, $configuration): void
+    public function testInvalidConfiguration($exceptionMessage, $configuration): void
     {
         $this->expectException(InvalidForEnvFixerConfigurationException::class);
-        $this->expectExceptionMessage($exceptionMessega);
+        $this->expectExceptionMessage($exceptionMessage);
 
         $this->fixer->configure($configuration);
     }

--- a/tests/Fixtures/Integration/set/@PER.test
+++ b/tests/Fixtures/Integration/set/@PER.test
@@ -1,0 +1,4 @@
+--TEST--
+Integration of @PER.
+--RULESET--
+{"@PER": true}

--- a/tests/Fixtures/Integration/set/@PER.test-in.php
+++ b/tests/Fixtures/Integration/set/@PER.test-in.php
@@ -1,0 +1,60 @@
+<?php
+
+abstract class PER
+{
+    static
+    protected string $keywords;
+
+    static  public
+    abstract function keywords();
+
+    public function heredocAndNowdoc()
+    {
+        $notAllowed = <<<COUNTEREXAMPLE
+Wrong indentation.
+Also, should be nowdoc.
+COUNTEREXAMPLE;
+    }
+
+    public function shortClosures()
+    {
+        $identity =fn(int $x) :int=>$x ;
+
+        $sum = fn (int $x, int $y): int =>
+        $x + $y
+        ;
+    }
+
+    public function trailingCommas()
+    {
+        $min = min(3, M_PI,);
+        $min = min(
+            3,
+            M_PI
+        );
+
+        [$foo, $bar,] = ['foo', 'bar',];
+        [
+            $foo,
+            $bar
+        ] = [
+            'foo',
+            'bar'
+        ];
+
+        list($foo, $bar,) = array('foo', 'bar',);
+        list(
+            $foo,
+            $bar
+        ) = array(
+            'foo',
+            'bar'
+        );
+    }
+
+    public function chaining()
+    {
+        $this->foo()
+        ->bar()->baz();
+    }
+}

--- a/tests/Fixtures/Integration/set/@PER.test-out.php
+++ b/tests/Fixtures/Integration/set/@PER.test-out.php
@@ -1,0 +1,59 @@
+<?php
+
+abstract class PER
+{
+    protected static string $keywords;
+
+    abstract public static function keywords();
+
+    public function heredocAndNowdoc()
+    {
+        $notAllowed = <<<'COUNTEREXAMPLE'
+            Wrong indentation.
+            Also, should be nowdoc.
+            COUNTEREXAMPLE;
+    }
+
+    public function shortClosures()
+    {
+        $identity = fn (int $x): int => $x;
+
+        $sum = fn (int $x, int $y): int
+            => $x + $y;
+    }
+
+    public function trailingCommas()
+    {
+        $min = min(3, M_PI);
+        $min = min(
+            3,
+            M_PI,
+        );
+
+        [$foo, $bar] = ['foo', 'bar'];
+        [
+            $foo,
+            $bar,
+        ] = [
+            'foo',
+            'bar',
+        ];
+
+        list($foo, $bar) = array('foo', 'bar');
+        list(
+            $foo,
+            $bar,
+        ) = array(
+            'foo',
+            'bar',
+        );
+    }
+
+    public function chaining()
+    {
+        $this
+            ->foo()
+            ->bar()
+            ->baz();
+    }
+}

--- a/tests/Fixtures/Integration/set/@PER_php80.test
+++ b/tests/Fixtures/Integration/set/@PER_php80.test
@@ -1,0 +1,4 @@
+--TEST--
+Integration of @PER [PHP 8.0 version].
+--RULESET--
+{"@PER": true}

--- a/tests/Fixtures/Integration/set/@PER_php80.test-in.php
+++ b/tests/Fixtures/Integration/set/@PER_php80.test-in.php
@@ -1,0 +1,18 @@
+<?php
+
+class PER80
+{
+    public function trailingCommas(
+        int|float $num
+    ) {
+        $match = match ($num) {
+            3 => 'three',
+            M_PI => 'pi',
+            default => 'other'
+        };
+
+        $sum = fn (int $x,
+                   int $y
+        ) => $x + $y;
+    }
+}

--- a/tests/Fixtures/Integration/set/@PER_php80.test-out.php
+++ b/tests/Fixtures/Integration/set/@PER_php80.test-out.php
@@ -1,0 +1,19 @@
+<?php
+
+class PER80
+{
+    public function trailingCommas(
+        int|float $num,
+    ) {
+        $match = match ($num) {
+            3 => 'three',
+            M_PI => 'pi',
+            default => 'other',
+        };
+
+        $sum = fn (
+            int $x,
+            int $y,
+        ) => $x + $y;
+    }
+}

--- a/tests/Fixtures/Integration/set/@PER_php81.test
+++ b/tests/Fixtures/Integration/set/@PER_php81.test
@@ -1,0 +1,4 @@
+--TEST--
+Integration of @PER [PHP 8.1 version].
+--RULESET--
+{"@PER": true}

--- a/tests/Fixtures/Integration/set/@PER_php81.test-in.php
+++ b/tests/Fixtures/Integration/set/@PER_php81.test-in.php
@@ -1,0 +1,20 @@
+<?php
+
+class PER80
+{
+    readonly public \DateTime $keywords;
+
+    public function firstClassCallables()
+    {
+        foo( ... );
+    }
+}
+
+enum  Suit :string{
+    case Hearts = 'H';case Diamonds = 'D';
+    case Spades = 'S';case Clubs = 'C';
+
+    protected function foo(): void
+    {
+    }
+}

--- a/tests/Fixtures/Integration/set/@PER_php81.test-out.php
+++ b/tests/Fixtures/Integration/set/@PER_php81.test-out.php
@@ -1,0 +1,23 @@
+<?php
+
+class PER80
+{
+    public readonly \DateTime $keywords;
+
+    public function firstClassCallables()
+    {
+        foo(...);
+    }
+}
+
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Spades = 'S';
+    case Clubs = 'C';
+
+    private function foo(): void
+    {
+    }
+}

--- a/tests/RuleSet/RuleSetsTest.php
+++ b/tests/RuleSet/RuleSetsTest.php
@@ -65,7 +65,6 @@ final class RuleSetsTest extends TestCase
     public function testHasIntegrationTest(string $setDefinitionName): void
     {
         $setsWithoutTests = [
-            '@PER',
             '@PER:risky',
             '@PHP56Migration',
             '@PHP56Migration:risky',


### PR DESCRIPTION
- [ ] `protected_to_private`, but for enums only
- [ ] `no_singleline_whitespace_before_semicolons`, but for arrow functions only
- [ ] #6518
- [x] #6529
- [ ] `fn` and `=>` must be surrounded by a space
- [ ] In multiline arrow functions, `=>` must be placed after a new line
- [ ] `=>` must be indented once when placed after a new line
- [ ] Method chaining must be fully multiline, with the first item on a new line
