### PR TITLE
minor: [BinaryOperatorFixer] Deprecate single_space option in favor of single_space_minimal

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -73,8 +73,8 @@ List of Available Rules
 
    - | ``default``
      | Default fix strategy.
-     | Allowed values: ``'align'``, ``'align_single_space'``, ``'align_single_space_minimal'``, ``'no_space'``, ``'single_space'``, ``null``
-     | Default value: ``'single_space'``
+     | Allowed values: ``'align'``, ``'align_single_space'``, ``'align_single_space_minimal'``, ``'no_space'``, ``'single_space'``, ``'single_space_minimal'``, ``null``
+     | Default value: ``'single_space_minimal'``
    - | ``operators``
      | Dictionary of `binary operator` => `fix strategy` values that differ from the default strategy. Supported are: `=`, `*`, `/`, `%`, `<`, `>`, `|`, `^`, `+`, `-`, `&`, `&=`, `&&`, `||`, `.=`, `/=`, `=>`, `==`, `>=`, `===`, `!=`, `<>`, `!==`, `<=`, `and`, `or`, `xor`, `-=`, `%=`, `*=`, `|=`, `+=`, `<<`, `<<=`, `>>`, `>>=`, `^=`, `**`, `**=`, `<=>`, `??`, `??=`
      | Allowed types: ``array``

--- a/doc/rules/operator/binary_operator_spaces.rst
+++ b/doc/rules/operator/binary_operator_spaces.rst
@@ -12,9 +12,9 @@ Configuration
 
 Default fix strategy.
 
-Allowed values: ``'align'``, ``'align_single_space'``, ``'align_single_space_minimal'``, ``'no_space'``, ``'single_space'``, ``null``
+Allowed values: ``'align'``, ``'align_single_space'``, ``'align_single_space_minimal'``, ``'no_space'``, ``'single_space'``, ``'single_space_minimal'``, ``null``
 
-Default value: ``'single_space'``
+Default value: ``'single_space_minimal'``
 
 ``operators``
 ~~~~~~~~~~~~~
@@ -117,7 +117,7 @@ With configuration: ``['operators' => ['|' => 'no_space']]``.
 Example #6
 ~~~~~~~~~~
 
-With configuration: ``['operators' => ['=>' => 'single_space']]``.
+With configuration: ``['operators' => ['=>' => 'single_space_minimal']]``.
 
 .. code-block:: diff
 

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -36,8 +36,15 @@ final class BinaryOperatorSpacesFixer extends AbstractFixer implements Configura
 {
     /**
      * @internal
+     *
+     * TODO: 4.0 - Remove this constant
      */
     public const SINGLE_SPACE = 'single_space';
+
+    /**
+     * @internal
+     */
+    public const SINGLE_SPACE_MINIMAL = 'single_space_minimal';
 
     /**
      * @internal
@@ -135,6 +142,7 @@ final class BinaryOperatorSpacesFixer extends AbstractFixer implements Configura
         self::ALIGN_SINGLE_SPACE,
         self::ALIGN_SINGLE_SPACE_MINIMAL,
         self::SINGLE_SPACE,
+        self::SINGLE_SPACE_MINIMAL,
         self::NO_SPACE,
         null,
     ];
@@ -213,7 +221,7 @@ $array = [
     "baaaaaaaaaaar"  =>  11,
 ];
 ',
-                    ['operators' => ['=>' => 'single_space']]
+                    ['operators' => ['=>' => 'single_space_minimal']]
                 ),
                 new CodeSample(
                     '<?php
@@ -304,7 +312,7 @@ $array = [
     {
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('default', 'Default fix strategy.'))
-                ->setDefault(self::SINGLE_SPACE)
+                ->setDefault(self::SINGLE_SPACE_MINIMAL)
                 ->setAllowedValues(self::$allowedValues)
                 ->getOption(),
             (new FixerOptionBuilder('operators', 'Dictionary of `binary operator` => `fix strategy` values that differ from the default strategy. Supported are: `'.implode('`, `', self::SUPPORTED_OPERATORS).'`'))
@@ -348,8 +356,11 @@ $array = [
             return; // not configured to be changed
         }
 
-        if (self::SINGLE_SPACE === $this->operators[$tokenContent]) {
-            $this->fixWhiteSpaceAroundOperatorToSingleSpace($tokens, $index);
+        if (
+            self::SINGLE_SPACE === $this->operators[$tokenContent]
+            || self::SINGLE_SPACE_MINIMAL === $this->operators[$tokenContent]
+        ) {
+            $this->fixWhiteSpaceAroundOperatorToSingleSpaceMinimal($tokens, $index);
 
             return;
         }
@@ -379,7 +390,7 @@ $array = [
         $tokens->insertAt($index + 1, new Token([T_WHITESPACE, ' ']));
     }
 
-    private function fixWhiteSpaceAroundOperatorToSingleSpace(Tokens $tokens, int $index): void
+    private function fixWhiteSpaceAroundOperatorToSingleSpaceMinimal(Tokens $tokens, int $index): void
     {
         // fix white space after operator
         if ($tokens[$index + 1]->isWhitespace()) {

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -125,7 +125,7 @@ $a//
 $a//
      =  1;
                 ',
-                ['operators' => ['=' => BinaryOperatorSpacesFixer::SINGLE_SPACE]],
+                ['operators' => ['=' => BinaryOperatorSpacesFixer::SINGLE_SPACE_MINIMAL]],
             ],
             [
                 '<?php
@@ -253,7 +253,7 @@ $a//
                 ',
                 [
                     'operators' => [
-                        'and' => BinaryOperatorSpacesFixer::SINGLE_SPACE,
+                        'and' => BinaryOperatorSpacesFixer::SINGLE_SPACE_MINIMAL,
                         '*=' => BinaryOperatorSpacesFixer::ALIGN,
                         'or' => null,
                     ],
@@ -404,7 +404,7 @@ $a//
                 ',
                 [
                     'default' => BinaryOperatorSpacesFixer::NO_SPACE,
-                    'operators' => ['=' => BinaryOperatorSpacesFixer::SINGLE_SPACE],
+                    'operators' => ['=' => BinaryOperatorSpacesFixer::SINGLE_SPACE_MINIMAL],
                 ],
             ],
             [
@@ -417,7 +417,7 @@ $a//
                 [
                     'default' => null,
                     'operators' => [
-                        '=' => BinaryOperatorSpacesFixer::SINGLE_SPACE,
+                        '=' => BinaryOperatorSpacesFixer::SINGLE_SPACE_MINIMAL,
                         '|' => BinaryOperatorSpacesFixer::NO_SPACE,
                     ],
                 ],


### PR DESCRIPTION
Related to https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4396

`single_space` currently means "Exactly one space"
`align_single_space` means "At least one space"
`aligne_single_space_minimal` means "Exactly one space"

I think we should rename `single_space` to `single_space_minimal`.

In 4.0, `single_space` can be newly implemented to `at least one space`.