### PR TITLE
feat: Introduce `AlignEnumValuesFixer`

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2,6 +2,11 @@
 List of Available Rules
 =======================
 
+-  `align_enum_values <./rules/whitespace/align_enum_values.rst>`_
+
+   Align enum values on the ``=`` operator.
+
+   `Source PhpCsFixer\\Fixer\\Whitespace\\AlignEnumValuesFixer <./../src/Fixer/Whitespace/AlignEnumValuesFixer.php>`_
 -  `align_multiline_comment <./rules/phpdoc/align_multiline_comment.rst>`_
 
    Each line of multi-line DocComments must have an asterisk [PSR-5] and must be aligned with the first one.

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -862,6 +862,9 @@ String Notation
 Whitespace
 ----------
 
+- `align_enum_values <./whitespace/align_enum_values.rst>`_
+
+  Align enum values on the ``=`` operator.
 - `array_indentation <./whitespace/array_indentation.rst>`_
 
   Each element of an array must be indented exactly once.

--- a/doc/rules/whitespace/align_enum_values.rst
+++ b/doc/rules/whitespace/align_enum_values.rst
@@ -1,0 +1,41 @@
+==========================
+Rule ``align_enum_values``
+==========================
+
+Align enum values on the ``=`` operator.
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php enum MyEnum: string
+    {
+   -    case AB = 'ab';
+   -    case C = 'c';
+   +    case AB    = 'ab';
+   +    case C     = 'c';
+        case DEFGH = 'defgh';
+    }
+
+Example #2
+~~~~~~~~~~
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php enum MyEnum: int
+    {
+   -    case BENJI          = 1;
+   -    case ELIZABETH      = 2;
+   -    case CORA           = 4;
+   +    case BENJI     = 1;
+   +    case ELIZABETH = 2;
+   +    case CORA      = 4;
+    }

--- a/src/Fixer/Whitespace/AlignEnumValuesFixer.php
+++ b/src/Fixer/Whitespace/AlignEnumValuesFixer.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Whitespace;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+
+final class AlignEnumValuesFixer extends AbstractFixer
+{
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Align enum values on the `=` operator.',
+            [
+                new CodeSample("<?php enum MyEnum: string
+{
+    case AB = 'ab';
+    case C = 'c';
+    case DEFGH = 'defgh';
+}
+"),
+                new CodeSample('<?php enum MyEnum: int
+{
+    case BENJI          = 1;
+    case ELIZABETH      = 2;
+    case CORA           = 4;
+}
+'),
+            ],
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        // @TODO: drop condition when PHP 8.1+ is required
+        if (!\defined('T_ENUM')) {
+            return false;
+        }
+
+        return $tokens->isTokenKindFound(T_ENUM);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        $tokenAnalyzer = new TokensAnalyzer($tokens);
+
+        // Ignore first & last indexes.
+        for ($index = 1; $index < \count($tokens); ++$index) {
+            /** @var Token $token */
+            $token = $tokens[$index];
+            if ($token->isGivenKind(T_ENUM)) {
+                $enumNameTokenIndex = $tokens->getNextMeaningfulToken($index);
+                $nextToEnumNameTokenIndex = $tokens->getNextMeaningfulToken($enumNameTokenIndex);
+
+                /** @var Token $nextToEnumNameToken */
+                $nextToEnumNameToken = $tokens[$nextToEnumNameTokenIndex];
+                if (!$nextToEnumNameToken->isGivenKind(CT::T_TYPE_COLON)) {
+                    // This is NOT a backed enum, jump to the end of the block.
+                    $blockType = Tokens::detectBlockType($nextToEnumNameToken);
+                    $index = $tokens->findBlockEnd($blockType['type'], $nextToEnumNameTokenIndex);
+
+                    continue;
+                }
+                $enumTypeTokenIndex = $tokens->getNextMeaningfulToken($nextToEnumNameTokenIndex);
+                $startBlockTokenIndex = $tokens->getNextMeaningfulToken($enumTypeTokenIndex);
+                if (!$tokenAnalyzer->isBlockMultiline($tokens, $startBlockTokenIndex)) {
+                    // This enum is a single line enum, jump to the end of the block.
+                    $blockType = Tokens::detectBlockType($tokens[$startBlockTokenIndex]);
+                    $index = $tokens->findBlockEnd($blockType['type'], $startBlockTokenIndex);
+
+                    continue;
+                }
+                $blockType = Tokens::detectBlockType($tokens[$startBlockTokenIndex]);
+                $endBlockTokenIndex = $tokens->findBlockEnd($blockType['type'], $startBlockTokenIndex);
+
+                $this->handleEnumBlock($tokens, $startBlockTokenIndex, $endBlockTokenIndex);
+                $index = $endBlockTokenIndex;
+            }
+        }
+    }
+
+    private function handleEnumBlock(Tokens $tokens, int $startIndex, int $endIndex): void
+    {
+        $maxLength = 0;
+        $enumCases = [];
+
+        // Ignore block indexes and first & last indexes within the block.
+        for ($index = $startIndex + 2; $index < $endIndex - 1; ++$index) {
+            if ('=' === $tokens[$index]->getContent()) {
+                $caseNameTokenIndex = $tokens->getPrevMeaningfulToken($index);
+
+                /** @var Token $caseNameToken */
+                $caseNameToken = $tokens[$caseNameTokenIndex];
+                if (!$caseNameToken->isGivenKind(T_STRING)) {
+                    throw new \LogicException('Should be a case value token.');
+                }
+                $caseNameLength = mb_strlen($caseNameToken->getContent());
+                if ($caseNameLength > $maxLength) {
+                    $maxLength = $caseNameLength;
+                }
+
+                $enumCases[] = [
+                    'length' => $caseNameLength,
+                    'spacingIndex' => $index - 1,
+                ];
+            }
+        }
+
+        foreach ($enumCases as $enumCase) {
+            self::replaceSpacingToken($tokens, $enumCase['spacingIndex'], $maxLength - $enumCase['length'] + 1);
+        }
+    }
+
+    private static function replaceSpacingToken(Tokens $tokens, int $index, int $spacingLength): void
+    {
+        $spacingContent = str_repeat(' ', $spacingLength);
+        if ($tokens[$index]->isGivenKind(T_WHITESPACE) && $tokens[$index]->getContent() === $spacingContent) {
+            // Spacing token is already well formatted. Avoid changing it.
+            return;
+        }
+
+        $tokens[$index] = new Token([T_WHITESPACE, $spacingContent]);
+    }
+}

--- a/tests/Fixer/Whitespace/AlignEnumValuesFixerTest.php
+++ b/tests/Fixer/Whitespace/AlignEnumValuesFixerTest.php
@@ -21,22 +21,19 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  *
  * @internal
  *
- * @covers \PhpCsFixer\Fixer\Comment\RemoveCommentsFixer
+ * @covers \PhpCsFixer\Fixer\Whitespace\AlignEnumValuesFixer
  */
 final class AlignEnumValuesFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @param string      $expected
-     * @param null|string $input
-     *
      * @dataProvider provideFixCases
      */
-    public function testFix($expected, $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases()
+    public function provideFixCases(): array
     {
         return [
             // Test already well formatted enum.
@@ -77,6 +74,25 @@ final class AlignEnumValuesFixerTest extends AbstractFixerTestCase
     = 1;
     case ELIZABETH = 2;
     case CORA = 4;
+}',
+            ],
+            // Test enum with empty lines.
+            [
+                '<?php enum MyEnum: int
+{
+    case BENJI     = 1;
+
+    case ELIZABETH = 2;
+
+    case CORA      = 4;
+}',
+                '<?php enum MyEnum: int
+{
+    case BENJI = 1;
+
+    case ELIZABETH = 2;
+
+    case CORA               = 4;
 }',
             ],
             // Test non-backed enum.

--- a/tests/Fixer/Whitespace/AlignEnumValuesFixerTest.php
+++ b/tests/Fixer/Whitespace/AlignEnumValuesFixerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Whitespace;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Kévin Pérais <vinorcola@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Comment\RemoveCommentsFixer
+ */
+final class AlignEnumValuesFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            // Test already well formatted enum.
+            [
+                "<?php enum MyEnum: string
+{
+    case AB    = 'ab';
+    case C     = 'c';
+    case DEFGH = 'defgh';
+}",
+            ],
+            // Test string backed enum.
+            [
+                "<?php enum MyEnum: string
+{
+    case AB    = 'ab';
+    case C     = 'c';
+    case DEFGH = 'defgh';
+}",
+                "<?php enum MyEnum: string
+{
+    case AB = 'ab';
+    case C = 'c';
+    case DEFGH = 'defgh';
+}",
+            ],
+            // Test int backed enum.
+            [
+                '<?php enum MyEnum: int
+{
+    case BENJI     = 1;
+    case ELIZABETH = 2;
+    case CORA      = 4;
+}',
+                '<?php enum MyEnum: int
+{
+    case BENJI
+    = 1;
+    case ELIZABETH = 2;
+    case CORA = 4;
+}',
+            ],
+            // Test non-backed enum.
+            [
+                '<?php enum MyEnum
+{
+    case ADIOS;
+    case AMIGOS;
+    case FOREVER;
+}',
+            ],
+            // Test inline backed enum.
+            [
+                '<?php enum MyEnum: int { case BENJI = 1; case ELIZABETH = 2; case CORA = 4; }',
+            ],
+            // Test backed enum with several cases on the same line.
+            // @todo This test fails, but should that case be tested? The enum should be formatted before by another rule
+            //            [
+            //                "<?php enum MyEnum: int
+            // {
+            //    case BENJI     = 1;
+            //    case ELIZABETH = 2;
+            //    case CORA      = 4;
+            // }",
+            //                "<?php enum MyEnum: int
+            // {
+            //    case BENJI = 1; case ELIZABETH = 2;
+            //    case CORA = 4;
+            // }",
+            //            ],
+            // Test several enums.
+            [
+                "<?php enum MyEnum: string
+{
+    case AB    = 'ab';
+    case C     = 'c';
+    case DEFGH = 'defgh';
+}
+
+enum MyOtherEnum
+{
+    case ADIOS;
+    case AMIGOS;
+    case FOREVER;
+}
+
+enum MyNamedEnum: int
+{
+    case BENJI     = 1;
+    case ELIZABETH = 2;
+    case CORA      = 4;
+}",
+                "<?php enum MyEnum: string
+{
+    case AB = 'ab';
+    case C = 'c';
+    case DEFGH = 'defgh';
+}
+
+enum MyOtherEnum
+{
+    case ADIOS;
+    case AMIGOS;
+    case FOREVER;
+}
+
+enum MyNamedEnum: int
+{
+    case BENJI = 1;
+    case ELIZABETH = 2;
+    case CORA = 4;
+}",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Hi there,

My first PR to PHP-CS-Fixer, please give advises on anything that can be enhanced.

Creation of a new rule to allow to align PHP 8.1's backed enum values:

Changes:
```php
enum MyEnum: string
{
    case AB = 'ab';
    case C = 'c';
    case DEFGH = 'defgh';
}
```

To:
```php
enum MyEnum: string
{
    case AB    = 'ab';
    case C     = 'c';
    case DEFGH = 'defgh';
}
```