### PR TITLE
feature: OrderedTypesFixer - Introduction

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1950,6 +1950,23 @@ List of Available Rules
    Part of rule sets `@PhpCsFixer:risky <./ruleSets/PhpCsFixerRisky.rst>`_ `@Symfony:risky <./ruleSets/SymfonyRisky.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ClassNotation\\OrderedTraitsFixer <./../src/Fixer/ClassNotation/OrderedTraitsFixer.php>`_
+-  `ordered_types <./rules/class_notation/ordered_types.rst>`_
+
+   Sort union types and intersection types using configured order.
+
+   Configuration options:
+
+   - | ``sort_algorithm``
+     | The sorting algorithm to apply.
+     | Allowed values: ``'alpha'``, ``'none'``
+     | Default value: ``'alpha'``
+   - | ``null_adjustment``
+     | Forces the position of `null` (overrides `sort_algorithm`).
+     | Allowed values: ``'always_first'``, ``'always_last'``, ``'none'``
+     | Default value: ``'always_first'``
+
+
+   `Source PhpCsFixer\\Fixer\\ClassNotation\\OrderedTypesFixer <./../src/Fixer/ClassNotation/OrderedTypesFixer.php>`_
 -  `phpdoc_add_missing_param_annotation <./rules/phpdoc/phpdoc_add_missing_param_annotation.rst>`_
 
    PHPDoc should contain ``@param`` for all params.

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1957,7 +1957,7 @@ List of Available Rules
    Configuration options:
 
    - | ``sort_algorithm``
-     | The sorting algorithm to apply.
+     | Whether the types should be sorted alphabetically, or not sorted.
      | Allowed values: ``'alpha'``, ``'none'``
      | Default value: ``'alpha'``
    - | ``null_adjustment``

--- a/doc/rules/class_notation/ordered_types.rst
+++ b/doc/rules/class_notation/ordered_types.rst
@@ -1,0 +1,83 @@
+======================
+Rule ``ordered_types``
+======================
+
+Sort union types and intersection types using configured order.
+
+Configuration
+-------------
+
+``sort_algorithm``
+~~~~~~~~~~~~~~~~~~
+
+The sorting algorithm to apply.
+
+Allowed values: ``'alpha'``, ``'none'``
+
+Default value: ``'alpha'``
+
+``null_adjustment``
+~~~~~~~~~~~~~~~~~~~
+
+Forces the position of ``null`` (overrides ``sort_algorithm``).
+
+Allowed values: ``'always_first'``, ``'always_last'``, ``'none'``
+
+Default value: ``'always_first'``
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+*Default* configuration.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    try {
+        cache()->save($foo);
+   -} catch (\RuntimeException|CacheException $e) {
+   +} catch (CacheException|\RuntimeException $e) {
+        logger($e);
+
+        throw $e;
+    }
+
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['null_adjustment' => 'always_last']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    interface Foo
+    {
+   -    public function bar(null|string|int $foo): string|int;
+   +    public function bar(int|string|null $foo): int|string;
+
+   -    public function foo(\Stringable&\Countable $obj): int;
+   +    public function foo(\Countable&\Stringable $obj): int;
+    }
+
+Example #3
+~~~~~~~~~~
+
+With configuration: ``['sort_algorithm' => 'none', 'null_adjustment' => 'always_last']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    interface Bar
+    {
+   -    public function bar(null|string|int $foo): string|int;
+   +    public function bar(string|int|null $foo): string|int;
+    }

--- a/doc/rules/class_notation/ordered_types.rst
+++ b/doc/rules/class_notation/ordered_types.rst
@@ -10,7 +10,7 @@ Configuration
 ``sort_algorithm``
 ~~~~~~~~~~~~~~~~~~
 
-The sorting algorithm to apply.
+Whether the types should be sorted alphabetically, or not sorted.
 
 Allowed values: ``'alpha'``, ``'none'``
 

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -187,6 +187,9 @@ Class Notation
 - `ordered_traits <./class_notation/ordered_traits.rst>`_ *(risky)*
 
   Trait ``use`` statements must be sorted alphabetically.
+- `ordered_types <./class_notation/ordered_types.rst>`_
+
+  Sort union types and intersection types using configured order.
 - `protected_to_private <./class_notation/protected_to_private.rst>`_
 
   Converts ``protected`` variables and methods to ``private`` where possible.

--- a/src/Fixer/ClassNotation/OrderedTypesFixer.php
+++ b/src/Fixer/ClassNotation/OrderedTypesFixer.php
@@ -1,0 +1,428 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\ClassNotation;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Preg;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\TypeAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+
+/**
+ * @author John Paul E. Balandan, CPA <paulbalandan@gmail.com>
+ */
+final class OrderedTypesFixer extends AbstractFixer implements ConfigurableFixerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Sort union types and intersection types using configured order.',
+            [
+                new CodeSample(
+                    '<?php
+try {
+    cache()->save($foo);
+} catch (\RuntimeException|CacheException $e) {
+    logger($e);
+
+    throw $e;
+}
+'
+                ),
+                new VersionSpecificCodeSample(
+                    '<?php
+interface Foo
+{
+    public function bar(null|string|int $foo): string|int;
+
+    public function foo(\Stringable&\Countable $obj): int;
+}
+',
+                    new VersionSpecification(80100),
+                    ['null_adjustment' => 'always_last']
+                ),
+                new VersionSpecificCodeSample(
+                    '<?php
+interface Bar
+{
+    public function bar(null|string|int $foo): string|int;
+}
+',
+                    new VersionSpecification(80000),
+                    [
+                        'sort_algorithm' => 'none',
+                        'null_adjustment' => 'always_last',
+                    ]
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Must run before TypesSpacesFixer.
+     */
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound([CT::T_TYPE_ALTERNATION, CT::T_TYPE_INTERSECTION]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('sort_algorithm', 'The sorting algorithm to apply.'))
+                ->setAllowedValues(['alpha', 'none'])
+                ->setDefault('alpha')
+                ->getOption(),
+            (new FixerOptionBuilder('null_adjustment', 'Forces the position of `null` (overrides `sort_algorithm`).'))
+                ->setAllowedValues(['always_first', 'always_last', 'none'])
+                ->setDefault('always_first')
+                ->getOption(),
+        ]);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        $functionsAnalyzer = new FunctionsAnalyzer();
+
+        foreach ($this->getElements($tokens) as $index => $type) {
+            if ('catch' === $type) {
+                $this->fixCatchArgumentType($tokens, $index);
+
+                continue;
+            }
+
+            if ('property' === $type) {
+                $this->fixPropertyType($tokens, $index);
+
+                continue;
+            }
+
+            $this->fixMethodArgumentType($functionsAnalyzer, $tokens, $index);
+            $this->fixMethodReturnType($functionsAnalyzer, $tokens, $index);
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     *
+     * @phpstan-return array<int, 'catch'|'method'|'property'>
+     */
+    private function getElements(Tokens $tokens): array
+    {
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+
+        $elements = array_map(
+            static fn (array $element): string => $element['type'],
+            array_filter(
+                $tokensAnalyzer->getClassyElements(),
+                static fn (array $element): bool => \in_array($element['type'], ['method', 'property'], true)
+            )
+        );
+
+        foreach ($tokens as $index => $token) {
+            if ($token->isGivenKind(T_CATCH)) {
+                $elements[$index] = 'catch';
+
+                continue;
+            }
+
+            if (
+                $token->isGivenKind(T_FN)
+                || ($token->isGivenKind(T_FUNCTION) && !isset($elements[$index]))
+            ) {
+                $elements[$index] = 'method';
+            }
+        }
+
+        return $elements;
+    }
+
+    private function collectTypeAnalysis(Tokens $tokens, int $startIndex, int $endIndex): ?TypeAnalysis
+    {
+        $type = '';
+        $typeStartIndex = $tokens->getNextMeaningfulToken($startIndex);
+        $typeEndIndex = $typeStartIndex;
+
+        for ($i = $typeStartIndex; $i < $endIndex; ++$i) {
+            if ($tokens[$i]->isWhitespace() || $tokens[$i]->isComment()) {
+                continue;
+            }
+
+            $type .= $tokens[$i]->getContent();
+            $typeEndIndex = $i;
+        }
+
+        return '' !== $type ? new TypeAnalysis($type, $typeStartIndex, $typeEndIndex) : null;
+    }
+
+    private function fixCatchArgumentType(Tokens $tokens, int $index): void
+    {
+        $catchStart = $tokens->getNextTokenOfKind($index, ['(']);
+        $catchEnd = $tokens->getNextTokenOfKind($catchStart, [')', [T_VARIABLE]]);
+
+        $catchArgumentType = $this->collectTypeAnalysis($tokens, $catchStart, $catchEnd);
+
+        if (null === $catchArgumentType || !$this->isTypeSortable($catchArgumentType)) {
+            return; // nothing to fix
+        }
+
+        $this->sortTypes($catchArgumentType, $tokens);
+    }
+
+    private function fixPropertyType(Tokens $tokens, int $index): void
+    {
+        $propertyIndex = $index;
+        $propertyModifiers = [T_PRIVATE, T_PROTECTED, T_PUBLIC, T_STATIC, T_VAR];
+
+        if (\defined('T_READONLY')) {
+            $propertyModifiers[] = T_READONLY; // @TODO drop condition when PHP 8.1 is supported
+        }
+
+        do {
+            $index = $tokens->getPrevMeaningfulToken($index);
+        } while (!$tokens[$index]->isGivenKind($propertyModifiers));
+
+        $propertyType = $this->collectTypeAnalysis($tokens, $index, $propertyIndex);
+
+        if (null === $propertyType || !$this->isTypeSortable($propertyType)) {
+            return; // nothing to fix
+        }
+
+        $this->sortTypes($propertyType, $tokens);
+    }
+
+    private function fixMethodArgumentType(FunctionsAnalyzer $functionsAnalyzer, Tokens $tokens, int $index): void
+    {
+        foreach ($functionsAnalyzer->getFunctionArguments($tokens, $index) as $argumentInfo) {
+            $argumentType = $argumentInfo->getTypeAnalysis();
+
+            if (null === $argumentType || !$this->isTypeSortable($argumentType)) {
+                continue; // nothing to fix
+            }
+
+            $this->sortTypes($argumentType, $tokens);
+        }
+    }
+
+    private function fixMethodReturnType(FunctionsAnalyzer $functionsAnalyzer, Tokens $tokens, int $index): void
+    {
+        $returnType = $functionsAnalyzer->getFunctionReturnType($tokens, $index);
+
+        if (null === $returnType || !$this->isTypeSortable($returnType)) {
+            return; // nothing to fix
+        }
+
+        $this->sortTypes($returnType, $tokens);
+    }
+
+    private function sortTypes(TypeAnalysis $typeAnalysis, Tokens $tokens): void
+    {
+        $type = $typeAnalysis->getName();
+
+        if (str_contains($type, '|') && str_contains($type, '&')) {
+            // a DNF type of the form (A&B)|C, available as of PHP 8.2
+            [$originalTypes, $glue] = $this->collectDisjunctiveNormalFormTypes($type);
+        } else {
+            [$originalTypes, $glue] = $this->collectUnionOrIntersectionTypes($type);
+        }
+
+        // If the $types array is coming from a DNF type, then we have parts
+        // which are also array. If so, we sort those sub-types first before
+        // running the sorting algorithm to the entire $types array.
+        $sortedTypes = array_map(function ($subType) {
+            if (\is_array($subType)) {
+                return $this->runTypesThroughSortingAlgorithm($subType);
+            }
+
+            return $subType;
+        }, $originalTypes);
+
+        $sortedTypes = $this->runTypesThroughSortingAlgorithm($sortedTypes);
+
+        if ($sortedTypes === $originalTypes) {
+            return;
+        }
+
+        $tokens->overrideRange(
+            $typeAnalysis->getStartIndex(),
+            $typeAnalysis->getEndIndex(),
+            $this->createTypeDeclarationTokens($sortedTypes, $glue)
+        );
+    }
+
+    private function isTypeSortable(TypeAnalysis $type): bool
+    {
+        return str_contains($type->getName(), '|') || str_contains($type->getName(), '&');
+    }
+
+    /**
+     * @return array{0: array<string|string[]>, 1: string}
+     */
+    private function collectDisjunctiveNormalFormTypes(string $type): array
+    {
+        $types = array_map(static function ($subType) {
+            if (str_starts_with($subType, '(')) {
+                return explode('&', trim($subType, '()'));
+            }
+
+            return $subType;
+        }, explode('|', $type));
+
+        return [$types, '|'];
+    }
+
+    /**
+     * @return array{0: string[], 1: string}
+     */
+    private function collectUnionOrIntersectionTypes(string $type): array
+    {
+        $types = explode('|', $type);
+        $glue = '|';
+
+        if (1 === \count($types)) {
+            $types = explode('&', $type);
+            $glue = '&';
+        }
+
+        return [$types, $glue];
+    }
+
+    /**
+     * @param array<string|string[]> $types
+     *
+     * @return array<string|string[]>
+     */
+    private function runTypesThroughSortingAlgorithm(array $types): array
+    {
+        $normalizeType = static fn (string $type): string => Preg::replace('/^\\\\?/', '', $type);
+
+        usort($types, function ($a, $b) use ($normalizeType): int {
+            if (\is_array($a)) {
+                $a = implode('&', $a);
+            }
+
+            if (\is_array($b)) {
+                $b = implode('&', $b);
+            }
+
+            $a = $normalizeType($a);
+            $b = $normalizeType($b);
+            $lowerCaseA = strtolower($a);
+            $lowerCaseB = strtolower($b);
+
+            if ('none' !== $this->configuration['null_adjustment']) {
+                if ('null' === $lowerCaseA && 'null' !== $lowerCaseB) {
+                    return 'always_last' === $this->configuration['null_adjustment'] ? 1 : -1;
+                }
+
+                if ('null' !== $lowerCaseA && 'null' === $lowerCaseB) {
+                    return 'always_last' === $this->configuration['null_adjustment'] ? -1 : 1;
+                }
+            }
+
+            if ('alpha' === $this->configuration['sort_algorithm']) {
+                return strcasecmp($a, $b);
+            }
+
+            return 0;
+        });
+
+        return $types;
+    }
+
+    /**
+     * @param array<int, string|string[]> $types
+     *
+     * @return array<int, Token>
+     */
+    private function createTypeDeclarationTokens(array $types, string $glue, bool $isDisjunctive = false): array
+    {
+        static $specialTypes = [
+            'array' => [CT::T_ARRAY_TYPEHINT, 'array'],
+            'callable' => [T_CALLABLE, 'callable'],
+            'static' => [T_STATIC, 'static'],
+        ];
+
+        static $glues = [
+            '|' => [CT::T_TYPE_ALTERNATION, '|'],
+            '&' => [CT::T_TYPE_INTERSECTION, '&'],
+        ];
+
+        $count = \count($types);
+        $newTokens = [];
+
+        foreach ($types as $i => $type) {
+            if (\is_array($type)) {
+                $newTokens = array_merge(
+                    $newTokens,
+                    $this->createTypeDeclarationTokens($type, '&', true)
+                );
+            } elseif (isset($specialTypes[$type])) {
+                $newTokens[] = new Token($specialTypes[$type]);
+            } else {
+                foreach (explode('\\', $type) as $nsIndex => $value) {
+                    if (0 === $nsIndex && '' === $value) {
+                        continue;
+                    }
+
+                    if ($nsIndex > 0) {
+                        $newTokens[] = new Token([T_NS_SEPARATOR, '\\']);
+                    }
+
+                    $newTokens[] = new Token([T_STRING, $value]);
+                }
+            }
+
+            if ($i <= $count - 2) {
+                $newTokens[] = new Token($glues[$glue]);
+            }
+        }
+
+        if ($isDisjunctive) {
+            array_unshift($newTokens, new Token([CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_OPEN, '(']));
+            $newTokens[] = new Token([CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_CLOSE, ')']);
+        }
+
+        return $newTokens;
+    }
+}

--- a/src/Fixer/ClassNotation/OrderedTypesFixer.php
+++ b/src/Fixer/ClassNotation/OrderedTypesFixer.php
@@ -109,7 +109,7 @@ interface Bar
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
         return new FixerConfigurationResolver([
-            (new FixerOptionBuilder('sort_algorithm', 'The sorting algorithm to apply.'))
+            (new FixerOptionBuilder('sort_algorithm', 'Whether the types should be sorted alphabetically, or not sorted.'))
                 ->setAllowedValues(['alpha', 'none'])
                 ->setDefault('alpha')
                 ->getOption(),

--- a/src/Fixer/Whitespace/TypesSpacesFixer.php
+++ b/src/Fixer/Whitespace/TypesSpacesFixer.php
@@ -65,6 +65,16 @@ final class TypesSpacesFixer extends AbstractFixer implements ConfigurableFixerI
 
     /**
      * {@inheritdoc}
+     *
+     * Must run after OrderedTypesFixer.
+     */
+    public function getPriority(): int
+    {
+        return -1;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function isCandidate(Tokens $tokens): bool
     {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -657,6 +657,9 @@ final class FixerFactoryTest extends TestCase
             'ordered_imports' => [
                 'blank_line_between_import_groups',
             ],
+            'ordered_types' => [
+                'types_spaces',
+            ],
             'php_unit_construct' => [
                 'php_unit_dedicate_assert',
             ],

--- a/tests/Fixer/ClassNotation/OrderedTypesFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedTypesFixerTest.php
@@ -146,6 +146,64 @@ try {
     }
 
     /**
+     * @dataProvider providePhp80Cases
+     *
+     * @param null|array<string, string> $config
+     *
+     * @requires PHP 8.0
+     */
+    public function testFixPhp80(string $expected, ?string $input = null, ?array $config = null): void
+    {
+        if (null !== $config) {
+            $this->fixer->configure($config);
+        }
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<(string|null|array<string, string>)[]>
+     */
+    public static function providePhp80Cases(): iterable
+    {
+        yield 'sort alpha, null none' => [
+            "<?php\nclass Foo\n{\n    public A|null|Z \$bar;\n}\n",
+            "<?php\nclass Foo\n{\n    public Z|null|A \$bar;\n}\n",
+            ['sort_algorithm' => 'alpha', 'null_adjustment' => 'none'],
+        ];
+
+        yield 'sort alpha, null first' => [
+            "<?php\nclass Foo\n{\n    public null|A|Z \$bar;\n}\n",
+            "<?php\nclass Foo\n{\n    public Z|null|A \$bar;\n}\n",
+            ['sort_algorithm' => 'alpha', 'null_adjustment' => 'always_first'],
+        ];
+
+        yield 'sort alpha, null last' => [
+            "<?php\nclass Foo\n{\n    public A|Z|null \$bar;\n}\n",
+            "<?php\nclass Foo\n{\n    public Z|null|A \$bar;\n}\n",
+            ['sort_algorithm' => 'alpha', 'null_adjustment' => 'always_last'],
+        ];
+
+        yield 'sort none, null first' => [
+            "<?php\nclass Foo\n{\n    public null|Z|A \$bar;\n}\n",
+            "<?php\nclass Foo\n{\n    public Z|null|A \$bar;\n}\n",
+            ['sort_algorithm' => 'none', 'null_adjustment' => 'always_first'],
+        ];
+
+        yield 'sort none, null last' => [
+            "<?php\nclass Foo\n{\n    public Z|A|null \$bar;\n}\n",
+            "<?php\nclass Foo\n{\n    public Z|null|A \$bar;\n}\n",
+            ['sort_algorithm' => 'none', 'null_adjustment' => 'always_last'],
+        ];
+
+        yield 'sort none, null none' => [
+            "<?php\nclass Foo\n{\n    public Z|null|A \$bar;\n}\n",
+            null,
+            ['sort_algorithm' => 'none', 'null_adjustment' => 'none'],
+        ];
+    }
+
+    /**
      * @dataProvider provideDefaultCases
      *
      * @requires PHP 8.0

--- a/tests/Fixer/ClassNotation/OrderedTypesFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedTypesFixerTest.php
@@ -1,0 +1,650 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\ClassNotation;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author John Paul E. Balandan, CPA <paulbalandan@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\ClassNotation\OrderedTypesFixer
+ */
+final class OrderedTypesFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     *
+     * @param null|array<string, string> $config
+     */
+    public function testFixCases(string $expected, ?string $input = null, ?array $config = null): void
+    {
+        if (null !== $config) {
+            $this->fixer->configure($config);
+        }
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string, string[]|(string|null|array<string, string>)[]>
+     */
+    public static function provideFixCases(): iterable
+    {
+        yield 'catch with default, no spaces, with both leading slash' => [
+            '<?php
+try {
+    $this->foo();
+} catch (\LogicException|\RuntimeException $e) {
+    // $e
+}
+',
+            '<?php
+try {
+    $this->foo();
+} catch (\RuntimeException|\LogicException $e) {
+    // $e
+}
+',
+        ];
+
+        yield 'catch with default, with spaces, with both leading slash' => [
+            '<?php
+try {
+    $this->foo();
+} catch (\LogicException|\RuntimeException $e) {
+    // $e
+}
+',
+            '<?php
+try {
+    $this->foo();
+} catch (\RuntimeException | \LogicException $e) {
+    // $e
+}
+',
+        ];
+
+        yield 'catch with default, no spaces, with no leading slash' => [
+            '<?php
+try {
+    cache()->save();
+} catch (CacheException|SimpleCacheException $e) {
+    // $e
+}
+',
+            '<?php
+try {
+    cache()->save();
+} catch (SimpleCacheException|CacheException $e) {
+    // $e
+}
+',
+        ];
+
+        yield 'catch with default, with spaces, with one leading slash' => [
+            '<?php
+try {
+    cache()->save();
+} catch (CacheException|\RuntimeException $e) {
+    // $e
+}
+',
+            '<?php
+try {
+    cache()->save();
+} catch (\RuntimeException | CacheException $e) {
+    // $e
+}
+',
+        ];
+
+        yield 'catch with no sorting' => [
+            '<?php
+try {
+    $this->foo();
+} catch (\RuntimeException|\LogicException $e) {
+    // $e
+}
+',
+            null,
+            ['sort_algorithm' => 'none'],
+        ];
+
+        yield 'nothing to fix' => [
+            '<?php
+try {
+    $this->foo();
+} catch (\LogicException $e) {
+    // $e
+}
+',
+        ];
+
+        yield 'already fixed' => [
+            '<?php
+try {
+    $this->foo();
+} catch (LogicException|RuntimeException $e) {
+    // $e
+}
+',
+        ];
+    }
+
+    /**
+     * @dataProvider provideDefaultCases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFixDefaultCases(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string[]|(string|null|array<string, string>)[]>
+     */
+    public static function provideDefaultCases(): iterable
+    {
+        yield [
+            "<?php\nclass Foo\n{\n    public null|int|string \$bar = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public string|null|int \$bar = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public null|A|B \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public B|A|null \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public null|\\A|B \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public B|\\A|null \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public null|\\A|\\B \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public \\B|\\A|null \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public null|int|string/* array */ \$bar = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public string|null|int/* array */ \$bar = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public /* int */null|A|B \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public /* int */B|A|null \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public     null|A|B     \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public     B|A|null     \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    private function bar(null|array|callable|int \$cb) {}\n}\n",
+            "<?php\nclass Foo\n{\n    private function bar(array|int|callable|null \$cb) {}\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    private function bar(\$cb): null|array|callable|int {}\n}\n",
+            "<?php\nclass Foo\n{\n    private function bar(\$cb): array|int|callable|null {}\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    private function bar(\$cb): null|static {}\n}\n",
+            "<?php\nclass Foo\n{\n    private function bar(\$cb): static|null {}\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public function bar(null|string \$str, null|array|int \$arr) {}\n}\n",
+            "<?php\nclass Foo\n{\n    public function bar(string|null \$str, int|array|null \$arr) {}\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public function bar(\\JsonSerializable|\\Stringable \$obj): array|int {}\n}\n",
+            "<?php\nclass Foo\n{\n    public function bar(\\Stringable|\\JsonSerializable \$obj): int|array {}\n}\n",
+        ];
+
+        yield [
+            '<?php function foo(null|int|string $bar): null|\Stringable {}',
+            '<?php function foo(string|int|null $bar): \Stringable|null {}',
+        ];
+
+        yield [
+            '<?php fn (null|\Countable|int $number): null|int => $number;',
+            '<?php fn (int|\Countable|null $number): int|null => $number;',
+        ];
+
+        yield [
+            "<?php\ntry {\n    foo();\n} catch (\\Error|\\TypeError) {\n}\n",
+            "<?php\ntry {\n    foo();\n} catch (\\TypeError|\\Error) {\n}\n",
+        ];
+
+        yield [
+            '<?php
+class Foo
+{
+    public ?string $foo = null;
+    public /* int|string */ $bar;
+    private null|array $baz = null;
+
+    public function baz(): null|string {}
+    protected function bar(string $str, ?array $config = null): callable {}
+}
+
+try {
+    (new Foo)->baz();
+} catch (Exception $e) {
+    return $e;
+}
+',
+        ];
+    }
+
+    /**
+     * @dataProvider provideAlphaAlgorithmAndNullAlwaysLastCases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFixWithAlphaAlgorithmAndNullAlwaysLast(string $expected, ?string $input = null): void
+    {
+        $this->fixer->configure([
+            'sort_algorithm' => 'alpha',
+            'null_adjustment' => 'always_last',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string[]|(string|null|string[])[]>
+     */
+    public static function provideAlphaAlgorithmAndNullAlwaysLastCases(): iterable
+    {
+        yield [
+            "<?php\nclass Foo\n{\n    public int|string|null \$bar = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public string|null|int \$bar = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public A|B|null \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public B|A|null \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public \\A|B|null \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public B|\\A|null \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public \\A|\\B|null \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public \\B|\\A|null \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public int|string|null/* array */ \$bar = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public string|null|int/* array */ \$bar = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public /* int */A|B|null \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public /* int */B|A|null \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public     A|B|null     \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public     B|A|null     \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    private function bar(array|callable|int|null \$cb) {}\n}\n",
+            "<?php\nclass Foo\n{\n    private function bar(array|int|callable|null \$cb) {}\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    private function bar(\$cb): array|callable|int|null {}\n}\n",
+            "<?php\nclass Foo\n{\n    private function bar(\$cb): array|int|callable|null {}\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    private function bar(\$cb): static|null {}\n}\n",
+            "<?php\nclass Foo\n{\n    private function bar(\$cb): null|static {}\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public function bar(string|null \$str, array|int|null \$arr) {}\n}\n",
+            "<?php\nclass Foo\n{\n    public function bar(string|null \$str, int|array|null \$arr) {}\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public function bar(\\JsonSerializable|\\Stringable \$obj): array|int {}\n}\n",
+            "<?php\nclass Foo\n{\n    public function bar(\\Stringable|\\JsonSerializable \$obj): int|array {}\n}\n",
+        ];
+
+        yield [
+            '<?php function foo(int|string|null $bar): \Stringable|null {}',
+            '<?php function foo(string|int|null $bar): \Stringable|null {}',
+        ];
+
+        yield [
+            '<?php fn (\Countable|int|null $number): int|null => $number;',
+            '<?php fn (int|\Countable|null $number): int|null => $number;',
+        ];
+
+        yield [
+            "<?php\ntry {\n    foo();\n} catch (\\Error|\\TypeError) {\n}\n",
+            "<?php\ntry {\n    foo();\n} catch (\\TypeError|\\Error) {\n}\n",
+        ];
+
+        yield [
+            '<?php
+class Foo
+{
+    public ?string $foo = null;
+    public /* int|string */ $bar;
+    private array|null $baz = null;
+
+    public function baz(): string|null {}
+    protected function bar(string $str, ?array $config = null): callable {}
+}
+
+try {
+    (new Foo)->baz();
+} catch (Exception $e) {
+    return $e;
+}
+',
+        ];
+    }
+
+    /**
+     * @dataProvider provideAlphaAlgorithmOnlyCases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFixWithAlphaAlgorithmOnly(string $expected, ?string $input = null): void
+    {
+        $this->fixer->configure([
+            'sort_algorithm' => 'alpha',
+            'null_adjustment' => 'none',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string[]|(string|null|array<string, string>)[]>
+     */
+    public static function provideAlphaAlgorithmOnlyCases(): iterable
+    {
+        yield [
+            "<?php\nclass Foo\n{\n    public int|null|string \$bar = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public string|null|int \$bar = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public A|B|null \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public B|A|null \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public \\A|B|null \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public B|\\A|null \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public \\A|\\B|null \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public \\B|\\A|null \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public int|null|string/* array */ \$bar = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public string|null|int/* array */ \$bar = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public /* int */A|B|null \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public /* int */B|A|null \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public     A|B|null     \$foo = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public     B|A|null     \$foo = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    private function bar(array|callable|int|null \$cb) {}\n}\n",
+            "<?php\nclass Foo\n{\n    private function bar(array|int|callable|null \$cb) {}\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    private function bar(\$cb): array|callable|int|null {}\n}\n",
+            "<?php\nclass Foo\n{\n    private function bar(\$cb): array|int|callable|null {}\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    private function bar(\$cb): null|static {}\n}\n",
+            "<?php\nclass Foo\n{\n    private function bar(\$cb): static|null {}\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public function bar(null|string \$str, array|int|null \$arr) {}\n}\n",
+            "<?php\nclass Foo\n{\n    public function bar(string|null \$str, int|array|null \$arr) {}\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public function bar(\\JsonSerializable|\\Stringable \$obj): array|int {}\n}\n",
+            "<?php\nclass Foo\n{\n    public function bar(\\Stringable|\\JsonSerializable \$obj): int|array {}\n}\n",
+        ];
+
+        yield [
+            '<?php function foo(int|null|string $bar): null|\Stringable {}',
+            '<?php function foo(string|int|null $bar): \Stringable|null {}',
+        ];
+
+        yield [
+            '<?php fn (\Countable|int|null $number): int|null => $number;',
+            '<?php fn (int|\Countable|null $number): int|null => $number;',
+        ];
+
+        yield [
+            "<?php\ntry {\n    foo();\n} catch (\\Error|\\TypeError) {\n}\n",
+            "<?php\ntry {\n    foo();\n} catch (\\TypeError|\\Error) {\n}\n",
+        ];
+
+        yield [
+            '<?php
+class Foo
+{
+    public ?string $foo = null;
+    public /* int|string */ $bar;
+    private array|null $baz = null;
+
+    public function baz(): null|string {}
+    protected function bar(string $str, ?array $config = null): callable {}
+}
+
+try {
+    (new Foo)->baz();
+} catch (Exception $e) {
+    return $e;
+}
+',
+        ];
+    }
+
+    /**
+     * @dataProvider provideSandwichedWhitespaceOrCommentInTypeCases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFixWithSandwichedWhitespaceOrCommentInType(string $expected, ?string $input = null): void
+    {
+        // The current design of the fixer uses the `TypeAnalysis` class which collects the
+        // types and ignores whitespaces and comments. These ignored tokens are not accounted
+        // during instantiation of the TypeAnalysis class, thus we have no way of recovering
+        // those token information. This test case mainly proves this fact.
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string[]|(string|null|array<string, string>)[]>
+     */
+    public static function provideSandwichedWhitespaceOrCommentInTypeCases(): iterable
+    {
+        yield [
+            "<?php\nclass Foo\n{\n    public null|int|string \$bar = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public string   |   null   |   int \$bar = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public null|int|string \$bar = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public string | null | int \$bar = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public null|int|string \$bar = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public string |/* array| */null|int \$bar = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    private function bar(\$cb): null|static {}\n}\n",
+            "<?php\nclass Foo\n{\n    private function bar(\$cb): static /* |int */ | null {}\n}\n",
+        ];
+    }
+
+    /**
+     * @dataProvider providePhp81Cases
+     *
+     * @param null|array<string, string> $config
+     *
+     * @requires PHP 8.1
+     */
+    public function testFixPhp81(string $expected, ?string $input = null, ?array $config = null): void
+    {
+        if (null !== $config) {
+            $this->fixer->configure($config);
+        }
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string[]|(string|null|array<string, string>)[]>
+     */
+    public static function providePhp81Cases(): iterable
+    {
+        yield [
+            "<?php\nclass Foo\n{\n    public A&B \$bar;\n}\n",
+            "<?php\nclass Foo\n{\n    public B&A \$bar;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public Ae&At \$bar;\n}\n",
+            "<?php\nclass Foo\n{\n    public At&Ae \$bar;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public readonly null|A|B \$bar;\n}\n",
+            "<?php\nclass Foo\n{\n    public readonly B|null|A \$bar;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public readonly A|B|null \$bar;\n}\n",
+            "<?php\nclass Foo\n{\n    public readonly B|null|A \$bar;\n}\n",
+            ['null_adjustment' => 'always_last'],
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public readonly A|null|X \$bar;\n}\n",
+            "<?php\nclass Foo\n{\n    public readonly X|A|null \$bar;\n}\n",
+            ['null_adjustment' => 'none'],
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public B&A \$bar;\n}\n",
+            null,
+            ['sort_algorithm' => 'none'],
+        ];
+    }
+
+    /**
+     * Provisional support for PHP 8.2's Disjunctive Normal Form (DNF) Types.
+     *
+     * @dataProvider providePhp82Cases
+     *
+     * @param null|array<string, string> $config
+     *
+     * @requires PHP 8.2
+     */
+    public function testFixPhp82(string $expected, ?string $input = null, ?array $config = null): void
+    {
+        if (null !== $config) {
+            $this->fixer->configure($config);
+        }
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string[]|(string|null|array<string, string>)[]>
+     */
+    public static function providePhp82Cases(): iterable
+    {
+        yield [
+            "<?php\nclass Foo\n{\n    public null|array|(At&Bz)|string \$bar = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public string|(Bz&At)|array|null \$bar = null;\n}\n",
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public array|(At&Bz)|string|null \$bar = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public string|(Bz&At)|array|null \$bar = null;\n}\n",
+            ['null_adjustment' => 'always_last'],
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public array|(At&Bz)|null|string \$bar = null;\n}\n",
+            "<?php\nclass Foo\n{\n    public string|(Bz&At)|array|null \$bar = null;\n}\n",
+            ['null_adjustment' => 'none'],
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public (A&B)|(A&C)|(B&D)|(C&D) \$bar;\n}\n",
+            "<?php\nclass Foo\n{\n    public (D&B)|(C&A)|(B&A)|(D&C) \$bar;\n}\n",
+            ['sort_algorithm' => 'alpha'],
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public (A&B)|(\\A&C)|(B&\\D)|(C&D) \$bar;\n}\n",
+            "<?php\nclass Foo\n{\n    public (\\D&B)|(C&\\A)|(B&A)|(D&C) \$bar;\n}\n",
+            ['sort_algorithm' => 'alpha'],
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public (A&C)|(B&D) \$bar;\n}\n",
+            "<?php\nclass Foo\n{\n    public (D&B)|(C&A) \$bar;\n}\n",
+            ['sort_algorithm' => 'alpha'],
+        ];
+
+        yield [
+            "<?php\nclass Foo\n{\n    public (\\A&\\C)|(\\B&\\D) \$bar;\n}\n",
+            "<?php\nclass Foo\n{\n    public (\\D&\\B)|(\\C&\\A) \$bar;\n}\n",
+            ['sort_algorithm' => 'alpha'],
+        ];
+    }
+}

--- a/tests/Fixtures/Integration/priority/ordered_types,types_spaces.test
+++ b/tests/Fixtures/Integration/priority/ordered_types,types_spaces.test
@@ -1,0 +1,33 @@
+--TEST--
+Integration of fixers: ordered_types,types_spaces.
+--RULESET--
+{"ordered_types": true, "types_spaces": {"space": "single"}}
+--REQUIREMENTS--
+{"php": 80000}
+--EXPECT--
+<?php
+
+class Foo
+{
+    public null | array | string $bar = null;
+}
+
+try {
+    return (new Foo)->bar;
+} catch (\Error | \Exception $e) {
+    return $e->getMessage();
+}
+
+--INPUT--
+<?php
+
+class Foo
+{
+    public string|array|null $bar = null;
+}
+
+try {
+    return (new Foo)->bar;
+} catch (\Exception|\Error $e) {
+    return $e->getMessage();
+}


### PR DESCRIPTION
Closes #6567 

This fixer is the "near" equivalent to `phpdoc_types_order` porting the same configuration options but orders type declarations instead. The only caveat to this fixer (that I can think of) is that this cannot preserve whitespace and comments in between the union/intersection types (because of the use of the `TypeAnalysis` class). This caveat is demonstrated in the tests.

This fixer also has provisional support for PHP 8.2's [Disjunctive Normal Form Types](https://wiki.php.net/rfc/dnf_types).

```console
$ php php-cs-fixer describe ordered_types

Description of ordered_types rule.
Sort union types and intersection types using configured order.

Fixer is configurable using following options:
* sort_algorithm ('alpha', 'none'): the sorting algorithm to apply; defaults to 'alpha'
* null_adjustment ('always_first', 'always_last', 'none'): forces the position of `null` (overrides `sort_algorithm`); defaults to 'always_first'

Fixing examples:
 * Example #1. Fixing with the default configuration.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,8 +1,8 @@
    <?php
    try {
        cache()->save($foo);
   -} catch (\RuntimeException|CacheException $e) {
   +} catch (CacheException|\RuntimeException $e) {
        logger($e);

        throw $e;
    }

   ----------- end diff -----------

 * Example #2. Fixing with configuration: ['null_adjustment' => 'always_last'].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,7 +1,7 @@
    <?php
    interface Foo
    {
   -    public function bar(null|string|int $foo): string|int;
   +    public function bar(int|string|null $foo): int|string;

   -    public function foo(\Stringable&\Countable $obj): int;
   +    public function foo(\Countable&\Stringable $obj): int;
    }

   ----------- end diff -----------

 * Example #3. Fixing with configuration: ['sort_algorithm' => 'none', 'null_adjustment' => 'always_last'].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,5 +1,5 @@
    <?php
    interface Bar
    {
   -    public function bar(null|string|int $foo): string|int;
   +    public function bar(string|int|null $foo): string|int;
    }

   ----------- end diff -----------
```