### PR TITLE
Ensure that omitting array item in ordered_class_elements['order'] with sort_algorithm=alpha leads to no sorting

### DIFF
--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -1275,7 +1275,6 @@ class Foo
     {}
 }
 EOT
-EOT
             ],
         ];
     }

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -1248,6 +1248,35 @@ class Foo
 }
 EOT
             ],
+            [
+                [
+                    'order' => ['use_trait', 'constant_public', 'constant_protected', 'constant_private', 'property_public', 'property_protected', 'property_private', 'construct', 'destruct', 'magic', 'phpunit'],
+                    'sort_algorithm' => OrderedClassElementsFixer::SORT_ALPHA
+                ],
+                <<<'EOT'
+<?php
+
+class Foo
+{
+    public function smth2(): void
+    {}
+    public function smth1(): void
+    {}
+}
+EOT
+                , <<<'EOT'
+<?php
+
+class Foo
+{
+    public function smth2(): void
+    {}
+    public function smth1(): void
+    {}
+}
+EOT
+EOT
+            ],
         ];
     }
 


### PR DESCRIPTION
Illustrates #6591 .