### PR TITLE
feature: Use phpstan/phpdoc-parser (and migrate 1st fixer)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "composer/semver": "^3.2",
         "composer/xdebug-handler": "^3.0.3",
         "doctrine/annotations": "^1.13",
+        "phpstan/phpdoc-parser": "^1.8.0",
         "sebastian/diff": "^4.0",
         "symfony/console": "^5.4 || ^6.0",
         "symfony/event-dispatcher": "^5.4 || ^6.0",

--- a/src/DocBlock.php
+++ b/src/DocBlock.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer;
+
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+
+/**
+ * @internal
+ */
+final class DocBlock
+{
+    public static function create(string $content): PhpDocNode
+    {
+        static $lexer = null;
+        static $phpDocParser = null;
+
+        if (null === $phpDocParser) {
+            $lexer = new Lexer();
+            $constExprParser = new ConstExprParser();
+            $typeParser = new TypeParser($constExprParser);
+            $phpDocParser = new PhpDocParser($typeParser, $constExprParser);
+        }
+
+        return $phpDocParser->parse(new TokenIterator($lexer->tokenize($content)));
+    }
+}

--- a/src/Fixer/ClassNotation/FinalInternalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalInternalClassFixer.php
@@ -16,7 +16,7 @@ namespace PhpCsFixer\Fixer\ClassNotation;
 
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
-use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\DocBlock;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
@@ -24,7 +24,6 @@ use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
@@ -195,14 +194,11 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurabl
             return $this->configuration['consider_absent_docblock_as_internal_class'];
         }
 
-        $doc = new DocBlock($docToken->getContent());
+        $docBlock = DocBlock::create($docToken->getContent());
         $tags = [];
 
-        foreach ($doc->getAnnotations() as $annotation) {
-            if (1 !== Preg::match('/@\S+(?=\s|$)/', $annotation->getContent(), $matches)) {
-                continue;
-            }
-            $tag = strtolower(substr(array_shift($matches), 1));
+        foreach ($docBlock->getTags() as $tagNode) {
+            $tag = ltrim(strtolower($tagNode->name), '@');
             foreach ($this->configuration['annotation_exclude'] as $tagStart => $true) {
                 if (str_starts_with($tag, $tagStart)) {
                     return false; // ignore class: class-level PHPDoc contains tag that has been excluded through configuration

--- a/tests/DocBlockTest.php
+++ b/tests/DocBlockTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests;
+
+use PhpCsFixer\DocBlock;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\DocBlock
+ */
+final class DocBlockTest extends TestCase
+{
+    public function testCreating(): void
+    {
+        $docBlock = DocBlock::create('/** @foo */');
+
+        static::assertCount(1, $docBlock->getTagsByName('@foo'));
+        static::assertCount(0, $docBlock->getTagsByName('@bar'));
+    }
+}


### PR DESCRIPTION
[The idea](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6568#issuecomment-1236297343) in theory sound great - not having to invent the wheel and I guess it would solve quite a few bugs reported.
The drawback is having one (but only one, no new transitive dependencies) another dependency, but this one seems like a good piece of code (although lacking documentation).

~There is one blocker - tests are failing because of it - PHPDoc tags are [not allowed to have `\`](https://github.com/phpstan/phpdoc-parser/blob/1.7.0/src/Lexer/Lexer.php#L149) - @ondrejmirtes what is your opinion on adding the `\` to that RegEx?~
EDIT: support [added](https://github.com/phpstan/phpdoc-parser/pull/146) in `1.8.0`.

// cc. @keradus @julienfalque @SpacePossum @localheinz what do you think about this? 