### PR TITLE
feature: Add 'functions_opening_brace' option 'next_line_if_return_typehint'

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -350,7 +350,7 @@ List of Available Rules
      | Default value: ``'same_line'``
    - | ``functions_opening_brace``
      | The position of the opening brace of functions‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
+     | Allowed values: ``'next_line_if_return_typehint'``, ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
      | Default value: ``'next_line_unless_newline_at_signature_end'``
    - | ``anonymous_functions_opening_brace``
      | The position of the opening brace of anonymous functions‘ body.

--- a/doc/rules/basic/curly_braces_position.rst
+++ b/doc/rules/basic/curly_braces_position.rst
@@ -21,7 +21,7 @@ Default value: ``'same_line'``
 
 The position of the opening brace of functions‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
+Allowed values: ``'next_line_if_return_typehint'``, ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
 
 Default value: ``'next_line_unless_newline_at_signature_end'``
 
@@ -153,6 +153,24 @@ With configuration: ``['functions_opening_brace' => 'same_line']``.
 Example #5
 ~~~~~~~~~~
 
+With configuration: ``['functions_opening_brace' => 'next_line_if_return_typehint']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    function foo(
+        $bar,
+        $baz
+   -): string {
+   +): string
+   +{
+    }
+
+Example #6
+~~~~~~~~~~
+
 With configuration: ``['anonymous_functions_opening_brace' => 'next_line_unless_newline_at_signature_end']``.
 
 .. code-block:: diff
@@ -165,7 +183,7 @@ With configuration: ``['anonymous_functions_opening_brace' => 'next_line_unless_
    +{
     };
 
-Example #6
+Example #7
 ~~~~~~~~~~
 
 With configuration: ``['classes_opening_brace' => 'same_line']``.
@@ -180,7 +198,7 @@ With configuration: ``['classes_opening_brace' => 'same_line']``.
    +class Foo {
     }
 
-Example #7
+Example #8
 ~~~~~~~~~~
 
 With configuration: ``['anonymous_classes_opening_brace' => 'next_line_unless_newline_at_signature_end']``.
@@ -195,7 +213,7 @@ With configuration: ``['anonymous_classes_opening_brace' => 'next_line_unless_ne
    +{
     };
 
-Example #8
+Example #9
 ~~~~~~~~~~
 
 With configuration: ``['allow_single_line_empty_anonymous_classes' => true]``.
@@ -211,8 +229,8 @@ With configuration: ``['allow_single_line_empty_anonymous_classes' => true]``.
    +private $baz;
    +};
 
-Example #9
-~~~~~~~~~~
+Example #10
+~~~~~~~~~~~
 
 With configuration: ``['allow_single_line_anonymous_functions' => true]``.
 

--- a/src/Fixer/Basic/CurlyBracesPositionFixer.php
+++ b/src/Fixer/Basic/CurlyBracesPositionFixer.php
@@ -261,7 +261,6 @@ $bar = function () { $result = true;
                 $whitespace = $this->whitespacesConfig->getLineEnding().$this->getLineIndentation($tokens, $index);
 
                 $previousTokenIndex = $tokens->getPrevMeaningfulToken($openBraceIndex);
-                $previousToken = $tokens[$previousTokenIndex];
 
                 if ($tokens[$previousTokenIndex]->equals(')')) {
                     if ($tokens[--$previousTokenIndex]->isComment()) {

--- a/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
+++ b/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
@@ -418,23 +418,6 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['functions_opening_brace' => 'next_line_if_return_typehint'],
         ];
 
-        yield 'function (next line if return typehint, same line)' => [
-            '<?php
-                function foo(
-                    $bar,
-                    $baz
-                ) : void
-                {
-                }',
-            '<?php
-                function foo(
-                    $bar,
-                    $baz
-                ) : void {
-                }',
-            ['functions_opening_brace' => 'next_line_if_return_typehint'],
-        ];
-
         yield 'anonymous function (default)' => [
             '<?php
                 $foo = function () {

--- a/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
+++ b/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
@@ -379,6 +379,62 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['functions_opening_brace' => 'same_line'],
         ];
 
+        yield 'function (next line if return typehint)' => [
+            '<?php
+                function foo() : void
+                {
+                }',
+            '<?php
+                function foo() : void {
+                }',
+            ['functions_opening_brace' => 'next_line_if_return_typehint'],
+        ];
+
+        yield 'function (next line if return typehint, multiline)' => [
+            '<?php
+                function foo(
+                    $bar,
+                    $baz
+                ) : void
+                {
+                }',
+            '<?php
+                function foo(
+                    $bar,
+                    $baz
+                ) : void {
+                }',
+            ['functions_opening_brace' => 'next_line_if_return_typehint'],
+        ];
+
+        yield 'function (next line if return typehint, no typehint)' => [
+            '<?php
+                function foo($bar, $baz)
+                {
+                }',
+            '<?php
+                function foo($bar, $baz) {
+                }',
+            ['functions_opening_brace' => 'next_line_if_return_typehint'],
+        ];
+
+        yield 'function (next line if return typehint, same line)' => [
+            '<?php
+                function foo(
+                    $bar,
+                    $baz
+                ) : void
+                {
+                }',
+            '<?php
+                function foo(
+                    $bar,
+                    $baz
+                ) : void {
+                }',
+            ['functions_opening_brace' => 'next_line_if_return_typehint'],
+        ];
+
         yield 'anonymous function (default)' => [
             '<?php
                 $foo = function () {


### PR DESCRIPTION
The `functions_opening_brace` option `next_line_unless_newline_at_signature_end` fixes muti-line function signatures to look like this:

```php
    public function veryLongFoo(
        VeryLongBar $bar,
        VeryLongBaz $baz
    ): VeryLongFoo {
        // function body
    }
```

This PR adds the option `next_line_if_return_typehint` to fix multi-line function signatures so that the opening brace goes on the next line if a return typehint is present:

```php
    public function veryLongFoo(
        VeryLongBar $bar,
        VeryLongBaz $baz
    ): VeryLongFoo
    {
        // function body
    }
```

This has the benefit of being visually similar to a single-line function signature ...

```php
    public function veryLongFoo(VeryLongBar $bar, VeryLongBaz $baz): VeryLongFoo
    {
        // function body
    }
```

... in that the opening brace remains on the next line instead of "jumping" to the same line, and keeps a (mostly) blank line at the top of the function body.

When combined with the `return_type_declaration` option `'space_before' => 'one'` with 4-space indentation, this has the further benefit of aligning the parameter types with the return type:

```php
    public function veryLongFoo(
        VeryLongBar $bar,
        VeryLongBaz $baz
    ) : VeryLongFoo
    {
        // function body
    }
```

That final combination is what I and several teams I have worked with prefer; this PR allows PHP-CS-Fixer to apply it.