### PR TITLE
minor: displaying number of checked files

### DIFF
--- a/docker-compose.override.yaml.dist
+++ b/docker-compose.override.yaml.dist
@@ -10,7 +10,7 @@ services:
     extra_hosts:
       # Required for Docker Linux until natively supported.
       # See https://github.com/docker/for-linux/issues/264
-      host.docker.internal: 172.17.0.1
+      - 'host.docker.internal: 172.17.0.1'
   php-8.0:
     <<: *php
   php-8.1:

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -315,7 +315,7 @@ EOF
 
         $reportSummary = new ReportSummary(
             $changed,
-            count($finder),
+            \count($finder),
             $fixEvent->getDuration(),
             $fixEvent->getMemory(),
             OutputInterface::VERBOSITY_VERBOSE <= $verbosity,

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -183,7 +183,7 @@ Exit code of the fix command is built using following bit flags:
 * 64 - Exception raised within the application.
 
 EOF
-            ;
+        ;
     }
 
     /**

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -183,7 +183,7 @@ Exit code of the fix command is built using following bit flags:
 * 64 - Exception raised within the application.
 
 EOF
-        ;
+            ;
     }
 
     /**
@@ -315,6 +315,7 @@ EOF
 
         $reportSummary = new ReportSummary(
             $changed,
+            count($finder),
             $fixEvent->getDuration(),
             $fixEvent->getMemory(),
             OutputInterface::VERBOSITY_VERBOSE <= $verbosity,

--- a/src/Console/Report/FixReport/ReportSummary.php
+++ b/src/Console/Report/FixReport/ReportSummary.php
@@ -26,7 +26,7 @@ final class ReportSummary
      */
     private array $changed;
 
-    private int $files;
+    private int $filesCount;
 
     private int $time;
 
@@ -45,7 +45,7 @@ final class ReportSummary
      */
     public function __construct(
         array $changed,
-        int $files,
+        int $filesCount,
         int $time,
         int $memory,
         bool $addAppliedFixers,
@@ -53,7 +53,7 @@ final class ReportSummary
         bool $isDecoratedOutput
     ) {
         $this->changed = $changed;
-        $this->files = $files;
+        $this->filesCount = $filesCount;
         $this->time = $time;
         $this->memory = $memory;
         $this->addAppliedFixers = $addAppliedFixers;
@@ -91,7 +91,7 @@ final class ReportSummary
 
     public function getFilesCount(): int
     {
-        return $this->files;
+        return $this->filesCount;
     }
 
     public function shouldAddAppliedFixers(): bool

--- a/src/Console/Report/FixReport/ReportSummary.php
+++ b/src/Console/Report/FixReport/ReportSummary.php
@@ -89,7 +89,7 @@ final class ReportSummary
         return $this->time;
     }
 
-    public function getFiles(): int
+    public function getFilesCount(): int
     {
         return $this->files;
     }

--- a/src/Console/Report/FixReport/ReportSummary.php
+++ b/src/Console/Report/FixReport/ReportSummary.php
@@ -26,6 +26,8 @@ final class ReportSummary
      */
     private array $changed;
 
+    private int $files;
+
     private int $time;
 
     private int $memory;
@@ -43,6 +45,7 @@ final class ReportSummary
      */
     public function __construct(
         array $changed,
+        int $files,
         int $time,
         int $memory,
         bool $addAppliedFixers,
@@ -50,6 +53,7 @@ final class ReportSummary
         bool $isDecoratedOutput
     ) {
         $this->changed = $changed;
+        $this->files = $files;
         $this->time = $time;
         $this->memory = $memory;
         $this->addAppliedFixers = $addAppliedFixers;
@@ -83,6 +87,11 @@ final class ReportSummary
     public function getTime(): int
     {
         return $this->time;
+    }
+
+    public function getFiles(): int
+    {
+        return $this->files;
     }
 
     public function shouldAddAppliedFixers(): bool

--- a/src/Console/Report/FixReport/TextReporter.php
+++ b/src/Console/Report/FixReport/TextReporter.php
@@ -38,10 +38,10 @@ final class TextReporter implements ReporterInterface
     {
         $output = '';
 
-        $i = 0;
+        $identifiedFiles = 0;
         foreach ($reportSummary->getChanged() as $file => $fixResult) {
-            ++$i;
-            $output .= sprintf('%4d) %s', $i, $file);
+            ++$identifiedFiles;
+            $output .= sprintf('%4d) %s', $identifiedFiles, $file);
 
             if ($reportSummary->shouldAddAppliedFixers()) {
                 $output .= $this->getAppliedFixers(
@@ -54,7 +54,13 @@ final class TextReporter implements ReporterInterface
             $output .= PHP_EOL;
         }
 
-        return $output.$this->getFooter($reportSummary->getTime(), count($reportSummary->getChanged()), $reportSummary->getFiles(), $reportSummary->getMemory(), $reportSummary->isDryRun());
+        return $output.$this->getFooter(
+            $reportSummary->getTime(),
+            $identifiedFiles,
+            $reportSummary->getFiles(),
+            $reportSummary->getMemory(),
+            $reportSummary->isDryRun()
+        );
     }
 
     /**
@@ -83,18 +89,20 @@ final class TextReporter implements ReporterInterface
         return PHP_EOL.$diffFormatter->format($diff).PHP_EOL;
     }
 
-    private function getFooter(int $time, int $changed, int $files, int $memory, bool $isDryRun): string
+    private function getFooter(int $time, int $identifiedFiles, int $files, int $memory, bool $isDryRun): string
     {
         if (0 === $time || 0 === $memory) {
             return '';
         }
 
         return PHP_EOL.sprintf(
-                '%s %d files in %.3f seconds, %.3f MB memory used'.PHP_EOL,
-                $isDryRun ? 'Checked' : sprintf('Fixed %d of', $changed),
-                $files,
-                $time / 1000,
-                $memory / 1024 / 1024
-            );
+            '%s %d of %d %s in %.3f seconds, %.3f MB memory used'.PHP_EOL,
+            $isDryRun ? 'Found' : 'Fixed',
+            $identifiedFiles,
+            $files,
+            $isDryRun ? 'files that can be fixed' : 'files',
+            $time / 1000,
+            $memory / 1024 / 1024
+        );
     }
 }

--- a/src/Console/Report/FixReport/TextReporter.php
+++ b/src/Console/Report/FixReport/TextReporter.php
@@ -57,7 +57,7 @@ final class TextReporter implements ReporterInterface
         return $output.$this->getFooter(
             $reportSummary->getTime(),
             $identifiedFiles,
-            $reportSummary->getFiles(),
+            $reportSummary->getFilesCount(),
             $reportSummary->getMemory(),
             $reportSummary->isDryRun()
         );

--- a/src/Console/Report/FixReport/TextReporter.php
+++ b/src/Console/Report/FixReport/TextReporter.php
@@ -54,7 +54,7 @@ final class TextReporter implements ReporterInterface
             $output .= PHP_EOL;
         }
 
-        return $output.$this->getFooter($reportSummary->getTime(), $reportSummary->getMemory(), $reportSummary->isDryRun());
+        return $output.$this->getFooter($reportSummary->getTime(), count($reportSummary->getChanged()), $reportSummary->getFiles(), $reportSummary->getMemory(), $reportSummary->isDryRun());
     }
 
     /**
@@ -83,17 +83,18 @@ final class TextReporter implements ReporterInterface
         return PHP_EOL.$diffFormatter->format($diff).PHP_EOL;
     }
 
-    private function getFooter(int $time, int $memory, bool $isDryRun): string
+    private function getFooter(int $time, int $changed, int $files, int $memory, bool $isDryRun): string
     {
         if (0 === $time || 0 === $memory) {
             return '';
         }
 
         return PHP_EOL.sprintf(
-            '%s all files in %.3f seconds, %.3f MB memory used'.PHP_EOL,
-            $isDryRun ? 'Checked' : 'Fixed',
-            $time / 1000,
-            $memory / 1024 / 1024
-        );
+                '%s %d files in %.3f seconds, %.3f MB memory used'.PHP_EOL,
+                $isDryRun ? 'Checked' : sprintf('Fixed %d of', $changed),
+                $files,
+                $time / 1000,
+                $memory / 1024 / 1024
+            );
     }
 }

--- a/tests/Console/Report/FixReport/AbstractReporterTestCase.php
+++ b/tests/Console/Report/FixReport/AbstractReporterTestCase.php
@@ -69,6 +69,7 @@ abstract class AbstractReporterTestCase extends TestCase
                 $this->createNoErrorReport(),
                 new ReportSummary(
                     [],
+                    10,
                     0,
                     0,
                     false,
@@ -85,6 +86,7 @@ abstract class AbstractReporterTestCase extends TestCase
                             'diff' => '',
                         ],
                     ],
+                    10,
                     0,
                     0,
                     false,
@@ -101,6 +103,7 @@ abstract class AbstractReporterTestCase extends TestCase
                             'diff' => 'this text is a diff ;)',
                         ],
                     ],
+                    10,
                     0,
                     0,
                     false,
@@ -117,6 +120,7 @@ abstract class AbstractReporterTestCase extends TestCase
                             'diff' => '',
                         ],
                     ],
+                    10,
                     0,
                     0,
                     true,
@@ -133,6 +137,7 @@ abstract class AbstractReporterTestCase extends TestCase
                             'diff' => '',
                         ],
                     ],
+                    10,
                     1234,
                     2621440, // 2.5 * 1024 * 1024
                     false,
@@ -153,6 +158,7 @@ abstract class AbstractReporterTestCase extends TestCase
                             'diff' => 'another diff here ;)',
                         ],
                     ],
+                    10,
                     1234,
                     2621440, // 2.5 * 1024 * 1024
                     true,

--- a/tests/Console/Report/FixReport/ReportSummaryTest.php
+++ b/tests/Console/Report/FixReport/ReportSummaryTest.php
@@ -50,7 +50,7 @@ final class ReportSummaryTest extends TestCase
         );
 
         static::assertSame($changed, $reportSummary->getChanged());
-        static::assertSame($files, $reportSummary->getFiles());
+        static::assertSame($files, $reportSummary->getFilesCount());
         static::assertSame($time, $reportSummary->getTime());
         static::assertSame($memory, $reportSummary->getMemory());
         static::assertSame($addAppliedFixers, $reportSummary->shouldAddAppliedFixers());

--- a/tests/Console/Report/FixReport/ReportSummaryTest.php
+++ b/tests/Console/Report/FixReport/ReportSummaryTest.php
@@ -32,6 +32,7 @@ final class ReportSummaryTest extends TestCase
                 'diff' => 'this text is a diff ;)',
             ],
         ];
+        $files = 10;
         $time = time();
         $memory = 123456789;
         $addAppliedFixers = true;
@@ -40,6 +41,7 @@ final class ReportSummaryTest extends TestCase
 
         $reportSummary = new ReportSummary(
             $changed,
+            $files,
             $time,
             $memory,
             $addAppliedFixers,
@@ -48,6 +50,7 @@ final class ReportSummaryTest extends TestCase
         );
 
         static::assertSame($changed, $reportSummary->getChanged());
+        static::assertSame($files, $reportSummary->getFiles());
         static::assertSame($time, $reportSummary->getTime());
         static::assertSame($memory, $reportSummary->getMemory());
         static::assertSame($addAppliedFixers, $reportSummary->shouldAddAppliedFixers());

--- a/tests/Console/Report/FixReport/ReportSummaryTest.php
+++ b/tests/Console/Report/FixReport/ReportSummaryTest.php
@@ -32,7 +32,7 @@ final class ReportSummaryTest extends TestCase
                 'diff' => 'this text is a diff ;)',
             ],
         ];
-        $files = 10;
+        $filesCount = 10;
         $time = time();
         $memory = 123456789;
         $addAppliedFixers = true;
@@ -41,7 +41,7 @@ final class ReportSummaryTest extends TestCase
 
         $reportSummary = new ReportSummary(
             $changed,
-            $files,
+            $filesCount,
             $time,
             $memory,
             $addAppliedFixers,
@@ -50,7 +50,7 @@ final class ReportSummaryTest extends TestCase
         );
 
         static::assertSame($changed, $reportSummary->getChanged());
-        static::assertSame($files, $reportSummary->getFilesCount());
+        static::assertSame($filesCount, $reportSummary->getFilesCount());
         static::assertSame($time, $reportSummary->getTime());
         static::assertSame($memory, $reportSummary->getMemory());
         static::assertSame($addAppliedFixers, $reportSummary->shouldAddAppliedFixers());

--- a/tests/Console/Report/FixReport/TextReporterTest.php
+++ b/tests/Console/Report/FixReport/TextReporterTest.php
@@ -81,7 +81,7 @@ TEXT
             <<<'TEXT'
    1) someFile.php
 
-Fixed all files in 1.234 seconds, 2.500 MB memory used
+Fixed 1 of 10 files in 1.234 seconds, 2.500 MB memory used
 
 TEXT
         );
@@ -104,7 +104,7 @@ another diff here ;)
 <comment>      ----------- end diff -----------</comment>
 
 
-Checked all files in 1.234 seconds, 2.500 MB memory used
+Checked 10 files in 1.234 seconds, 2.500 MB memory used
 
 TEXT
         );

--- a/tests/Console/Report/FixReport/TextReporterTest.php
+++ b/tests/Console/Report/FixReport/TextReporterTest.php
@@ -104,7 +104,7 @@ another diff here ;)
 <comment>      ----------- end diff -----------</comment>
 
 
-Checked 10 files in 1.234 seconds, 2.500 MB memory used
+Found 2 of 10 files that can be fixed in 1.234 seconds, 2.500 MB memory used
 
 TEXT
         );

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -194,7 +194,7 @@ Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Exec
         static::assertSame(substr_count($expectedResult3FilesDots, 'S'), substr_count($matches[1], 'S'));
 
         static::assertMatchesRegularExpression(
-            '/^\s*Checked all files in \d+\.\d+ seconds, \d+\.\d+ MB memory used\s*$/',
+            '/^\s*Checked \d+ files in \d+\.\d+ seconds, \d+\.\d+ MB memory used\s*$/',
             $result3->getOutput()
         );
     }

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -194,7 +194,7 @@ Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Exec
         static::assertSame(substr_count($expectedResult3FilesDots, 'S'), substr_count($matches[1], 'S'));
 
         static::assertMatchesRegularExpression(
-            '/^\s*Checked \d+ files in \d+\.\d+ seconds, \d+\.\d+ MB memory used\s*$/',
+            '/^\s*Found \d+ of \d+ files that can be fixed in \d+\.\d+ seconds, \d+\.\d+ MB memory used\s*$/',
             $result3->getOutput()
         );
     }

--- a/tests/Smoke/StdinTest.php
+++ b/tests/Smoke/StdinTest.php
@@ -75,7 +75,7 @@ final class StdinTest extends AbstractSmokeTest
     private function unifyFooter(string $output): string
     {
         return preg_replace(
-            '/Checked all files in \d+\.\d+ seconds, \d+\.\d+ MB memory used/',
+            '/Checked \d+ files in \d+\.\d+ seconds, \d+\.\d+ MB memory used/',
             'Footer',
             $output
         );

--- a/tests/Smoke/StdinTest.php
+++ b/tests/Smoke/StdinTest.php
@@ -75,7 +75,7 @@ final class StdinTest extends AbstractSmokeTest
     private function unifyFooter(string $output): string
     {
         return preg_replace(
-            '/Checked \d+ of \d+ files that can be fixed in \d+\.\d+ seconds, \d+\.\d+ MB memory used/',
+            '/Found \d+ of \d+ files that can be fixed in \d+\.\d+ seconds, \d+\.\d+ MB memory used/',
             'Footer',
             $output
         );

--- a/tests/Smoke/StdinTest.php
+++ b/tests/Smoke/StdinTest.php
@@ -75,7 +75,7 @@ final class StdinTest extends AbstractSmokeTest
     private function unifyFooter(string $output): string
     {
         return preg_replace(
-            '/Checked \d+ files in \d+\.\d+ seconds, \d+\.\d+ MB memory used/',
+            '/Checked \d+ of \d+ files that can be fixed in \d+\.\d+ seconds, \d+\.\d+ MB memory used/',
             'Footer',
             $output
         );


### PR DESCRIPTION
I refactored a little `PhpCsFixer\Console\Report\FixReport\TextReporter` and `PhpCsFixer\Console\Report\FixReport\ReportSummary` with number of checked files. I think this is more verbose:
```
Checked 18 files in 0.272 seconds, 16.000 MB memory used
```

than current implementation:
```
Checked all files in 0.272 seconds, 16.000 MB memory used
```

I wonder if these changes should be applied to Json/Xml reporters as well?

I also updated Docker Composer override file, because provided syntax was invalid.