### PR TITLE
BracesFixer incorrectly indents comments inside switch statements

### DIFF
--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -5481,6 +5481,29 @@ return foo($i);
  */
 }',
         ];
+
+        yield [
+            "<?php
+switch (true) {
+    // Case foo
+    case 'foo':
+        return 'foo';
+
+    // Default
+    default:
+        return 'bar';
+}",
+            "<?php
+switch (true) {
+        // Case foo
+    case 'foo':
+        return 'foo';
+
+        // Default
+    default:
+        return 'bar';
+}",
+        ];
     }
 
     /**


### PR DESCRIPTION
I have set up a test case that shows the problem. I was not able to fix it myself, though.

Expected formatting:

```
switch (true) {
    // Case foo
    case 'foo':
        return 'foo';

    // Default
    default:
        return 'bar';
}
```

Actual formatting:

```
switch (true) {
        // Case foo
    case 'foo':
        return 'foo';

        // Default
    default:
        return 'bar';
}
```
