### PR TITLE
docs: Update installation recommended commands for `mkdir` argument (`-p` insteadof `--parents`).

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ in a dedicated `composer.json` file in your project, for example in the
 `tools/php-cs-fixer` directory:
 
 ```console
-mkdir --parents tools/php-cs-fixer
+mkdir -p tools/php-cs-fixer
 composer require --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer
 ```
 


### PR DESCRIPTION
Fixes #6684

Update README, in "Documentation > Installation" part, for the recommended command `mkdir` : use of the argument `-p` insteadof `--parents`, to avoid an error on macOS because of inexistence of `--parents` argument.