### PR TITLE
Make static data providers that are not using dynamic calls

### DIFF
--- a/tests/AbstractDoctrineAnnotationFixerTestCase.php
+++ b/tests/AbstractDoctrineAnnotationFixerTestCase.php
@@ -34,7 +34,7 @@ abstract class AbstractDoctrineAnnotationFixerTestCase extends AbstractFixerTest
         $this->fixer->configure($configuration);
     }
 
-    public function provideInvalidConfigurationCases(): array
+    public static function provideInvalidConfigurationCases(): array
     {
         return [
             [['foo' => 'bar']],

--- a/tests/AbstractFunctionReferenceFixerTest.php
+++ b/tests/AbstractFunctionReferenceFixerTest.php
@@ -55,7 +55,7 @@ final class AbstractFunctionReferenceFixerTest extends TestCase
         static::assertFalse($tokens->isChanged());
     }
 
-    public function provideAbstractFunctionReferenceFixerCases(): array
+    public static function provideAbstractFunctionReferenceFixerCases(): array
     {
         return [
             'simple case I' => [

--- a/tests/AutoReview/CommandTest.php
+++ b/tests/AutoReview/CommandTest.php
@@ -38,7 +38,7 @@ final class CommandTest extends TestCase
         static::assertNotNull($command::getDefaultName());
     }
 
-    public function provideCommandHasNameConstCases(): array
+    public static function provideCommandHasNameConstCases(): array
     {
         $application = new Application();
         $commands = $application->all();

--- a/tests/AutoReview/DescribeCommandTest.php
+++ b/tests/AutoReview/DescribeCommandTest.php
@@ -49,7 +49,7 @@ final class DescribeCommandTest extends TestCase
         static::assertSame(0, $commandTester->getStatusCode());
     }
 
-    public function provideDescribeCommandCases(): iterable
+    public static function provideDescribeCommandCases(): iterable
     {
         $factory = new FixerFactory();
         $factory->registerBuiltInFixers();

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -137,7 +137,7 @@ final class FixerFactoryTest extends TestCase
         static::assertCount(0, $missingIntegrationsTests, sprintf("There shall be an integration test. How do you know that priority set up is good, if there is no integration test to check it?\nMissing:\n- %s", implode("\n- ", $missingIntegrationsTests)));
     }
 
-    public function provideFixersPriorityCasesHaveIntegrationCases(): iterable
+    public static function provideFixersPriorityCasesHaveIntegrationCases(): iterable
     {
         foreach (self::getFixersPriorityGraph() as $fixerName => $edges) {
             yield $fixerName => [$fixerName, $edges];
@@ -168,7 +168,7 @@ final class FixerFactoryTest extends TestCase
         );
     }
 
-    public function provideIntegrationTestFilesCases(): iterable
+    public static function provideIntegrationTestFilesCases(): iterable
     {
         foreach (new \DirectoryIterator(self::getIntegrationPriorityDirectory()) as $candidate) {
             if (!$candidate->isDot()) {

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -683,7 +683,7 @@ final class ProjectCodeTest extends TestCase
     /**
      * @return iterable<array{class-string<TestCase>}>
      */
-    public function provideTestClassCases(): iterable
+    public static function provideTestClassCases(): iterable
     {
         if (null === self::$testClassCases) {
             self::$testClassCases = array_map(
@@ -716,7 +716,7 @@ final class ProjectCodeTest extends TestCase
         static::assertTrue($reflection->isSubclassOf(AbstractPhpUnitFixer::class));
     }
 
-    public function providePhpUnitFixerExtendsAbstractPhpUnitFixerCases(): iterable
+    public static function providePhpUnitFixerExtendsAbstractPhpUnitFixerCases(): iterable
     {
         $factory = new FixerFactory();
         $factory->registerBuiltInFixers();

--- a/tests/AutoReview/TransformerTest.php
+++ b/tests/AutoReview/TransformerTest.php
@@ -101,7 +101,7 @@ final class TransformerTest extends TestCase
     /**
      * @return TransformerInterface[]
      */
-    public function provideTransformerCases(): array
+    public static function provideTransformerCases(): array
     {
         static $transformersArray = null;
 

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -119,7 +119,7 @@ final class CacheTest extends TestCase
         Cache::fromJson($json);
     }
 
-    public function provideMissingDataCases(): array
+    public static function provideMissingDataCases(): array
     {
         $data = [
             'php' => '7.1.2',
@@ -158,7 +158,7 @@ final class CacheTest extends TestCase
         static::assertSame($hash, $cached->get($file));
     }
 
-    public function provideCanConvertToAndFromJsonCases(): array
+    public static function provideCanConvertToAndFromJsonCases(): array
     {
         $toolInfo = new ToolInfo();
         $config = new Config();

--- a/tests/Cache/SignatureTest.php
+++ b/tests/Cache/SignatureTest.php
@@ -65,7 +65,7 @@ final class SignatureTest extends TestCase
         static::assertFalse($signature->equals($anotherSignature));
     }
 
-    public function provideEqualsReturnsFalseIfValuesAreNotIdenticalCases(): iterable
+    public static function provideEqualsReturnsFalseIfValuesAreNotIdenticalCases(): iterable
     {
         $php = PHP_VERSION;
         $version = '2.0';

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -248,7 +248,7 @@ final class ConfigTest extends TestCase
         static::assertFalse($config->getUsingCache());
     }
 
-    public function provideRegisterCustomFixersCases(): array
+    public static function provideRegisterCustomFixersCases(): array
     {
         $fixers = [
             new NoWhitespaceBeforeCommaInArrayFixer(),

--- a/tests/Console/Command/FixCommandExitStatusCalculatorTest.php
+++ b/tests/Console/Command/FixCommandExitStatusCalculatorTest.php
@@ -40,7 +40,7 @@ final class FixCommandExitStatusCalculatorTest extends TestCase
         );
     }
 
-    public function provideCalculateCases(): array
+    public static function provideCalculateCases(): array
     {
         return [
             [0, true, false, false, false, false],

--- a/tests/Console/Command/HelpCommandTest.php
+++ b/tests/Console/Command/HelpCommandTest.php
@@ -36,7 +36,7 @@ final class HelpCommandTest extends TestCase
         static::assertSame($expected, HelpCommand::toString($input));
     }
 
-    public function provideToStringCases(): iterable
+    public static function provideToStringCases(): iterable
     {
         yield ["['a' => 3, 'b' => 'c']", ['a' => 3, 'b' => 'c']];
 
@@ -71,7 +71,7 @@ final class HelpCommandTest extends TestCase
         static::assertSame($expected, HelpCommand::getDisplayableAllowedValues($input));
     }
 
-    public function provideGetDisplayableAllowedValuesCases(): iterable
+    public static function provideGetDisplayableAllowedValuesCases(): iterable
     {
         yield [null, new FixerOption('foo', 'bar', false, null, ['int'], [])];
 

--- a/tests/Console/Command/SelfUpdateCommandTest.php
+++ b/tests/Console/Command/SelfUpdateCommandTest.php
@@ -81,7 +81,7 @@ final class SelfUpdateCommandTest extends TestCase
         static::assertSame($command, $application->find($name));
     }
 
-    public function provideCommandNameCases(): array
+    public static function provideCommandNameCases(): array
     {
         return [
             ['self-update'],
@@ -276,7 +276,7 @@ OUTPUT;
         static::assertSame(1, $commandTester->getStatusCode());
     }
 
-    public function provideExecuteWhenNotAbleToGetLatestVersionsCases(): array
+    public static function provideExecuteWhenNotAbleToGetLatestVersionsCases(): array
     {
         return [
             [false, false, [], true],
@@ -322,7 +322,7 @@ OUTPUT;
         static::assertSame(1, $commandTester->getStatusCode());
     }
 
-    public function provideExecuteWhenNotInstalledAsPharCases(): array
+    public static function provideExecuteWhenNotInstalledAsPharCases(): array
     {
         return [
             [[], true],

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -130,7 +130,7 @@ final class ConfigurationResolverTest extends TestCase
         static::assertSame($progressType, $resolver->getProgress());
     }
 
-    public function provideProgressTypeCases(): array
+    public static function provideProgressTypeCases(): array
     {
         return [
             ['none'],
@@ -297,7 +297,7 @@ final class ConfigurationResolverTest extends TestCase
         static::assertSame($expectedPaths, $resolver->getPath());
     }
 
-    public function providePathCases(): iterable
+    public static function providePathCases(): iterable
     {
         yield [
             ['Command'],
@@ -343,7 +343,7 @@ final class ConfigurationResolverTest extends TestCase
         $resolver->getPath();
     }
 
-    public function provideEmptyPathCases(): iterable
+    public static function provideEmptyPathCases(): iterable
     {
         yield [
             [''],
@@ -497,7 +497,7 @@ final class ConfigurationResolverTest extends TestCase
         static::assertSame($expected, $intersectionItems);
     }
 
-    public function provideResolveIntersectionOfPathsCases(): array
+    public static function provideResolveIntersectionOfPathsCases(): array
     {
         $dir = __DIR__.'/../Fixtures/ConfigurationResolverPathsIntersection';
         $cb = static function (array $items) use ($dir): array {
@@ -665,7 +665,7 @@ final class ConfigurationResolverTest extends TestCase
         static::assertSame($expectedResult, $resolver->configFinderIsOverridden());
     }
 
-    public function provideConfigFinderIsOverriddenCases(): array
+    public static function provideConfigFinderIsOverriddenCases(): array
     {
         $root = __DIR__.'/../..';
 
@@ -971,7 +971,7 @@ final class ConfigurationResolverTest extends TestCase
         $resolver->getRules();
     }
 
-    public function provideRenamedRulesCases(): iterable
+    public static function provideRenamedRulesCases(): iterable
     {
         yield 'with config' => [
             'The rules contain unknown fixers: "blank_line_before_return" is renamed (did you mean "blank_line_before_statement"? (note: use configuration "[\'statements\' => [\'return\']]")).
@@ -1079,7 +1079,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         static::assertInstanceOf($expected, $resolver->getDiffer());
     }
 
-    public function provideDifferCases(): array
+    public static function provideDifferCases(): array
     {
         return [
             [
@@ -1120,7 +1120,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         $resolver->getRiskyAllowed();
     }
 
-    public function provideResolveBooleanOptionCases(): array
+    public static function provideResolveBooleanOptionCases(): array
     {
         return [
             [true, true, 'yes'],
@@ -1161,7 +1161,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         $resolver->getFixers();
     }
 
-    public function provideDeprecatedFixerConfiguredCases(): array
+    public static function provideDeprecatedFixerConfiguredCases(): array
     {
         return [
             [true],
@@ -1170,7 +1170,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         ];
     }
 
-    public function provideGetDirectoryCases(): array
+    public static function provideGetDirectoryCases(): array
     {
         return [
             [null, '/my/path/my/file', 'path/my/file'],

--- a/tests/Console/Output/ProcessOutputTest.php
+++ b/tests/Console/Output/ProcessOutputTest.php
@@ -55,7 +55,7 @@ final class ProcessOutputTest extends TestCase
         static::assertSame($expectedOutput, $output->fetch());
     }
 
-    public function provideProcessProgressOutputCases(): array
+    public static function provideProcessProgressOutputCases(): array
     {
         return [
             [

--- a/tests/Console/SelfUpdate/NewVersionCheckerTest.php
+++ b/tests/Console/SelfUpdate/NewVersionCheckerTest.php
@@ -42,7 +42,7 @@ final class NewVersionCheckerTest extends TestCase
         static::assertSame($expectedVersion, $checker->getLatestVersionOfMajor($majorVersion));
     }
 
-    public function provideLatestVersionOfMajorCases(): array
+    public static function provideLatestVersionOfMajorCases(): array
     {
         return [
             [1, 'v1.13.2'],
@@ -68,7 +68,7 @@ final class NewVersionCheckerTest extends TestCase
         );
     }
 
-    public function provideCompareVersionsCases(): array
+    public static function provideCompareVersionsCases(): array
     {
         $cases = [];
 

--- a/tests/Differ/DiffConsoleFormatterTest.php
+++ b/tests/Differ/DiffConsoleFormatterTest.php
@@ -38,7 +38,7 @@ final class DiffConsoleFormatterTest extends TestCase
         );
     }
 
-    public function provideTestCases(): array
+    public static function provideTestCases(): array
     {
         return [
             [

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -99,7 +99,7 @@ final class AnnotationTest extends TestCase
         static::assertSame($content, (string) $annotation);
     }
 
-    public function provideGetContentCases(): iterable
+    public static function provideGetContentCases(): iterable
     {
         foreach (self::$content as $index => $content) {
             yield [$index, $content];
@@ -117,7 +117,7 @@ final class AnnotationTest extends TestCase
         static::assertSame($start, $annotation->getStart());
     }
 
-    public function provideStartCases(): iterable
+    public static function provideStartCases(): iterable
     {
         foreach (self::$start as $index => $start) {
             yield [$index, $start];
@@ -135,7 +135,7 @@ final class AnnotationTest extends TestCase
         static::assertSame($end, $annotation->getEnd());
     }
 
-    public function provideEndCases(): iterable
+    public static function provideEndCases(): iterable
     {
         foreach (self::$end as $index => $end) {
             yield [$index, $end];
@@ -153,7 +153,7 @@ final class AnnotationTest extends TestCase
         static::assertSame($tag, $annotation->getTag()->getName());
     }
 
-    public function provideGetTagCases(): iterable
+    public static function provideGetTagCases(): iterable
     {
         foreach (self::$tags as $index => $tag) {
             yield [$index, $tag];
@@ -174,7 +174,7 @@ final class AnnotationTest extends TestCase
         static::assertSame('', $doc->getLine($end)->getContent());
     }
 
-    public function provideRemoveCases(): iterable
+    public static function provideRemoveCases(): iterable
     {
         foreach (self::$start as $index => $start) {
             yield [$index, $start, self::$end[$index]];
@@ -193,7 +193,7 @@ final class AnnotationTest extends TestCase
         static::assertSame($expected, $doc->getContent());
     }
 
-    public function provideRemoveEdgeCasesCases(): array
+    public static function provideRemoveEdgeCasesCases(): array
     {
         return [
             // Single line
@@ -242,7 +242,7 @@ final class AnnotationTest extends TestCase
         static::assertSame($expected, $tag->getTypes());
     }
 
-    public function provideTypeParsingCases(): array
+    public static function provideTypeParsingCases(): array
     {
         return [
             [
@@ -468,7 +468,7 @@ final class AnnotationTest extends TestCase
         static::assertSame($output, $line->getContent());
     }
 
-    public function provideTypesCases(): array
+    public static function provideTypesCases(): array
     {
         return [
             [['Foo', 'null'], ['Bar[]'], '     * @param Foo|null $foo', '     * @param Bar[] $foo'],
@@ -494,7 +494,7 @@ final class AnnotationTest extends TestCase
         static::assertSame($expected, $tag->getNormalizedTypes());
     }
 
-    public function provideNormalizedTypesCases(): array
+    public static function provideNormalizedTypesCases(): array
     {
         return [
             [['null', 'string'], '* @param StRiNg|NuLl $foo'],
@@ -553,7 +553,7 @@ final class AnnotationTest extends TestCase
         static::assertSame($expectedCommonType, $result->getCommonType());
     }
 
-    public function provideTypeExpressionCases(): iterable
+    public static function provideTypeExpressionCases(): iterable
     {
         $appNamespace = new NamespaceAnalysis('App', 'App', 0, 999, 0, 999);
         $useTraversable = new NamespaceUseAnalysis('Traversable', 'Traversable', false, 0, 999, NamespaceUseAnalysis::TYPE_CLASS);
@@ -574,7 +574,7 @@ final class AnnotationTest extends TestCase
         static::assertSame($expectedVariableName, $annotation->getVariableName());
     }
 
-    public function provideGetVariableCases(): iterable
+    public static function provideGetVariableCases(): iterable
     {
         yield ['* @param int $foo', '$foo'];
 

--- a/tests/DocBlock/DocBlockTest.php
+++ b/tests/DocBlock/DocBlockTest.php
@@ -170,7 +170,7 @@ final class DocBlockTest extends TestCase
         static::assertSame($outputDocBlock, $doc->getContent());
     }
 
-    public function provideDocBlocksToConvertToMultiLineCases(): array
+    public static function provideDocBlocksToConvertToMultiLineCases(): array
     {
         return [
             'It keeps a multi line doc block as is' => [
@@ -215,7 +215,7 @@ final class DocBlockTest extends TestCase
         static::assertSame($outputDocBlock, $doc->getContent());
     }
 
-    public function provideDocBlocksToConvertToSingleLineCases(): array
+    public static function provideDocBlocksToConvertToSingleLineCases(): array
     {
         return [
             'It keeps a single line doc block as is' => [

--- a/tests/DocBlock/LineTest.php
+++ b/tests/DocBlock/LineTest.php
@@ -141,7 +141,7 @@ final class LineTest extends TestCase
         static::assertSame(14 === $pos, $line->isTheEnd());
     }
 
-    public function provideLinesCases(): iterable
+    public static function provideLinesCases(): iterable
     {
         foreach (self::$content as $index => $content) {
             yield [$index, $content];
@@ -159,7 +159,7 @@ final class LineTest extends TestCase
         static::assertSame($useful, $line->containsUsefulContent());
     }
 
-    public function provideLinesWithUsefulCases(): iterable
+    public static function provideLinesWithUsefulCases(): iterable
     {
         foreach (self::$useful as $index => $useful) {
             yield [$index, $useful];
@@ -177,7 +177,7 @@ final class LineTest extends TestCase
         static::assertSame($tag, $line->containsATag());
     }
 
-    public function provideLinesWithTagCases(): iterable
+    public static function provideLinesWithTagCases(): iterable
     {
         foreach (self::$tag as $index => $tag) {
             yield [$index, $tag];

--- a/tests/DocBlock/ShortDescriptionTest.php
+++ b/tests/DocBlock/ShortDescriptionTest.php
@@ -36,7 +36,7 @@ final class ShortDescriptionTest extends TestCase
         static::assertSame($expected, $shortDescription->getEnd());
     }
 
-    public function provideGetEndCases(): array
+    public static function provideGetEndCases(): array
     {
         return [
             [1, '/**

--- a/tests/DocBlock/TagComparatorTest.php
+++ b/tests/DocBlock/TagComparatorTest.php
@@ -40,7 +40,7 @@ final class TagComparatorTest extends TestCase
         static::assertSame($expected, TagComparator::shouldBeTogether($tag1, $tag2));
     }
 
-    public function provideComparatorCases(): array
+    public static function provideComparatorCases(): array
     {
         return [
             ['return', 'return', true],
@@ -71,7 +71,7 @@ final class TagComparatorTest extends TestCase
         );
     }
 
-    public function provideComparatorWithDefinedGroupsCases(): array
+    public static function provideComparatorWithDefinedGroupsCases(): array
     {
         return [
             [[['param', 'return']], 'return', 'return', true],

--- a/tests/DocBlock/TagTest.php
+++ b/tests/DocBlock/TagTest.php
@@ -46,7 +46,7 @@ final class TagTest extends TestCase
         static::assertSame($new, $tag->getName());
     }
 
-    public function provideNameCases(): array
+    public static function provideNameCases(): array
     {
         return [
             ['param', 'var', '     * @param Foo $foo'],
@@ -72,7 +72,7 @@ final class TagTest extends TestCase
         static::assertSame($expected, $tag->valid());
     }
 
-    public function provideValidCases(): array
+    public static function provideValidCases(): array
     {
         return [
             [true, '     * @param Foo $foo'],

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -37,7 +37,7 @@ final class TypeExpressionTest extends TestCase
         static::assertSame($expectedTypes, $expression->getTypes());
     }
 
-    public function provideGetTypesCases(): iterable
+    public static function provideGetTypesCases(): iterable
     {
         yield ['int', ['int']];
 
@@ -161,7 +161,7 @@ final class TypeExpressionTest extends TestCase
         static::assertSame($expectedCommonType, $expression->getCommonType());
     }
 
-    public function provideCommonTypeCases(): iterable
+    public static function provideCommonTypeCases(): iterable
     {
         $globalNamespace = new NamespaceAnalysis('', '', 0, 999, 0, 999);
         $appNamespace = new NamespaceAnalysis('App', 'App', 0, 999, 0, 999);
@@ -279,7 +279,7 @@ final class TypeExpressionTest extends TestCase
         static::assertSame($expectNullAllowed, $expression->allowsNull());
     }
 
-    public function provideAllowsNullCases(): iterable
+    public static function provideAllowsNullCases(): iterable
     {
         yield ['null', true];
 
@@ -312,7 +312,7 @@ final class TypeExpressionTest extends TestCase
         static::assertSame($expectResult, $expression->toString());
     }
 
-    public function provideSortTypesCases(): iterable
+    public static function provideSortTypesCases(): iterable
     {
         yield 'not a union type' => [
             'int',

--- a/tests/Doctrine/Annotation/TokenTest.php
+++ b/tests/Doctrine/Annotation/TokenTest.php
@@ -74,7 +74,7 @@ final class TokenTest extends TestCase
         static::assertTrue($token->isType($types));
     }
 
-    public function provideIsTypeCases(): array
+    public static function provideIsTypeCases(): array
     {
         return [
             'same-value' => [
@@ -105,7 +105,7 @@ final class TokenTest extends TestCase
         static::assertFalse($token->isType($types));
     }
 
-    public function provideIsNotTypeCases(): array
+    public static function provideIsNotTypeCases(): array
     {
         return [
             'different-value' => [

--- a/tests/Doctrine/Annotation/TokensTest.php
+++ b/tests/Doctrine/Annotation/TokensTest.php
@@ -53,7 +53,7 @@ final class TokensTest extends TestCase
         $tokens[1] = $wrongType;
     }
 
-    public function provideOffSetOtherThanTokenCases(): iterable
+    public static function provideOffSetOtherThanTokenCases(): iterable
     {
         yield [
             'Token must be an instance of PhpCsFixer\Doctrine\Annotation\Token, "null" given.',

--- a/tests/Fixer/Alias/ArrayPushFixerTest.php
+++ b/tests/Fixer/Alias/ArrayPushFixerTest.php
@@ -31,7 +31,7 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'minimal' => [
             '<?php $a[] =$b;',
@@ -275,7 +275,7 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php $a5{1*3}[2+1][] = $b4{2+1};',
@@ -298,7 +298,7 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php array_push($b?->c[2], $b19);',
@@ -315,7 +315,7 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'simple 8.1' => [
             '<?php

--- a/tests/Fixer/Alias/BacktickToShellExecFixerTest.php
+++ b/tests/Fixer/Alias/BacktickToShellExecFixerTest.php
@@ -33,7 +33,7 @@ final class BacktickToShellExecFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'plain' => [

--- a/tests/Fixer/Alias/EregToPregFixerTest.php
+++ b/tests/Fixer/Alias/EregToPregFixerTest.php
@@ -33,7 +33,7 @@ final class EregToPregFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php $x = 1;'];
 
@@ -140,7 +140,7 @@ final class EregToPregFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php $x = spliti(...);',

--- a/tests/Fixer/Alias/MbStrFunctionsFixerTest.php
+++ b/tests/Fixer/Alias/MbStrFunctionsFixerTest.php
@@ -34,7 +34,7 @@ final class MbStrFunctionsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             ['<?php $x = "strlen";'],

--- a/tests/Fixer/Alias/ModernizeStrposFixerTest.php
+++ b/tests/Fixer/Alias/ModernizeStrposFixerTest.php
@@ -33,7 +33,7 @@ final class ModernizeStrposFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'yoda ===' => [
             '<?php if (  str_starts_with($haystack1, $needle)) {}',

--- a/tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
+++ b/tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
@@ -246,7 +246,7 @@ abstract class A
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'simple 8.1' => [
             '<?php $a = is_double(...);',

--- a/tests/Fixer/Alias/NoAliasLanguageConstructCallFixerTest.php
+++ b/tests/Fixer/Alias/NoAliasLanguageConstructCallFixerTest.php
@@ -31,7 +31,7 @@ final class NoAliasLanguageConstructCallFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
+++ b/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
@@ -37,7 +37,7 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideEchoToPrintFixCases(): array
+    public static function provideEchoToPrintFixCases(): array
     {
         return [
             [
@@ -154,7 +154,7 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function providePrintToEchoFixCases(): array
+    public static function providePrintToEchoFixCases(): array
     {
         return [
             [
@@ -302,7 +302,7 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
         $this->fixer->configure($wrongConfig);
     }
 
-    public function provideWrongConfigCases(): array
+    public static function provideWrongConfigCases(): array
     {
         return [
             [

--- a/tests/Fixer/Alias/PowToExponentiationFixerTest.php
+++ b/tests/Fixer/Alias/PowToExponentiationFixerTest.php
@@ -32,7 +32,7 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             [
@@ -247,7 +247,7 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php echo $a{1}** $b{2+5};',
@@ -263,7 +263,7 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected);
     }
 
-    public function provideNotFixCases(): array
+    public static function provideNotFixCases(): array
     {
         return [
             [
@@ -291,7 +291,7 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): array
+    public static function provideFix80Cases(): array
     {
         return [
             [

--- a/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+++ b/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
@@ -72,7 +72,7 @@ final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
     /**
      * @return array[]
      */
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -194,7 +194,7 @@ class srand extends SrandClass{
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'simple 8.1' => [
             '<?php $f = srand(...);',

--- a/tests/Fixer/Alias/SetTypeToCastFixerTest.php
+++ b/tests/Fixer/Alias/SetTypeToCastFixerTest.php
@@ -31,7 +31,7 @@ final class SetTypeToCastFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'null cast' => [

--- a/tests/Fixer/ArrayNotation/ArraySyntaxFixerTest.php
+++ b/tests/Fixer/ArrayNotation/ArraySyntaxFixerTest.php
@@ -53,7 +53,7 @@ final class ArraySyntaxFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideLongSyntaxCases(): array
+    public static function provideLongSyntaxCases(): array
     {
         return [
             ['<?php $x = array();', '<?php $x = [];'],
@@ -91,7 +91,7 @@ final class ArraySyntaxFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideShortSyntaxCases(): array
+    public static function provideShortSyntaxCases(): array
     {
         return [
             ['<?php $x = [];', '<?php $x = array();'],

--- a/tests/Fixer/ArrayNotation/NoMultilineWhitespaceAroundDoubleArrowFixerTest.php
+++ b/tests/Fixer/ArrayNotation/NoMultilineWhitespaceAroundDoubleArrowFixerTest.php
@@ -35,7 +35,7 @@ final class NoMultilineWhitespaceAroundDoubleArrowFixerTest extends AbstractFixe
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/ArrayNotation/NoTrailingCommaInSinglelineArrayFixerTest.php
+++ b/tests/Fixer/ArrayNotation/NoTrailingCommaInSinglelineArrayFixerTest.php
@@ -33,7 +33,7 @@ final class NoTrailingCommaInSinglelineArrayFixerTest extends AbstractFixerTestC
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             ['<?php $x = array();'],

--- a/tests/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixerTest.php
+++ b/tests/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixerTest.php
@@ -37,7 +37,7 @@ final class NoWhitespaceBeforeCommaInArrayFixerTest extends AbstractFixerTestCas
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             // old style array

--- a/tests/Fixer/ArrayNotation/NormalizeIndexBraceFixerTest.php
+++ b/tests/Fixer/ArrayNotation/NormalizeIndexBraceFixerTest.php
@@ -35,7 +35,7 @@ final class NormalizeIndexBraceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/ArrayNotation/TrimArraySpacesFixerTest.php
+++ b/tests/Fixer/ArrayNotation/TrimArraySpacesFixerTest.php
@@ -33,7 +33,7 @@ final class TrimArraySpacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixerTest.php
+++ b/tests/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixerTest.php
@@ -39,7 +39,7 @@ final class WhitespaceAfterCommaInArrayFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             // old style array

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -52,7 +52,7 @@ final class BracesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixControlContinuationBracesCases(): iterable
+    public static function provideFixControlContinuationBracesCases(): iterable
     {
         return [
             [
@@ -847,7 +847,7 @@ if (true) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixMissingBracesAndIndentCases(): iterable
+    public static function provideFixMissingBracesAndIndentCases(): iterable
     {
         return [
             [
@@ -2667,7 +2667,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFixClassyBracesCases(): iterable
+    public static function provideFixClassyBracesCases(): iterable
     {
         return [
             [
@@ -2850,7 +2850,7 @@ function foo()
         $this->doTest($expected, $input);
     }
 
-    public function provideFixAnonFunctionInShortArraySyntaxCases(): iterable
+    public static function provideFixAnonFunctionInShortArraySyntaxCases(): iterable
     {
         return [
             [
@@ -2966,7 +2966,7 @@ function foo()
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCommentBeforeBraceCases(): iterable
+    public static function provideFixCommentBeforeBraceCases(): iterable
     {
         return [
             [
@@ -3098,7 +3098,7 @@ if ($a) { /* */ /* */ /* */ /* */ /* */
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWhitespaceBeforeBraceCases(): iterable
+    public static function provideFixWhitespaceBeforeBraceCases(): iterable
     {
         return [
             [
@@ -3315,7 +3315,7 @@ if ($a) { /* */ /* */ /* */ /* */ /* */
         $this->doTest($expected, $input);
     }
 
-    public function provideFixFunctionsCases(): iterable
+    public static function provideFixFunctionsCases(): iterable
     {
         return [
             [
@@ -3675,7 +3675,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFixMultiLineStructuresCases(): iterable
+    public static function provideFixMultiLineStructuresCases(): iterable
     {
         return [
             [
@@ -3795,7 +3795,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFixSpaceAroundTokenCases(): iterable
+    public static function provideFixSpaceAroundTokenCases(): iterable
     {
         return [
             [
@@ -3992,7 +3992,7 @@ declare   (   ticks   =   1   )   {
         $this->doTest($expected, $input);
     }
 
-    public function provideFinallyCases(): iterable
+    public static function provideFinallyCases(): iterable
     {
         return [
             [
@@ -4091,7 +4091,7 @@ declare   (   ticks   =   1   )   {
         $this->doTest($expected, $input);
     }
 
-    public function provideFunctionImportCases(): iterable
+    public static function provideFunctionImportCases(): iterable
     {
         return [
             [
@@ -4141,7 +4141,7 @@ declare   (   ticks   =   1   )   {
         $this->doTest($expected, $input);
     }
 
-    public function provideFix70Cases(): iterable
+    public static function provideFix70Cases(): iterable
     {
         return [
             [
@@ -4855,7 +4855,7 @@ $foo = new class () extends \Exception { protected $message = "Surprise"; };
         $this->doTest($expected, $input);
     }
 
-    public function providePreserveLineAfterControlBraceCases(): iterable
+    public static function providePreserveLineAfterControlBraceCases(): iterable
     {
         return [
             [
@@ -4994,7 +4994,7 @@ if (true) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithAllowOnelineLambdaCases(): iterable
+    public static function provideFixWithAllowOnelineLambdaCases(): iterable
     {
         return [
             [
@@ -5036,7 +5036,7 @@ if (true) {
         $this->doTest($expected, $input);
     }
 
-    public function provideDoWhileLoopInsideAnIfWithoutBracketsCases(): iterable
+    public static function provideDoWhileLoopInsideAnIfWithoutBracketsCases(): iterable
     {
         return [
             [
@@ -5069,7 +5069,7 @@ if (true)
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): iterable
+    public static function provideMessyWhitespacesCases(): iterable
     {
         return [
             [
@@ -5132,7 +5132,7 @@ if(true) if(true) echo 1; elseif(true) echo 2; else echo 3;',
         $this->doTest($expected, $input);
     }
 
-    public function provideNowdocInTemplatesCases(): iterable
+    public static function provideNowdocInTemplatesCases(): iterable
     {
         return [
             [
@@ -5195,7 +5195,7 @@ EOT
         $this->doTest(str_replace('//', '#', $expected), null === $input ? null : str_replace('//', '#', $input));
     }
 
-    public function provideFixCommentsCases(): iterable
+    public static function provideFixCommentsCases(): iterable
     {
         return [
             [
@@ -5405,7 +5405,7 @@ function example()
         $this->doTest($expected, $input);
     }
 
-    public function provideIndentCommentCases(): iterable
+    public static function provideIndentCommentCases(): iterable
     {
         yield [
             "<?php
@@ -5491,7 +5491,7 @@ return foo($i);
         $this->doTest($expected, $input);
     }
 
-    public function provideFixAlternativeSyntaxCases(): iterable
+    public static function provideFixAlternativeSyntaxCases(): iterable
     {
         yield [
             '<?php if (foo()) {
@@ -5696,7 +5696,7 @@ break;
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield 'match' => [
             '<?php echo match ($x) {
@@ -5719,7 +5719,7 @@ break;
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'enum' => [
             '<?php

--- a/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
+++ b/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
@@ -35,7 +35,7 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'if (default)' => [
             '<?php
@@ -678,7 +678,7 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield 'function (multiline + union return)' => [
             '<?php
@@ -743,7 +743,7 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'function (multiline + intersection return)' => [
             '<?php

--- a/tests/Fixer/Basic/NoMultipleStatementsPerLineFixerTest.php
+++ b/tests/Fixer/Basic/NoMultipleStatementsPerLineFixerTest.php
@@ -31,7 +31,7 @@ final class NoMultipleStatementsPerLineFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'simple' => [
             '<?php

--- a/tests/Fixer/Basic/NoTrailingCommaInSinglelineFixerTest.php
+++ b/tests/Fixer/Basic/NoTrailingCommaInSinglelineFixerTest.php
@@ -31,7 +31,7 @@ final class NoTrailingCommaInSinglelineFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php [$x, $y] = $a;',
@@ -59,7 +59,7 @@ final class NoTrailingCommaInSinglelineFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixNoTrailingCommaInSinglelineFunctionCallCases(): iterable
+    public static function provideFixNoTrailingCommaInSinglelineFunctionCallCases(): iterable
     {
         yield 'simple var' => [
             '<?php $a(1);',
@@ -256,7 +256,7 @@ $foo1b = function() use ($bar, ) {};
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81NoTrailingCommaInSinglelineFunctionCallFixerCases(): iterable
+    public static function provideFix81NoTrailingCommaInSinglelineFunctionCallFixerCases(): iterable
     {
         yield [
             '<?php $object?->method(1); strlen(...);',
@@ -274,7 +274,7 @@ $foo1b = function() use ($bar, ) {};
         $this->doTest($expected, $input);
     }
 
-    public function provideFixNoTrailingCommaInSinglelineArrayFixerCases(): array
+    public static function provideFixNoTrailingCommaInSinglelineArrayFixerCases(): array
     {
         return [
             ['<?php $x = array();'],
@@ -378,7 +378,7 @@ TWIG
         $this->doTest($expected, $input);
     }
 
-    public function provideFixNoTrailingCommaInListCallFixerCases(): iterable
+    public static function provideFixNoTrailingCommaInListCallFixerCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
+++ b/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
@@ -49,7 +49,7 @@ final class NonPrintableCharacterFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -134,7 +134,7 @@ echo "Hello'.pack('H*', 'e280af').'World'.pack('H*', 'c2a0').'!";',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithEscapeSequencesInStringsCases(): array
+    public static function provideFixWithEscapeSequencesInStringsCases(): array
     {
         return [
             [

--- a/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
+++ b/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
@@ -401,7 +401,7 @@ class Bar {}',
         }, $cases);
     }
 
-    public function provideAnonymousClassCases(): iterable
+    public static function provideAnonymousClassCases(): iterable
     {
         yield 'class with anonymous class' => [
             '<?php
@@ -456,7 +456,7 @@ class ClassTwo {};
         $this->doTest($expected, $input);
     }
 
-    public function providePhp80Cases(): iterable
+    public static function providePhp80Cases(): iterable
     {
         yield 'anonymous + annotation' => [
             '<?php
@@ -478,7 +478,7 @@ class extends stdClass {};
         $this->doTest($expected, $input, $this->getTestFile(__FILE__));
     }
 
-    public function providePhp81Cases(): iterable
+    public static function providePhp81Cases(): iterable
     {
         yield 'enum with wrong casing' => [
             '<?php enum PsrAutoloadingFixerTest {}',

--- a/tests/Fixer/Casing/ClassReferenceNameCasingFixerTest.php
+++ b/tests/Fixer/Casing/ClassReferenceNameCasingFixerTest.php
@@ -31,7 +31,7 @@ final class ClassReferenceNameCasingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php
@@ -256,7 +256,7 @@ use Sonata\\Exporter\\Writer\\EXCEPTION;
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php enum exception {}',

--- a/tests/Fixer/Casing/ConstantCaseFixerTest.php
+++ b/tests/Fixer/Casing/ConstantCaseFixerTest.php
@@ -33,7 +33,7 @@ final class ConstantCaseFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -107,7 +107,7 @@ final class ConstantCaseFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideLowerGeneratedCases(): iterable
+    public static function provideLowerGeneratedCases(): iterable
     {
         foreach (['true', 'false', 'null'] as $case) {
             yield [
@@ -139,7 +139,7 @@ final class ConstantCaseFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideUpperGeneratedCases(): iterable
+    public static function provideUpperGeneratedCases(): iterable
     {
         foreach (['true', 'false', 'null'] as $case) {
             yield [

--- a/tests/Fixer/Casing/IntegerLiteralCaseFixerTest.php
+++ b/tests/Fixer/Casing/IntegerLiteralCaseFixerTest.php
@@ -31,7 +31,7 @@ final class IntegerLiteralCaseFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php $foo1 = 0xFF; $foo2 = 0xDEFA; $foo3 = 0xFA; $foo4 = 0xFA;',

--- a/tests/Fixer/Casing/LowercaseKeywordsFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseKeywordsFixerTest.php
@@ -33,7 +33,7 @@ final class LowercaseKeywordsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             ['<?php $x = (1 and 2);', '<?php $x = (1 AND 2);'],
@@ -62,7 +62,7 @@ final class LowercaseKeywordsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php
@@ -109,7 +109,7 @@ class Point {
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
@@ -33,7 +33,7 @@ final class LowercaseStaticReferenceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -197,7 +197,7 @@ final class LowercaseStaticReferenceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield ['<?php $foo?->Self();'];
 

--- a/tests/Fixer/Casing/MagicConstantCasingFixerTest.php
+++ b/tests/Fixer/Casing/MagicConstantCasingFixerTest.php
@@ -33,7 +33,7 @@ final class MagicConstantCasingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -93,7 +93,7 @@ final class MagicConstantCasingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix74Cases(): array
+    public static function provideFix74Cases(): array
     {
         return [
             [

--- a/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
+++ b/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
@@ -32,7 +32,7 @@ final class MagicMethodCasingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         $fixerReflection = new \ReflectionClass(MagicMethodCasingFixer::class);
         $property = $fixerReflection->getProperty('magicNames');
@@ -273,7 +273,7 @@ class Foo extends Bar
         $this->doTest($expected, $input);
     }
 
-    public function provideDoNotFixCases(): array
+    public static function provideDoNotFixCases(): array
     {
         return [
             [
@@ -359,7 +359,7 @@ function __Tostring() {}',
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'static call to "__set_state".' => [
             '<?php $f = Foo::__set_state(...);',

--- a/tests/Fixer/Casing/NativeFunctionCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionCasingFixerTest.php
@@ -31,7 +31,7 @@ final class NativeFunctionCasingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -188,7 +188,7 @@ final class NativeFunctionCasingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield ['<?php $a?->STRTOLOWER(1,);'];
 

--- a/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
@@ -31,7 +31,7 @@ final class NativeFunctionTypeDeclarationCasingFixerTest extends AbstractFixerTe
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -141,7 +141,7 @@ function Foo(INTEGER $a) {}
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php class T { public function Foo(object $A): static {}}',
@@ -194,7 +194,7 @@ function Foo(INTEGER $a) {}
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'return type `never`' => [
             '<?php class T { public function Foo(object $A): never {die;}}',
@@ -212,7 +212,7 @@ function Foo(INTEGER $a) {}
         $this->doTest($expected, $input);
     }
 
-    public function provideFix82Cases(): iterable
+    public static function provideFix82Cases(): iterable
     {
         foreach (['true', 'false', 'null'] as $type) {
             yield sprintf('standalone type `%s` in class method', $type) => [

--- a/tests/Fixer/CastNotation/CastSpacesFixerTest.php
+++ b/tests/Fixer/CastNotation/CastSpacesFixerTest.php
@@ -57,7 +57,7 @@ final class CastSpacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCastsCases(): array
+    public static function provideFixCastsCases(): array
     {
         return [
             [
@@ -121,7 +121,7 @@ final class CastSpacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideNoneSpaceFixCases(): array
+    public static function provideNoneSpaceFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
+++ b/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
@@ -34,7 +34,7 @@ final class ModernizeTypesCastingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         $multiLinePatternToFix = <<<'FIX'
 <?php $x =
@@ -194,7 +194,7 @@ OVERRIDDEN;
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php $foo = ((string) ($x + $y)){0};',
@@ -240,7 +240,7 @@ intval#
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php $x = intval(...);',

--- a/tests/Fixer/CastNotation/NoShortBoolCastFixerTest.php
+++ b/tests/Fixer/CastNotation/NoShortBoolCastFixerTest.php
@@ -31,7 +31,7 @@ final class NoShortBoolCastFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/CastNotation/NoUnsetCastFixerTest.php
+++ b/tests/Fixer/CastNotation/NoUnsetCastFixerTest.php
@@ -33,7 +33,7 @@ final class NoUnsetCastFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'simple form I' => [

--- a/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
+++ b/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
@@ -69,7 +69,7 @@ final class ShortScalarCastFixerTest extends AbstractFixerTestCase
         $this->doTest($expected);
     }
 
-    public function provideNoFixCases(): array
+    public static function provideNoFixCases(): array
     {
         $cases = [];
         $types = ['string', 'array', 'object'];

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -34,7 +34,7 @@ final class ClassAttributesSeparationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php
@@ -286,7 +286,7 @@ private $d = 123;
         );
     }
 
-    public function provideCommentBlockStartDetectionCases(): array
+    public static function provideCommentBlockStartDetectionCases(): array
     {
         return [
             [
@@ -371,7 +371,7 @@ private $d = 123;
         $this->doTest($expected, $input);
     }
 
-    public function provideFixClassesCases(): array
+    public static function provideFixClassesCases(): array
     {
         $cases = [];
 
@@ -969,7 +969,7 @@ public function B1(); // allowed comment
         $this->doTest($expected, $input);
     }
 
-    public function provideFixTraitsCases(): array
+    public static function provideFixTraitsCases(): array
     {
         $cases = [];
 
@@ -1063,7 +1063,7 @@ trait SomeReturnInfo {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixInterfaceCases(): array
+    public static function provideFixInterfaceCases(): array
     {
         $cases = [];
         $cases[] = [
@@ -1148,7 +1148,7 @@ class ezcReflectionMethod extends ReflectionMethod {
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [
@@ -1173,7 +1173,7 @@ class ezcReflectionMethod extends ReflectionMethod {
         $this->doTest($expected, $input);
     }
 
-    public function provideConfigCases(): array
+    public static function provideConfigCases(): array
     {
         return [
             'multi line property' => [
@@ -1799,7 +1799,7 @@ abstract class Example
         $this->doTest($expected, $input);
     }
 
-    public function provideFix71Cases(): array
+    public static function provideFix71Cases(): array
     {
         return [
             [
@@ -1844,7 +1844,7 @@ abstract class Example
         $this->doTest($expected, $input);
     }
 
-    public function provideFix74Cases(): iterable
+    public static function provideFix74Cases(): iterable
     {
         yield [
             '<?php
@@ -1933,7 +1933,7 @@ abstract class Example
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPhp80Cases(): iterable
+    public static function provideFixPhp80Cases(): iterable
     {
         yield 'attributes' => [
             '<?php
@@ -2156,7 +2156,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFixClassesWithTraitsCases(): iterable
+    public static function provideFixClassesWithTraitsCases(): iterable
     {
         yield [
             '<?php
@@ -2194,7 +2194,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php class A {
@@ -2367,7 +2367,7 @@ enum Cards: string
         $this->doTest($expected, $input);
     }
 
-    public function provideFix82Cases(): iterable
+    public static function provideFix82Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -118,7 +118,7 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
         $fixer->configure(['single_line' => 'z']);
     }
 
-    public function provideAnonymousClassesCases(): array
+    public static function provideAnonymousClassesCases(): array
     {
         return [
             [
@@ -324,7 +324,7 @@ A#
         );
     }
 
-    public function provideClassesWithConfigCases(): array
+    public static function provideClassesWithConfigCases(): array
     {
         return [
             [
@@ -434,7 +434,7 @@ TestInterface3, /**/     TestInterface4   ,
         static::assertSame($expected, $result);
     }
 
-    public function provideClassyDefinitionInfoCases(): array
+    public static function provideClassyDefinitionInfoCases(): array
     {
         return [
             [
@@ -513,7 +513,7 @@ TestInterface3, /**/     TestInterface4   ,
         $this->doTestClassyInheritanceInfo($source, $label, $expected);
     }
 
-    public function provideClassyImplementsInfoCases(): iterable
+    public static function provideClassyImplementsInfoCases(): iterable
     {
         yield from [
             '1' => [
@@ -628,7 +628,7 @@ namespace {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -686,7 +686,7 @@ $a = new class implements
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [
@@ -706,7 +706,7 @@ $a = new class implements
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             "<?php enum SomeEnum implements SomeInterface, D\n{};",

--- a/tests/Fixer/ClassNotation/FinalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalClassFixerTest.php
@@ -33,7 +33,7 @@ final class FinalClassFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             ['<?php /** @Entity */ class MyEntity {}'],

--- a/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
@@ -35,7 +35,7 @@ final class FinalInternalClassFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         $input = $expected = '<?php ';
 
@@ -153,7 +153,7 @@ abstract class class4 {}
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithConfigCases(): array
+    public static function provideFixWithConfigCases(): array
     {
         return [
             [
@@ -281,7 +281,7 @@ class B{}
         $this->doTest($expected, $input);
     }
 
-    public function provideAnonymousClassesCases(): iterable
+    public static function provideAnonymousClassesCases(): iterable
     {
         yield [
             '<?php
@@ -319,7 +319,7 @@ $a = new class{};',
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixerTest.php
@@ -42,7 +42,7 @@ final class NoBlankLinesAfterClassOpeningFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         $cases = [];
 
@@ -164,7 +164,7 @@ function bar() {}
         return $cases;
     }
 
-    public function provideTraitsCases(): array
+    public static function provideTraitsCases(): array
     {
         $cases = [];
 
@@ -201,7 +201,7 @@ trait Good
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [
@@ -225,7 +225,7 @@ trait Good
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/ClassNotation/NoNullPropertyInitializationFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoNullPropertyInitializationFixerTest.php
@@ -33,7 +33,7 @@ final class NoNullPropertyInitializationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -307,7 +307,7 @@ null;#13
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPrePHP80Cases(): iterable
+    public static function provideFixPrePHP80Cases(): iterable
     {
         yield [
             '<?php class Foo { public $bar; }',
@@ -356,7 +356,7 @@ class Point {
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'readonly - cannot have default value, fixer should not crash' => [
             '<?php

--- a/tests/Fixer/ClassNotation/NoPhp4ConstructorFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoPhp4ConstructorFixerTest.php
@@ -33,7 +33,7 @@ final class NoPhp4ConstructorFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -71,7 +71,7 @@ final class NoPhp4ConstructorFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideSimpleCases(): array
+    public static function provideSimpleCases(): array
     {
         return [
             [
@@ -1140,7 +1140,7 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPhp80Cases(): iterable
+    public static function provideFixPhp80Cases(): iterable
     {
         yield [
             <<<'EOF'

--- a/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
@@ -33,7 +33,7 @@ final class NoUnneededFinalMethodFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'default' => [
@@ -359,7 +359,7 @@ abstract class Foo {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixConfigCases(): iterable
+    public static function provideFixConfigCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -35,7 +35,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             <<<'EOT'
@@ -396,7 +396,7 @@ EOT
         $this->doTest($expected, $input);
     }
 
-    public function provideConfigurationCases(): array
+    public static function provideConfigurationCases(): array
     {
         return [
             [
@@ -929,7 +929,7 @@ EOT
         $this->doTest($expected, $input);
     }
 
-    public function provideSortingConfigurationCases(): array
+    public static function provideSortingConfigurationCases(): array
     {
         return [
             [
@@ -1267,7 +1267,7 @@ EOT
         $this->doTest($expected, $input);
     }
 
-    public function provideFix74Cases(): iterable
+    public static function provideFix74Cases(): iterable
     {
         yield [
             '<?php
@@ -1333,7 +1333,7 @@ class TestClass
         );
     }
 
-    public function provideWithConfigWithNoCandidateCases(): iterable
+    public static function provideWithConfigWithNoCandidateCases(): iterable
     {
         yield ['z', '__construct'];
 
@@ -1354,7 +1354,7 @@ class TestClass
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php
@@ -1429,7 +1429,7 @@ trait TestTrait
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php
@@ -1503,7 +1503,7 @@ class A
         $this->doTest($expected, $input);
     }
 
-    public function provideFix82Cases(): iterable
+    public static function provideFix82Cases(): iterable
     {
         yield [
             '<?php trait Foo { const C1 = 1; protected $abc = "abc"; }',

--- a/tests/Fixer/ClassNotation/OrderedInterfacesFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedInterfacesFixerTest.php
@@ -34,7 +34,7 @@ final class OrderedInterfacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixAlphaCases(): array
+    public static function provideFixAlphaCases(): array
     {
         return [
             'single' => [
@@ -128,7 +128,7 @@ final class OrderedInterfacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixAlphaDescendCases(): array
+    public static function provideFixAlphaDescendCases(): array
     {
         return [
             'single' => [
@@ -154,7 +154,7 @@ final class OrderedInterfacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixLengthCases(): array
+    public static function provideFixLengthCases(): array
     {
         return [
             'single' => [
@@ -197,7 +197,7 @@ final class OrderedInterfacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixLengthDescendCases(): array
+    public static function provideFixLengthDescendCases(): array
     {
         return [
             'single' => [

--- a/tests/Fixer/ClassNotation/OrderedTraitsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedTraitsFixerTest.php
@@ -34,7 +34,7 @@ final class OrderedTraitsFixerTest extends AbstractFixerTestCase
     /**
      * @return iterable<array>
      */
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'simple' => [
             '<?php

--- a/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
@@ -33,7 +33,7 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -179,7 +179,7 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPhp80Cases(): iterable
+    public static function provideFixPhp80Cases(): iterable
     {
         yield [
             '<?php interface Foo { public function bar(self $foo, self $bar,): self; }',

--- a/tests/Fixer/ClassNotation/SelfStaticAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfStaticAccessorFixerTest.php
@@ -31,7 +31,7 @@ final class SelfStaticAccessorFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'simple' => [

--- a/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
+++ b/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
@@ -35,7 +35,7 @@ final class SingleClassElementPerStatementFixerTest extends AbstractFixerTestCas
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             [
@@ -707,7 +707,7 @@ EOT;
         $this->doTest($expected, $input);
     }
 
-    public function provideConfigurationCases(): array
+    public static function provideConfigurationCases(): array
     {
         return [
             [
@@ -771,7 +771,7 @@ EOT
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): iterable
+    public static function provideMessyWhitespacesCases(): iterable
     {
         yield [
             "<?php\r\n\tclass Foo {\r\n\t\tconst AAA=0;\r\n\t\tconst BBB=1;\r\n\t}",
@@ -835,7 +835,7 @@ EOT
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php
@@ -864,7 +864,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php
@@ -955,7 +955,7 @@ var_dump(Foo::A.Foo::B);",
         $this->doTest($expected, $input);
     }
 
-    public function provideFix82Cases(): iterable
+    public static function provideFix82Cases(): iterable
     {
         yield [
             '<?php trait Foo { public const Bar = 1; public const Baz = 1; }',

--- a/tests/Fixer/ClassNotation/SingleTraitInsertPerStatementFixerTest.php
+++ b/tests/Fixer/ClassNotation/SingleTraitInsertPerStatementFixerTest.php
@@ -31,7 +31,7 @@ final class SingleTraitInsertPerStatementFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'simple' => [

--- a/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+++ b/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
@@ -94,7 +94,7 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function provideFixMethodsCases(): iterable
+    public static function provideFixMethodsCases(): iterable
     {
         return [
             [
@@ -526,7 +526,7 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function provideFixClassConstCases(): array
+    public static function provideFixClassConstCases(): array
     {
         return [
             [
@@ -726,7 +726,7 @@ AB# <- this is the name
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php class Foo { private int $foo; }',
@@ -774,7 +774,7 @@ AB# <- this is the name
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php class Foo { private int|float|null $foo; }',
@@ -808,7 +808,7 @@ AB# <- this is the name
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php class Foo { public Foo1&Bar $foo; }',
@@ -904,7 +904,7 @@ var_dump(Foo::CAT->test());',
         $this->doTest($expected, $input);
     }
 
-    public function provideFix82Cases(): iterable
+    public static function provideFix82Cases(): iterable
     {
         yield [
             '<?php trait Foo { public const Bar = 1; }',

--- a/tests/Fixer/ClassUsage/DateTimeImmutableFixerTest.php
+++ b/tests/Fixer/ClassUsage/DateTimeImmutableFixerTest.php
@@ -33,7 +33,7 @@ final class DateTimeImmutableFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -187,7 +187,7 @@ final class DateTimeImmutableFixerTest extends AbstractFixerTestCase
         $this->doTest($expected);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield ['<?php $foo?->DateTime();'];
 

--- a/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
+++ b/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
@@ -36,7 +36,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestCases(): array
+    public static function provideTestCases(): array
     {
         return [
             [

--- a/tests/Fixer/Comment/HeaderCommentFixerTest.php
+++ b/tests/Fixer/Comment/HeaderCommentFixerTest.php
@@ -38,7 +38,7 @@ final class HeaderCommentFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -630,7 +630,7 @@ echo 1;'
         $this->fixer->configure($configuration);
     }
 
-    public function provideMisconfigurationCases(): array
+    public static function provideMisconfigurationCases(): array
     {
         return [
             [[], 'Missing required configuration: The required option "header" is missing.'],
@@ -689,7 +689,7 @@ echo 1;'
         );
     }
 
-    public function provideHeaderGenerationCases(): array
+    public static function provideHeaderGenerationCases(): array
     {
         return [
             [
@@ -721,7 +721,7 @@ echo 1;'
         $this->doTest($expected);
     }
 
-    public function provideDoNotTouchCases(): array
+    public static function provideDoNotTouchCases(): array
     {
         return [
             ["<?php\nphpinfo();\n?>\n<?"],
@@ -754,7 +754,7 @@ echo 1;'
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [
@@ -823,7 +823,7 @@ echo 1;'
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             ['header' => 'tmp'],

--- a/tests/Fixer/Comment/MultilineCommentOpeningClosingFixerTest.php
+++ b/tests/Fixer/Comment/MultilineCommentOpeningClosingFixerTest.php
@@ -33,7 +33,7 @@ final class MultilineCommentOpeningClosingFixerTest extends AbstractFixerTestCas
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             ['<?php /** Opening DocBlock */'],

--- a/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
+++ b/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
@@ -32,7 +32,7 @@ final class NoEmptyCommentFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             // fix cases
@@ -272,7 +272,7 @@ echo 1;
         static::assertSame($isEmpty, $foundIsEmpty, 'Is empty comment block detection failed.');
     }
 
-    public function provideCommentBlockCases(): array
+    public static function provideCommentBlockCases(): array
     {
         $cases = [
             [

--- a/tests/Fixer/Comment/NoTrailingWhitespaceInCommentFixerTest.php
+++ b/tests/Fixer/Comment/NoTrailingWhitespaceInCommentFixerTest.php
@@ -33,7 +33,7 @@ final class NoTrailingWhitespaceInCommentFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Comment/SingleLineCommentSpacingFixerTest.php
+++ b/tests/Fixer/Comment/SingleLineCommentSpacingFixerTest.php
@@ -31,7 +31,7 @@ final class SingleLineCommentSpacingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestCases(): iterable
+    public static function provideTestCases(): iterable
     {
         yield 'comment list' => [
             '<?php

--- a/tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
+++ b/tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
@@ -43,7 +43,7 @@ final class SingleLineCommentStyleFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideAsteriskCases(): array
+    public static function provideAsteriskCases(): array
     {
         return [
             [
@@ -226,7 +226,7 @@ second line*/',
         $this->doTest($expected, $input);
     }
 
-    public function provideHashCases(): array
+    public static function provideHashCases(): array
     {
         return [
             [
@@ -295,7 +295,7 @@ second line*/',
         $this->doTest($expected, $input);
     }
 
-    public function provideAllCases(): array
+    public static function provideAllCases(): array
     {
         return [
             [

--- a/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+++ b/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
@@ -78,7 +78,7 @@ final class NativeConstantInvocationFixerTest extends AbstractFixerTestCase
         ]);
     }
 
-    public function provideInvalidConfigurationElementCases(): array
+    public static function provideInvalidConfigurationElementCases(): array
     {
         return [
             'null' => [null],
@@ -118,7 +118,7 @@ final class NativeConstantInvocationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithDefaultConfigurationCases(): array
+    public static function provideFixWithDefaultConfigurationCases(): array
     {
         return [
             ['<?php var_dump(NULL, FALSE, TRUE, 1);'],
@@ -197,7 +197,7 @@ try {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithConfiguredCustomIncludeCases(): array
+    public static function provideFixWithConfiguredCustomIncludeCases(): array
     {
         return [
             [
@@ -226,7 +226,7 @@ try {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithConfiguredOnlyIncludeCases(): array
+    public static function provideFixWithConfiguredOnlyIncludeCases(): array
     {
         return [
             [
@@ -254,7 +254,7 @@ try {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithConfiguredExcludeCases(): array
+    public static function provideFixWithConfiguredExcludeCases(): array
     {
         return [
             [
@@ -498,7 +498,7 @@ echo M_PI;
         $this->doTest($expected);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/ControlStructure/ControlStructureBracesFixerTest.php
+++ b/tests/Fixer/ControlStructure/ControlStructureBracesFixerTest.php
@@ -31,7 +31,7 @@ final class ControlStructureBracesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'if' => [
             '<?php if ($foo) { foo(); }',

--- a/tests/Fixer/ControlStructure/ControlStructureContinuationPositionFixerTest.php
+++ b/tests/Fixer/ControlStructure/ControlStructureContinuationPositionFixerTest.php
@@ -37,7 +37,7 @@ final class ControlStructureContinuationPositionFixerTest extends AbstractFixerT
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'else (same line, default)' => [
             '<?php

--- a/tests/Fixer/ControlStructure/ElseifFixerTest.php
+++ b/tests/Fixer/ControlStructure/ElseifFixerTest.php
@@ -33,7 +33,7 @@ final class ElseifFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): array
+    public static function provideTestFixCases(): array
     {
         return [
             ['<?php if ($some) { $test = true; } else { $test = false; }'],

--- a/tests/Fixer/ControlStructure/EmptyLoopBodyFixerTest.php
+++ b/tests/Fixer/ControlStructure/EmptyLoopBodyFixerTest.php
@@ -46,7 +46,7 @@ final class EmptyLoopBodyFixerTest extends AbstractFixerTestCase
         }
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'simple "while"' => [
             '<?php while(foo());',

--- a/tests/Fixer/ControlStructure/EmptyLoopConditionFixerTest.php
+++ b/tests/Fixer/ControlStructure/EmptyLoopConditionFixerTest.php
@@ -35,7 +35,7 @@ final class EmptyLoopConditionFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'from `for` to `while`' => [
             '<?php

--- a/tests/Fixer/ControlStructure/IncludeFixerTest.php
+++ b/tests/Fixer/ControlStructure/IncludeFixerTest.php
@@ -33,7 +33,7 @@ final class IncludeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php include # A

--- a/tests/Fixer/ControlStructure/NoAlternativeSyntaxFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoAlternativeSyntaxFixerTest.php
@@ -37,7 +37,7 @@ final class NoAlternativeSyntaxFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -45,7 +45,7 @@ final class NoBreakCommentFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -1202,7 +1202,7 @@ switch ($foo) {
         ]);
     }
 
-    public function provideFixWithCommentTextContainingNewLinesCases(): array
+    public static function provideFixWithCommentTextContainingNewLinesCases(): array
     {
         return [
             ["No\nbreak"],
@@ -1229,7 +1229,7 @@ switch ($foo) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php
@@ -1294,7 +1294,7 @@ switch ($foo) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'enums' => [
             '<?php

--- a/tests/Fixer/ControlStructure/NoSuperfluousElseifFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoSuperfluousElseifFixerTest.php
@@ -32,7 +32,7 @@ final class NoSuperfluousElseifFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -272,7 +272,7 @@ if ($some) { return 1; } elseif ($a == 6){ $test = false; } //',
         $this->doTest($expected);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/ControlStructure/NoTrailingCommaInListCallFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoTrailingCommaInListCallFixerTest.php
@@ -33,7 +33,7 @@ final class NoTrailingCommaInListCallFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
@@ -50,7 +50,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -368,7 +368,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixAllCases(): iterable
+    public static function provideFixAllCases(): iterable
     {
         yield '===' => [
             '<?php $at = $a === $b;',
@@ -1481,7 +1481,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
         $this->doTest($input);
     }
 
-    public function provideFixWithConfigCases(): iterable
+    public static function provideFixWithConfigCases(): iterable
     {
         yield 'config: break' => [
             ['statements' => ['break']],
@@ -1606,7 +1606,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function providePrePhp8Cases(): iterable
+    public static function providePrePhp8Cases(): iterable
     {
         yield 'block type array index curly brace' => [
             '<?php echo $a12 = $a{1};',
@@ -1651,7 +1651,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPhp80Cases(): iterable
+    public static function provideFixPhp80Cases(): iterable
     {
         yield 'fn throw' => [
             '<?php $triggerError = fn () => throw new MyError();',
@@ -1709,7 +1709,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPhp81Cases(): iterable
+    public static function provideFixPhp81Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
@@ -31,7 +31,7 @@ final class NoUnneededCurlyBracesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             'simple sample, last token candidate' => [
@@ -137,7 +137,7 @@ final class NoUnneededCurlyBracesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield 'no fixes, offset access syntax with curly braces' => [
             '<?php
@@ -156,7 +156,7 @@ final class NoUnneededCurlyBracesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixNamespaceCases(): iterable
+    public static function provideFixNamespaceCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
@@ -33,7 +33,7 @@ final class NoUselessElseFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function providePHPCloseTagCases(): array
+    public static function providePHPCloseTagCases(): array
     {
         return [
             [
@@ -315,7 +315,7 @@ else?><?php echo 5;',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixNestedIfCases(): array
+    public static function provideFixNestedIfCases(): array
     {
         return [
             [
@@ -353,7 +353,7 @@ else?><?php echo 5;',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixEmptyElseCases(): array
+    public static function provideFixEmptyElseCases(): array
     {
         return [
             [
@@ -445,7 +445,7 @@ else?><?php echo 5;',
         $this->doTest($expected);
     }
 
-    public function provideNegativeCases(): iterable
+    public static function provideNegativeCases(): iterable
     {
         yield from [
             [
@@ -617,7 +617,7 @@ else?><?php echo 5;',
         $this->doTest($expected);
     }
 
-    public function provideNegativePhp80Cases(): iterable
+    public static function provideNegativePhp80Cases(): iterable
     {
         $cases = [
             '$bar = $foo1 ?? throw new \Exception($e);',
@@ -663,7 +663,7 @@ else?><?php echo 5;',
         static::assertSame($expected, $result);
     }
 
-    public function provideBlockDetectionCases(): array
+    public static function provideBlockDetectionCases(): array
     {
         $cases = [];
 
@@ -789,7 +789,7 @@ else?><?php echo 5;',
         }
     }
 
-    public function provideIsInConditionWithoutBracesCases(): array
+    public static function provideIsInConditionWithoutBracesCases(): array
     {
         return [
             [

--- a/tests/Fixer/ControlStructure/SimplifiedIfReturnFixerTest.php
+++ b/tests/Fixer/ControlStructure/SimplifiedIfReturnFixerTest.php
@@ -33,7 +33,7 @@ final class SimplifiedIfReturnFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'simple' => [
             '<?php return (bool) ($foo)      ;',

--- a/tests/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixerTest.php
@@ -31,7 +31,7 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             [
@@ -246,7 +246,7 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php
@@ -274,7 +274,7 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): array
+    public static function provideFix80Cases(): array
     {
         return [
             'Simple match' => [
@@ -324,7 +324,7 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'enums' => [
             '<?php

--- a/tests/Fixer/ControlStructure/SwitchCaseSpaceFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchCaseSpaceFixerTest.php
@@ -33,7 +33,7 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             [
@@ -342,7 +342,7 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php
@@ -370,7 +370,7 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php
@@ -410,7 +410,7 @@ $a = function (): ?string {
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'enums' => [
             '<?php

--- a/tests/Fixer/ControlStructure/SwitchContinueToBreakFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchContinueToBreakFixerTest.php
@@ -31,7 +31,7 @@ final class SwitchContinueToBreakFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): iterable
+    public static function provideTestFixCases(): iterable
     {
         yield from [
             'alternative syntax |' => [

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -55,7 +55,7 @@ final class YodaStyleFixerTest extends AbstractFixerTestCase
         }
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             [
@@ -748,7 +748,7 @@ switch ($a) {
         $this->doTest($input, $expected);
     }
 
-    public function provideLessGreaterCases(): array
+    public static function provideLessGreaterCases(): array
     {
         return [
             [
@@ -801,7 +801,7 @@ switch ($a) {
         $this->fixer->configure($config);
     }
 
-    public function provideInvalidConfigurationCases(): array
+    public static function provideInvalidConfigurationCases(): array
     {
         return [
             [['equal' => 2], 'Invalid configuration: The option "equal" with value 2 is expected to be of type "bool" or "null", but is of type "(int|integer)"\.'],
@@ -839,7 +839,7 @@ switch ($a) {
         }
     }
 
-    public function providePHP71Cases(): array
+    public static function providePHP71Cases(): array
     {
         return [
             // no fix cases
@@ -894,7 +894,7 @@ switch ($a) {
         $this->doTest($expected);
     }
 
-    public function provideFixWithConfigCases(): iterable
+    public static function provideFixWithConfigCases(): iterable
     {
         yield [
             [
@@ -932,7 +932,7 @@ while (2 !== $b = array_pop($c));
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPhp74Cases(): iterable
+    public static function provideFixPhp74Cases(): iterable
     {
         yield [
             '<?php if (1_000 === $b);',
@@ -954,7 +954,7 @@ while (2 !== $b = array_pop($c));
         $this->doTest($expected, $input);
     }
 
-    public function providePHP74Cases(): iterable
+    public static function providePHP74Cases(): iterable
     {
         yield [
             '<?php fn() => $c === array(1) ? $b : $d;',
@@ -980,7 +980,7 @@ while (2 !== $b = array_pop($c));
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPrePHP80Cases(): iterable
+    public static function provideFixPrePHP80Cases(): iterable
     {
         yield [
             '<?php return \A/*5*/\/*6*/B\/*7*/C::MY_CONST === \A/*1*//*1*//*1*//*1*//*1*/\/*2*/B/*3*/\C/*4*/::$myVariable;',
@@ -1019,7 +1019,7 @@ while (2 !== $b = array_pop($c));
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php
@@ -1065,7 +1065,7 @@ if ($a = $obj instanceof (foo()) === true) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'does not make a lot of sense but is valid syntax, do not break 1' => [
             '<?php $b = strlen( ... ) === $a;',

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixerTest.php
@@ -185,7 +185,7 @@ final class DoctrineAnnotationArrayAssignmentFixerTest extends AbstractDoctrineA
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php class FooClass{

--- a/tests/Fixer/FunctionNotation/CombineNestedDirnameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/CombineNestedDirnameFixerTest.php
@@ -33,7 +33,7 @@ final class CombineNestedDirnameFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -114,7 +114,7 @@ final class CombineNestedDirnameFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield ['<?php $a = dirname(dirname(...));'];
     }

--- a/tests/Fixer/FunctionNotation/DateTimeCreateFromFormatCallFixerTest.php
+++ b/tests/Fixer/FunctionNotation/DateTimeCreateFromFormatCallFixerTest.php
@@ -31,7 +31,7 @@ final class DateTimeCreateFromFormatCallFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         foreach (['DateTime', 'DateTimeImmutable'] as $class) {
             $lowerCaseClass = strtolower($class);

--- a/tests/Fixer/FunctionNotation/FopenFlagOrderFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FopenFlagOrderFixerTest.php
@@ -32,7 +32,7 @@ final class FopenFlagOrderFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'most simple fix case' => [

--- a/tests/Fixer/FunctionNotation/FopenFlagsFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FopenFlagsFixerTest.php
@@ -35,7 +35,7 @@ final class FopenFlagsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'missing "b"' => [
@@ -111,7 +111,7 @@ final class FopenFlagsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected);
     }
 
-    public function provideDoNotFixCases(): array
+    public static function provideDoNotFixCases(): array
     {
         return [
             'not simple flags' => [

--- a/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
@@ -69,7 +69,7 @@ final class FunctionDeclarationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -451,7 +451,7 @@ foo#
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPhp80Cases(): iterable
+    public static function provideFixPhp80Cases(): iterable
     {
         yield [
             '<?php function ($i) {};',

--- a/tests/Fixer/FunctionNotation/FunctionTypehintSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionTypehintSpaceFixerTest.php
@@ -33,7 +33,7 @@ final class FunctionTypehintSpaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -241,7 +241,7 @@ final class FunctionTypehintSpaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php function foo(mixed $a){}',

--- a/tests/Fixer/FunctionNotation/ImplodeCallFixerTest.php
+++ b/tests/Fixer/FunctionNotation/ImplodeCallFixerTest.php
@@ -33,7 +33,7 @@ final class ImplodeCallFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ["<?php implode('', [1,2,3]);"];
 

--- a/tests/Fixer/FunctionNotation/LambdaNotUsedImportFixerTest.php
+++ b/tests/Fixer/FunctionNotation/LambdaNotUsedImportFixerTest.php
@@ -31,7 +31,7 @@ final class LambdaNotUsedImportFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'simple' => [
@@ -122,7 +122,7 @@ $a = function() use ($b) { new class(){ public function foo($b){echo $b;}}; }; /
         $this->doTest($expected);
     }
 
-    public function provideDoNotFixCases(): iterable
+    public static function provideDoNotFixCases(): iterable
     {
         yield from [
             'reference' => [
@@ -190,7 +190,7 @@ $foo();
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield 'simple' => [
             '<?php $foo = function() {};',

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -79,7 +79,7 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
         );
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -957,7 +957,7 @@ $example = function () use ($message1,$message2) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFix2Cases(): iterable
+    public static function provideFix2Cases(): iterable
     {
         yield [
             '<?php function A($c, ...$a){}',
@@ -1050,7 +1050,7 @@ $fn = fn(
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -63,7 +63,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
         ]);
     }
 
-    public function provideInvalidConfigurationElementCases(): array
+    public static function provideInvalidConfigurationElementCases(): array
     {
         return [
             'null' => [null],
@@ -99,7 +99,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
         }
     }
 
-    public function provideConfigureIncludeSetsCases(): array
+    public static function provideConfigureIncludeSetsCases(): array
     {
         return [
             [['foo', 'bar']],
@@ -173,7 +173,7 @@ PHP;
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithDefaultConfigurationCases(): array
+    public static function provideFixWithDefaultConfigurationCases(): array
     {
         return [
             [
@@ -273,7 +273,7 @@ strlen($foo);
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithConfiguredExcludeCases(): array
+    public static function provideFixWithConfiguredExcludeCases(): array
     {
         return [
             [
@@ -306,7 +306,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithNamespaceConfigurationCases(): array
+    public static function provideFixWithNamespaceConfigurationCases(): array
     {
         return [
             [
@@ -476,7 +476,7 @@ namespace {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithConfiguredIncludeCases(): iterable
+    public static function provideFixWithConfiguredIncludeCases(): iterable
     {
         yield from [
             'include set + 1, exclude 1' => [
@@ -628,7 +628,7 @@ echo strlen($a);
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield 'attribute and strict' => [
             '<?php

--- a/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
@@ -33,7 +33,7 @@ final class NoSpacesAfterFunctionNameFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             'test function call' => [
@@ -166,7 +166,7 @@ $$e(2);
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield 'test dynamic by array, curly mix' => [
             '<?php $a["e"](1); $a{2}(1);',
@@ -189,7 +189,7 @@ $$e(2);
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php strlen(...);',

--- a/tests/Fixer/FunctionNotation/NoTrailingCommaInSinglelineFunctionCallFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoTrailingCommaInSinglelineFunctionCallFixerTest.php
@@ -31,7 +31,7 @@ final class NoTrailingCommaInSinglelineFunctionCallFixerTest extends AbstractFix
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'simple var' => [
             '<?php $a(1);',
@@ -230,7 +230,7 @@ $foo1b = function() use ($bar, ) {};
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php $object?->method(1); strlen(...);',

--- a/tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
@@ -31,7 +31,7 @@ final class NoUnreachableDefaultArgumentValueFixerTest extends AbstractFixerTest
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -190,7 +190,7 @@ $bar) {}',
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield 'handle trailing comma' => [
             '<?php function foo($x, $y = 42, $z = 42 ) {}',
@@ -233,7 +233,7 @@ $bar) {}',
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'do not crash' => [
             '<?php strlen( ... );',

--- a/tests/Fixer/FunctionNotation/NoUselessSprintfFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoUselessSprintfFixerTest.php
@@ -31,7 +31,7 @@ final class NoUselessSprintfFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'simple' => [
             '<?php echo "bar";',
@@ -116,7 +116,7 @@ final class NoUselessSprintfFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php echo  "bar";',

--- a/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
@@ -34,7 +34,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         $this->doTest($expected);
     }
 
-    public function provideDoNotFixCases(): iterable
+    public static function provideDoNotFixCases(): iterable
     {
         yield ['<?php function foo($param = null) {}'];
 
@@ -150,7 +150,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php function foo(?string $param = null) {}',
@@ -332,7 +332,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         return TestCaseUtils::swapExpectedInputTestCases($this->provideFixCases());
     }
 
-    public function provideNonInverseOnlyFixCases(): iterable
+    public static function provideNonInverseOnlyFixCases(): iterable
     {
         yield [
             '<?php function foo( ?string $param = null) {}',
@@ -350,7 +350,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         ];
     }
 
-    public function provideInverseOnlyFixCases(): iterable
+    public static function provideInverseOnlyFixCases(): iterable
     {
         yield [
             '<?php function foo(string $param = null) {}',
@@ -385,7 +385,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPhp74Cases(): iterable
+    public static function provideFixPhp74Cases(): iterable
     {
         yield [
             '<?php $foo = fn (?string $param = null) => null;',
@@ -448,7 +448,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield 'trailing comma' => [
             '<?php function foo(?string $param = null,) {}',
@@ -522,7 +522,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre81Cases(): iterable
+    public static function provideFixPre81Cases(): iterable
     {
         yield 'do not fix pre PHP 8.1' => [
             '<?php
@@ -555,7 +555,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         $this->doTest($expected);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
@@ -45,7 +45,7 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'typehint already defined' => [

--- a/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
@@ -34,7 +34,7 @@ final class PhpdocToPropertyTypeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'no phpdoc return' => [
@@ -467,7 +467,7 @@ final class PhpdocToPropertyTypeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'readonly properties are always typed, make sure the fixer does not crash' => [
             '<?php class Foo { /** @var int */ private readonly string $foo; }',

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -44,7 +44,7 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             'no phpdoc return' => [
@@ -349,7 +349,7 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield 'report static as self' => [
             '<?php
@@ -379,7 +379,7 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPhp80Cases(): iterable
+    public static function provideFixPhp80Cases(): iterable
     {
         yield 'static' => [
             '<?php

--- a/tests/Fixer/FunctionNotation/RegularCallableCallFixerTest.php
+++ b/tests/Fixer/FunctionNotation/RegularCallableCallFixerTest.php
@@ -33,7 +33,7 @@ final class RegularCallableCallFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'call by name - list' => [
             '<?php
@@ -251,7 +251,7 @@ class Foo {
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php \call_user_func(...) ?>',

--- a/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
@@ -57,7 +57,7 @@ final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithSpaceBeforeNoneCases(): array
+    public static function provideFixWithSpaceBeforeNoneCases(): array
     {
         return [
             [
@@ -127,7 +127,7 @@ string {}',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithSpaceBeforeOneCases(): array
+    public static function provideFixWithSpaceBeforeOneCases(): array
     {
         return [
             [
@@ -161,7 +161,7 @@ string {}',
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php function foo(): mixed{}',
@@ -184,7 +184,7 @@ string {}',
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php enum Foo: int {}',

--- a/tests/Fixer/FunctionNotation/SingleLineThrowFixerTest.php
+++ b/tests/Fixer/FunctionNotation/SingleLineThrowFixerTest.php
@@ -31,7 +31,7 @@ final class SingleLineThrowFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php throw new Exception; foo(
                     "Foo"

--- a/tests/Fixer/FunctionNotation/StaticLambdaFixerTest.php
+++ b/tests/Fixer/FunctionNotation/StaticLambdaFixerTest.php
@@ -31,7 +31,7 @@ final class StaticLambdaFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'sample' => [
@@ -132,7 +132,7 @@ final class StaticLambdaFixerTest extends AbstractFixerTestCase
         $this->doTest($expected);
     }
 
-    public function provideDoNotFixCases(): array
+    public static function provideDoNotFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/FunctionNotation/UseArrowFunctionsFixerTest.php
+++ b/tests/Fixer/FunctionNotation/UseArrowFunctionsFixerTest.php
@@ -33,7 +33,7 @@ final class UseArrowFunctionsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
+++ b/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
@@ -34,7 +34,7 @@ final class VoidReturnFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             ['<?php class Test { public function __construct() {} }'],

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -33,7 +33,7 @@ final class FullyQualifiedStrictTypesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideNewLogicCases(): iterable
+    public static function provideNewLogicCases(): iterable
     {
         yield 'namespace === type name' => [
             '<?php
@@ -114,7 +114,7 @@ namespace A\B\C\D
         $this->doTest($expected, $input);
     }
 
-    public function provideCodeWithReturnTypesCases(): iterable
+    public static function provideCodeWithReturnTypesCases(): iterable
     {
         yield 'Import common strict types' => [
             '<?php
@@ -326,7 +326,7 @@ class SomeClass
         $this->doTest($expected, $input);
     }
 
-    public function provideCodeWithoutReturnTypesCases(): iterable
+    public static function provideCodeWithoutReturnTypesCases(): iterable
     {
         yield 'import from namespace and global' => [
             '<?php
@@ -573,7 +573,7 @@ namespace {
         ];
     }
 
-    public function provideCodeWithReturnTypesCasesWithNullableCases(): array
+    public static function provideCodeWithReturnTypesCasesWithNullableCases(): array
     {
         return [
             'Test namespace fixes with nullable types' => [

--- a/tests/Fixer/Import/GlobalNamespaceImportFixerTest.php
+++ b/tests/Fixer/Import/GlobalNamespaceImportFixerTest.php
@@ -34,7 +34,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixImportConstantsCases(): array
+    public static function provideFixImportConstantsCases(): array
     {
         return [
             'non-global names' => [
@@ -235,7 +235,7 @@ INPUT
         $this->doTest($expected, $input);
     }
 
-    public function provideFixImportFunctionsCases(): array
+    public static function provideFixImportFunctionsCases(): array
     {
         return [
             'non-global names' => [
@@ -439,7 +439,7 @@ EXPECTED
         $this->doTest($expected, $input);
     }
 
-    public function provideFixImportClassesCases(): array
+    public static function provideFixImportClassesCases(): array
     {
         return [
             'non-global names' => [
@@ -726,7 +726,7 @@ INPUT
         $this->doTest($expected, $input);
     }
 
-    public function provideFixFullyQualifyConstantsCases(): array
+    public static function provideFixFullyQualifyConstantsCases(): array
     {
         return [
             'already fqn or sub namespace' => [
@@ -785,7 +785,7 @@ INPUT
         $this->doTest($expected, $input);
     }
 
-    public function provideFixFullyQualifyFunctionsCases(): array
+    public static function provideFixFullyQualifyFunctionsCases(): array
     {
         return [
             'already fqn or sub namespace' => [
@@ -851,7 +851,7 @@ INPUT
         $this->doTest($expected, $input);
     }
 
-    public function provideFixFullyQualifyClassesCases(): array
+    public static function provideFixFullyQualifyClassesCases(): array
     {
         return [
             'already fqn or sub namespace' => [
@@ -940,7 +940,7 @@ INPUT
         $this->doTest($expected);
     }
 
-    public function provideMultipleNamespacesCases(): iterable
+    public static function provideMultipleNamespacesCases(): iterable
     {
         yield [
             <<<'INPUT'
@@ -1046,7 +1046,7 @@ class Bar
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'ignore enum methods' => [
             <<<'EXPECTED'

--- a/tests/Fixer/Import/GroupImportFixerTest.php
+++ b/tests/Fixer/Import/GroupImportFixerTest.php
@@ -33,7 +33,7 @@ final class GroupImportFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php
@@ -334,7 +334,7 @@ use function Foo\b;
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Import/NoLeadingImportSlashFixerTest.php
+++ b/tests/Fixer/Import/NoLeadingImportSlashFixerTest.php
@@ -33,7 +33,7 @@ final class NoLeadingImportSlashFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -213,7 +213,7 @@ use const \some\Z\{ConstX,ConstY,ConstZ,};
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPrePHP80Cases(): iterable
+    public static function provideFixPrePHP80Cases(): iterable
     {
         yield [
             '<?php use /*1*/A\D;',

--- a/tests/Fixer/Import/NoUnneededImportAliasFixerTest.php
+++ b/tests/Fixer/Import/NoUnneededImportAliasFixerTest.php
@@ -31,7 +31,7 @@ final class NoUnneededImportAliasFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php use some\ns\{ClassA, ClassB, ClassC  };',

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -31,7 +31,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'simple' => [
@@ -1356,7 +1356,7 @@ use /**/A\B/**/;
         $this->doTest($expected, $input);
     }
 
-    public function providePhp80Cases(): iterable
+    public static function providePhp80Cases(): iterable
     {
         yield [
             '<?php
@@ -1428,7 +1428,7 @@ function f( #[Target(\'xxx\')] LoggerInterface|null $logger) {}
         $this->doTest($expected, $input);
     }
 
-    public function providePhp81Cases(): iterable
+    public static function providePhp81Cases(): iterable
     {
         yield 'final const' => [
             '<?php
@@ -1503,7 +1503,7 @@ const D = new Foo7(1,2);
         $this->doTest($expected);
     }
 
-    public function provideFixPhp81Cases(): iterable
+    public static function provideFixPhp81Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -562,7 +562,7 @@ B#
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             <<<'EOF'
@@ -1130,7 +1130,7 @@ use function some\a\{fn_a, fn_b, fn_c,};
         $this->fixer->configure($configuration);
     }
 
-    public function provideInvalidSortAlgorithmCases(): array
+    public static function provideInvalidSortAlgorithmCases(): array
     {
         return [
             [
@@ -1747,7 +1747,7 @@ EOF
         $this->doTest($expected, $input);
     }
 
-    public function provideFixByLengthCases(): array
+    public static function provideFixByLengthCases(): array
     {
         return [
             [
@@ -1893,7 +1893,7 @@ use const ZZZ;
         $this->doTest($expected, $input);
     }
 
-    public function provideFixTypesOrderAndLengthCases(): array
+    public static function provideFixTypesOrderAndLengthCases(): array
     {
         return [
             [
@@ -1950,7 +1950,7 @@ use function some\f\{fn_c, fn_d, fn_e};
         $this->doTest($expected, $input);
     }
 
-    public function provideFixTypesOrderAndAlphabetCases(): iterable
+    public static function provideFixTypesOrderAndAlphabetCases(): iterable
     {
         return [
             [
@@ -2018,7 +2018,7 @@ use function some\a\{fn_a, fn_b};
         $this->doTest($expected, $input);
     }
 
-    public function provideFixTypesOrderAndNoneCases(): array
+    public static function provideFixTypesOrderAndNoneCases(): array
     {
         return [
             [

--- a/tests/Fixer/Import/SingleImportPerStatementFixerTest.php
+++ b/tests/Fixer/Import/SingleImportPerStatementFixerTest.php
@@ -34,7 +34,7 @@ final class SingleImportPerStatementFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -305,7 +305,7 @@ use Space\Models\ {
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): iterable
+    public static function provideMessyWhitespacesCases(): iterable
     {
         yield [
             "<?php\r\n    use FooA;\r\n    use FooB;",
@@ -323,7 +323,7 @@ use Space\Models\ {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPrePHP80Cases(): iterable
+    public static function provideFixPrePHP80Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
+++ b/tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
@@ -34,7 +34,7 @@ final class SingleLineAfterImportsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php
@@ -514,7 +514,7 @@ use some\a\ClassA; use function some\a\fn_a; use const some\c;
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [

--- a/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
@@ -33,7 +33,7 @@ final class ClassKeywordRemoveFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixerTest.php
@@ -31,7 +31,7 @@ final class CombineConsecutiveIssetsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixerTest.php
@@ -31,7 +31,7 @@ final class CombineConsecutiveUnsetsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             [
@@ -140,7 +140,7 @@ final class CombineConsecutiveUnsetsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php (unset)$f;',

--- a/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
@@ -37,7 +37,7 @@ final class DeclareEqualNormalizeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'minimal case remove whitespace (default config)' => [
@@ -115,7 +115,7 @@ final class DeclareEqualNormalizeFixerTest extends AbstractFixerTestCase
         $this->fixer->configure($config);
     }
 
-    public function provideInvalidConfigCases(): array
+    public static function provideInvalidConfigCases(): array
     {
         return [
             [

--- a/tests/Fixer/LanguageConstruct/DeclareParenthesesFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/DeclareParenthesesFixerTest.php
@@ -31,7 +31,7 @@ final class DeclareParenthesesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'spaces around parentheses' => [
             '<?php declare(strict_types = 1);',

--- a/tests/Fixer/LanguageConstruct/DirConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/DirConstantFixerTest.php
@@ -34,7 +34,7 @@ final class DirConstantFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         $multiLinePatternToFix = <<<'FIX'
 <?php $x =

--- a/tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
@@ -38,7 +38,7 @@ final class ErrorSuppressionFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             [
@@ -132,7 +132,7 @@ Trigger_Error/**/("This is a deprecation warning.", E_USER_DEPRECATED/***/); ?>'
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php \A\B/* */\trigger_error("This is not a deprecation warning.", E_USER_DEPRECATED); ?>',
@@ -149,7 +149,7 @@ Trigger_Error/**/("This is a deprecation warning.", E_USER_DEPRECATED/***/); ?>'
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php $a = trigger_error(...);',

--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -33,7 +33,7 @@ final class ExplicitIndirectVariableFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): array
+    public static function provideTestFixCases(): array
     {
         return [
             [
@@ -82,7 +82,7 @@ $foo
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFix80Cases(): array
+    public static function provideTestFix80Cases(): array
     {
         return [
             [

--- a/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
@@ -35,7 +35,7 @@ final class FunctionToConstantFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestCases(): array
+    public static function provideTestCases(): array
     {
         return [
             'Minimal case, alternative casing, alternative statement end.' => [
@@ -256,7 +256,7 @@ get_called_class#1
         $this->fixer->configure($config);
     }
 
-    public function provideInvalidConfigurationKeysCases(): array
+    public static function provideInvalidConfigurationKeysCases(): array
     {
         return [
             [['functions' => ['a']]],
@@ -284,7 +284,7 @@ get_called_class#1
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'first callable class' => [
             '<?php $a = get_class(...);',

--- a/tests/Fixer/LanguageConstruct/GetClassToClassKeywordFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/GetClassToClassKeywordFixerTest.php
@@ -35,7 +35,7 @@ final class GetClassToClassKeywordFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '

--- a/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
@@ -33,7 +33,7 @@ final class IsNullFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         $multiLinePatternToFix = <<<'FIX'
 <?php $x =

--- a/tests/Fixer/LanguageConstruct/NoUnsetOnPropertyFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NoUnsetOnPropertyFixerTest.php
@@ -33,7 +33,7 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             'It replaces an unset on a property with = null' => [
@@ -221,7 +221,7 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield 'It does not break curly access expressions' => [
             '<?php unset(a(){"a"});',

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
@@ -42,7 +42,7 @@ final class SingleSpaceAfterConstructFixerTest extends AbstractFixerTestCase
         ]);
     }
 
-    public function provideInvalidConstructCases(): array
+    public static function provideInvalidConstructCases(): array
     {
         return [
             'null' => [null],
@@ -70,7 +70,7 @@ final class SingleSpaceAfterConstructFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithAbstractCases(): array
+    public static function provideFixWithAbstractCases(): array
     {
         return [
             [
@@ -166,7 +166,7 @@ abstract class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithBreakCases(): array
+    public static function provideFixWithBreakCases(): array
     {
         return [
             [
@@ -215,7 +215,7 @@ abstract class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithAsCases(): array
+    public static function provideFixWithAsCases(): array
     {
         return [
             [
@@ -331,7 +331,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithCaseCases(): array
+    public static function provideFixWithCaseCases(): array
     {
         return [
             [
@@ -401,7 +401,7 @@ switch ($i) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithCatchCases(): array
+    public static function provideFixWithCatchCases(): array
     {
         return [
             [
@@ -443,7 +443,7 @@ switch ($i) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithClassCases(): array
+    public static function provideFixWithClassCases(): array
     {
         return [
             [
@@ -517,7 +517,7 @@ Foo {}',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithContinueCases(): array
+    public static function provideFixWithContinueCases(): array
     {
         return [
             [
@@ -562,7 +562,7 @@ Foo {}',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithConstCases(): array
+    public static function provideFixWithConstCases(): array
     {
         return [
             [
@@ -644,7 +644,7 @@ const     A = 3 ?>
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithConstImportCases(): array
+    public static function provideFixWithConstImportCases(): array
     {
         return [
             [
@@ -682,7 +682,7 @@ FOO\BAR;',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithCloneCases(): array
+    public static function provideFixWithCloneCases(): array
     {
         return [
             [
@@ -720,7 +720,7 @@ $foo;',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithDoCases(): array
+    public static function provideFixWithDoCases(): array
     {
         return [
             [
@@ -766,7 +766,7 @@ $foo;',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithEchoCases(): array
+    public static function provideFixWithEchoCases(): array
     {
         return [
             [
@@ -804,7 +804,7 @@ $foo;',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithElseCases(): array
+    public static function provideFixWithElseCases(): array
     {
         return [
             [
@@ -842,7 +842,7 @@ $foo;',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithElseIfCases(): array
+    public static function provideFixWithElseIfCases(): array
     {
         return [
             [
@@ -880,7 +880,7 @@ $foo;',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithExtendsCases(): array
+    public static function provideFixWithExtendsCases(): array
     {
         return [
             [
@@ -979,7 +979,7 @@ Bar6, Baz, Qux {}',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithFinalCases(): array
+    public static function provideFixWithFinalCases(): array
     {
         return [
             [
@@ -1075,7 +1075,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithFinallyCases(): array
+    public static function provideFixWithFinallyCases(): array
     {
         return [
             [
@@ -1117,7 +1117,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithForCases(): array
+    public static function provideFixWithForCases(): array
     {
         return [
             [
@@ -1159,7 +1159,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithForeachCases(): array
+    public static function provideFixWithForeachCases(): array
     {
         return [
             [
@@ -1201,7 +1201,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithFunctionCases(): array
+    public static function provideFixWithFunctionCases(): array
     {
         return [
             [
@@ -1297,7 +1297,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithFunctionImportCases(): array
+    public static function provideFixWithFunctionImportCases(): array
     {
         return [
             [
@@ -1335,7 +1335,7 @@ Foo\bar;',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithGlobalCases(): array
+    public static function provideFixWithGlobalCases(): array
     {
         return [
             [
@@ -1377,7 +1377,7 @@ $bar; }',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithGotoCases(): array
+    public static function provideFixWithGotoCases(): array
     {
         return [
             [
@@ -1411,7 +1411,7 @@ foo; foo: echo "Bar";',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithIfCases(): array
+    public static function provideFixWithIfCases(): array
     {
         return [
             [
@@ -1449,7 +1449,7 @@ foo; foo: echo "Bar";',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithImplementsCases(): array
+    public static function provideFixWithImplementsCases(): array
     {
         return [
             [
@@ -1512,7 +1512,7 @@ foo; foo: echo "Bar";',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithIncludeCases(): array
+    public static function provideFixWithIncludeCases(): array
     {
         return [
             [
@@ -1550,7 +1550,7 @@ foo; foo: echo "Bar";',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithIncludeOnceCases(): array
+    public static function provideFixWithIncludeOnceCases(): array
     {
         return [
             [
@@ -1588,7 +1588,7 @@ foo; foo: echo "Bar";',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithInstanceofCases(): array
+    public static function provideFixWithInstanceofCases(): array
     {
         return [
             [
@@ -1630,7 +1630,7 @@ foo; foo: echo "Bar";',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithInsteadofCases(): array
+    public static function provideFixWithInsteadofCases(): array
     {
         return [
             [
@@ -1724,7 +1724,7 @@ class Talker {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithInterfaceCases(): array
+    public static function provideFixWithInterfaceCases(): array
     {
         return [
             [
@@ -1762,7 +1762,7 @@ Foo {}',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithNewCases(): array
+    public static function provideFixWithNewCases(): array
     {
         return [
             [
@@ -1800,7 +1800,7 @@ Bar();',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithOpenTagWithEchoCases(): array
+    public static function provideFixWithOpenTagWithEchoCases(): array
     {
         return [
             [
@@ -1842,7 +1842,7 @@ $foo ?>',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithPrintCases(): array
+    public static function provideFixWithPrintCases(): array
     {
         return [
             [
@@ -1880,7 +1880,7 @@ $foo ?>',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithPrivateCases(): array
+    public static function provideFixWithPrivateCases(): array
     {
         return [
             [
@@ -1958,7 +1958,7 @@ CONST BAR = 9000; }',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithProtectedCases(): array
+    public static function provideFixWithProtectedCases(): array
     {
         return [
             [
@@ -2036,7 +2036,7 @@ CONST BAR = 9000; }',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithPublicCases(): array
+    public static function provideFixWithPublicCases(): array
     {
         return [
             [
@@ -2114,7 +2114,7 @@ CONST BAR = 9000; }',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithRequireCases(): array
+    public static function provideFixWithRequireCases(): array
     {
         return [
             [
@@ -2152,7 +2152,7 @@ CONST BAR = 9000; }',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithRequireOnceCases(): array
+    public static function provideFixWithRequireOnceCases(): array
     {
         return [
             [
@@ -2190,7 +2190,7 @@ CONST BAR = 9000; }',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithReturnCases(): array
+    public static function provideFixWithReturnCases(): array
     {
         return [
             [
@@ -2324,7 +2324,7 @@ return
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithStaticCases(): array
+    public static function provideFixWithStaticCases(): array
     {
         return [
             [
@@ -2390,7 +2390,7 @@ function bar() {} }',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithThrowCases(): array
+    public static function provideFixWithThrowCases(): array
     {
         return [
             [
@@ -2428,7 +2428,7 @@ new Exception();',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithTraitCases(): array
+    public static function provideFixWithTraitCases(): array
     {
         return [
             [
@@ -2466,7 +2466,7 @@ Foo {}',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithTryCases(): array
+    public static function provideFixWithTryCases(): array
     {
         return [
             [
@@ -2508,7 +2508,7 @@ Foo {}',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithUseCases(): array
+    public static function provideFixWithUseCases(): array
     {
         return [
             [
@@ -2582,7 +2582,7 @@ function Foo\bar;',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithUseLambdaCases(): array
+    public static function provideFixWithUseLambdaCases(): array
     {
         return [
             [
@@ -2624,7 +2624,7 @@ function Foo\bar;',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithUseTraitCases(): array
+    public static function provideFixWithUseTraitCases(): array
     {
         return [
             [
@@ -2662,7 +2662,7 @@ Bar; }',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithVarCases(): array
+    public static function provideFixWithVarCases(): array
     {
         return [
             [
@@ -2704,7 +2704,7 @@ $bar; }',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithWhileCases(): array
+    public static function provideFixWithWhileCases(): array
     {
         return [
             [
@@ -2746,7 +2746,7 @@ $bar; }',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithYieldCases(): array
+    public static function provideFixWithYieldCases(): array
     {
         return [
             [
@@ -2784,7 +2784,7 @@ $bar; }',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithYieldFromCases(): array
+    public static function provideFixWithYieldFromCases(): array
     {
         return [
             [
@@ -2858,7 +2858,7 @@ baz(); }',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithPhpOpenCases(): array
+    public static function provideFixWithPhpOpenCases(): array
     {
         return [
             [
@@ -2901,7 +2901,7 @@ baz(); }',
         $this->doTest($expected, $input);
     }
 
-    public function provideCommentsCases(): iterable
+    public static function provideCommentsCases(): iterable
     {
         yield [
             '<?php
@@ -2954,7 +2954,7 @@ foreach ($fields as [$field/** @var string*/]) {
         $this->doTest($expected, $input);
     }
 
-    public function provideWithNamespaceCases(): iterable
+    public static function provideWithNamespaceCases(): iterable
     {
         yield 'simple' => [
             '<?php
@@ -3020,7 +3020,7 @@ namespace/* comment */ Foo;',
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield 'match 1' => [
             '<?php echo match ($x) {
@@ -3094,7 +3094,7 @@ class Point {
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'readonly' => [
             '<?php
@@ -3188,7 +3188,7 @@ class    Test {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithSwitchCases(): iterable
+    public static function provideFixWithSwitchCases(): iterable
     {
         yield [
             '<?php
@@ -3216,7 +3216,7 @@ class    Test {
         $this->doTest($expected, $input);
     }
 
-    public function provideTypeColonCases(): iterable
+    public static function provideTypeColonCases(): iterable
     {
         yield [
             '<?php function foo(): array { return []; }',
@@ -3260,7 +3260,7 @@ class    Test {
         $this->doTest($expected, $input);
     }
 
-    public function provideEnumTypeColonCases(): iterable
+    public static function provideEnumTypeColonCases(): iterable
     {
         yield [
             '<?php enum Foo: int {}',

--- a/tests/Fixer/ListNotation/ListSyntaxFixerTest.php
+++ b/tests/Fixer/ListNotation/ListSyntaxFixerTest.php
@@ -104,7 +104,7 @@ class Test
         $this->doTest($expected, $input);
     }
 
-    public function provideFixToShortSyntaxCases(): array
+    public static function provideFixToShortSyntaxCases(): array
     {
         return [
             [
@@ -200,7 +200,7 @@ $a;#
         $this->doTest($expected, $input);
     }
 
-    public function provideFixToShortSyntaxPhp72Cases(): iterable
+    public static function provideFixToShortSyntaxPhp72Cases(): iterable
     {
         yield [
             '<?php [$a, $b,, [$c, $d]] = $a;',
@@ -231,7 +231,7 @@ $a;#
         $this->doTest($expected, $input);
     }
 
-    public function provideFixToShortSyntaxPhp73Cases(): iterable
+    public static function provideFixToShortSyntaxPhp73Cases(): iterable
     {
         yield [
             '<?php [&$a, $b] = $a;',
@@ -264,7 +264,7 @@ $a;#
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'simple 8.1' => [
             '<?php $a = _list(...);',

--- a/tests/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixerTest.php
@@ -34,7 +34,7 @@ final class BlankLineAfterNamespaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -226,7 +226,7 @@ class X extends Y {}',
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [

--- a/tests/Fixer/NamespaceNotation/CleanNamespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/CleanNamespaceFixerTest.php
@@ -33,7 +33,7 @@ final class CleanNamespaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php use function FooLibrary\Bar\Baz\ClassA as Foo ?>',

--- a/tests/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixerTest.php
@@ -38,7 +38,7 @@ final class NoBlankLinesBeforeNamespaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             ['<?php namespace Some\Name\Space;'],

--- a/tests/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixerTest.php
@@ -35,7 +35,7 @@ final class NoLeadingNamespaceWhitespaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         $manySpaces = [];
 
@@ -150,7 +150,7 @@ namespace TestComment;',
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [

--- a/tests/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixerTest.php
@@ -38,7 +38,7 @@ final class SingleBlankLineBeforeNamespaceFixerTest extends AbstractFixerTestCas
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             ["<?php\n\nnamespace X;"],

--- a/tests/Fixer/Naming/NoHomoglyphNamesFixerTest.php
+++ b/tests/Fixer/Naming/NoHomoglyphNamesFixerTest.php
@@ -33,7 +33,7 @@ final class NoHomoglyphNamesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             ['<?php $øøøøa = 1;'],

--- a/tests/Fixer/Operator/AssignNullCoalescingToCoalesceEqualFixerTest.php
+++ b/tests/Fixer/Operator/AssignNullCoalescingToCoalesceEqualFixerTest.php
@@ -31,7 +31,7 @@ final class AssignNullCoalescingToCoalesceEqualFixerTest extends AbstractFixerTe
         $this->doTest($expected, $input);
     }
 
-    public function provideFix74Cases(): iterable
+    public static function provideFix74Cases(): iterable
     {
         yield 'simple' => [
             '<?php $a ??= 1;',

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -40,7 +40,7 @@ final class BinaryOperatorSpacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideWithTabsCases(): array
+    public static function provideWithTabsCases(): array
     {
         return [
             [
@@ -87,7 +87,7 @@ public function myFunction() {
         $this->doTest($expected, $input);
     }
 
-    public function provideConfiguredCases(): array
+    public static function provideConfiguredCases(): array
     {
         return [
             [
@@ -525,7 +525,7 @@ $a = $ae?? $b;
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -724,7 +724,7 @@ $b;
         $this->doTest($expected, $input);
     }
 
-    public function provideUnalignEqualsCases(): array
+    public static function provideUnalignEqualsCases(): array
     {
         return [
             [
@@ -900,7 +900,7 @@ $b;
         $this->doTest($expected, $input);
     }
 
-    public function provideUnalignDoubleArrowCases(): array
+    public static function provideUnalignDoubleArrowCases(): array
     {
         return [
             [
@@ -1295,7 +1295,7 @@ $b;
         $this->doTest($expected, $input);
     }
 
-    public function provideAlignEqualsCases(): array
+    public static function provideAlignEqualsCases(): array
     {
         return [
             [
@@ -1642,7 +1642,7 @@ $start = (
         $this->doTest($expected, $input);
     }
 
-    public function provideAlignDoubleArrowCases(): array
+    public static function provideAlignDoubleArrowCases(): array
     {
         return [
             [
@@ -2356,7 +2356,7 @@ function foo () {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPhp74Cases(): array
+    public static function provideFixPhp74Cases(): array
     {
         return [
             [

--- a/tests/Fixer/Operator/ConcatSpaceFixerTest.php
+++ b/tests/Fixer/Operator/ConcatSpaceFixerTest.php
@@ -51,7 +51,7 @@ final class ConcatSpaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideWithoutSpaceCases(): array
+    public static function provideWithoutSpaceCases(): array
     {
         return [
             [
@@ -150,7 +150,7 @@ final class ConcatSpaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideWithSpaceCases(): array
+    public static function provideWithSpaceCases(): array
     {
         return [
             [

--- a/tests/Fixer/Operator/IncrementStyleFixerTest.php
+++ b/tests/Fixer/Operator/IncrementStyleFixerTest.php
@@ -53,7 +53,7 @@ final class IncrementStyleFixerTest extends AbstractFixerTestCase
         }, $this->provideFixPreIncrementCases());
     }
 
-    public function provideFixPreIncrementCases(): array
+    public static function provideFixPreIncrementCases(): array
     {
         $cases = [
             [

--- a/tests/Fixer/Operator/LogicalOperatorsFixerTest.php
+++ b/tests/Fixer/Operator/LogicalOperatorsFixerTest.php
@@ -33,7 +33,7 @@ final class LogicalOperatorsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Operator/NewWithBracesFixerTest.php
+++ b/tests/Fixer/Operator/NewWithBracesFixerTest.php
@@ -33,7 +33,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideNamedWithDefaultConfigurationCases(): iterable
+    public static function provideNamedWithDefaultConfigurationCases(): iterable
     {
         yield from [
             ['<?php $x = new X(foo(/**/));'],
@@ -285,7 +285,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideNamedWithoutBracesCases(): iterable
+    public static function provideNamedWithoutBracesCases(): iterable
     {
         yield from [
             ['<?php $x = new X(foo(/**/));'],
@@ -538,7 +538,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideAnonymousWithDefaultConfigurationCases(): iterable
+    public static function provideAnonymousWithDefaultConfigurationCases(): iterable
     {
         yield from [
             ['<?php $a = new class($a) {use SomeTrait;};'],
@@ -601,7 +601,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideAnonymousWithoutBracesCases(): iterable
+    public static function provideAnonymousWithoutBracesCases(): iterable
     {
         yield from [
             ['<?php $a = new class($a) {use SomeTrait;};'],
@@ -657,7 +657,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php $a = new $b{$c}();',
@@ -685,7 +685,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php $a = new (foo());',
@@ -734,7 +734,7 @@ $a = new ($foo."ar");',
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Operator/NoUselessConcatOperatorFixerTest.php
+++ b/tests/Fixer/Operator/NoUselessConcatOperatorFixerTest.php
@@ -32,7 +32,7 @@ final class NoUselessConcatOperatorFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         $templateExpected = '<?php $b = %s;';
         $templateInput = '<?php $b = %s.%s;';

--- a/tests/Fixer/Operator/NoUselessNullsafeOperatorFixerTest.php
+++ b/tests/Fixer/Operator/NoUselessNullsafeOperatorFixerTest.php
@@ -33,7 +33,7 @@ final class NoUselessNullsafeOperatorFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'simple case + comment' => [
             '<?php $a = new class extends foo {

--- a/tests/Fixer/Operator/NotOperatorWithSpaceFixerTest.php
+++ b/tests/Fixer/Operator/NotOperatorWithSpaceFixerTest.php
@@ -33,7 +33,7 @@ final class NotOperatorWithSpaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Operator/NotOperatorWithSuccessorSpaceFixerTest.php
+++ b/tests/Fixer/Operator/NotOperatorWithSuccessorSpaceFixerTest.php
@@ -33,7 +33,7 @@ final class NotOperatorWithSuccessorSpaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixerTest.php
+++ b/tests/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixerTest.php
@@ -33,7 +33,7 @@ final class ObjectOperatorWithoutWhitespaceFixerTest extends AbstractFixerTestCa
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Operator/StandardizeIncrementFixerTest.php
+++ b/tests/Fixer/Operator/StandardizeIncrementFixerTest.php
@@ -34,7 +34,7 @@ final class StandardizeIncrementFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             [
@@ -605,7 +605,7 @@ $i#3
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php echo ++$foo->{$bar};',

--- a/tests/Fixer/Operator/StandardizeNotEqualsFixerTest.php
+++ b/tests/Fixer/Operator/StandardizeNotEqualsFixerTest.php
@@ -33,7 +33,7 @@ final class StandardizeNotEqualsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             ['<?php $a = ($b != $c);'],

--- a/tests/Fixer/Operator/TernaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/TernaryOperatorSpacesFixerTest.php
@@ -33,7 +33,7 @@ final class TernaryOperatorSpacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'handle goto labels 1' => [
@@ -207,7 +207,7 @@ $a = ($b
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): array
+    public static function provideFix80Cases(): array
     {
         return [
             'nullable types in constructor property promotion' => [
@@ -237,7 +237,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             <<<'PHP'

--- a/tests/Fixer/Operator/TernaryToElvisOperatorFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToElvisOperatorFixerTest.php
@@ -31,7 +31,7 @@ final class TernaryToElvisOperatorFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         $operators = ['+=', '-=', '*=', '**=', '/=', '.=', '%=', '&=', '|=', '^=', '<<=', '>>='];
 
@@ -445,7 +445,7 @@ EOT
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php $foo = $a->{$b} ? $bar{0} : $foo;',
@@ -502,7 +502,7 @@ EOT
         $this->doTest($input);
     }
 
-    public function provideDoNotFix80Cases(): array
+    public static function provideDoNotFix80Cases(): array
     {
         return [
             ['<?php

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -33,7 +33,7 @@ final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             // Do not fix cases.
@@ -187,7 +187,7 @@ null
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield ['<?php $x = $a ? $a : isset($b) ? $b : isset($c) ? $c : "";'];
 

--- a/tests/Fixer/Operator/UnaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/UnaryOperatorSpacesFixerTest.php
@@ -33,7 +33,7 @@ final class UnaryOperatorSpacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/PhpTag/BlankLineAfterOpeningTagFixerTest.php
+++ b/tests/Fixer/PhpTag/BlankLineAfterOpeningTagFixerTest.php
@@ -35,7 +35,7 @@ final class BlankLineAfterOpeningTagFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -141,7 +141,7 @@ $foo = $bar;
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [

--- a/tests/Fixer/PhpTag/EchoTagSyntaxFixerTest.php
+++ b/tests/Fixer/PhpTag/EchoTagSyntaxFixerTest.php
@@ -35,7 +35,7 @@ final class EchoTagSyntaxFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideLongToShortFormatCases(): array
+    public static function provideLongToShortFormatCases(): array
     {
         return [
             ['<?= \'Foo\';', '<?php echo \'Foo\';'],
@@ -101,7 +101,7 @@ EOT
         $this->doTest($expected, $input);
     }
 
-    public function provideShortToLongFormatCases(): array
+    public static function provideShortToLongFormatCases(): array
     {
         $cases = [
             ['<?php <fn> 1;', '<?= 1;'],

--- a/tests/Fixer/PhpTag/FullOpeningTagFixerTest.php
+++ b/tests/Fixer/PhpTag/FullOpeningTagFixerTest.php
@@ -31,7 +31,7 @@ final class FullOpeningTagFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             ['<?php echo \'Foo\';', '<? echo \'Foo\';'],

--- a/tests/Fixer/PhpTag/LinebreakAfterOpeningTagFixerTest.php
+++ b/tests/Fixer/PhpTag/LinebreakAfterOpeningTagFixerTest.php
@@ -35,7 +35,7 @@ final class LinebreakAfterOpeningTagFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -98,7 +98,7 @@ $foo = $bar;
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [

--- a/tests/Fixer/PhpTag/NoClosingTagFixerTest.php
+++ b/tests/Fixer/PhpTag/NoClosingTagFixerTest.php
@@ -43,7 +43,7 @@ final class NoClosingTagFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideWithFullOpenTagCases(): array
+    public static function provideWithFullOpenTagCases(): array
     {
         return [
             [
@@ -141,7 +141,7 @@ if (true) {
         ];
     }
 
-    public function provideWithShortOpenTagCases(): array
+    public static function provideWithShortOpenTagCases(): array
     {
         return [
             [

--- a/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
@@ -165,7 +165,7 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix73Cases(): array
+    public static function provideFix73Cases(): array
     {
         return [
             [
@@ -195,7 +195,7 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             self::generateTest('$this->assertEquals(...);'),

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
@@ -36,7 +36,7 @@ final class PhpUnitDedicateAssertFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): iterable
+    public static function provideTestFixCases(): iterable
     {
         yield from [
             [
@@ -329,7 +329,7 @@ $a#
         $this->doTest($expected);
     }
 
-    public function provideNotFixCases(): iterable
+    public static function provideNotFixCases(): iterable
     {
         yield 'not a method call' => [
             self::generateTest('echo $this->assertTrue;'),
@@ -403,7 +403,7 @@ $a#
         $this->doTest($expected, $input);
     }
 
-    public function provideTestAssertCountCases(): array
+    public static function provideTestAssertCountCases(): array
     {
         return [
             // positive fixing
@@ -548,7 +548,7 @@ $a# 5
         $this->doTest($expected, $input);
     }
 
-    public function provideTestAssertCountCasingCases(): iterable
+    public static function provideTestAssertCountCasingCases(): iterable
     {
         yield [
             self::generateTest('$this->assertCount(1, $a);'),
@@ -570,7 +570,7 @@ $a# 5
         $this->doTest($expected, $input);
     }
 
-    public function provideFix73Cases(): iterable
+    public static function provideFix73Cases(): iterable
     {
         yield [
             self::generateTest('$this->assertNan($a, );'),
@@ -624,7 +624,7 @@ $a# 5
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             self::generateTest('$a = $this->assertTrue(...);'),

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixerTest.php
@@ -33,7 +33,7 @@ final class PhpUnitDedicateAssertInternalTypeFixerTest extends AbstractFixerTest
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixInternalTypeCases(): iterable
+    public static function provideTestFixInternalTypeCases(): iterable
     {
         yield 'skip cases' => [
             '<?php

--- a/tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
@@ -39,7 +39,7 @@ final class PhpUnitExpectationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): array
+    public static function provideTestFixCases(): array
     {
         return [
             [
@@ -412,7 +412,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         $expectedTemplate =
 '

--- a/tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
@@ -36,7 +36,7 @@ final class PhpUnitInternalClassFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'It does not change normal classes' => [

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -51,7 +51,7 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'skip non phpunit methods' => [

--- a/tests/Fixer/PhpUnit/PhpUnitMockFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMockFixerTest.php
@@ -38,7 +38,7 @@ final class PhpUnitMockFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): array
+    public static function provideTestFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixerTest.php
@@ -33,7 +33,7 @@ final class PhpUnitMockShortWillReturnFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'do not fix' => [

--- a/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
@@ -38,7 +38,7 @@ final class PhpUnitNamespacedFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): array
+    public static function provideTestFixCases(): array
     {
         return [
             'class_mapping' => [
@@ -290,7 +290,7 @@ final class PhpUnitNamespacedFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
@@ -38,7 +38,7 @@ final class PhpUnitNoExpectationAnnotationFixerTest extends AbstractFixerTestCas
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): array
+    public static function provideTestFixCases(): array
     {
         return [
             'empty exception message' => [
@@ -690,7 +690,7 @@ EOT
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [

--- a/tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
@@ -33,7 +33,7 @@ final class PhpUnitSetUpTearDownVisibilityFixerTest extends AbstractFixerTestCas
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'setUp and tearDown are made protected if they are public' => [

--- a/tests/Fixer/PhpUnit/PhpUnitSizeClassFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitSizeClassFixerTest.php
@@ -36,7 +36,7 @@ final class PhpUnitSizeClassFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'It does not change normal classes' => [

--- a/tests/Fixer/PhpUnit/PhpUnitTargetVersionTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTargetVersionTest.php
@@ -41,7 +41,7 @@ final class PhpUnitTargetVersionTest extends TestCase
         );
     }
 
-    public function provideTestFulfillsCases(): array
+    public static function provideTestFulfillsCases(): array
     {
         return [
             [true, PhpUnitTargetVersion::VERSION_NEWEST, PhpUnitTargetVersion::VERSION_5_6],

--- a/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
@@ -37,7 +37,7 @@ final class PhpUnitTestAnnotationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'Annotation is used, and it should not be' => [
@@ -991,7 +991,7 @@ class Test extends \PhpUnit\FrameWork\TestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [

--- a/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
@@ -74,7 +74,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): array
+    public static function provideTestFixCases(): array
     {
         return [
             [
@@ -549,7 +549,7 @@ class MyTest extends \PHPUnit_Framework_TestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
@@ -34,7 +34,7 @@ final class PhpUnitTestClassRequiresCoversFixerTest extends AbstractFixerTestCas
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'already with annotation: @covers' => [
@@ -247,7 +247,7 @@ class FooTest extends \PHPUnit_Framework_TestCase {}
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/AlignMultilineCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/AlignMultilineCommentFixerTest.php
@@ -42,7 +42,7 @@ final class AlignMultilineCommentFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideDefaultCases(): array
+    public static function provideDefaultCases(): array
     {
         return [
             [
@@ -180,7 +180,7 @@ class A
         $this->doTest($expected, $input);
     }
 
-    public function provideDocLikeMultilineCommentsCases(): array
+    public static function provideDocLikeMultilineCommentsCases(): array
     {
         return [
             [
@@ -228,7 +228,7 @@ class A
         $this->doTest($expected, $input);
     }
 
-    public function provideMixedContentMultilineCommentsCases(): array
+    public static function provideMixedContentMultilineCommentsCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixerTest.php
+++ b/tests/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixerTest.php
@@ -36,7 +36,7 @@ final class GeneralPhpdocAnnotationRemoveFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'An Annotation gets removed' => [

--- a/tests/Fixer/Phpdoc/GeneralPhpdocTagRenameFixerTest.php
+++ b/tests/Fixer/Phpdoc/GeneralPhpdocTagRenameFixerTest.php
@@ -36,7 +36,7 @@ final class GeneralPhpdocTagRenameFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -277,7 +277,7 @@ final class GeneralPhpdocTagRenameFixerTest extends AbstractFixerTestCase
         ]);
     }
 
-    public function provideConfigureWithInvalidReplacementsCases(): array
+    public static function provideConfigureWithInvalidReplacementsCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixerTest.php
@@ -324,7 +324,7 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function provideInlineTypehintingDocsBeforeFlowBreakCases(): array
+    public static function provideInlineTypehintingDocsBeforeFlowBreakCases(): array
     {
         $cases = [];
 

--- a/tests/Fixer/Phpdoc/NoEmptyPhpdocFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoEmptyPhpdocFixerTest.php
@@ -31,7 +31,7 @@ final class NoEmptyPhpdocFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -34,7 +34,7 @@ final class NoSuperfluousPhpdocTagsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'no typehint' => [
             '<?php
@@ -2299,7 +2299,7 @@ class Foo {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPhp80Cases(): iterable
+    public static function provideFixPhp80Cases(): iterable
     {
         yield 'static return' => [
             '<?php
@@ -2539,7 +2539,7 @@ new #[Bar] class() extends Foo {
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'some readonly properties' => [
             '<?php

--- a/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
@@ -60,7 +60,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
     /**
      * @return iterable<string, array>
      */
-    public function provideConfigureRejectsInvalidConfigurationValueCases(): iterable
+    public static function provideConfigureRejectsInvalidConfigurationValueCases(): iterable
     {
         yield 'null' => [
             null,
@@ -99,7 +99,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -381,7 +381,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [
@@ -400,7 +400,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
         $this->doTest($expected, $input);
     }
 
-    public function provideByReferenceCases(): array
+    public static function provideByReferenceCases(): array
     {
         return [
             [
@@ -445,7 +445,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
         $this->doTest($expected, $input);
     }
 
-    public function provideVariableNumberOfArgumentsCases(): array
+    public static function provideVariableNumberOfArgumentsCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -787,7 +787,7 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [
@@ -1268,7 +1268,7 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function provideVariadicCases(): array
+    public static function provideVariadicCases(): array
     {
         return [
             [
@@ -1391,7 +1391,7 @@ class Foo {}
         $this->doTest($input);
     }
 
-    public function provideInvalidPhpdocCases(): array
+    public static function provideInvalidPhpdocCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
@@ -33,7 +33,7 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocIndentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocIndentFixerTest.php
@@ -33,7 +33,7 @@ final class PhpdocIndentFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixIndentCases(): array
+    public static function provideFixIndentCases(): array
     {
         $cases = [];
 

--- a/tests/Fixer/Phpdoc/PhpdocInlineTagNormalizerFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocInlineTagNormalizerFixerTest.php
@@ -35,7 +35,7 @@ final class PhpdocInlineTagNormalizerFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         $cases = [
             [

--- a/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
@@ -36,7 +36,7 @@ final class PhpdocLineSpanFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'It does not change doc blocks if not needed' => [
@@ -572,7 +572,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield 'It detects attributes between docblock and token' => [
             '<?php
@@ -720,7 +720,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'It handles readonly properties correctly' => [
             '<?php
@@ -876,7 +876,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFix82Cases(): iterable
+    public static function provideFix82Cases(): iterable
     {
         yield 'constant in trait' => [
             <<<'PHP'

--- a/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
@@ -99,7 +99,7 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function providePropertyCases(): array
+    public static function providePropertyCases(): array
     {
         return [
             [
@@ -137,7 +137,7 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTypeToVarCases(): array
+    public static function provideTypeToVarCases(): array
     {
         return [
             [
@@ -195,7 +195,7 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideVarToTypeCases(): array
+    public static function provideVarToTypeCases(): array
     {
         return [
             [
@@ -261,7 +261,7 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideDefaultConfigCases(): array
+    public static function provideDefaultConfigCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixerTest.php
@@ -31,7 +31,7 @@ final class PhpdocNoUselessInheritdocFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocOrderByValueFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocOrderByValueFixerTest.php
@@ -43,7 +43,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         ]);
     }
 
-    public function provideInvalidAnnotationCases(): array
+    public static function provideInvalidAnnotationCases(): array
     {
         return [
             'null' => [null],
@@ -79,7 +79,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithAuthorCases(): array
+    public static function provideFixWithAuthorCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -199,7 +199,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithCoversCases(): array
+    public static function provideFixWithCoversCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -319,7 +319,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithCoversNothingCases(): array
+    public static function provideFixWithCoversNothingCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -439,7 +439,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithDataProviderCases(): array
+    public static function provideFixWithDataProviderCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -559,7 +559,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithDependsCases(): array
+    public static function provideFixWithDependsCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -679,7 +679,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithGroupCases(): array
+    public static function provideFixWithGroupCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -799,7 +799,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithInternalCases(): array
+    public static function provideFixWithInternalCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -919,7 +919,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithMethodCases(): array
+    public static function provideFixWithMethodCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -1043,7 +1043,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithMixinCases(): array
+    public static function provideFixWithMixinCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -1165,7 +1165,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithPropertyCases(): array
+    public static function provideFixWithPropertyCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -1273,7 +1273,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithPropertyReadCases(): array
+    public static function provideFixWithPropertyReadCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -1381,7 +1381,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithPropertyWriteCases(): array
+    public static function provideFixWithPropertyWriteCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -1489,7 +1489,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithRequiresCases(): array
+    public static function provideFixWithRequiresCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -1609,7 +1609,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithThrowsCases(): array
+    public static function provideFixWithThrowsCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -1745,7 +1745,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithUsesCases(): array
+    public static function provideFixWithUsesCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [
@@ -1866,7 +1866,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithMultipleConfiguredAnnotationsCases(): array
+    public static function provideFixWithMultipleConfiguredAnnotationsCases(): array
     {
         return [
             'skip on 1 or 0 occurrences' => [

--- a/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
@@ -387,7 +387,7 @@ EOF;
     /**
      * @return array<string, mixed>[][]
      */
-    public function provideDifferentOrderCases(): array
+    public static function provideDifferentOrderCases(): array
     {
         return [
             [['order' => ['param', 'throw', 'return']]],
@@ -410,7 +410,7 @@ EOF;
     /**
      * @return array<array<null|array<string, mixed>|string>>
      */
-    public function provideBasicCodeWithDifferentOrdersCases(): array
+    public static function provideBasicCodeWithDifferentOrdersCases(): array
     {
         $input = <<<'EOF'
 <?php
@@ -533,7 +533,7 @@ EOF;
     /**
      * @return array<string, array<int, string|string[][]>>
      */
-    public function provideCompleteCasesWithCustomOrdersCases(): array
+    public static function provideCompleteCasesWithCustomOrdersCases(): array
     {
         return [
             'intepacuthre' => [

--- a/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
@@ -33,7 +33,7 @@ final class PhpdocReturnSelfReferenceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideDefaultConfigurationTestCases(): array
+    public static function provideDefaultConfigurationTestCases(): array
     {
         return [
             [
@@ -88,7 +88,7 @@ trait SomeTrait
         $this->doTest($expected, $input);
     }
 
-    public function provideTestCases(): array
+    public static function provideTestCases(): array
     {
         return [
             [
@@ -146,7 +146,7 @@ class F
         $this->doTest($expected, $input);
     }
 
-    public function provideGeneratedFixCases(): array
+    public static function provideGeneratedFixCases(): array
     {
         return [
             ['$this', 'this'],
@@ -171,7 +171,7 @@ class F
         $this->fixer->configure($configuration);
     }
 
-    public function provideInvalidConfigurationCases(): array
+    public static function provideInvalidConfigurationCases(): array
     {
         return [
             [
@@ -241,7 +241,7 @@ class F
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
@@ -536,7 +536,7 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function provideInheritDocCases(): array
+    public static function provideInheritDocCases(): array
     {
         return [
             [
@@ -832,7 +832,7 @@ EOF;
     /**
      * @return array<array<null|array<string, mixed>|string>>
      */
-    public function provideDocCodeCases(): array
+    public static function provideDocCodeCases(): array
     {
         $input = <<<'EOF'
 <?php

--- a/tests/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixerTest.php
@@ -31,7 +31,7 @@ final class PhpdocSingleLineVarSpacingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocSummaryFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSummaryFixerTest.php
@@ -367,7 +367,7 @@ EOF;
         $this->doTest($expected);
     }
 
-    public function provideInheritDocCases(): array
+    public static function provideInheritDocCases(): array
     {
         return [
             [
@@ -410,7 +410,7 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocTagCasingFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTagCasingFixerTest.php
@@ -35,7 +35,7 @@ final class PhpdocTagCasingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocTagTypeFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTagTypeFixerTest.php
@@ -36,7 +36,7 @@ final class PhpdocTagTypeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
@@ -39,7 +39,7 @@ final class PhpdocToCommentFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideDocblocksCases(): array
+    public static function provideDocblocksCases(): array
     {
         $cases = [];
 
@@ -684,7 +684,7 @@ foreach($connections as $key => $sqlite) {
         return $cases;
     }
 
-    public function provideTraitsCases(): array
+    public static function provideTraitsCases(): array
     {
         return [
             [
@@ -702,7 +702,7 @@ trait DocBlocks
         ];
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -805,7 +805,7 @@ $first = true;// needed because by default first docblock is never fixed.
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php
@@ -882,7 +882,7 @@ class Foo
         $this->doTest($expected);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'enum' => [
             '<?php

--- a/tests/Fixer/Phpdoc/PhpdocTrimConsecutiveBlankLineSeparationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTrimConsecutiveBlankLineSeparationFixerTest.php
@@ -34,7 +34,7 @@ final class PhpdocTrimConsecutiveBlankLineSeparationFixerTest extends AbstractFi
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'no changes' => ['<?php /** Summary. */'],

--- a/tests/Fixer/Phpdoc/PhpdocTrimFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTrimFixerTest.php
@@ -33,7 +33,7 @@ final class PhpdocTrimFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -44,7 +44,7 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -194,7 +194,7 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithNullLastCases(): array
+    public static function provideFixWithNullLastCases(): array
     {
         return [
             [
@@ -313,7 +313,7 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithAlphaAlgorithmCases(): array
+    public static function provideFixWithAlphaAlgorithmCases(): array
     {
         return [
             [
@@ -443,7 +443,7 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithAlphaAlgorithmAndNullAlwaysFirstCases(): array
+    public static function provideFixWithAlphaAlgorithmAndNullAlwaysFirstCases(): array
     {
         return [
             [
@@ -558,7 +558,7 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithAlphaAlgorithmAndNullAlwaysLastCases(): array
+    public static function provideFixWithAlphaAlgorithmAndNullAlwaysLastCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocVarAnnotationCorrectOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocVarAnnotationCorrectOrderFixerTest.php
@@ -33,7 +33,7 @@ final class PhpdocVarAnnotationCorrectOrderFixerTest extends AbstractFixerTestCa
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [ // It's @param, we care only about @var
             '<?php /** @param $foo Foo */',

--- a/tests/Fixer/Phpdoc/PhpdocVarWithoutNameFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocVarWithoutNameFixerTest.php
@@ -46,7 +46,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixVarCases(): array
+    public static function provideFixVarCases(): array
     {
         return [
             'testFixVar' => [
@@ -516,7 +516,7 @@ class A
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'readonly' => [
             '<?php

--- a/tests/Fixer/ReturnNotation/NoUselessReturnFixerTest.php
+++ b/tests/Fixer/ReturnNotation/NoUselessReturnFixerTest.php
@@ -31,7 +31,7 @@ final class NoUselessReturnFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -31,7 +31,7 @@ final class ReturnAssignmentFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixNestedFunctionsCases(): array
+    public static function provideFixNestedFunctionsCases(): array
     {
         return [
             [
@@ -191,7 +191,7 @@ function B($b0, $b1, $b2)
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -631,7 +631,7 @@ var names are case-insensitive */ return $a   ;}
         $this->doTest($expected);
     }
 
-    public function provideDoNotFixCases(): array
+    public static function provideDoNotFixCases(): array
     {
         return [
             'invalid reference stays invalid' => [
@@ -988,7 +988,7 @@ var_dump($a); // $a = 2 here _╯°□°╯︵┻━┻
         $this->doTest($expected, $input);
     }
 
-    public function provideRepetitiveFixCases(): iterable
+    public static function provideRepetitiveFixCases(): iterable
     {
         yield [
             '<?php
@@ -1041,7 +1041,7 @@ function foo(&$c) {
         $this->doTest($expected, $input);
     }
 
-    public function providePhp80Cases(): iterable
+    public static function providePhp80Cases(): iterable
     {
         yield 'match' => [
             '<?php

--- a/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
+++ b/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
@@ -33,7 +33,7 @@ final class SimplifiedNullReturnFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             // check correct statements aren't changed

--- a/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
+++ b/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
@@ -39,7 +39,7 @@ final class MultilineWhitespaceBeforeSemicolonsFixerTest extends AbstractFixerTe
         $this->doTest($expected, $input);
     }
 
-    public function provideMultiLineWhitespaceFixCases(): array
+    public static function provideMultiLineWhitespaceFixCases(): array
     {
         return [
             [
@@ -211,7 +211,7 @@ self
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesMultiLineWhitespaceFixCases(): array
+    public static function provideMessyWhitespacesMultiLineWhitespaceFixCases(): array
     {
         return [
             [
@@ -229,7 +229,7 @@ self
         $this->doTest($expected, $input);
     }
 
-    public function provideSemicolonForChainedCallsFixCases(): array
+    public static function provideSemicolonForChainedCallsFixCases(): array
     {
         return [
             [
@@ -858,7 +858,7 @@ Service
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesSemicolonForChainedCallsFixCases(): array
+    public static function provideMessyWhitespacesSemicolonForChainedCallsFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
+++ b/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
@@ -33,7 +33,7 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideNoEmptyStatementsCases(): iterable
+    public static function provideNoEmptyStatementsCases(): iterable
     {
         yield from [
             [
@@ -433,7 +433,7 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -528,7 +528,7 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideCasesWithShortOpenTagCases(): array
+    public static function provideCasesWithShortOpenTagCases(): array
     {
         return [
             [
@@ -546,7 +546,7 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixMultipleSemicolonsCases(): array
+    public static function provideFixMultipleSemicolonsCases(): array
     {
         return [
             [
@@ -613,7 +613,7 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php enum Foo{}',

--- a/tests/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixerTest.php
+++ b/tests/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixerTest.php
@@ -35,7 +35,7 @@ final class NoSinglelineWhitespaceBeforeSemicolonsFixerTest extends AbstractFixe
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
+++ b/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
@@ -31,7 +31,7 @@ final class SemicolonAfterInstructionFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             'comment' => [
@@ -92,7 +92,7 @@ A is equal to 5
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php $a = [1,2,3]; echo $a{1}; ?>',

--- a/tests/Fixer/Semicolon/SpaceAfterSemicolonFixerTest.php
+++ b/tests/Fixer/Semicolon/SpaceAfterSemicolonFixerTest.php
@@ -42,7 +42,7 @@ final class SpaceAfterSemicolonFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -290,7 +290,7 @@ final class SpaceAfterSemicolonFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithoutSpacesInEmptyForExpressionsCases(): array
+    public static function provideFixWithoutSpacesInEmptyForExpressionsCases(): array
     {
         return [
             [

--- a/tests/Fixer/Strict/DeclareStrictTypesFixerTest.php
+++ b/tests/Fixer/Strict/DeclareStrictTypesFixerTest.php
@@ -32,7 +32,7 @@ final class DeclareStrictTypesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -129,7 +129,7 @@ $a = 456;
         $this->doTest($input);
     }
 
-    public function provideDoNotFixCases(): array
+    public static function provideDoNotFixCases(): array
     {
         return [
             ['  <?php echo 123;'], // first statement must be an open tag
@@ -147,7 +147,7 @@ $a = 456;
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [

--- a/tests/Fixer/Strict/StrictComparisonFixerTest.php
+++ b/tests/Fixer/Strict/StrictComparisonFixerTest.php
@@ -33,7 +33,7 @@ final class StrictComparisonFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): array
+    public static function provideTestFixCases(): array
     {
         return [
             ['<?php $a === $b;', '<?php $a == $b;'],

--- a/tests/Fixer/Strict/StrictParamFixerTest.php
+++ b/tests/Fixer/Strict/StrictParamFixerTest.php
@@ -33,7 +33,7 @@ final class StrictParamFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/StringNotation/EscapeImplicitBackslashesFixerTest.php
+++ b/tests/Fixer/StringNotation/EscapeImplicitBackslashesFixerTest.php
@@ -36,7 +36,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): array
+    public static function provideTestFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
@@ -33,7 +33,7 @@ final class ExplicitStringVariableFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): array
+    public static function provideTestFixCases(): array
     {
         $input = $expected = '<?php';
 

--- a/tests/Fixer/StringNotation/HeredocToNowdocFixerTest.php
+++ b/tests/Fixer/StringNotation/HeredocToNowdocFixerTest.php
@@ -33,7 +33,7 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): array
+    public static function provideTestFixCases(): array
     {
         return [
             [<<<'EOF'

--- a/tests/Fixer/StringNotation/NoBinaryStringFixerTest.php
+++ b/tests/Fixer/StringNotation/NoBinaryStringFixerTest.php
@@ -33,7 +33,7 @@ final class NoBinaryStringFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): array
+    public static function provideTestFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/StringNotation/NoTrailingWhitespaceInStringFixerTest.php
+++ b/tests/Fixer/StringNotation/NoTrailingWhitespaceInStringFixerTest.php
@@ -33,7 +33,7 @@ final class NoTrailingWhitespaceInStringFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             "<?php \$a = ' foo\r bar\r\n\nbaz\n  ';",

--- a/tests/Fixer/StringNotation/SimpleToComplexStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/SimpleToComplexStringVariableFixerTest.php
@@ -33,7 +33,7 @@ final class SimpleToComplexStringVariableFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'basic fix' => [

--- a/tests/Fixer/StringNotation/SingleQuoteFixerTest.php
+++ b/tests/Fixer/StringNotation/SingleQuoteFixerTest.php
@@ -33,7 +33,7 @@ final class SingleQuoteFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): array
+    public static function provideTestFixCases(): array
     {
         return [
             [
@@ -133,7 +133,7 @@ EOF
         $this->doTest($expected, $input);
     }
 
-    public function provideTestSingleQuoteFixCases(): array
+    public static function provideTestSingleQuoteFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/StringNotation/StringLengthToEmptyFixerTest.php
+++ b/tests/Fixer/StringNotation/StringLengthToEmptyFixerTest.php
@@ -31,7 +31,7 @@ final class StringLengthToEmptyFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): iterable
+    public static function provideTestFixCases(): iterable
     {
         yield [
             '<?php $a = \'\' === $b;',

--- a/tests/Fixer/StringNotation/StringLineEndingFixerTest.php
+++ b/tests/Fixer/StringNotation/StringLineEndingFixerTest.php
@@ -34,7 +34,7 @@ final class StringLineEndingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         $heredocTemplate = "<?php\n\$a=\n<<<EOT\n%s\n\nEOT;\n";
         $nowdocTemplate = "<?php\n\$a=\n<<<'EOT'\n%s\n\nEOT;\n";

--- a/tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
@@ -915,7 +915,7 @@ INPUT
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPhp80Cases(): iterable
+    public static function provideFixPhp80Cases(): iterable
     {
         yield 'attribute' => [
             '<?php

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -42,7 +42,7 @@ final class BlankLineBeforeStatementFixerTest extends AbstractFixerTestCase
         ]);
     }
 
-    public function provideInvalidControlStatementCases(): array
+    public static function provideInvalidControlStatementCases(): array
     {
         return [
             'null' => [null],
@@ -76,7 +76,7 @@ final class BlankLineBeforeStatementFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithBreakCases(): array
+    public static function provideFixWithBreakCases(): array
     {
         return [
             [
@@ -175,7 +175,7 @@ while (true) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithCaseCases(): array
+    public static function provideFixWithCaseCases(): array
     {
         return [
             [
@@ -215,7 +215,7 @@ switch ($a) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithContinueCases(): array
+    public static function provideFixWithContinueCases(): array
     {
         return [
             [
@@ -307,7 +307,7 @@ while (true) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithDeclareCases(): array
+    public static function provideFixWithDeclareCases(): array
     {
         return [
             [
@@ -344,7 +344,7 @@ declare(ticks=1);',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithDefaultCases(): array
+    public static function provideFixWithDefaultCases(): array
     {
         return [
             [
@@ -389,7 +389,7 @@ switch ($a1) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithDoCases(): array
+    public static function provideFixWithDoCases(): array
     {
         return [
             [
@@ -423,7 +423,7 @@ do {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithExitCases(): array
+    public static function provideFixWithExitCases(): array
     {
         return [
             [
@@ -479,7 +479,7 @@ if ($foo === $bar) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithForCases(): array
+    public static function provideFixWithForCases(): array
     {
         return [
             [
@@ -508,7 +508,7 @@ if ($foo === $bar) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithGotoCases(): array
+    public static function provideFixWithGotoCases(): array
     {
         return [
             [
@@ -561,7 +561,7 @@ if ($foo === $bar) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithIfCases(): array
+    public static function provideFixWithIfCases(): array
     {
         return [
             [
@@ -608,7 +608,7 @@ if ($foo) { }',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithForEachCases(): array
+    public static function provideFixWithForEachCases(): array
     {
         return [
             [
@@ -637,7 +637,7 @@ if ($foo) { }',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithIncludeCases(): array
+    public static function provideFixWithIncludeCases(): array
     {
         return [
             [
@@ -668,7 +668,7 @@ include "foo.php";',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithIncludeOnceCases(): array
+    public static function provideFixWithIncludeOnceCases(): array
     {
         return [
             [
@@ -699,7 +699,7 @@ include_once "foo.php";',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithRequireCases(): array
+    public static function provideFixWithRequireCases(): array
     {
         return [
             [
@@ -730,7 +730,7 @@ require "foo.php";',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithRequireOnceCases(): array
+    public static function provideFixWithRequireOnceCases(): array
     {
         return [
             [
@@ -761,7 +761,7 @@ require_once "foo.php";',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithReturnCases(): array
+    public static function provideFixWithReturnCases(): array
     {
         return [
             [
@@ -903,7 +903,7 @@ function foo()
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithReturnAndMessyWhitespacesCases(): array
+    public static function provideFixWithReturnAndMessyWhitespacesCases(): array
     {
         return [
             [
@@ -933,7 +933,7 @@ function foo()
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithSwitchCases(): array
+    public static function provideFixWithSwitchCases(): array
     {
         return [
             [
@@ -973,7 +973,7 @@ switch ($foo) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithThrowCases(): array
+    public static function provideFixWithThrowCases(): array
     {
         return [
             [
@@ -1010,7 +1010,7 @@ if (false) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithTryCases(): array
+    public static function provideFixWithTryCases(): array
     {
         return [
             [
@@ -1053,7 +1053,7 @@ try {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithWhileCases(): array
+    public static function provideFixWithWhileCases(): array
     {
         return [
             [
@@ -1112,7 +1112,7 @@ do {
     /**
      * @yield array
      */
-    public function provideFixWithYieldCases(): array
+    public static function provideFixWithYieldCases(): array
     {
         return [
             [
@@ -1234,7 +1234,7 @@ function foo() {
     /**
      * @yield array
      */
-    public function provideFixWithYieldFromCases(): array
+    public static function provideFixWithYieldFromCases(): array
     {
         return [
             [
@@ -1294,7 +1294,7 @@ function foo() {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithMultipleConfigStatementsCases(): array
+    public static function provideFixWithMultipleConfigStatementsCases(): array
     {
         $statementsWithoutCaseOrDefault = [
             'break',
@@ -1401,7 +1401,7 @@ do {
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield 'match' => [
             '<?php
@@ -1434,7 +1434,7 @@ do {
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'enum' => [
             '<?php
@@ -1508,7 +1508,7 @@ enum UserStatus: string {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithDocCommentCases(): iterable
+    public static function provideFixWithDocCommentCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Whitespace/BlankLineBetweenImportGroupsFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBetweenImportGroupsFixerTest.php
@@ -31,7 +31,7 @@ final class BlankLineBetweenImportGroupsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixTypesOrderAndWhitespaceCases(): iterable
+    public static function provideFixTypesOrderAndWhitespaceCases(): iterable
     {
         yield [
             '<?php
@@ -537,7 +537,7 @@ use const C\D; // bar
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPre80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Whitespace/CompactNullableTypehintFixerTest.php
+++ b/tests/Fixer/Whitespace/CompactNullableTypehintFixerTest.php
@@ -33,7 +33,7 @@ final class CompactNullableTypehintFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Whitespace/HeredocIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/HeredocIndentationFixerTest.php
@@ -37,7 +37,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Whitespace/IndentationTypeFixerTest.php
+++ b/tests/Fixer/Whitespace/IndentationTypeFixerTest.php
@@ -34,7 +34,7 @@ final class IndentationTypeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         $cases = [];
 
@@ -233,7 +233,7 @@ final class IndentationTypeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         $cases = [];
 
@@ -328,7 +328,7 @@ function myFunction() {
         $this->doTest($expected, $input);
     }
 
-    public function provideDoubleSpaceIndentCases(): array
+    public static function provideDoubleSpaceIndentCases(): array
     {
         return [
             ['<?php

--- a/tests/Fixer/Whitespace/MethodChainingIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/MethodChainingIndentationFixerTest.php
@@ -34,7 +34,7 @@ final class MethodChainingIndentationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -444,7 +444,7 @@ abc(),
         $this->doTest($expected, $input);
     }
 
-    public function provideWindowsWhitespacesCases(): array
+    public static function provideWindowsWhitespacesCases(): array
     {
         return [
             [

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -105,7 +105,7 @@ EOF;
         $this->doTest($this->removeLinesFromString($this->template, $lineNumberRemoved), $this->template);
     }
 
-    public function provideWithConfigCases(): iterable
+    public static function provideWithConfigCases(): iterable
     {
         $tests = [
             [
@@ -366,7 +366,7 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function provideCommentCases(): array
+    public static function provideCommentCases(): array
     {
         return [
             [
@@ -420,7 +420,7 @@ EOF
         $this->doTest($expected, $input);
     }
 
-    public function provideLineBreakCases(): iterable
+    public static function provideLineBreakCases(): iterable
     {
         $input = '<?php //
 
@@ -479,7 +479,7 @@ $b = 1;
         $this->doTest($expected, $input);
     }
 
-    public function provideBetweenUseCases(): iterable
+    public static function provideBetweenUseCases(): iterable
     {
         yield from [
             ['<?php use A\B;'],
@@ -565,7 +565,7 @@ use const some\Z\{ConstX,ConstY,ConstZ,};
         $this->doTest($expected, $input);
     }
 
-    public function provideRemoveLinesBetweenUseStatementsCases(): array
+    public static function provideRemoveLinesBetweenUseStatementsCases(): array
     {
         return [
             [
@@ -639,7 +639,7 @@ use const some\a\{ConstA, ConstB, ConstC};
         $this->doTest($expected);
     }
 
-    public function provideWithoutUsesCases(): iterable
+    public static function provideWithoutUsesCases(): iterable
     {
         yield [
             '<?php
@@ -677,7 +677,7 @@ $a = new Qux();',
         $this->doTest($expected, $input);
     }
 
-    public function provideRemoveBetweenUseTraitsCases(): iterable
+    public static function provideRemoveBetweenUseTraitsCases(): iterable
     {
         yield [
             '<?php
@@ -792,7 +792,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideOneAndInLineCases(): iterable
+    public static function provideOneAndInLineCases(): iterable
     {
         yield [
             "<?php\n\n\$a = function() use (\$b) { while(3<1)break; \$c = \$b[1]; while(\$b<1)continue; if (true) throw \$e; return 1; };\n\n",
@@ -834,7 +834,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideBraceCases(): array
+    public static function provideBraceCases(): array
     {
         return [
             [
@@ -935,7 +935,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): iterable
+    public static function provideMessyWhitespacesCases(): iterable
     {
         yield [
             [],
@@ -974,7 +974,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideSwitchCases(): array
+    public static function provideSwitchCases(): array
     {
         return [
             [
@@ -1117,7 +1117,7 @@ class Foo {}'
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             ['tokens' => ['throw']],
@@ -1175,7 +1175,7 @@ function foo(){}
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
@@ -72,7 +72,7 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function provideCommentCases(): array
+    public static function provideCommentCases(): array
     {
         return [
             [
@@ -115,7 +115,7 @@ EOF;
         $this->doTest($expected);
     }
 
-    public function provideOutsideCases(): iterable
+    public static function provideOutsideCases(): iterable
     {
         yield from [
             [
@@ -206,7 +206,7 @@ $var = $arr[0]{     0
         }
     }
 
-    public function provideInsideCases(): array
+    public static function provideInsideCases(): array
     {
         return [
             [
@@ -303,7 +303,7 @@ $var = $arr[0][     0
         $this->doTest($expected, $input);
     }
 
-    public function provideConfigurationCases(): iterable
+    public static function provideConfigurationCases(): iterable
     {
         $tests = [
             [

--- a/tests/Fixer/Whitespace/NoSpacesInsideParenthesisFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesInsideParenthesisFixerTest.php
@@ -56,7 +56,7 @@ EOF;
         $this->doTest($expected);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -138,7 +138,7 @@ $a = $b->test(  // do not remove space
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php function foo(mixed $a){}',
@@ -156,7 +156,7 @@ $a = $b->test(  // do not remove space
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'first callable class' => [
             '<?php $a = strlen(...);',

--- a/tests/Fixer/Whitespace/NoTrailingWhitespaceFixerTest.php
+++ b/tests/Fixer/Whitespace/NoTrailingWhitespaceFixerTest.php
@@ -33,7 +33,7 @@ final class NoTrailingWhitespaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             [
@@ -146,7 +146,7 @@ EOT;
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php class Foo {

--- a/tests/Fixer/Whitespace/NoWhitespaceInBlankLineFixerTest.php
+++ b/tests/Fixer/Whitespace/NoWhitespaceInBlankLineFixerTest.php
@@ -34,7 +34,7 @@ final class NoWhitespaceInBlankLineFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -152,7 +152,7 @@ $t = true> 9;       '.'
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public static function provideMessyWhitespacesCases(): array
     {
         return [
             [

--- a/tests/Fixer/Whitespace/SingleBlankLineAtEofFixerTest.php
+++ b/tests/Fixer/Whitespace/SingleBlankLineAtEofFixerTest.php
@@ -34,7 +34,7 @@ final class SingleBlankLineAtEofFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'Not adding an empty line in empty file.' => [
@@ -156,7 +156,7 @@ inline 1
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): iterable
+    public static function provideMessyWhitespacesCases(): iterable
     {
         yield [
             "<?php\r\n\$a = 4;\r\n",

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -32,7 +32,7 @@ final class StatementIndentationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'no brace block' => [
             '<?php
@@ -787,7 +787,7 @@ switch ($foo) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithTabsCases(): iterable
+    public static function provideFixWithTabsCases(): iterable
     {
         yield 'simple' => [
             "<?php
@@ -813,7 +813,7 @@ if ($foo) {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPhp80Cases(): iterable
+    public static function provideFixPhp80Cases(): iterable
     {
         yield 'match expression' => [
             '<?php
@@ -880,7 +880,7 @@ class Foo {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPhp81Cases(): iterable
+    public static function provideFixPhp81Cases(): iterable
     {
         yield 'simple enum' => [
             '<?php

--- a/tests/Fixer/Whitespace/TypesSpacesFixerTest.php
+++ b/tests/Fixer/Whitespace/TypesSpacesFixerTest.php
@@ -34,7 +34,7 @@ final class TypesSpacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php try {} catch (ErrorA|ErrorB $e) {}',
@@ -102,7 +102,7 @@ final class TypesSpacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php function foo(TypeA|TypeB $x) {}',
@@ -280,7 +280,7 @@ TypeB $x) {}',
         $this->doTest($expected, $input);
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php class Foo {

--- a/tests/FixerConfiguration/AliasedFixerOptionTest.php
+++ b/tests/FixerConfiguration/AliasedFixerOptionTest.php
@@ -37,7 +37,7 @@ final class AliasedFixerOptionTest extends TestCase
         static::assertSame($name, $option->getName());
     }
 
-    public function provideGetNameCases(): array
+    public static function provideGetNameCases(): array
     {
         return [
             ['foo'],
@@ -55,7 +55,7 @@ final class AliasedFixerOptionTest extends TestCase
         static::assertSame($description, $option->getDescription());
     }
 
-    public function provideGetDescriptionCases(): array
+    public static function provideGetDescriptionCases(): array
     {
         return [
             ['Foo.'],
@@ -71,7 +71,7 @@ final class AliasedFixerOptionTest extends TestCase
         static::assertSame($hasDefault, $input->hasDefault());
     }
 
-    public function provideHasDefaultCases(): array
+    public static function provideHasDefaultCases(): array
     {
         return [
             [
@@ -95,7 +95,7 @@ final class AliasedFixerOptionTest extends TestCase
         static::assertSame($default, $option->getDefault());
     }
 
-    public function provideGetDefaultCases(): array
+    public static function provideGetDefaultCases(): array
     {
         return [
             ['baz'],
@@ -124,7 +124,7 @@ final class AliasedFixerOptionTest extends TestCase
         static::assertSame($allowedTypes, $option->getAllowedTypes());
     }
 
-    public function provideGetAllowedTypesCases(): array
+    public static function provideGetAllowedTypesCases(): array
     {
         return [
             [null],
@@ -145,7 +145,7 @@ final class AliasedFixerOptionTest extends TestCase
         static::assertSame($allowedValues, $option->getAllowedValues());
     }
 
-    public function provideGetAllowedValuesCases(): array
+    public static function provideGetAllowedValuesCases(): array
     {
         return [
             [null],
@@ -183,7 +183,7 @@ final class AliasedFixerOptionTest extends TestCase
         static::assertSame($alias, $options->getAlias());
     }
 
-    public function provideGetAliasCases(): array
+    public static function provideGetAliasCases(): array
     {
         return [
             ['bar'],

--- a/tests/FixerConfiguration/AllowedValueSubsetTest.php
+++ b/tests/FixerConfiguration/AllowedValueSubsetTest.php
@@ -29,7 +29,7 @@ final class AllowedValueSubsetTest extends TestCase
         static::assertIsCallable(new AllowedValueSubset(['foo', 'bar']));
     }
 
-    public function provideGetAllowedValuesAreSortedCases(): iterable
+    public static function provideGetAllowedValuesAreSortedCases(): iterable
     {
         yield [
             ['bar', 'foo'],
@@ -67,7 +67,7 @@ final class AllowedValueSubsetTest extends TestCase
         static::assertSame($expectedResult, $subset($inputValue));
     }
 
-    public function provideInvokeCases(): array
+    public static function provideInvokeCases(): array
     {
         return [
             [

--- a/tests/FixerConfiguration/DeprecatedFixerOptionTest.php
+++ b/tests/FixerConfiguration/DeprecatedFixerOptionTest.php
@@ -71,7 +71,7 @@ final class DeprecatedFixerOptionTest extends TestCase
         static::assertSame(!$isRequired, $option->hasDefault());
     }
 
-    public function provideHasDefaultCases(): array
+    public static function provideHasDefaultCases(): array
     {
         return [
             [true],
@@ -94,7 +94,7 @@ final class DeprecatedFixerOptionTest extends TestCase
         static::assertSame($default, $option->getDefault());
     }
 
-    public function provideGetDefaultCases(): array
+    public static function provideGetDefaultCases(): array
     {
         return [
             ['foo'],

--- a/tests/FixerDefinition/VersionSpecificCodeSampleTest.php
+++ b/tests/FixerDefinition/VersionSpecificCodeSampleTest.php
@@ -75,7 +75,7 @@ final class VersionSpecificCodeSampleTest extends TestCase
         static::assertSame($isSatisfied, $codeSample->isSuitableFor($version));
     }
 
-    public function provideIsSuitableForVersionUsesVersionSpecificationCases(): array
+    public static function provideIsSuitableForVersionUsesVersionSpecificationCases(): array
     {
         return [
             'is-satisfied' => [\PHP_VERSION_ID, true],

--- a/tests/FixerDefinition/VersionSpecificationTest.php
+++ b/tests/FixerDefinition/VersionSpecificationTest.php
@@ -56,7 +56,7 @@ final class VersionSpecificationTest extends TestCase
         );
     }
 
-    public function provideInvalidVersionCases(): array
+    public static function provideInvalidVersionCases(): array
     {
         return [
             'negative' => [-1],
@@ -87,7 +87,7 @@ final class VersionSpecificationTest extends TestCase
         static::assertTrue($versionSpecification->isSatisfiedBy($actual));
     }
 
-    public function provideIsSatisfiedByReturnsTrueCases(): array
+    public static function provideIsSatisfiedByReturnsTrueCases(): array
     {
         return [
             'version-same-as-maximum' => [null, \PHP_VERSION_ID, \PHP_VERSION_ID],
@@ -110,7 +110,7 @@ final class VersionSpecificationTest extends TestCase
         static::assertFalse($versionSpecification->isSatisfiedBy($actual));
     }
 
-    public function provideIsSatisfiedByReturnsFalseCases(): array
+    public static function provideIsSatisfiedByReturnsFalseCases(): array
     {
         return [
             'version-greater-than-maximum' => [null, \PHP_VERSION_ID, \PHP_VERSION_ID + 1],

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -272,7 +272,7 @@ final class FixerFactoryTest extends TestCase
             ->registerBuiltInFixers()->useRuleSet($ruleSet);
     }
 
-    public function provideConflictingFixersCases(): array
+    public static function provideConflictingFixersCases(): array
     {
         return [
             [new RuleSet(['no_blank_lines_before_namespace' => true, 'single_blank_line_before_namespace' => true])],
@@ -370,7 +370,7 @@ final class FixerFactoryTest extends TestCase
         ]));
     }
 
-    public function provideConfigureFixerWithNonArrayCases(): array
+    public static function provideConfigureFixerWithNonArrayCases(): array
     {
         return [
             ['bar'],

--- a/tests/FixerNameValidatorTest.php
+++ b/tests/FixerNameValidatorTest.php
@@ -35,7 +35,7 @@ final class FixerNameValidatorTest extends TestCase
         static::assertSame($isValid, $validator->isValid($name, $isCustom));
     }
 
-    public function provideIsValidCases(): array
+    public static function provideIsValidCases(): array
     {
         return [
             ['', true, false],

--- a/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
+++ b/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
@@ -49,7 +49,7 @@ final class PhpUnitTestCaseIndicatorTest extends TestCase
         static::assertSame($expected, $this->indicator->isPhpUnitClass($tokens, $index));
     }
 
-    public function provideIsPhpUnitClassCases(): iterable
+    public static function provideIsPhpUnitClassCases(): iterable
     {
         yield 'Test class' => [
             true,
@@ -165,7 +165,7 @@ class Foo extends A implements TestInterface, SomethingElse
         static::assertSame($expectedIndexes, $classes);
     }
 
-    public function provideFindPhpUnitClassesCases(): iterable
+    public static function provideFindPhpUnitClassesCases(): iterable
     {
         yield 'empty' => [
             [],

--- a/tests/Linter/AbstractLinterTestCase.php
+++ b/tests/Linter/AbstractLinterTestCase.php
@@ -59,7 +59,7 @@ abstract class AbstractLinterTestCase extends TestCase
     /**
      * @medium
      */
-    public function provideLintFileCases(): array
+    public static function provideLintFileCases(): array
     {
         return [
             [
@@ -92,7 +92,7 @@ abstract class AbstractLinterTestCase extends TestCase
         $linter->lintSource($source)->check();
     }
 
-    public function provideLintSourceCases(): array
+    public static function provideLintSourceCases(): array
     {
         return [
             [

--- a/tests/Linter/CachingLinterTest.php
+++ b/tests/Linter/CachingLinterTest.php
@@ -40,7 +40,7 @@ final class CachingLinterTest extends TestCase
         static::assertSame($isAsync, $linter->isAsync());
     }
 
-    public function provideIsAsyncCases(): array
+    public static function provideIsAsyncCases(): array
     {
         return [
             [true],

--- a/tests/PregTest.php
+++ b/tests/PregTest.php
@@ -46,7 +46,7 @@ final class PregTest extends TestCase
         static::assertSame($expectedMatches, $actualMatches);
     }
 
-    public function providePatternValidationCases(): iterable
+    public static function providePatternValidationCases(): iterable
     {
         yield from [
             'invalid_blank' => ['', null, PregException::class],
@@ -212,7 +212,7 @@ final class PregTest extends TestCase
         static::assertSame($expectedResult, $actualResult);
     }
 
-    public function provideCommonCases(): array
+    public static function provideCommonCases(): array
     {
         return [
             ['/u/u', 'u'],

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -126,7 +126,7 @@ final class RuleSetTest extends TestCase
         static::assertNotInstanceOf(DeprecatedFixerInterface::class, $fixer, sprintf('RuleSet "%s" contains deprecated rule "%s".', $setName, $ruleName));
     }
 
-    public function provideAllRulesFromSetsCases(): iterable
+    public static function provideAllRulesFromSetsCases(): iterable
     {
         foreach (RuleSets::getSetDefinitionNames() as $setName) {
             $ruleSet = new RuleSet([$setName => true]);
@@ -302,7 +302,7 @@ final class RuleSetTest extends TestCase
         );
     }
 
-    public function provideSafeSetCases(): iterable
+    public static function provideSafeSetCases(): iterable
     {
         foreach (RuleSets::getSetDefinitionNames() as $name) {
             yield $name => [
@@ -383,7 +383,7 @@ final class RuleSetTest extends TestCase
         ));
     }
 
-    public function provideAllSetCases(): iterable
+    public static function provideAllSetCases(): iterable
     {
         foreach (RuleSets::getSetDefinitions() as $name => $set) {
             yield $name => [$set];

--- a/tests/RuleSet/RuleSetsTest.php
+++ b/tests/RuleSet/RuleSetsTest.php
@@ -139,7 +139,7 @@ Integration of %s.
         static::assertSame($sortedSetDefinition, $setDefinition);
     }
 
-    public function provideSetDefinitionNameCases(): array
+    public static function provideSetDefinitionNameCases(): array
     {
         $setDefinitionNames = RuleSets::getSetDefinitionNames();
 
@@ -165,7 +165,7 @@ Integration of %s.
     /**
      * @return string[][]
      */
-    public function providePHPUnitMigrationSetDefinitionNameCases(): array
+    public static function providePHPUnitMigrationSetDefinitionNameCases(): array
     {
         $setDefinitionNames = RuleSets::getSetDefinitionNames();
 

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -199,7 +199,7 @@ Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Exec
         );
     }
 
-    public function provideIntegrationCases(): array
+    public static function provideIntegrationCases(): array
     {
         return [
             'random-changes' => [

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -138,7 +138,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
      *
      * @return IntegrationCase[][]
      */
-    public function provideIntegrationCases(): array
+    public static function provideIntegrationCases(): array
     {
         $dir = static::getFixturesDir();
         $fixturesDir = realpath($dir);

--- a/tests/TextDiffTest.php
+++ b/tests/TextDiffTest.php
@@ -62,7 +62,7 @@ final class TextDiffTest extends TestCase
         static::assertStringMatchesFormat($expected, $commandTester->getDisplay(false));
     }
 
-    public function provideDiffReportingCases(): iterable
+    public static function provideDiffReportingCases(): iterable
     {
         $expected = <<<'TEST'
 %A$output->writeln('<error>'.(int)$output.'</error>');%A

--- a/tests/Tokenizer/Analyzer/AlternativeSyntaxAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/AlternativeSyntaxAnalyzerTest.php
@@ -43,7 +43,7 @@ final class AlternativeSyntaxAnalyzerTest extends TestCase
         }
     }
 
-    public function provideBelongsToAlternativeSyntaxCases(): iterable
+    public static function provideBelongsToAlternativeSyntaxCases(): iterable
     {
         yield 'declare' => [
             [7],
@@ -102,7 +102,7 @@ final class AlternativeSyntaxAnalyzerTest extends TestCase
         );
     }
 
-    public function provideFindBlockEndCases(): iterable
+    public static function provideFindBlockEndCases(): iterable
     {
         yield ['<?php if ($foo): foo(); endif;', 1, 13];
 
@@ -195,7 +195,7 @@ final class AlternativeSyntaxAnalyzerTest extends TestCase
         $analyzer->findAlternativeSyntaxBlockEnd($tokens, $startIndex);
     }
 
-    public function provideFindInvalidBlockEndCases(): iterable
+    public static function provideFindInvalidBlockEndCases(): iterable
     {
         yield ['<?php if ($foo): foo(); endif;', 0, 'Token at index 0 is not the start of an alternative syntax block.'];
 

--- a/tests/Tokenizer/Analyzer/Analysis/TypeAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/TypeAnalysisTest.php
@@ -58,7 +58,7 @@ final class TypeAnalysisTest extends TestCase
         static::assertSame($expected, $analysis->isReservedType());
     }
 
-    public function provideReservedCases(): array
+    public static function provideReservedCases(): array
     {
         return [
             ['array', true],

--- a/tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
@@ -43,7 +43,7 @@ final class ArgumentsAnalyzerTest extends TestCase
         static::assertSame($arguments, $analyzer->getArguments($tokens, $openIndex, $closeIndex));
     }
 
-    public function provideArgumentsCases(): iterable
+    public static function provideArgumentsCases(): iterable
     {
         yield ['<?php function(){};', 2, 3, []];
 
@@ -103,7 +103,7 @@ final class ArgumentsAnalyzerTest extends TestCase
         static::assertSame($arguments, $analyzer->getArguments($tokens, $openIndex, $closeIndex));
     }
 
-    public function provideArguments80Cases(): iterable
+    public static function provideArguments80Cases(): iterable
     {
         yield ['<?php class Foo { public function __construct(public ?string $param = null) {} }', 12, 23, [13 => 22]];
 
@@ -132,7 +132,7 @@ final class ArgumentsAnalyzerTest extends TestCase
         static::assertSame($arguments, $analyzer->getArguments($tokens, $openIndex, $closeIndex));
     }
 
-    public function provideArguments81Cases(): iterable
+    public static function provideArguments81Cases(): iterable
     {
         yield ['<?php function setFoo(\A\B&C $param1, C&D $param2){}', 4, 20, [5 => 12, 14 => 19]];
     }
@@ -148,7 +148,7 @@ final class ArgumentsAnalyzerTest extends TestCase
         self::assertArgumentAnalysis($expected, $analyzer->getArgumentInfo($tokens, $openIndex, $closeIndex));
     }
 
-    public function provideArgumentsInfoCases(): iterable
+    public static function provideArgumentsInfoCases(): iterable
     {
         yield ['<?php function($a){};', 3, 3, new ArgumentAnalysis(
             '$a',
@@ -284,7 +284,7 @@ final class ArgumentsAnalyzerTest extends TestCase
         self::assertArgumentAnalysis($expected, $analyzer->getArgumentInfo($tokens, $openIndex, $closeIndex));
     }
 
-    public function provideArgumentsInfo80Cases(): iterable
+    public static function provideArgumentsInfo80Cases(): iterable
     {
         yield [
             '<?php function foo(#[AnAttribute] ?string $param = null) {}',
@@ -334,7 +334,7 @@ final class ArgumentsAnalyzerTest extends TestCase
         self::assertArgumentAnalysis($expected, $analyzer->getArgumentInfo($tokens, $openIndex, $closeIndex));
     }
 
-    public function provideArgumentsInfo81Cases(): iterable
+    public static function provideArgumentsInfo81Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Tokenizer/Analyzer/BlocksAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/BlocksAnalyzerTest.php
@@ -38,7 +38,7 @@ final class BlocksAnalyzerTest extends TestCase
         static::assertTrue($analyzer->isBlock($tokens, $openIndex, $closeIndex));
     }
 
-    public function provideBlocksCases(): array
+    public static function provideBlocksCases(): array
     {
         return [
             ['<?php foo(1);', 2, 4],
@@ -67,7 +67,7 @@ final class BlocksAnalyzerTest extends TestCase
         static::assertSame($isBlock, $analyzer->isBlock($tokens, $openIndex, $closeIndex));
     }
 
-    public function provideNonBlocksCases(): array
+    public static function provideNonBlocksCases(): array
     {
         return [
             ['<?php foo(1);', null, 4],

--- a/tests/Tokenizer/Analyzer/ClassyAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ClassyAnalyzerTest.php
@@ -35,7 +35,7 @@ final class ClassyAnalyzerTest extends TestCase
         self::assertClassyInvocation($source, $expected);
     }
 
-    public function provideIsClassyInvocationCases(): iterable
+    public static function provideIsClassyInvocationCases(): iterable
     {
         yield from [
             [
@@ -155,7 +155,7 @@ final class ClassyAnalyzerTest extends TestCase
         self::assertClassyInvocation($source, $expected);
     }
 
-    public function provideIsClassyInvocation80Cases(): iterable
+    public static function provideIsClassyInvocation80Cases(): iterable
     {
         yield [
             '<?php function foo(): \Foo|int {}',
@@ -195,7 +195,7 @@ final class ClassyAnalyzerTest extends TestCase
         self::assertClassyInvocation($source, $expected);
     }
 
-    public function provideIsClassyInvocation81Cases(): iterable
+    public static function provideIsClassyInvocation81Cases(): iterable
     {
         yield 'never' => [
             '<?php function foo(): never {}',

--- a/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
@@ -52,7 +52,7 @@ final class CommentsAnalyzerTest extends TestCase
         static::assertFalse($analyzer->isHeaderComment($tokens, $index));
     }
 
-    public function provideCommentsCases(): array
+    public static function provideCommentsCases(): array
     {
         return [
             'discover all 4 comments for the 1st comment with slash' => [
@@ -168,7 +168,7 @@ $bar;',
         static::assertTrue($analyzer->isHeaderComment($tokens, $index));
     }
 
-    public function provideHeaderCommentCases(): array
+    public static function provideHeaderCommentCases(): array
     {
         return [
             ['<?php /* Comment */ namespace Foo;', 1],
@@ -190,7 +190,7 @@ $bar;',
         static::assertFalse($analyzer->isHeaderComment($tokens, $index));
     }
 
-    public function provideNotHeaderCommentCases(): array
+    public static function provideNotHeaderCommentCases(): array
     {
         return [
             ['<?php $foo; /* Comment */ $bar;', 4],
@@ -224,7 +224,7 @@ $bar;',
         static::assertTrue($analyzer->isBeforeStructuralElement($tokens, $index));
     }
 
-    public function providePhpdocCandidateCases(): array
+    public static function providePhpdocCandidateCases(): array
     {
         return [
             ['<?php /* @var Foo */ $bar = "baz";'],
@@ -277,7 +277,7 @@ $bar;',
         static::assertFalse($analyzer->isBeforeStructuralElement($tokens, $index));
     }
 
-    public function provideNotPhpdocCandidateCases(): array
+    public static function provideNotPhpdocCandidateCases(): array
     {
         return [
             ['<?php class Foo {} /* At the end of file */'],
@@ -320,7 +320,7 @@ $bar;',
         static::assertTrue($analyzer->isBeforeStructuralElement($tokens, $index));
     }
 
-    public function providePhpdocCandidatePhp74Cases(): array
+    public static function providePhpdocCandidatePhp74Cases(): array
     {
         return [
             ['<?php /* Before anonymous function */ $fn = fn($x) => $x + 1;'],
@@ -341,7 +341,7 @@ $bar;',
         static::assertTrue($analyzer->isBeforeStructuralElement($tokens, $index));
     }
 
-    public function providePhpdocCandidatePhp80Cases(): array
+    public static function providePhpdocCandidatePhp80Cases(): array
     {
         return [
             ['<?php
@@ -367,7 +367,7 @@ Class MyAnnotation3 {}'],
         static::assertTrue($analyzer->isBeforeStructuralElement($tokens, $index));
     }
 
-    public function providePhpdocCandidatePhp81Cases(): iterable
+    public static function providePhpdocCandidatePhp81Cases(): iterable
     {
         yield 'public readonly' => [
             '<?php class Foo { /* */ public readonly int $a1; }',

--- a/tests/Tokenizer/Analyzer/ControlCaseStructuresAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ControlCaseStructuresAnalyzerTest.php
@@ -48,7 +48,7 @@ final class ControlCaseStructuresAnalyzerTest extends TestCase
         }
     }
 
-    public function provideFindControlStructuresCases(): iterable
+    public static function provideFindControlStructuresCases(): iterable
     {
         yield 'two cases' => [
             [1 => new SwitchAnalysis(1, 7, 46, [new CaseAnalysis(9, 12), new CaseAnalysis(36, 39)], null)],
@@ -339,7 +339,7 @@ endswitch ?>',
         }
     }
 
-    public function provideFindControlStructuresPhp81Cases(): iterable
+    public static function provideFindControlStructuresPhp81Cases(): iterable
     {
         $switchAnalysis = new SwitchAnalysis(1, 6, 26, [new CaseAnalysis(8, 11)], new DefaultAnalysis(18, 19));
         $enumAnalysis = new EnumAnalysis(28, 35, 51, [new CaseAnalysis(37, 41), new CaseAnalysis(46, 49)]);

--- a/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
@@ -39,7 +39,7 @@ final class FunctionsAnalyzerTest extends TestCase
         self::assertIsGlobalFunctionCall($indices, $code);
     }
 
-    public function provideIsGlobalFunctionCallCases(): iterable
+    public static function provideIsGlobalFunctionCallCases(): iterable
     {
         yield [
             '<?php CONSTANT;',
@@ -290,7 +290,7 @@ A();
         self::assertIsGlobalFunctionCall($indices, $code);
     }
 
-    public function provideIsGlobalFunctionCallPhp80Cases(): iterable
+    public static function provideIsGlobalFunctionCallPhp80Cases(): iterable
     {
         yield [
             '<?php $a = new (foo());',
@@ -336,7 +336,7 @@ class Foo {}
         self::assertIsGlobalFunctionCall($indices, $code);
     }
 
-    public function provideIsGlobalFunctionCallPhp81Cases(): iterable
+    public static function provideIsGlobalFunctionCallPhp81Cases(): iterable
     {
         yield 'first class callable cases' => [
             [],
@@ -391,7 +391,7 @@ class(){};
         static::assertSame(serialize($expected), serialize($actual));
     }
 
-    public function provideFunctionsWithArgumentsCases(): iterable
+    public static function provideFunctionsWithArgumentsCases(): iterable
     {
         yield from [
             ['<?php function(){};', 1, []],
@@ -586,7 +586,7 @@ class(){};
         }
     }
 
-    public function provideFunctionReturnTypeInfoCases(): iterable
+    public static function provideFunctionReturnTypeInfoCases(): iterable
     {
         yield ['<?php function(){};', 1, null];
 
@@ -626,7 +626,7 @@ class(){};
         static::assertSame($isTheSameClassCall, $analyzer->isTheSameClassCall($tokens, $index));
     }
 
-    public function provideIsTheSameClassCallCases(): iterable
+    public static function provideIsTheSameClassCallCases(): iterable
     {
         $template = '<?php
             class Foo {
@@ -712,7 +712,7 @@ class(){};
         static::assertSame(serialize($expected), serialize($analyzer->getFunctionArguments($tokens, $methodIndex)));
     }
 
-    public function provideFunctionsWithArgumentsPhp80Cases(): iterable
+    public static function provideFunctionsWithArgumentsPhp80Cases(): iterable
     {
         yield ['<?php function($aa,){};', 1, [
             '$aa' => new ArgumentAnalysis(

--- a/tests/Tokenizer/Analyzer/GotoLabelAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/GotoLabelAnalyzerTest.php
@@ -43,7 +43,7 @@ final class GotoLabelAnalyzerTest extends TestCase
         }
     }
 
-    public function provideIsClassyInvocationCases(): iterable
+    public static function provideIsClassyInvocationCases(): iterable
     {
         yield from [
             'no candidates' => [

--- a/tests/Tokenizer/Analyzer/NamespaceUsesAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/NamespaceUsesAnalyzerTest.php
@@ -45,7 +45,7 @@ final class NamespaceUsesAnalyzerTest extends TestCase
         );
     }
 
-    public function provideNamespaceUsesCases(): array
+    public static function provideNamespaceUsesCases(): array
     {
         return [
             ['<?php // no uses', [], []],
@@ -174,7 +174,7 @@ final class NamespaceUsesAnalyzerTest extends TestCase
         );
     }
 
-    public function provideGetDeclarationsInNamespaceCases(): array
+    public static function provideGetDeclarationsInNamespaceCases(): array
     {
         return [
             [

--- a/tests/Tokenizer/Analyzer/NamespacesAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/NamespacesAnalyzerTest.php
@@ -44,7 +44,7 @@ final class NamespacesAnalyzerTest extends TestCase
         );
     }
 
-    public function provideNamespacesCases(): array
+    public static function provideNamespacesCases(): array
     {
         return [
             ['<?php // no namespaces', [
@@ -102,7 +102,7 @@ final class NamespacesAnalyzerTest extends TestCase
         );
     }
 
-    public function provideGetNamespaceAtCases(): iterable
+    public static function provideGetNamespaceAtCases(): iterable
     {
         yield [
             '<?php // no namespaces',

--- a/tests/Tokenizer/Analyzer/RangeAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/RangeAnalyzerTest.php
@@ -38,7 +38,7 @@ final class RangeAnalyzerTest extends TestCase
         static::assertSame($expected, RangeAnalyzer::rangeEqualsRange($tokens, $range1, $range2));
     }
 
-    public function provideRangeEqualsRangeCases(): iterable
+    public static function provideRangeEqualsRangeCases(): iterable
     {
         $ranges = [
             [['start' => 2, 'end' => 6], ['start' => 10, 'end' => 14]],

--- a/tests/Tokenizer/Analyzer/WhitespacesAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/WhitespacesAnalyzerTest.php
@@ -35,7 +35,7 @@ final class WhitespacesAnalyzerTest extends TestCase
         static::assertSame($indent, WhitespacesAnalyzer::detectIndent($tokens, $index));
     }
 
-    public function provideIndentCases(): iterable
+    public static function provideIndentCases(): iterable
     {
         yield ['<?php function foo() { return true; }', '', 10];
 

--- a/tests/Tokenizer/TokenTest.php
+++ b/tests/Tokenizer/TokenTest.php
@@ -39,7 +39,7 @@ final class TokenTest extends TestCase
         new Token($input);
     }
 
-    public function provideConstructorValidationCases(): array
+    public static function provideConstructorValidationCases(): array
     {
         return [
             [null],
@@ -294,7 +294,7 @@ final class TokenTest extends TestCase
         static::assertSame($expectedIsArray, $token->isArray());
     }
 
-    public function provideCreatingTokenCases(): array
+    public static function provideCreatingTokenCases(): array
     {
         return [
             [[T_FOREACH, 'foreach'], T_FOREACH, 'foreach', true],
@@ -443,7 +443,7 @@ final class TokenTest extends TestCase
         static::assertSame($isKeyCaseSensitive, Token::isKeyCaseSensitive($caseSensitive, $key));
     }
 
-    public function provideIsKeyCaseSensitiveCases(): iterable
+    public static function provideIsKeyCaseSensitiveCases(): iterable
     {
         yield [true, true, 0];
 
@@ -478,7 +478,7 @@ final class TokenTest extends TestCase
         static::assertSame($expected, Token::getNameForId($id));
     }
 
-    public function provideTokenGetNameCases(): array
+    public static function provideTokenGetNameCases(): array
     {
         return [
             [
@@ -504,7 +504,7 @@ final class TokenTest extends TestCase
         static::assertSame($expected, $token->getName());
     }
 
-    public function provideGetNameCases(): iterable
+    public static function provideGetNameCases(): iterable
     {
         yield [
             new Token([T_FUNCTION, 'function', 1]),
@@ -532,7 +532,7 @@ final class TokenTest extends TestCase
         static::assertSame($expected, $token->toArray());
     }
 
-    public function provideToArrayCases(): iterable
+    public static function provideToArrayCases(): iterable
     {
         yield [
             new Token([T_FUNCTION, 'function', 1]),

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -54,7 +54,7 @@ final class TokensAnalyzerTest extends TestCase
         );
     }
 
-    public function provideGetClassyElementsCases(): iterable
+    public static function provideGetClassyElementsCases(): iterable
     {
         yield 'trait import' => [
             [
@@ -506,7 +506,7 @@ PHP;
         static::assertSame($expected, $elements);
     }
 
-    public function provideGetClassyElements81Cases(): iterable
+    public static function provideGetClassyElements81Cases(): iterable
     {
         yield [
             [
@@ -692,7 +692,7 @@ enum Foo: string
         static::assertSame($expected, $elements);
     }
 
-    public function provideGetClassyElements82Cases(): iterable
+    public static function provideGetClassyElements82Cases(): iterable
     {
         yield 'constant in trait' => [
             [
@@ -730,7 +730,7 @@ enum Foo: string
         }
     }
 
-    public function provideIsAnonymousClassCases(): iterable
+    public static function provideIsAnonymousClassCases(): iterable
     {
         yield [
             [1 => false],
@@ -796,7 +796,7 @@ enum Foo: string
         }
     }
 
-    public function provideIsLambdaCases(): array
+    public static function provideIsLambdaCases(): array
     {
         return [
             [
@@ -896,7 +896,7 @@ preg_replace_callback(
         }
     }
 
-    public function provideIsLambda74Cases(): iterable
+    public static function provideIsLambda74Cases(): iterable
     {
         yield [
             [5 => true],
@@ -925,7 +925,7 @@ preg_replace_callback(
         }
     }
 
-    public function provideIsLambda80Cases(): array
+    public static function provideIsLambda80Cases(): array
     {
         return [
             [
@@ -980,7 +980,7 @@ $a(1,2);',
         $this->doIsConstantInvocationTest($expected, $source);
     }
 
-    public function provideIsConstantInvocationCases(): array
+    public static function provideIsConstantInvocationCases(): array
     {
         return [
             [
@@ -1196,7 +1196,7 @@ abstract class Baz
         $this->doIsConstantInvocationTest($expected, $source);
     }
 
-    public function provideIsConstantInvocationPhp80Cases(): iterable
+    public static function provideIsConstantInvocationPhp80Cases(): iterable
     {
         yield 'abstract method return alternation' => [
             [6 => false, 16 => false, 21 => false, 23 => false],
@@ -1306,7 +1306,7 @@ function f( #[Target(\'xxx\')] LoggerInterface|null $logger) {}
         $this->doIsConstantInvocationTest($expected, $source);
     }
 
-    public function provideIsConstantInvocationPhp81Cases(): iterable
+    public static function provideIsConstantInvocationPhp81Cases(): iterable
     {
         yield [
             [5 => false, 15 => false],
@@ -1392,7 +1392,7 @@ abstract class Baz
         }
     }
 
-    public function provideIsUnarySuccessorOperatorCases(): array
+    public static function provideIsUnarySuccessorOperatorCases(): array
     {
         return [
             [
@@ -1453,7 +1453,7 @@ abstract class Baz
         }
     }
 
-    public function provideIsUnaryPredecessorOperatorCases(): array
+    public static function provideIsUnaryPredecessorOperatorCases(): array
     {
         return [
             [
@@ -1538,7 +1538,7 @@ abstract class Baz
         }
     }
 
-    public function provideIsBinaryOperatorCases(): iterable
+    public static function provideIsBinaryOperatorCases(): iterable
     {
         yield from [
             [
@@ -1705,7 +1705,7 @@ $b;',
         static::assertSame($isMultiLineArray, $tokensAnalyzer->isArrayMultiLine($tokenIndex), sprintf('Expected %sto be a multiline array', $isMultiLineArray ? '' : 'not '));
     }
 
-    public function provideIsArrayCases(): array
+    public static function provideIsArrayCases(): array
     {
         return [
             [
@@ -1788,7 +1788,7 @@ $b;',
         }
     }
 
-    public function provideIsArray71Cases(): array
+    public static function provideIsArray71Cases(): array
     {
         return [
             [
@@ -1823,7 +1823,7 @@ $b;',
         }
     }
 
-    public function provideIsBinaryOperator71Cases(): iterable
+    public static function provideIsBinaryOperator71Cases(): iterable
     {
         yield [
             [11 => false],
@@ -1857,7 +1857,7 @@ $b;',
         }
     }
 
-    public function provideIsBinaryOperator80Cases(): iterable
+    public static function provideIsBinaryOperator80Cases(): iterable
     {
         yield [
             [6 => false],
@@ -1901,7 +1901,7 @@ $b;',
         }
     }
 
-    public function provideIsBinaryOperator81Cases(): iterable
+    public static function provideIsBinaryOperator81Cases(): iterable
     {
         yield 'type intersection' => [
             [6 => false],
@@ -1932,7 +1932,7 @@ $b;',
         $tokensAnalyzer->isArrayMultiLine($tokenIndex);
     }
 
-    public function provideArrayExceptionsCases(): array
+    public static function provideArrayExceptionsCases(): array
     {
         return [
             ['<?php $a;', 1],
@@ -2010,7 +2010,7 @@ $b;',
         static::assertSame($expected, $attributes);
     }
 
-    public function provideGetFunctionPropertiesCases(): array
+    public static function provideGetFunctionPropertiesCases(): array
     {
         $defaultAttributes = [
             'visibility' => null,
@@ -2157,7 +2157,7 @@ SRC;
         static::assertSame($expected, $tokensAnalyzer->getImportUseIndexes($perNamespace));
     }
 
-    public function provideGetImportUseIndexesCases(): array
+    public static function provideGetImportUseIndexesCases(): array
     {
         return [
             [
@@ -2341,7 +2341,7 @@ class MyTestWithAnonymousClass extends TestCase
         static::assertSame($expected, $tokensAnalyzer->isSuperGlobal($index));
     }
 
-    public function provideIsSuperGlobalCases(): array
+    public static function provideIsSuperGlobalCases(): array
     {
         $superNames = [
             '$_COOKIE',

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -75,7 +75,7 @@ final class TokensTest extends TestCase
         );
     }
 
-    public function provideFindSequenceCases(): array
+    public static function provideFindSequenceCases(): array
     {
         return [
             [
@@ -293,7 +293,7 @@ final class TokensTest extends TestCase
         $tokens->findSequence($sequence);
     }
 
-    public function provideFindSequenceExceptionCases(): array
+    public static function provideFindSequenceExceptionCases(): array
     {
         $emptyToken = new Token('');
 
@@ -354,7 +354,7 @@ PHP;
         static::assertSame($isMonolithic, $tokens->isMonolithicPhp());
     }
 
-    public function provideMonolithicPhpDetectionCases(): iterable
+    public static function provideMonolithicPhpDetectionCases(): iterable
     {
         yield [true, "<?php\n"];
 
@@ -533,7 +533,7 @@ PHP;
         }
     }
 
-    public function provideGetClearTokenAndMergeSurroundingWhitespaceCases(): array
+    public static function provideGetClearTokenAndMergeSurroundingWhitespaceCases(): array
     {
         $clearToken = new Token('');
 
@@ -656,7 +656,7 @@ PHP;
         static::assertSame($expectedIndex, $tokens->getTokenOfKindSibling($index, $direction, $findTokens, $caseSensitive));
     }
 
-    public function provideTokenOfKindSiblingCases(): array
+    public static function provideTokenOfKindSiblingCases(): array
     {
         return [
             // find next cases
@@ -695,7 +695,7 @@ PHP;
         static::assertFindBlockEnd($expectedIndex, $source, $type, $searchIndex);
     }
 
-    public function provideFindBlockEndCases(): array
+    public static function provideFindBlockEndCases(): array
     {
         return [
             [4, '<?php ${$bar};', Tokens::BLOCK_TYPE_DYNAMIC_VAR_BRACE, 2],
@@ -726,7 +726,7 @@ PHP;
         static::assertFindBlockEnd($expectedIndex, $source, $type, $searchIndex);
     }
 
-    public function provideFindBlockEnd80Cases(): array
+    public static function provideFindBlockEnd80Cases(): array
     {
         return [
             [
@@ -844,7 +844,7 @@ PHP;
         static::assertSame($isEmpty, $tokens->isEmptyAt(0), $token->toJson());
     }
 
-    public function provideIsEmptyCases(): array
+    public static function provideIsEmptyCases(): array
     {
         return [
             [new Token(''), true],
@@ -883,7 +883,7 @@ PHP;
         static::assertTokens(Tokens::fromCode($expected), $tokens);
     }
 
-    public function provideEnsureWhitespaceAtIndexCases(): array
+    public static function provideEnsureWhitespaceAtIndexCases(): array
     {
         return [
             [
@@ -1047,7 +1047,7 @@ echo $a;',
         static::assertSame($expected, $tokens->generateCode());
     }
 
-    public function provideRemoveLeadingWhitespaceCases(): array
+    public static function provideRemoveLeadingWhitespaceCases(): array
     {
         return [
             [
@@ -1201,7 +1201,7 @@ $bar;',
         static::assertSame($expected, Tokens::detectBlockType($tokens[$index]));
     }
 
-    public function provideDetectBlockTypeCases(): iterable
+    public static function provideDetectBlockTypeCases(): iterable
     {
         yield [
             [
@@ -1261,7 +1261,7 @@ $bar;',
         self::assertTokens(Tokens::fromArray($expected), $tokens);
     }
 
-    public function provideOverrideRangeCases(): iterable
+    public static function provideOverrideRangeCases(): iterable
     {
         // typically done by transformers, here we test the reverse
 
@@ -1382,7 +1382,7 @@ $bar;',
         static::assertSame($expectIndex, $tokens->getMeaningfulTokenSibling($index, $direction));
     }
 
-    public function provideGetMeaningfulTokenSiblingCases(): iterable
+    public static function provideGetMeaningfulTokenSiblingCases(): iterable
     {
         yield [null, 0, 1, '<?php '];
 
@@ -1429,7 +1429,7 @@ EOF;
         static::assertTokens(Tokens::fromCode($expected), $tokens);
     }
 
-    public function provideInsertSlicesAtMultiplePlacesCases(): iterable
+    public static function provideInsertSlicesAtMultiplePlacesCases(): iterable
     {
         yield 'one slice count' => [
             <<<'EOF'
@@ -1491,7 +1491,7 @@ EOF
         static::assertTokens($expected, $tokens);
     }
 
-    public function provideInsertSlicesCases(): iterable
+    public static function provideInsertSlicesCases(): iterable
     {
         // basic insert of single token at 3 different locations including appending as new token
 

--- a/tests/Tokenizer/Transformer/ArrayTypehintTransformerTest.php
+++ b/tests/Tokenizer/Transformer/ArrayTypehintTransformerTest.php
@@ -43,7 +43,7 @@ final class ArrayTypehintTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases(): array
+    public static function provideProcessCases(): array
     {
         return [
             [

--- a/tests/Tokenizer/Transformer/AttributeTransformerTest.php
+++ b/tests/Tokenizer/Transformer/AttributeTransformerTest.php
@@ -37,7 +37,7 @@ final class AttributeTransformerTest extends AbstractTransformerTestCase
         $this->doTest($source, $expectedTokens);
     }
 
-    public function provideProcessCases(): iterable
+    public static function provideProcessCases(): iterable
     {
         yield ['<?php class Foo {
     #[Listens(ProductCreatedEvent::class)]
@@ -189,7 +189,7 @@ class User
         }
     }
 
-    public function provideNotChangeCases(): iterable
+    public static function provideNotChangeCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Tokenizer/Transformer/BraceClassInstantiationTransformerTest.php
+++ b/tests/Tokenizer/Transformer/BraceClassInstantiationTransformerTest.php
@@ -41,7 +41,7 @@ final class BraceClassInstantiationTransformerTest extends AbstractTransformerTe
         );
     }
 
-    public function provideProcessCases(): array
+    public static function provideProcessCases(): array
     {
         return [
             [
@@ -360,7 +360,7 @@ final class BraceClassInstantiationTransformerTest extends AbstractTransformerTe
         );
     }
 
-    public function provideProcessPhp80Cases(): iterable
+    public static function provideProcessPhp80Cases(): iterable
     {
         yield [
             [
@@ -411,7 +411,7 @@ final class BraceClassInstantiationTransformerTest extends AbstractTransformerTe
         );
     }
 
-    public function provideProcessPhp81Cases(): iterable
+    public static function provideProcessPhp81Cases(): iterable
     {
         yield [
             [

--- a/tests/Tokenizer/Transformer/ClassConstantTransformerTest.php
+++ b/tests/Tokenizer/Transformer/ClassConstantTransformerTest.php
@@ -42,7 +42,7 @@ final class ClassConstantTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases(): array
+    public static function provideProcessCases(): array
     {
         return [
             [

--- a/tests/Tokenizer/Transformer/ConstructorPromotionTransformerTest.php
+++ b/tests/Tokenizer/Transformer/ConstructorPromotionTransformerTest.php
@@ -45,7 +45,7 @@ final class ConstructorPromotionTransformerTest extends AbstractTransformerTestC
         );
     }
 
-    public function provideProcessCases(): iterable
+    public static function provideProcessCases(): iterable
     {
         yield [
             [
@@ -144,7 +144,7 @@ class Point {
         );
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'readonly' => [
             [

--- a/tests/Tokenizer/Transformer/CurlyBraceTransformerTest.php
+++ b/tests/Tokenizer/Transformer/CurlyBraceTransformerTest.php
@@ -53,7 +53,7 @@ final class CurlyBraceTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases(): array
+    public static function provideProcessCases(): array
     {
         return [
             'curly open/close I' => [

--- a/tests/Tokenizer/Transformer/FirstClassCallableTransformerTest.php
+++ b/tests/Tokenizer/Transformer/FirstClassCallableTransformerTest.php
@@ -36,7 +36,7 @@ final class FirstClassCallableTransformerTest extends AbstractTransformerTestCas
         $this->doTest($source, $expectedTokens, [CT::T_FIRST_CLASS_CALLABLE]);
     }
 
-    public function provideProcessCases(): iterable
+    public static function provideProcessCases(): iterable
     {
         yield 'set' => [
             [

--- a/tests/Tokenizer/Transformer/ImportTransformerTest.php
+++ b/tests/Tokenizer/Transformer/ImportTransformerTest.php
@@ -45,7 +45,7 @@ final class ImportTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases(): array
+    public static function provideProcessCases(): array
     {
         return [
             [

--- a/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php
@@ -61,7 +61,7 @@ final class NameQualifiedTransformerTest extends AbstractTransformerTestCase
         }
     }
 
-    public function provideProcessCases(): iterable
+    public static function provideProcessCases(): iterable
     {
         if (\PHP_VERSION_ID < 80000) {
             return; // PHPUnit still calls this for no reason on non PHP8.0
@@ -165,7 +165,7 @@ final class NameQualifiedTransformerTest extends AbstractTransformerTestCase
         self::assertTokens(Tokens::fromArray($expected), Tokens::fromCode($source));
     }
 
-    public function providePriorityCases(): iterable
+    public static function providePriorityCases(): iterable
     {
         yield [
             [

--- a/tests/Tokenizer/Transformer/NamedArgumentTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NamedArgumentTransformerTest.php
@@ -37,7 +37,7 @@ final class NamedArgumentTransformerTest extends AbstractTransformerTestCase
         $this->doTest($source, $expectedTokens);
     }
 
-    public function provideProcessCases(): iterable
+    public static function provideProcessCases(): iterable
     {
         yield 'function call' => [
             '<?php foo(test: 1);',
@@ -95,7 +95,7 @@ final class NamedArgumentTransformerTest extends AbstractTransformerTestCase
         static::assertNotChange($source);
     }
 
-    public function provideDoNotChangeCases(): iterable
+    public static function provideDoNotChangeCases(): iterable
     {
         yield 'switch/case/constants' => [
             '<?php

--- a/tests/Tokenizer/Transformer/NamespaceOperatorTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NamespaceOperatorTransformerTest.php
@@ -43,7 +43,7 @@ final class NamespaceOperatorTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases(): array
+    public static function provideProcessCases(): array
     {
         return [
             [

--- a/tests/Tokenizer/Transformer/NullableTypeTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NullableTypeTransformerTest.php
@@ -42,7 +42,7 @@ final class NullableTypeTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases(): array
+    public static function provideProcessCases(): array
     {
         return [
             [
@@ -132,7 +132,7 @@ final class NullableTypeTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcess80Cases(): iterable
+    public static function provideProcess80Cases(): iterable
     {
         yield [
             [
@@ -181,7 +181,7 @@ final class NullableTypeTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcess81Cases(): iterable
+    public static function provideProcess81Cases(): iterable
     {
         yield [
             [

--- a/tests/Tokenizer/Transformer/ReturnRefTransformerTest.php
+++ b/tests/Tokenizer/Transformer/ReturnRefTransformerTest.php
@@ -42,7 +42,7 @@ final class ReturnRefTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases(): array
+    public static function provideProcessCases(): array
     {
         return [
             [

--- a/tests/Tokenizer/Transformer/SquareBraceTransformerTest.php
+++ b/tests/Tokenizer/Transformer/SquareBraceTransformerTest.php
@@ -63,7 +63,7 @@ final class SquareBraceTransformerTest extends AbstractTransformerTestCase
         }
     }
 
-    public function provideIsShortArrayCases(): array
+    public static function provideIsShortArrayCases(): array
     {
         return [
             ['<?php $a=[];', [3], false],
@@ -97,7 +97,7 @@ final class SquareBraceTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases(): array
+    public static function provideProcessCases(): array
     {
         return [
             'Array offset only.' => [
@@ -379,7 +379,7 @@ class Test
         );
     }
 
-    public function provideProcess72Cases(): array
+    public static function provideProcess72Cases(): array
     {
         return [
             [

--- a/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
@@ -43,7 +43,7 @@ final class TypeAlternationTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases(): array
+    public static function provideProcessCases(): array
     {
         return [
             'no namespace' => [
@@ -103,7 +103,7 @@ final class TypeAlternationTransformerTest extends AbstractTransformerTestCase
         $this->doTest($source, $expectedTokens);
     }
 
-    public function provideProcess80Cases(): iterable
+    public static function provideProcess80Cases(): iterable
     {
         yield 'arrow function' => [
             '<?php $a = fn(int|null $item): int|null => $item * 2;',
@@ -361,7 +361,7 @@ function f( #[Target(\'a\')] #[Target(\'b\')] #[Target(\'c\')] #[Target(\'d\')] 
         );
     }
 
-    public function provideFix81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'readonly' => [
             [
@@ -402,7 +402,7 @@ class Foo
         $this->doTest($source, $expectedTokens);
     }
 
-    public function provideProcess81Cases(): iterable
+    public static function provideProcess81Cases(): iterable
     {
         yield 'arrow function with intersection' => [
             '<?php $a = fn(int|null $item): int&null => $item * 2;',

--- a/tests/Tokenizer/Transformer/TypeColonTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeColonTransformerTest.php
@@ -42,7 +42,7 @@ final class TypeColonTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases(): array
+    public static function provideProcessCases(): array
     {
         return [
             [
@@ -121,7 +121,7 @@ final class TypeColonTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcess81Cases(): array
+    public static function provideProcess81Cases(): array
     {
         return [
             [

--- a/tests/Tokenizer/Transformer/TypeIntersectionTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeIntersectionTransformerTest.php
@@ -42,7 +42,7 @@ final class TypeIntersectionTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases(): iterable
+    public static function provideProcessCases(): iterable
     {
         yield 'do not fix cases' => [
             '<?php

--- a/tests/Tokenizer/Transformer/UseTransformerTest.php
+++ b/tests/Tokenizer/Transformer/UseTransformerTest.php
@@ -44,7 +44,7 @@ final class UseTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases(): iterable
+    public static function provideProcessCases(): iterable
     {
         yield [
             '<?php use Foo;',
@@ -157,7 +157,7 @@ use C\{D,E,};
         $this->doTest($source, $expectedTokens, [CT::T_USE_TRAIT]);
     }
 
-    public function provideProcessPhp81Cases(): iterable
+    public static function provideProcessPhp81Cases(): iterable
     {
         yield [
             '<?php enum Foo: string

--- a/tests/Tokenizer/Transformer/WhitespacyCommentTransformerTest.php
+++ b/tests/Tokenizer/Transformer/WhitespacyCommentTransformerTest.php
@@ -43,7 +43,7 @@ final class WhitespacyCommentTransformerTest extends AbstractTransformerTestCase
         }
     }
 
-    public function provideProcessCases(): array
+    public static function provideProcessCases(): array
     {
         return [
             [

--- a/tests/Tokenizer/TransformersTest.php
+++ b/tests/Tokenizer/TransformersTest.php
@@ -42,7 +42,7 @@ final class TransformersTest extends TestCase
         }
     }
 
-    public function provideTransformCases(): array
+    public static function provideTransformCases(): array
     {
         return [
             'use trait after complex string variable' => [

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -61,7 +61,7 @@ final class UtilsTest extends TestCase
         static::assertSame($expected, Utils::camelCaseToUnderscore($expected));
     }
 
-    public function provideCamelCaseToUnderscoreCases(): array
+    public static function provideCamelCaseToUnderscoreCases(): array
     {
         return [
             [
@@ -126,7 +126,7 @@ final class UtilsTest extends TestCase
         static::assertSame($spaces, Utils::calculateTrailingWhitespaceIndent($token));
     }
 
-    public function provideCalculateTrailingWhitespaceIndentCases(): array
+    public static function provideCalculateTrailingWhitespaceIndentCases(): array
     {
         return [
             ['    ', [T_WHITESPACE, "\n\n    "]],
@@ -166,7 +166,7 @@ final class UtilsTest extends TestCase
         );
     }
 
-    public function provideStableSortCases(): array
+    public static function provideStableSortCases(): array
     {
         return [
             [
@@ -233,7 +233,7 @@ final class UtilsTest extends TestCase
         static::assertSame($joined, Utils::naturalLanguageJoinWithBackticks($names));
     }
 
-    public function provideNaturalLanguageJoinWithBackticksCases(): array
+    public static function provideNaturalLanguageJoinWithBackticksCases(): array
     {
         return [
             [

--- a/tests/WhitespacesFixerConfigTest.php
+++ b/tests/WhitespacesFixerConfigTest.php
@@ -41,7 +41,7 @@ final class WhitespacesFixerConfigTest extends TestCase
         static::assertSame($lineEnding, $config->getLineEnding());
     }
 
-    public function provideTestCases(): array
+    public static function provideTestCases(): array
     {
         return [
             ['    ', "\n"],

--- a/tests/WordMatcherTest.php
+++ b/tests/WordMatcherTest.php
@@ -36,7 +36,7 @@ final class WordMatcherTest extends TestCase
         static::assertSame($expected, $matcher->match($needle));
     }
 
-    public function provideMatchCases(): array
+    public static function provideMatchCases(): array
     {
         return [
             [


### PR DESCRIPTION
Non-static data providers will be [deprecated in PHPUnit 10](https://github.com/sebastianbergmann/phpunit/commit/9caafe2d49b33a21f87db248a8ad6ca7c7bdac09) and [removed in PHPUnit 11](https://github.com/sebastianbergmann/phpunit/issues/5100).

This PR makes static all data providers that are not using dynamic calls - basically, nothing to review here, this PR simply adds `static` 893 times.

Data providers using dynamic calls will need that call to be changed - will be done in separate PR as changes might be up for some discussion.