### PR TITLE
minor: Follow PSR12 ordered imports in Symfony ruleset

### DIFF
--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -87,6 +87,8 @@ Rules
 - `normalize_index_brace <./../rules/array_notation/normalize_index_brace.rst>`_
 - `object_operator_without_whitespace <./../rules/operator/object_operator_without_whitespace.rst>`_
 - `ordered_imports <./../rules/import/ordered_imports.rst>`_
+  config:
+  ``['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha']``
 - `php_unit_fqcn_annotation <./../rules/php_unit/php_unit_fqcn_annotation.rst>`_
 - `php_unit_method_casing <./../rules/php_unit/php_unit_method_casing.rst>`_
 - `phpdoc_align <./../rules/phpdoc/phpdoc_align.rst>`_

--- a/doc/rules/import/ordered_imports.rst
+++ b/doc/rules/import/ordered_imports.rst
@@ -148,7 +148,11 @@ The rule is part of the following rule sets:
   ``['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'none']``
 
 @PhpCsFixer
-  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``ordered_imports`` rule with the default config.
+  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``ordered_imports`` rule with the config below:
+
+  ``['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha']``
 
 @Symfony
-  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``ordered_imports`` rule with the default config.
+  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``ordered_imports`` rule with the config below:
+
+  ``['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha']``

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -280,7 +280,7 @@ use Bar;
 
                     return true;
                 }])
-                ->setDefault(null)
+                ->setDefault(null) // @TODO set to ['class', 'function', 'const'] on 4.0
                 ->getOption(),
         ]);
     }

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -133,7 +133,14 @@ final class SymfonySet extends AbstractRuleSetDescription
             'no_whitespace_before_comma_in_array' => true,
             'normalize_index_brace' => true,
             'object_operator_without_whitespace' => true,
-            'ordered_imports' => true,
+            'ordered_imports' => [
+                'imports_order' => [
+                    'class',
+                    'function',
+                    'const',
+                ],
+                'sort_algorithm' => 'alpha',
+            ],
             'php_unit_fqcn_annotation' => true,
             'php_unit_method_casing' => true,
             'phpdoc_align' => true,


### PR DESCRIPTION
PSR12 ordered imports is set this way
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/ff49030e8508ea9b71091b6fdf94de858d898cdc/src/RuleSet/Sets/PSR12Set.php#L50

And Symfony extends the PSR12
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/ff49030e8508ea9b71091b6fdf94de858d898cdc/src/RuleSet/Sets/SymfonySet.php#L27

but then when setting the ordered import, it's `true`
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/ff49030e8508ea9b71091b6fdf94de858d898cdc/src/RuleSet/Sets/SymfonySet.php#L136
Which means the previous config is lost, in order to have an `alpha` sort.

IMHO both config should be used.
- alpha sort like it always was in Symfony Ruleset
- sorting classes/functions/constantes to be PSR12

I would say it was never updated when Symfony moved from PSR2 to PSR12.

I'll fix test if this is accepted