### PR TITLE
feature: add default config value, `$this` to phpdoc_return_self_reference

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2108,7 +2108,7 @@ List of Available Rules
    - | ``replacements``
      | Mapping between replaced return types with new ones.
      | Allowed types: ``array``
-     | Default value: ``['this' => '$this', '@this' => '$this', '$self' => 'self', '@self' => 'self', '$static' => 'static', '@static' => 'static']``
+     | Default value: ``['this' => '$this', '@this' => '$this', '$this' => '$this', '$self' => 'self', '@self' => 'self', '$static' => 'static', '@static' => 'static']``
 
 
    Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_

--- a/doc/rules/phpdoc/phpdoc_return_self_reference.rst
+++ b/doc/rules/phpdoc/phpdoc_return_self_reference.rst
@@ -15,7 +15,7 @@ Mapping between replaced return types with new ones.
 
 Allowed types: ``array``
 
-Default value: ``['this' => '$this', '@this' => '$this', '$self' => 'self', '@self' => 'self', '$static' => 'static', '@static' => 'static']``
+Default value: ``['this' => '$this', '@this' => '$this', '$this' => '$this', '$self' => 'self', '@self' => 'self', '$static' => 'static', '@static' => 'static']``
 
 Examples
 --------

--- a/src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
@@ -138,6 +138,7 @@ class Sample
         $default = [
             'this' => '$this',
             '@this' => '$this',
+            '$this' => '$this',
             '$self' => 'self',
             '@self' => 'self',
             '$static' => 'static',

--- a/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
@@ -151,6 +151,7 @@ class F
         return [
             ['$this', 'this'],
             ['$this', '@this'],
+            ['self', '$this'],
             ['self', '$self'],
             ['self', '@self'],
             ['static', '$static'],
@@ -176,7 +177,7 @@ class F
         return [
             [
                 ['replacements' => [1 => 'a']],
-                'Invalid configuration: Unknown key "integer#1", expected any of "this", "@this", "$self", "@self", "$static", "@static".',
+                'Invalid configuration: Unknown key "integer#1", expected any of "this", "@this", "$this", "$self", "@self", "$static", "@static".',
             ],
             [
                 ['replacements' => [
@@ -269,5 +270,55 @@ enum Foo {
 var_dump(Foo::CAT->test());
 ',
         ];
+    }
+
+    public function testThisStartWithDollarMark(): void
+    {
+        $this->fixer->configure([
+            'replacements' => [
+                '$this' => 'self',
+            ],
+        ]);
+
+        $this->doTest(
+            '<?php
+                $a = new class() {
+
+                    /** @return self */
+                    public function a() {
+                    }
+                };
+
+                class C
+                {
+                    public function A()
+                    {
+                        $a = new class() {
+                            /** @return self */
+                            public function a() {}
+                        };
+                    }
+                }
+            ',
+            '<?php
+                $a = new class() {
+
+                    /** @return $this */
+                    public function a() {
+                    }
+                };
+
+                class C
+                {
+                    public function A()
+                    {
+                        $a = new class() {
+                            /** @return $this */
+                            public function a() {}
+                        };
+                    }
+                }
+            '
+        );
     }
 }


### PR DESCRIPTION
Hi.

As mentioned in the title.
I have added the default value `$this`.


This PR makes it possible to change the value `$this`.

For example, from `$this` to `self`


Thank you.