### PR TITLE
Update php-cs-fixer to run with 8.2.0 php version

### DIFF
--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -28,8 +28,8 @@ set_error_handler(static function ($severity, $message, $file, $line) {
         exit(1);
     }
 
-    if (\PHP_VERSION_ID < 70400 || \PHP_VERSION_ID >= 80200) {
-        fwrite(STDERR, "PHP needs to be a minimum version of PHP 7.4.0 and maximum version of PHP 8.1.*.\n");
+    if (\PHP_VERSION_ID < 70400 || \PHP_VERSION_ID >= 80300) {
+        fwrite(STDERR, "PHP needs to be a minimum version of PHP 7.4.0 and maximum version of PHP 8.2.*.\n");
         fwrite(STDERR, 'Current PHP version: '.PHP_VERSION.".\n");
 
         if (getenv('PHP_CS_FIXER_IGNORE_ENV')) {


### PR DESCRIPTION
Fixes the issue when we run php-cs-fixer with php 8.2 on CI.

Example of a failed test:
https://github.com/FabienPapet/stripe-bundle/actions/runs/3735128514/jobs/6338008057#step:8:1