### PR TITLE
feature: make OrderedInterfacesFixer non-risky

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1916,10 +1916,6 @@ List of Available Rules
 
    Orders the interfaces in an ``implements`` or ``interface extends`` clause.
 
-   *warning risky* Risky for ``implements`` when specifying both an interface and its parent
-   interface, because PHP doesn't break on ``parent, child`` but does on
-   ``child, parent``.
-
    Configuration options:
 
    - | ``order``

--- a/doc/rules/class_notation/ordered_interfaces.rst
+++ b/doc/rules/class_notation/ordered_interfaces.rst
@@ -4,16 +4,6 @@ Rule ``ordered_interfaces``
 
 Orders the interfaces in an ``implements`` or ``interface extends`` clause.
 
-Warning
--------
-
-Using this rule is risky
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-Risky for ``implements`` when specifying both an interface and its parent
-interface, because PHP doesn't break on ``parent, child`` but does on ``child,
-parent``.
-
 Configuration
 -------------
 

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -178,7 +178,7 @@ Class Notation
 - `ordered_class_elements <./class_notation/ordered_class_elements.rst>`_
 
   Orders the elements of classes/interfaces/traits/enums.
-- `ordered_interfaces <./class_notation/ordered_interfaces.rst>`_ *(risky)*
+- `ordered_interfaces <./class_notation/ordered_interfaces.rst>`_
 
   Orders the interfaces in an ``implements`` or ``interface extends`` clause.
 - `ordered_traits <./class_notation/ordered_traits.rst>`_ *(risky)*

--- a/src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+++ b/src/Fixer/ClassNotation/OrderedInterfacesFixer.php
@@ -95,8 +95,6 @@ final class OrderedInterfacesFixer extends AbstractFixer implements Configurable
                     ]
                 ),
             ],
-            null,
-            "Risky for `implements` when specifying both an interface and its parent interface, because PHP doesn't break on `parent, child` but does on `child, parent`."
         );
     }
 
@@ -107,14 +105,6 @@ final class OrderedInterfacesFixer extends AbstractFixer implements Configurable
     {
         return $tokens->isTokenKindFound(T_IMPLEMENTS)
             || $tokens->isAllTokenKindsFound([T_INTERFACE, T_EXTENDS]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isRisky(): bool
-    {
-        return true;
     }
 
     /**


### PR DESCRIPTION
The reason it was marked risky is because "[Class (class name here) cannot implement previously implemented interface (interface name here)](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/4113#pullrequestreview-188507958)" which is not an error since PHP 7.4.

For code:
```
<?php

interface A {}
interface B extends A {}

class C1 implements A, B {}
class C2 implements B, A {}
```

it is correct for PHP 7.4.0 - 7.4.33, 8.0.0 - 8.0.26, 8.1.0 - 8.1.13, 8.2.0: https://3v4l.org/sRH9L