### PR TITLE
fix: enum case "PARENT" must not be renamed

### DIFF
--- a/src/Fixer/Casing/LowercaseStaticReferenceFixer.php
+++ b/src/Fixer/Casing/LowercaseStaticReferenceFixer.php
@@ -100,6 +100,10 @@ class Foo extends Bar
                 continue;
             }
 
+            if ($tokens[$prevIndex]->isGivenKind(T_CASE) && !$tokens[$nextIndex]->isGivenKind(T_PAAMAYIM_NEKUDOTAYIM)) {
+                continue;
+            }
+
             $tokens[$index] = new Token([$token->getId(), $newContent]);
         }
     }

--- a/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
@@ -184,6 +184,30 @@ final class LowercaseStaticReferenceFixerTest extends AbstractFixerTestCase
                 private STATIC ?int $baz2;
             }',
             ],
+            [
+                '<?php
+                class Foo { public function bar() {} }
+                class FooChild extends Foo
+                {
+                    public function bar()
+                    {
+                        switch (true) {
+                            case parent::bar():
+                        }
+                    }
+                }',
+                '<?php
+                class Foo { public function bar() {} }
+                class FooChild extends Foo
+                {
+                    public function bar()
+                    {
+                        switch (true) {
+                            case PARENT::bar():
+                        }
+                    }
+                }',
+            ],
         ];
     }
 
@@ -259,6 +283,10 @@ class Foo
     {
         yield [
             '<?php class A { final const PARENT = 42; }',
+        ];
+
+        yield [
+            '<?php enum Foo: string { case PARENT = \'parent\'; }',
         ];
     }
 }


### PR DESCRIPTION
Fixes #6673 and #6695.