### PR TITLE
feature: Support readonly classes for PHP 8.2

### DIFF
--- a/src/Tokenizer/CT.php
+++ b/src/Tokenizer/CT.php
@@ -54,6 +54,7 @@ final class CT
     public const T_NAMED_ARGUMENT_COLON = 10033;
     public const T_FIRST_CLASS_CALLABLE = 10034;
     public const T_TYPE_INTERSECTION = 10035;
+    public const T_CLASS_READONLY = 10036;
 
     private function __construct()
     {

--- a/src/Tokenizer/Transformer/ClassReadonlyTransformer.php
+++ b/src/Tokenizer/Transformer/ClassReadonlyTransformer.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer\Transformer;
+
+use PhpCsFixer\Tokenizer\AbstractTransformer;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * Transform class T_READONLY from T_READONLY into CT::T_CLASS_READONLY.
+ *
+ * @author Mateusz Sip <mateusz.sip@gmail.com>
+ *
+ * @internal
+ */
+final class ClassReadonlyTransformer extends AbstractTransformer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequiredPhpVersionId(): int
+    {
+        return 80200;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(Tokens $tokens, Token $token, int $index): void
+    {
+        if (!\defined('T_READONLY')) {
+            return;
+        }
+
+        if (!$token->isGivenKind(T_READONLY)) {
+            return;
+        }
+
+        $nextIndex = $tokens->getNextMeaningfulToken($index);
+        $nextToken = $tokens[$nextIndex];
+
+        if ($nextToken->isGivenKind(T_CLASS)) {
+            $tokens[$index] = new Token([CT::T_CLASS_READONLY, $token->getContent()]);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomTokens(): array
+    {
+        return [CT::T_CLASS_READONLY];
+    }
+}

--- a/tests/Tokenizer/Transformer/ClassReadonlyTransformerTest.php
+++ b/tests/Tokenizer/Transformer/ClassReadonlyTransformerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Tokenizer\Transformer;
+
+use PhpCsFixer\Tests\Test\AbstractTransformerTestCase;
+use PhpCsFixer\Tokenizer\CT;
+
+/**
+ * @author Mateusz Sip <mateusz.sip@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Tokenizer\Transformer\ClassReadonlyTransformer
+ */
+final class ClassReadonlyTransformerTest extends AbstractTransformerTestCase
+{
+    /**
+     * @param array<int, int> $expectedTokens
+     *
+     * @dataProvider provideProcessCases
+     */
+    public function testProcess(string $source, array $expectedTokens = []): void
+    {
+        $this->doTest(
+            $source,
+            $expectedTokens,
+            [
+                CT::T_CLASS_READONLY,
+            ]
+        );
+    }
+
+    public static function provideProcessCases(): array
+    {
+        return [
+            [
+                '<?php final readonly class Foo {}',
+                [
+                    3 => CT::T_CLASS_READONLY,
+                ],
+            ],
+            [
+                '<?php readonly class Foo {}',
+                [
+                    1 => CT::T_CLASS_READONLY,
+                ],
+            ],
+            [
+                <<<'PHP'
+                    class Foo {
+                        public readonly string $foo;
+                    }
+                PHP
+            ],
+            [
+                <<<'PHP'
+                    class Foo {
+                        public function __construct(
+                            public readonly string $foo = "foobar"
+                        ) {}
+                    }
+                PHP
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Hi!
I want to implement readonly classes support to help with PHP 8.2 compatibility, but I need some guidance.

Where (outside Transformer tests) should I add test cases to make sure it doesn't break existing rules?

What do we need to consider cs-fixer 8.2 compatible, and what can be implemented later as a follow-up?

Related to #6604 