### PR TITLE
feature: add "force" option to PhpUnitDataProviderStaticFixer

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2342,7 +2342,7 @@ List of Available Rules
    Configuration options:
 
    - | ``force``
-     | whether to make static data providers having dynamic class calls
+     | Whether to make the data providers static even if they have a dynamic class call(might introduce fatal error "using $this when not in object context" - you have to adjust code manually by converting dynamic calls to static ones).
      | Allowed types: ``bool``
      | Default value: ``false``
 

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2339,6 +2339,14 @@ List of Available Rules
 
    *warning risky* Fixer could be risky if one is calling data provider function dynamically.
 
+   Configuration options:
+
+   - | ``force``
+     | whether to make static data providers having dynamic class calls
+     | Allowed types: ``bool``
+     | Default value: ``false``
+
+
    Part of rule set `@PHPUnit100Migration:risky <./ruleSets/PHPUnit100MigrationRisky.rst>`_
 
    `Source PhpCsFixer\\Fixer\\PhpUnit\\PhpUnitDataProviderStaticFixer <./../src/Fixer/PhpUnit/PhpUnitDataProviderStaticFixer.php>`_

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2342,7 +2342,7 @@ List of Available Rules
    Configuration options:
 
    - | ``force``
-     | Whether to make the data providers static even if they have a dynamic class call(might introduce fatal error "using $this when not in object context" - you have to adjust code manually by converting dynamic calls to static ones).
+     | Whether to make the data providers static even if they have a dynamic class call (may introduce fatal error "using $this when not in object context", and you may have to adjust the code manually by converting dynamic calls to static ones).
      | Allowed types: ``bool``
      | Default value: ``false``
 

--- a/doc/rules/php_unit/php_unit_data_provider_static.rst
+++ b/doc/rules/php_unit/php_unit_data_provider_static.rst
@@ -18,7 +18,9 @@ Configuration
 ``force``
 ~~~~~~~~~
 
-whether to make static data providers having dynamic class calls
+Whether to make the data providers static even if they have a dynamic class
+call(might introduce fatal error "using $this when not in object context" - you
+have to adjust code manually by converting dynamic calls to static ones).
 
 Allowed types: ``bool``
 
@@ -58,11 +60,35 @@ With configuration: ``['force' => true]``.
     <?php
     class FooTest extends TestCase {
         /**
-         * @dataProvider provideSomethingCases
+         * @dataProvider provideSomethingCases1
+         * @dataProvider provideSomethingCases2
          */
         public function testSomething($expected, $actual) {}
-   -    public function provideSomethingCases() { $this->getData(); }
-   +    public static function provideSomethingCases() { $this->getData(); }
+   -    public function provideSomethingCases1() { $this->getData1(); }
+   -    public function provideSomethingCases2() { self::getData2(); }
+   +    public static function provideSomethingCases1() { $this->getData1(); }
+   +    public static function provideSomethingCases2() { self::getData2(); }
+    }
+
+Example #3
+~~~~~~~~~~
+
+With configuration: ``['force' => false]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    class FooTest extends TestCase {
+        /**
+         * @dataProvider provideSomething1Cases
+         * @dataProvider provideSomething2Cases
+         */
+        public function testSomething($expected, $actual) {}
+        public function provideSomething1Cases() { $this->getData1(); }
+   -    public function provideSomething2Cases() { self::getData2(); }
+   +    public static function provideSomething2Cases() { self::getData2(); }
     }
 
 Rule sets

--- a/doc/rules/php_unit/php_unit_data_provider_static.rst
+++ b/doc/rules/php_unit/php_unit_data_provider_static.rst
@@ -18,9 +18,9 @@ Configuration
 ``force``
 ~~~~~~~~~
 
-Whether to make the data providers static even if they have a dynamic class
-call(might introduce fatal error "using $this when not in object context" - you
-have to adjust code manually by converting dynamic calls to static ones).
+Whether to make the data providers static even if they have a dynamic class call
+(may introduce fatal error "using $this when not in object context", and you may
+have to adjust the code manually by converting dynamic calls to static ones).
 
 Allowed types: ``bool``
 

--- a/doc/rules/php_unit/php_unit_data_provider_static.rst
+++ b/doc/rules/php_unit/php_unit_data_provider_static.rst
@@ -12,11 +12,25 @@ Using this rule is risky
 
 Fixer could be risky if one is calling data provider function dynamically.
 
+Configuration
+-------------
+
+``force``
+~~~~~~~~~
+
+whether to make static data providers having dynamic class calls
+
+Allowed types: ``bool``
+
+Default value: ``false``
+
 Examples
 --------
 
 Example #1
 ~~~~~~~~~~
+
+*Default* configuration.
 
 .. code-block:: diff
 
@@ -32,10 +46,29 @@ Example #1
    +    public static function provideSomethingCases() {}
     }
 
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['force' => true]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    class FooTest extends TestCase {
+        /**
+         * @dataProvider provideSomethingCases
+         */
+        public function testSomething($expected, $actual) {}
+   -    public function provideSomethingCases() { $this->getData(); }
+   +    public static function provideSomethingCases() { $this->getData(); }
+    }
+
 Rule sets
 ---------
 
 The rule is part of the following rule set:
 
 @PHPUnit100Migration:risky
-  Using the `@PHPUnit100Migration:risky <./../../ruleSets/PHPUnit100MigrationRisky.rst>`_ rule set will enable the ``php_unit_data_provider_static`` rule.
+  Using the `@PHPUnit100Migration:risky <./../../ruleSets/PHPUnit100MigrationRisky.rst>`_ rule set will enable the ``php_unit_data_provider_static`` rule with the default config.

--- a/src/Fixer/PhpUnit/PhpUnitDataProviderStaticFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDataProviderStaticFixer.php
@@ -52,13 +52,29 @@ class FooTest extends TestCase {
                     '<?php
 class FooTest extends TestCase {
     /**
-     * @dataProvider provideSomethingCases
+     * @dataProvider provideSomethingCases1
+     * @dataProvider provideSomethingCases2
      */
     public function testSomething($expected, $actual) {}
-    public function provideSomethingCases() { $this->getData(); }
+    public function provideSomethingCases1() { $this->getData1(); }
+    public function provideSomethingCases2() { self::getData2(); }
 }
 ',
                     ['force' => true]
+                ),
+                new CodeSample(
+                    '<?php
+class FooTest extends TestCase {
+    /**
+     * @dataProvider provideSomething1Cases
+     * @dataProvider provideSomething2Cases
+     */
+    public function testSomething($expected, $actual) {}
+    public function provideSomething1Cases() { $this->getData1(); }
+    public function provideSomething2Cases() { self::getData2(); }
+}
+',
+                    ['force' => false]
                 ),
             ],
             null,
@@ -80,7 +96,12 @@ class FooTest extends TestCase {
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
         return new FixerConfigurationResolver([
-            (new FixerOptionBuilder('force', 'whether to make static data providers having dynamic class calls'))
+            (new FixerOptionBuilder(
+                'force',
+                'Whether to make the data providers static even if they have a dynamic class call'
+                .'(might introduce fatal error "using $this when not in object context"'
+                .' - you have to adjust code manually by converting dynamic calls to static ones).'
+            ))
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)
                 ->getOption(),

--- a/src/Fixer/PhpUnit/PhpUnitDataProviderStaticFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDataProviderStaticFixer.php
@@ -99,8 +99,8 @@ class FooTest extends TestCase {
             (new FixerOptionBuilder(
                 'force',
                 'Whether to make the data providers static even if they have a dynamic class call'
-                .'(might introduce fatal error "using $this when not in object context"'
-                .' - you have to adjust code manually by converting dynamic calls to static ones).'
+                .' (may introduce fatal error "using $this when not in object context",'
+                .' and you may have to adjust the code manually by converting dynamic calls to static ones).'
             ))
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)

--- a/tests/Fixer/PhpUnit/PhpUnitDataProviderStaticFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDataProviderStaticFixerTest.php
@@ -24,10 +24,13 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class PhpUnitDataProviderStaticFixerTest extends AbstractFixerTestCase
 {
     /**
+     * @param array<string, bool> $configuration
+     *
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $input = null, array $configuration = []): void
     {
+        $this->fixer->configure($configuration);
         $this->doTest($expected, $input);
     }
 
@@ -139,6 +142,26 @@ abstract class FooTest extends TestCase {
     public function testFoo() {}
     abstract public function provideFooCases();
 }',
+        ];
+
+        yield 'fix when containing dynamic calls and with `force` enabled' => [
+            '<?php
+class FooTest extends TestCase {
+    /**
+     * @dataProvider provideFoo1Cases
+     */
+    public function testFoo1() {}
+    public static function provideFoo1Cases() { $this->init(); }
+}',
+            '<?php
+class FooTest extends TestCase {
+    /**
+     * @dataProvider provideFoo1Cases
+     */
+    public function testFoo1() {}
+    public function provideFoo1Cases() { $this->init(); }
+}',
+            ['force' => true],
         ];
     }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitDataProviderStaticFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDataProviderStaticFixerTest.php
@@ -144,22 +144,50 @@ abstract class FooTest extends TestCase {
 }',
         ];
 
-        yield 'fix when containing dynamic calls and with `force` enabled' => [
+        yield 'fix when containing dynamic calls and with `force` disabled' => [
             '<?php
 class FooTest extends TestCase {
     /**
-     * @dataProvider provideFoo1Cases
+     * @dataProvider provideFooCases1
+     * @dataProvider provideFooCases2
      */
-    public function testFoo1() {}
-    public static function provideFoo1Cases() { $this->init(); }
+    public function testFoo() {}
+    public function provideFooCases1() { return $this->getFoo(); }
+    public static function provideFooCases2() { /* no dynamic calls */ }
 }',
             '<?php
 class FooTest extends TestCase {
     /**
-     * @dataProvider provideFoo1Cases
+     * @dataProvider provideFooCases1
+     * @dataProvider provideFooCases2
      */
-    public function testFoo1() {}
-    public function provideFoo1Cases() { $this->init(); }
+    public function testFoo() {}
+    public function provideFooCases1() { return $this->getFoo(); }
+    public function provideFooCases2() { /* no dynamic calls */ }
+}',
+            ['force' => false],
+        ];
+
+        yield 'fix when containing dynamic calls and with `force` enabled' => [
+            '<?php
+class FooTest extends TestCase {
+    /**
+     * @dataProvider provideFooCases1
+     * @dataProvider provideFooCases2
+     */
+    public function testFoo() {}
+    public static function provideFooCases1() { return $this->getFoo(); }
+    public static function provideFooCases2() { /* no dynamic calls */ }
+}',
+            '<?php
+class FooTest extends TestCase {
+    /**
+     * @dataProvider provideFooCases1
+     * @dataProvider provideFooCases2
+     */
+    public function testFoo() {}
+    public function provideFooCases1() { return $this->getFoo(); }
+    public function provideFooCases2() { /* no dynamic calls */ }
 }',
             ['force' => true],
         ];


### PR DESCRIPTION
Follow up to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6696 to help fully migrate to static data providers.