### PR TITLE
docs: Add supported PHP versions section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,18 @@ projects. This tool does not only detect them, but also fixes them for you.
 
 ## Supported PHP Versions
 
+* PHP 7.4
+* PHP 8.0 (except PHP 8.0.0 due to [bug in PHP tokenizer](https://bugs.php.net/bug.php?id=80462))
+* PHP 8.1
+
+To run PHP CS Fixer on yet unsupported versions "at your own risk" - leverage
+the [PHP_CS_FIXER_IGNORE_ENV](https://cs.symfony.com/doc/usage.html#environment-options).
+
 > **Note**
 > Each new PHP version requires a huge effort to support the new syntax.
 > That's why the latest PHP version might not be supported yet. If you need it,
 > please, consider supporting the project in any convenient way, for example
 > with code contribution or reviewing existing RPs.
-
-* PHP 7.4
-* PHP 8.0 (except PHP 8.0.0 due to [bug in PHP tokenizer](https://bugs.php.net/bug.php?id=80462))
-* PHP 8.1
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are already using a linter to identify coding standards problems in your
 code, you know that fixing them by hand is tedious, especially on large
 projects. This tool does not only detect them, but also fixes them for you.
 
-## Supported versions
+## Supported PHP Versions
 
 > NOTE: Each new PHP version requires a huge effort to support the new syntax.
 > That's why the latest PHP version might not be supported yet. If you need it,

--- a/README.md
+++ b/README.md
@@ -20,8 +20,14 @@ code, you know that fixing them by hand is tedious, especially on large
 projects. This tool does not only detect them, but also fixes them for you.
 
 ## Supported versions
+
+> NOTE: Each new PHP version requires a huge effort to support the new syntax.
+> That's why the latest PHP version might not be supported yet. If you need it,
+> please, consider supporting the project in any convenient way, for example
+> with code contribution or reviewing existing RPs.
+
 * PHP 7.4
-* PHP 8.0
+* PHP 8.0 (except PHP 8.0.0 due to [bug in PHP tokenizer](https://bugs.php.net/bug.php?id=80462))
 * PHP 8.1
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ projects. This tool does not only detect them, but also fixes them for you.
 > please, consider supporting the project in any convenient way, for example
 > with code contribution or reviewing existing RPs. To run PHP CS Fixer on yet
 > unsupported versions "at your own risk" - leverage the
-> [PHP_CS_FIXER_IGNORE_ENV](./doc/usage.html#environment-options).
+> [PHP_CS_FIXER_IGNORE_ENV](./doc/usage.rst#environment-options).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ If you are already using a linter to identify coding standards problems in your
 code, you know that fixing them by hand is tedious, especially on large
 projects. This tool does not only detect them, but also fixes them for you.
 
+## Supported versions
+* PHP 7.4
+* PHP 8.0
+* PHP 8.1
+
 ## Documentation
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -25,14 +25,13 @@ projects. This tool does not only detect them, but also fixes them for you.
 * PHP 8.0 (except PHP 8.0.0 due to [bug in PHP tokenizer](https://bugs.php.net/bug.php?id=80462))
 * PHP 8.1
 
-To run PHP CS Fixer on yet unsupported versions "at your own risk" - leverage
-the [PHP_CS_FIXER_IGNORE_ENV](https://cs.symfony.com/doc/usage.html#environment-options).
-
 > **Note**
 > Each new PHP version requires a huge effort to support the new syntax.
 > That's why the latest PHP version might not be supported yet. If you need it,
 > please, consider supporting the project in any convenient way, for example
-> with code contribution or reviewing existing RPs.
+> with code contribution or reviewing existing RPs. To run PHP CS Fixer on yet
+> unsupported versions "at your own risk" - leverage the
+> [PHP_CS_FIXER_IGNORE_ENV](https://cs.symfony.com/doc/usage.html#environment-options).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ projects. This tool does not only detect them, but also fixes them for you.
 > please, consider supporting the project in any convenient way, for example
 > with code contribution or reviewing existing RPs. To run PHP CS Fixer on yet
 > unsupported versions "at your own risk" - leverage the
-> [PHP_CS_FIXER_IGNORE_ENV](https://cs.symfony.com/doc/usage.html#environment-options).
+> [PHP_CS_FIXER_IGNORE_ENV](./doc/usage.html#environment-options).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ projects. This tool does not only detect them, but also fixes them for you.
 
 ## Supported PHP Versions
 
-> NOTE: Each new PHP version requires a huge effort to support the new syntax.
+> **Note**
+> Each new PHP version requires a huge effort to support the new syntax.
 > That's why the latest PHP version might not be supported yet. If you need it,
 > please, consider supporting the project in any convenient way, for example
 > with code contribution or reviewing existing RPs.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ projects. This tool does not only detect them, but also fixes them for you.
 > Each new PHP version requires a huge effort to support the new syntax.
 > That's why the latest PHP version might not be supported yet. If you need it,
 > please, consider supporting the project in any convenient way, for example
-> with code contribution or reviewing existing RPs. To run PHP CS Fixer on yet
+> with code contribution or reviewing existing PRs. To run PHP CS Fixer on yet
 > unsupported versions "at your own risk" - leverage the
 > [PHP_CS_FIXER_IGNORE_ENV](./doc/usage.rst#environment-options).
 

--- a/tests/AutoReview/ReadmeTest.php
+++ b/tests/AutoReview/ReadmeTest.php
@@ -42,7 +42,7 @@ final class ReadmeTest extends TestCase
         // Unset the file to call __destruct(), closing the file handle.
         $file = null;
 
-        self::assertEqualsCanonicalizing([
+        static::assertEqualsCanonicalizing([
             '    if (\PHP_VERSION_ID === 80000) {'."\n",
             '    if (\PHP_VERSION_ID < 70400 || \PHP_VERSION_ID >= 80200) {'."\n",
         ], $phpVersionIdLines, 'Seems supported PHP versions changed in "./php-cs-fixer" - edit the README.md to match them!');

--- a/tests/AutoReview/ReadmeTest.php
+++ b/tests/AutoReview/ReadmeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\AutoReview;
+
+use PhpCsFixer\Tests\TestCase;
+
+/**
+ * @author Victor Bocharsky <bocharsky.bw@gmail.com>
+ *
+ * @internal
+ *
+ * @coversNothing
+ *
+ * @group auto-review
+ * @group covers-nothing
+ */
+final class ReadmeTest extends TestCase
+{
+    public function testSupportedPhpVersions(): void
+    {
+        $phpVersionIdLines = [];
+
+        $file = new \SplFileObject(__DIR__.'/../../php-cs-fixer');
+        while (!$file->eof()) {
+            $line = $file->fgets();
+            if (str_contains($line, 'PHP_VERSION_ID')) {
+                $phpVersionIdLines[] = $line;
+            }
+        }
+        // Unset the file to call __destruct(), closing the file handle.
+        $file = null;
+
+        self::assertEqualsCanonicalizing([
+            '    if (\PHP_VERSION_ID === 80000) {'."\n",
+            '    if (\PHP_VERSION_ID < 70400 || \PHP_VERSION_ID >= 80200) {'."\n",
+        ], $phpVersionIdLines, 'Seems supported PHP versions changed in "./php-cs-fixer" - edit the README.md to match them!');
+    }
+}

--- a/tests/AutoReview/ReadmeTest.php
+++ b/tests/AutoReview/ReadmeTest.php
@@ -45,6 +45,6 @@ final class ReadmeTest extends TestCase
         static::assertEqualsCanonicalizing([
             '    if (\PHP_VERSION_ID === 80000) {'."\n",
             '    if (\PHP_VERSION_ID < 70400 || \PHP_VERSION_ID >= 80200) {'."\n",
-        ], $phpVersionIdLines, 'Seems supported PHP versions changed in "./php-cs-fixer" - edit the README.md to match them!');
+        ], $phpVersionIdLines, 'Seems supported PHP versions changed in "./php-cs-fixer" - edit the README.md (and this test file) to match them!');
     }
 }


### PR DESCRIPTION
I hope it will help with discovering supported versions better and prevent creating issues.

Ref: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6764#issuecomment-1410320295