### PR TITLE
feature: Allow installation of `sebastian/diff:^5.0.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "composer/xdebug-handler": "^3.0.3",
         "doctrine/annotations": "^2",
         "doctrine/lexer": "^2 || ^3",
-        "sebastian/diff": "^4.0",
+        "sebastian/diff": "^4.0 || ^5.0",
         "symfony/console": "^5.4 || ^6.0",
         "symfony/event-dispatcher": "^5.4 || ^6.0",
         "symfony/filesystem": "^5.4 || ^6.0",


### PR DESCRIPTION
This pull request

- [x] allows installation of `sebastian/diff:^5.0.0`

💁‍♂️ `phpunit/phpunit:10.0.0` [requires `sebastian/diff:^5.0.0`](https://github.com/sebastianbergmann/phpunit/blob/10.0.0/composer.json#L42), so currently `phpunit/phpunit:^10.0.0` and `friendsofphp/php-cs-fixer:^3.14.3` conflict.

For reference, see https://github.com/sebastianbergmann/diff/compare/4.0.0...5.0.0. 