### PR TITLE
bug: CurlyBracesPositionFixer - fix for open brace not preceded by space and followed by a comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }}
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }} tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }} tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }}
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/src/Fixer/Basic/CurlyBracesPositionFixer.php
+++ b/src/Fixer/Basic/CurlyBracesPositionFixer.php
@@ -312,7 +312,7 @@ $bar = function () { $result = true;
                         } else {
                             $tokens->clearAt($openBraceIndex + 1);
                         }
-                    } else {
+                    } elseif ($tokens[$openBraceIndex - 1]->isWhitespace()) {
                         $tokens->clearAt($openBraceIndex - 1);
                     }
                 }

--- a/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
+++ b/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
@@ -666,6 +666,22 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                     foo();
                 }',
         ];
+
+        yield 'open brace not preceded by space and followed by a comment' => [
+            '<?php class test
+{
+    public function example( // example
+    {
+    }
+}
+',
+            '<?php class test
+{
+    public function example(){ // example
+    }
+}
+',
+        ];
     }
 
     /**

--- a/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
+++ b/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
@@ -670,6 +670,22 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
         yield 'open brace not preceded by space and followed by a comment' => [
             '<?php class test
 {
+    public function example()// example
+    {
+    }
+}
+',
+            '<?php class test
+{
+    public function example(){// example
+    }
+}
+',
+        ];
+
+        yield 'open brace not preceded by space and followed by a space and comment' => [
+            '<?php class test
+{
     public function example() // example
     {
     }

--- a/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
+++ b/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
@@ -670,7 +670,7 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
         yield 'open brace not preceded by space and followed by a comment' => [
             '<?php class test
 {
-    public function example( // example
+    public function example() // example
     {
     }
 }


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6775

Take a look at the changes in the first commit - the new test is failing not because of the changes not being as in the test, but because of broken PHP syntax.