### PR TITLE
DX: Add composer keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "friendsofphp/php-cs-fixer",
     "description": "A tool to automatically fix PHP code style",
     "license": "MIT",
-    "keywords": ["dev", "code style", "code-style", "fixer"],
+    "keywords": ["fixer", "standards", "static analysis"],
     "type": "application",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "standards",
         "static analysis"
     ],
-   "authors": [
+    "authors": [
         {
             "name": "Fabien Potencier",
             "email": "fabien@symfony.com"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "friendsofphp/php-cs-fixer",
     "description": "A tool to automatically fix PHP code style",
     "license": "MIT",
-    "keywords": ["dev"],
+    "keywords": ["dev", "code style", "code-style", "fixer"],
     "type": "application",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "friendsofphp/php-cs-fixer",
     "description": "A tool to automatically fix PHP code style",
     "license": "MIT",
+    "keywords": ["dev"],
     "type": "application",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,11 @@
     "name": "friendsofphp/php-cs-fixer",
     "description": "A tool to automatically fix PHP code style",
     "license": "MIT",
-    "keywords": ["fixer", "standards", "static analysis"],
+    "keywords": [
+        "fixer",
+        "standards",
+        "static analysis"
+    ],
     "type": "application",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "keywords": [
         "fixer",
         "standards",
-        "static analysis"
+        "static analysis",
+        "static code analysis"
     ],
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,13 @@
     "name": "friendsofphp/php-cs-fixer",
     "description": "A tool to automatically fix PHP code style",
     "license": "MIT",
+    "type": "application",
     "keywords": [
         "fixer",
         "standards",
         "static analysis"
     ],
-    "type": "application",
-    "authors": [
+   "authors": [
         {
             "name": "Fabien Potencier",
             "email": "fabien@symfony.com"


### PR DESCRIPTION
as per https://github.com/composer/composer/pull/10960 this allows composer to warn the user, when installing the tool as a project dependency instead of a dev-dependency