### PR TITLE
feature: Parse parenthesized & conditional phpdoc type

### DIFF
--- a/src/FixerConfiguration/AliasedFixerOptionBuilder.php
+++ b/src/FixerConfiguration/AliasedFixerOptionBuilder.php
@@ -52,7 +52,7 @@ final class AliasedFixerOptionBuilder
     }
 
     /**
-     * @param list<(callable(mixed): bool)|null|scalar> $allowedValues
+     * @param list<null|(callable(mixed): bool)|scalar> $allowedValues
      */
     public function setAllowedValues(array $allowedValues): self
     {

--- a/src/FixerConfiguration/FixerOption.php
+++ b/src/FixerConfiguration/FixerOption.php
@@ -33,7 +33,7 @@ final class FixerOption implements FixerOptionInterface
     private $allowedTypes;
 
     /**
-     * @var null|list<(callable(mixed): bool)|null|scalar>
+     * @var null|list<null|(callable(mixed): bool)|scalar>
      */
     private $allowedValues;
 
@@ -43,9 +43,9 @@ final class FixerOption implements FixerOptionInterface
     private $normalizer;
 
     /**
-     * @param mixed             $default
-     * @param null|list<string> $allowedTypes
-     * @param null|list<(callable(mixed): bool)|null|scalar> $allowedValues
+     * @param mixed                                          $default
+     * @param null|list<string>                              $allowedTypes
+     * @param null|list<null|(callable(mixed): bool)|scalar> $allowedValues
      */
     public function __construct(
         string $name,

--- a/src/FixerConfiguration/FixerOptionBuilder.php
+++ b/src/FixerConfiguration/FixerOptionBuilder.php
@@ -33,7 +33,7 @@ final class FixerOptionBuilder
     private $allowedTypes;
 
     /**
-     * @var null|list<(callable(mixed): bool)|null|scalar>
+     * @var null|list<null|(callable(mixed): bool)|scalar>
      */
     private $allowedValues;
 
@@ -79,7 +79,7 @@ final class FixerOptionBuilder
     }
 
     /**
-     * @param list<(callable(mixed): bool)|null|scalar> $allowedValues
+     * @param list<null|(callable(mixed): bool)|scalar> $allowedValues
      *
      * @return $this
      */

--- a/src/FixerConfiguration/FixerOptionInterface.php
+++ b/src/FixerConfiguration/FixerOptionInterface.php
@@ -35,7 +35,7 @@ interface FixerOptionInterface
     public function getAllowedTypes(): ?array;
 
     /**
-     * @return null|list<(callable(mixed): bool)|null|scalar>
+     * @return null|list<null|(callable(mixed): bool)|scalar>
      */
     public function getAllowedValues(): ?array;
 

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -146,6 +146,12 @@ final class TypeExpressionTest extends TestCase
         yield ['\\Closure(string|int, bool): bool', ['\\Closure(string|int, bool): bool']];
 
         yield ['array  <  int   , callable  (  string  )  :   bool  >', ['array  <  int   , callable  (  string  )  :   bool  >']];
+
+        yield ['(int)', ['(int)']];
+
+        yield ['(int|\\Exception)', ['(int|\\Exception)']];
+
+        yield ['($foo is int ? false : true)', ['($foo is int ? false : true)']];
     }
 
     /**
@@ -423,6 +429,36 @@ final class TypeExpressionTest extends TestCase
         yield 'nesty stuff' => [
             'array<Level11&array<Level2|array<Level31&Level32>>>',
             'array<array<array<Level31&Level32>|Level2>&Level11>',
+        ];
+
+        yield 'parenthesized' => [
+            '(Foo|Bar)',
+            '(Bar|Foo)',
+        ];
+
+        yield 'parenthesized intersect' => [
+            '(Foo&Bar)',
+            '(Bar&Foo)',
+        ];
+
+        yield 'parenthesized in closure return type' => [
+            'Closure(): (string|float)',
+            'Closure(): (float|string)',
+        ];
+
+        yield 'conditional with variable' => [
+            '($x is (CFoo|(CBaz&CBar)) ? (TFoo|(TBaz&TBar)) : (FFoo|(FBaz&FBar)))',
+            '($x is ((CBar&CBaz)|CFoo) ? ((TBar&TBaz)|TFoo) : ((FBar&FBaz)|FFoo))',
+        ];
+
+        yield 'conditional with type' => [
+            '((Foo|Bar) is x ? y : z)',
+            '((Bar|Foo) is x ? y : z)',
+        ];
+
+        yield 'conditional in conditional' => [
+            '((Foo|Bar) is x ? ($x is (CFoo|CBar) ? (TFoo|TBar) : (FFoo|FBar)) : z)',
+            '((Bar|Foo) is x ? ($x is (CBar|CFoo) ? (TBar|TFoo) : (FBar|FFoo)) : z)',
         ];
     }
 }

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -1495,6 +1495,24 @@ class Foo {}
         ');
     }
 
+    public function testTypesParenthesized(): void
+    {
+        $this->doTest(
+            '<?php
+            /**
+             * @param list<string>                                   $allowedTypes
+             * @param null|list<\Closure(mixed): (bool|null|scalar)> $allowedValues
+             */
+            ',
+            '<?php
+            /**
+             * @param list<string> $allowedTypes
+             * @param null|list<\Closure(mixed): (bool|null|scalar)> $allowedValues
+             */
+            '
+        );
+    }
+
     /**
      * @dataProvider provideCallableTypesWithUglyCodeCases
      */

--- a/tests/FixerConfiguration/AliasedFixerOptionTest.php
+++ b/tests/FixerConfiguration/AliasedFixerOptionTest.php
@@ -134,7 +134,7 @@ final class AliasedFixerOptionTest extends TestCase
     }
 
     /**
-     * @param list<(callable(mixed): bool)|null|scalar>|null $allowedValues
+     * @param null|list<null|(callable(mixed): bool)|scalar> $allowedValues
      *
      * @dataProvider provideGetAllowedValuesCases
      */


### PR DESCRIPTION
fix #6568

based on @VincentLanglet https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6568#issuecomment-1221552499, thank you!

and https://github.com/phpstan/phpdoc-parser/blob/1.9.x/doc/grammars/type.abnf grammar used by phpstan