### PR TITLE
bug: Allow string quote to be escaped within phpdoc constant

### DIFF
--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -88,7 +88,7 @@ final class TypeExpression
                     (?i)
                     null | true | false
                     | -?(?:\d+(?:\.\d*)?|\.\d+) # all sorts of numbers with or without minus, e.g.: 1, 1.1, 1., .1, -1
-                    | \'[^\']+?\' | "[^"]+?"
+                    | \'(?:[^\'\\\\]|\\\\.)+?\' | "(?:[^"\\\\]|\\\\.)+?"
                     | [@$]?(?:this | self | static)
                     (?-i)
                 )

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -152,6 +152,16 @@ final class TypeExpressionTest extends TestCase
         yield ['(int|\\Exception)', ['(int|\\Exception)']];
 
         yield ['($foo is int ? false : true)', ['($foo is int ? false : true)']];
+
+        yield ['\'\'', ['\'\'']];
+
+        yield ['\'foo\'', ['\'foo\'']];
+
+        yield ['\'\\\\\'', ['\'\\\\\'']];
+
+        yield ['\'\\\'\'', ['\'\\\'\'']];
+
+        yield ['\'a\\\'s"\\\\\n\r\t\'|"b\\"s\'\\\\\n\r\t"', ['\'a\\\'s"\\\\\n\r\t\'', '"b\\"s\'\\\\\n\r\t"']];
     }
 
     /**


### PR DESCRIPTION
Reference: phpstan/phpdoc-parser#142 ([1](https://phpstan.org/r/41f1530f-eaee-4e7d-8bfc-e7ccc7cfc7a7), [2](https://phpstan.org/r/a884b37d-682b-45a4-b891-1725ffd1c428)).