### PR TITLE
bug: EmptyLoopBodyFixer must keep comments inside

### DIFF
--- a/src/Fixer/ControlStructure/EmptyLoopBodyFixer.php
+++ b/src/Fixer/ControlStructure/EmptyLoopBodyFixer.php
@@ -101,7 +101,7 @@ final class EmptyLoopBodyFixer extends AbstractFixer implements ConfigurableFixe
                     return;
                 }
 
-                $braceCloseIndex = $tokens->getNextMeaningfulToken($braceOpenIndex);
+                $braceCloseIndex = $tokens->getNextNonWhitespace($braceOpenIndex);
 
                 if (!$tokens[$braceCloseIndex]->equals('}')) {
                     return;

--- a/tests/Fixer/ControlStructure/EmptyLoopBodyFixerTest.php
+++ b/tests/Fixer/ControlStructure/EmptyLoopBodyFixerTest.php
@@ -139,5 +139,11 @@ echo 1;
 ',
             ['style' => 'semicolon'],
         ];
+
+        yield 'empty "foreach" with comment' => [
+            '<?php foreach (Foo() as $f) {
+    // $this->add($f);
+}',
+        ];
     }
 }


### PR DESCRIPTION
Commented code and comments in general must be kept inside the loop body otherwise the meaning could be changed.