### PR TITLE
docs: increment_style - "fix" confusing examples

### DIFF
--- a/doc/rules/operator/increment_style.rst
+++ b/doc/rules/operator/increment_style.rst
@@ -28,11 +28,11 @@ Example #1
 
    --- Original
    +++ New
-    <?php
-   -$a++;
-   -$b--;
-   +++$a;
-   +--$b;
+     <?php
+   - $a++;
+   - $b--;
+   + ++$a;
+   + --$b;
 
 Example #2
 ~~~~~~~~~~
@@ -43,11 +43,11 @@ With configuration: ``['style' => 'post']``.
 
    --- Original
    +++ New
-    <?php
-   -++$a;
-   ---$b;
-   +$a++;
-   +$b--;
+     <?php
+   - ++$a;
+   - --$b;
+   + $a++;
+   + $b--;
 
 Rule sets
 ---------


### PR DESCRIPTION
The given examples are confusing to read since the diff `+`/`-` merge into the operator `++`/`--` without whitespaces

I don't know if your RST parser handles this properly but its easier to differentiate diff from operator when adding a whitespace to the start of each example