### PR TITLE
bug: BinaryOperatorSpacesFixer - fix parameters with union types passed by reference

### DIFF
--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -3107,6 +3107,9 @@ function test()
                     callable|array $a,
                     array|callable $b,
                 ) {}
+                public function qux(
+                    bool|int | string &$reference
+                ) {}
             }'
         );
     }

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -1878,6 +1878,11 @@ $b;',
             [6 => false],
             '<?php function foo(callable|int $x) {}',
         ];
+
+        yield [
+            [6 => false],
+            '<?php function foo(bool|int &$x) {}',
+        ];
     }
 
     /**

--- a/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
@@ -388,6 +388,25 @@ class Foo
                 ) {}
             }',
         ];
+
+        yield 'parameters by reference' => [
+            [
+                19 => CT::T_TYPE_ALTERNATION,
+                21 => CT::T_TYPE_ALTERNATION,
+                89 => CT::T_TYPE_ALTERNATION,
+                91 => CT::T_TYPE_ALTERNATION,
+            ],
+            '<?php
+                f(FOO|BAR|BAZ&$x);
+                function f1(FOO|BAR|BAZ&$x) {}
+                function f2(FOO&BAR&BAZ&$x) {}
+                f(FOO&BAR|BAZ&$x);
+                f(FOO|BAR&BAZ&$x);
+                fn(FOO&BAR&BAZ&$x) => 0;
+                fn(FOO|BAR|BAZ&$x) => 0;
+                f(FOO&BAR&BAZ&$x);
+            ',
+        ];
     }
 
     /**

--- a/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
@@ -393,8 +393,8 @@ class Foo
             [
                 19 => CT::T_TYPE_ALTERNATION,
                 21 => CT::T_TYPE_ALTERNATION,
-                89 => CT::T_TYPE_ALTERNATION,
                 91 => CT::T_TYPE_ALTERNATION,
+                93 => CT::T_TYPE_ALTERNATION,
             ],
             '<?php
                 f(FOO|BAR|BAZ&$x);

--- a/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
@@ -398,12 +398,12 @@ class Foo
             ],
             '<?php
                 f(FOO|BAR|BAZ&$x);
-                function f1(FOO|BAR|BAZ&$x) {}
+                function f1(FOO|BAR|BAZ&$x) {} // Alternation found
                 function f2(FOO&BAR&BAZ&$x) {}
                 f(FOO&BAR|BAZ&$x);
                 f(FOO|BAR&BAZ&$x);
                 fn(FOO&BAR&BAZ&$x) => 0;
-                fn(FOO|BAR|BAZ&$x) => 0;
+                fn(FOO|BAR|BAZ&$x) => 0; // Alternation found
                 f(FOO&BAR&BAZ&$x);
             ',
         ];

--- a/tests/Tokenizer/Transformer/TypeIntersectionTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeIntersectionTransformerTest.php
@@ -328,18 +328,18 @@ function f( #[Target(\'a\')] #[Target(\'b\')] #[Target(\'c\')] #[Target(\'d\')] 
             '<?php
                 f(FOO|BAR|BAZ&$x);
                 function f1(FOO|BAR|BAZ&$x) {}
-                function f2(FOO&BAR&BAZ&$x) {}
+                function f2(FOO&BAR&BAZ&$x) {} // Intersection found
                 f(FOO&BAR|BAZ&$x);
                 f(FOO|BAR&BAZ&$x);
-                fn(FOO&BAR&BAZ&$x) => 0;
+                fn(FOO&BAR&BAZ&$x) => 0; // Intersection found
                 fn(FOO|BAR|BAZ&$x) => 0;
                 f(FOO&BAR&BAZ&$x);
             ',
             [
                 35 => CT::T_TYPE_INTERSECTION,
                 37 => CT::T_TYPE_INTERSECTION,
-                73 => CT::T_TYPE_INTERSECTION,
                 75 => CT::T_TYPE_INTERSECTION,
+                77 => CT::T_TYPE_INTERSECTION,
             ],
         ];
     }

--- a/tests/Tokenizer/Transformer/TypeIntersectionTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeIntersectionTransformerTest.php
@@ -323,6 +323,25 @@ function f( #[Target(\'a\')] #[Target(\'b\')] #[Target(\'c\')] #[Target(\'d\')] 
                 45 => CT::T_TYPE_INTERSECTION,
             ],
         ];
+
+        yield 'parameters by reference' => [
+            '<?php
+                f(FOO|BAR|BAZ&$x);
+                function f1(FOO|BAR|BAZ&$x) {}
+                function f2(FOO&BAR&BAZ&$x) {}
+                f(FOO&BAR|BAZ&$x);
+                f(FOO|BAR&BAZ&$x);
+                fn(FOO&BAR&BAZ&$x) => 0;
+                fn(FOO|BAR|BAZ&$x) => 0;
+                f(FOO&BAR&BAZ&$x);
+            ',
+            [
+                35 => CT::T_TYPE_INTERSECTION,
+                37 => CT::T_TYPE_INTERSECTION,
+                73 => CT::T_TYPE_INTERSECTION,
+                75 => CT::T_TYPE_INTERSECTION,
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes #6828