### PR TITLE
minor: PHP8.2 Docker runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.env
 /.php-cs-fixer.php
 /.phpunit.result.cache
 /box.json
@@ -10,5 +11,5 @@
 /php-cs-fixer.phar.asc
 /phpunit.xml
 /vendor/
-.env
+
 xdebug.log

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /php-cs-fixer.phar.asc
 /phpunit.xml
 /vendor/
+.env
+xdebug.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Symfony projects for instance).
 * If you are adding functionality or fixing a bug - add a test! Prefer adding new test cases over modifying existing ones.
 * Make sure there is no wrong file permissions in the repository: `./dev-tools/check_file_permissions.sh`.
 * Make sure there is no trailing spaces in the code: `./dev-tools/check_trailing_spaces.sh`.
-* Update documentation: `php dev-tools/doc.php`. This requires the highest version of PHP supported by PHP CS Fixer. If it is not installed on your system, you can run it in a Docker container instead: `docker run -it --rm --user="$(id -u):$(id -g)" -w="/app" --volume="$(pwd):/app" php:7.4-cli php dev-tools/doc.php`.
+* Update documentation: `php dev-tools/doc.php`. This requires the highest version of PHP supported by PHP CS Fixer. If it is not installed on your system, you can run it in a Docker container instead: `docker-compose run php-8.2 php dev-tools/doc.php`.
 * Install dev tools: `dev-tools/install.sh`
 * Run static analysis using PHPStan: `php -d memory_limit=256M dev-tools/vendor/bin/phpstan analyse`
 * Check if tests pass: `vendor/bin/phpunit`.

--- a/docker-compose.override.yaml.dist
+++ b/docker-compose.override.yaml.dist
@@ -11,7 +11,13 @@ services:
       # Required for Docker Linux until natively supported.
       # See https://github.com/docker/for-linux/issues/264
       - 'host.docker.internal: 172.17.0.1'
+    environment:
+      # Switch to 'debug' when you want to enable XDebug
+      XDEBUG_MODE: off
+      XDEBUG_CONFIG: 'idekey=PHPSTORM client_host=host.docker.internal'
   php-8.0:
     <<: *php
   php-8.1:
+    <<: *php
+  php-8.2:
     <<: *php

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,3 +15,6 @@ services:
   php-8.1:
     <<: *php
     build: docker/php-8.1
+  php-8.2:
+    <<: *php
+    build: docker/php-8.2

--- a/docker/php-8.2/Dockerfile
+++ b/docker/php-8.2/Dockerfile
@@ -1,0 +1,27 @@
+FROM php:8.2-cli-alpine3.16
+
+ARG DOCKER_USER_ID
+ARG DOCKER_GROUP_ID
+
+RUN if ! getent group "${DOCKER_GROUP_ID}" > /dev/null; \
+    then addgroup -S -g "${DOCKER_GROUP_ID}" devs; \
+  fi \
+  && if ! getent passwd "${DOCKER_USER_ID}" > /dev/null; \
+    then adduser -S -u "${DOCKER_USER_ID}" -G "$(getent group "${DOCKER_GROUP_ID}" | awk -F: '{printf $1}')" dev; \
+  fi \
+  # php extensions
+  && curl --location --output /usr/local/bin/install-php-extensions https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions \
+  && chmod +x /usr/local/bin/install-php-extensions \
+  && sync \
+  && install-php-extensions \
+    pcntl \
+    xdebug-3.2.0 \
+  # composer
+  && curl --output composer-setup.php https://getcomposer.org/installer \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+  && rm composer-setup.php \
+  # xdebug command
+  && curl --location --output /usr/local/bin/xdebug https://github.com/julienfalque/xdebug/releases/download/v2.0.0/xdebug \
+  && chmod +x /usr/local/bin/xdebug
+
+COPY xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/docker/php-8.2/Dockerfile
+++ b/docker/php-8.2/Dockerfile
@@ -3,6 +3,10 @@ FROM php:8.2-cli-alpine3.16
 ARG DOCKER_USER_ID
 ARG DOCKER_GROUP_ID
 
+# https://blog.codito.dev/2022/11/composer-binary-only-docker-images/
+# https://github.com/composer/docker/pull/250
+COPY --from=composer/composer:2-bin /composer /usr/local/bin/composer
+
 RUN if ! getent group "${DOCKER_GROUP_ID}" > /dev/null; \
     then addgroup -S -g "${DOCKER_GROUP_ID}" devs; \
   fi \
@@ -16,10 +20,6 @@ RUN if ! getent group "${DOCKER_GROUP_ID}" > /dev/null; \
   && install-php-extensions \
     pcntl \
     xdebug-3.2.0 \
-  # composer
-  && curl --output composer-setup.php https://getcomposer.org/installer \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
-  && rm composer-setup.php \
   # xdebug command
   && curl --location --output /usr/local/bin/xdebug https://github.com/julienfalque/xdebug/releases/download/v2.0.0/xdebug \
   && chmod +x /usr/local/bin/xdebug

--- a/docker/php-8.2/xdebug.ini
+++ b/docker/php-8.2/xdebug.ini
@@ -7,7 +7,6 @@ xdebug.mode = off
 xdebug.start_with_request = yes
 xdebug.discover_client_host = true
 xdebug.client_host = host.docker.internal
-xdebug.client_port = 9003
 
 ; Required so XDebug DOES NOT print warning "Could not connect to debugging client"
 xdebug.log = /app/docker/php-8.2/xdebug.log

--- a/docker/php-8.2/xdebug.ini
+++ b/docker/php-8.2/xdebug.ini
@@ -1,0 +1,14 @@
+;zend_extension = xdebug.so
+
+; XDebug 3 → https://xdebug.org/docs/upgrade_guide
+; You can dynamically enable XDebug by setting XDEBUG_MODE env variable.
+; Some options can be dynamically overridden with XDEBUG_CONFIG env variable.
+xdebug.mode = off
+xdebug.start_with_request = yes
+xdebug.discover_client_host = true
+xdebug.client_host = host.docker.internal
+xdebug.client_port = 9003
+
+; Required so XDebug DOES NOT print warning "Could not connect to debugging client"
+xdebug.log = /app/docker/php-8.2/xdebug.log
+xdebug.log_level = 1


### PR DESCRIPTION
Missing in v3.15 release, we should provide environment for 8.2 out-of-the-box.