### PR TITLE
minor: Fix autocompletion for `Tokens::offsetGet()`

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -27,6 +27,8 @@ use PhpCsFixer\Preg;
  *
  * @extends \SplFixedArray<Token>
  *
+ * @method Token offsetGet($offset)
+ *
  * @final
  */
 class Tokens extends \SplFixedArray


### PR DESCRIPTION
`$tokens[$index]` did not provide API from `Token` and it was cumbersome to work with.

Before:

<img width="559" alt="image" src="https://user-images.githubusercontent.com/600668/224860808-b3ec9c50-075c-4d3b-b99d-fa2d4bb374a0.png">

After:

<img width="692" alt="image" src="https://user-images.githubusercontent.com/600668/224860885-ad4b8dc6-ff2c-4022-a45c-bb0614760999.png">
