### PR TITLE
feature: AbstractPhpUnitFixer - support attribute detection in docblock insertion

### DIFF
--- a/src/Fixer/AbstractPhpUnitFixer.php
+++ b/src/Fixer/AbstractPhpUnitFixer.php
@@ -19,6 +19,7 @@ use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\DocBlock\Line;
 use PhpCsFixer\Indicator\PhpUnitTestCaseIndicator;
 use PhpCsFixer\Tokenizer\Analyzer\WhitespacesAnalyzer;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -50,12 +51,20 @@ abstract class AbstractPhpUnitFixer extends AbstractFixer
     {
         $modifiers = [T_PUBLIC, T_PROTECTED, T_PRIVATE, T_FINAL, T_ABSTRACT, T_COMMENT];
 
+        if (\defined('T_ATTRIBUTE')) { // @TODO: drop condition when PHP 8.0+ is required
+            $modifiers[] = T_ATTRIBUTE;
+        }
+
         if (\defined('T_READONLY')) { // @TODO: drop condition when PHP 8.2+ is required
             $modifiers[] = T_READONLY;
         }
 
         do {
             $index = $tokens->getPrevNonWhitespace($index);
+
+            if ($tokens[$index]->isGivenKind(CT::T_ATTRIBUTE_CLOSE)) {
+                $index = $tokens->getPrevTokenOfKind($index, [[T_ATTRIBUTE]]);
+            }
         } while ($tokens[$index]->isGivenKind($modifiers));
 
         return $index;

--- a/tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
@@ -375,6 +375,67 @@ class Test extends TestCase
     }
 
     /**
+     * @dataProvider provideFix80Cases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFix80(string $expected, string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string[]>
+     */
+    public static function provideFix80Cases(): iterable
+    {
+        yield 'it adds a docblock above when there is an attribute' => [
+            '<?php
+
+            /**
+             * @internal
+             */
+            #[SimpleTest]
+            class Test extends TestCase
+            {
+            }
+            ',
+            '<?php
+
+            #[SimpleTest]
+            class Test extends TestCase
+            {
+            }
+            ',
+        ];
+
+        yield 'it adds the internal tag along other tags when there is an attribute' => [
+            '<?php
+
+            /**
+             * @coversNothing
+             *
+             * @internal
+             */
+            #[SimpleTest]
+            class Test extends TestCase
+            {
+            }
+            ',
+            '<?php
+
+            /**
+             * @coversNothing
+             */
+            #[SimpleTest]
+            class Test extends TestCase
+            {
+            }
+            ',
+        ];
+    }
+
+    /**
      * @param array<string, mixed> $config
      *
      * @dataProvider provideFix82Cases

--- a/tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
@@ -433,6 +433,55 @@ class Test extends TestCase
             }
             ',
         ];
+
+        yield 'it adds a docblock above when there are attributes' => [
+            '<?php
+
+            /**
+             * @internal
+             */
+            #[SimpleTest]
+            #[Annotated]
+            class Test extends TestCase
+            {
+            }
+            ',
+            '<?php
+
+            #[SimpleTest]
+            #[Annotated]
+            class Test extends TestCase
+            {
+            }
+            ',
+        ];
+
+        yield 'it adds the internal tag along other tags when there are attributes' => [
+            '<?php
+
+            /**
+             * @coversNothing
+             *
+             * @internal
+             */
+            #[SimpleTest]
+            #[Annotated]
+            class Test extends TestCase
+            {
+            }
+            ',
+            '<?php
+
+            /**
+             * @coversNothing
+             */
+            #[SimpleTest]
+            #[Annotated]
+            class Test extends TestCase
+            {
+            }
+            ',
+        ];
     }
 
     /**

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -166,4 +166,41 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider provideFix80ToCamelCaseCases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFix80ToCamelCase(string $expected, string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string[]>
+     */
+    public static function provideFix80ToCamelCaseCases(): iterable
+    {
+        yield '@depends annotation with class name in Snake_Case' => [
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+                public function testMyApp () {}
+
+                /**
+                 * @depends Foo_Bar_Test::testMyApp
+                 */
+                #[SimpleTest]
+                public function testMyAppToo() {}
+            }',
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+                public function test_my_app () {}
+
+                /**
+                 * @depends Foo_Bar_Test::test_my_app
+                 */
+                #[SimpleTest]
+                public function test_my_app_too() {}
+            }',
+        ];
+    }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -202,5 +202,28 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
                 public function test_my_app_too() {}
             }',
         ];
+
+        yield '@depends annotation with class name in Snake_Case and attributes in between' => [
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+                public function testMyApp () {}
+
+                /**
+                 * @depends Foo_Bar_Test::testMyApp
+                 */
+                #[SimpleTest]
+                #[Deprecated]
+                public function testMyAppToo() {}
+            }',
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+                public function test_my_app () {}
+
+                /**
+                 * @depends Foo_Bar_Test::test_my_app
+                 */
+                #[SimpleTest]
+                #[Deprecated]
+                public function test_my_app_too() {}
+            }',
+        ];
     }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitSizeClassFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitSizeClassFixerTest.php
@@ -316,4 +316,65 @@ class Test3 extends TestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider provideFix80Cases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFix80(string $expected, string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string[]>
+     */
+    public static function provideFix80Cases(): iterable
+    {
+        yield 'it adds a docblock above when there is an attribute' => [
+            '<?php
+
+            /**
+             * @small
+             */
+            #[SimpleTest]
+            class Test extends TestCase
+            {
+            }
+            ',
+            '<?php
+
+            #[SimpleTest]
+            class Test extends TestCase
+            {
+            }
+            ',
+        ];
+
+        yield 'it adds the internal tag along other tags when there is an attribute' => [
+            '<?php
+
+            /**
+             * @coversNothing
+             *
+             * @small
+             */
+            #[SimpleTest]
+            class Test extends TestCase
+            {
+            }
+            ',
+            '<?php
+
+            /**
+             * @coversNothing
+             */
+            #[SimpleTest]
+            class Test extends TestCase
+            {
+            }
+            ',
+        ];
+    }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitSizeClassFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitSizeClassFixerTest.php
@@ -376,5 +376,58 @@ class Test3 extends TestCase
             }
             ',
         ];
+
+        yield 'it adds a docblock above when there are attributes' => [
+            '<?php
+
+            /**
+             * @small
+             */
+            #[SimpleTest]
+            #[Deprecated]
+            #[Annotated]
+            class Test extends TestCase
+            {
+            }
+            ',
+            '<?php
+
+            #[SimpleTest]
+            #[Deprecated]
+            #[Annotated]
+            class Test extends TestCase
+            {
+            }
+            ',
+        ];
+
+        yield 'it adds the internal tag along other tags when there are attributes' => [
+            '<?php
+
+            /**
+             * @coversNothing
+             *
+             * @small
+             */
+            #[SimpleTest]
+            #[Deprecated]
+            #[Annotated]
+            class Test extends TestCase
+            {
+            }
+            ',
+            '<?php
+
+            /**
+             * @coversNothing
+             */
+            #[SimpleTest]
+            #[Deprecated]
+            #[Annotated]
+            class Test extends TestCase
+            {
+            }
+            ',
+        ];
     }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
@@ -1030,4 +1030,52 @@ class Test extends \PhpUnit\FrameWork\TestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider provideFix80Cases
+     *
+     * @param array<string, string> $config
+     *
+     * @requires PHP 8.0
+     */
+    public function testFix80(string $expected, string $input, array $config): void
+    {
+        $this->fixer->configure($config);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<(string|array<string, string>)[]>
+     */
+    public static function provideFix80Cases(): iterable
+    {
+        yield [
+            '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    #[OneTest]
+    public function itWorks() {}
+
+    /**
+     * @test
+     */
+    #[TwoTest]
+    public function itDoesSomething() {}
+}',
+            '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    #[OneTest]
+    public function testItWorks() {}
+
+    #[TwoTest]
+    public function testItDoesSomething() {}
+}',
+            ['style' => 'annotation'],
+        ];
+    }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
@@ -1077,5 +1077,37 @@ class Test extends \PhpUnit\FrameWork\TestCase
 }',
             ['style' => 'annotation'],
         ];
+
+        yield [
+            '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    #[OneTest]
+    #[Internal]
+    public function itWorks() {}
+
+    /**
+     * @test
+     */
+    #[TwoTest]
+    #[Internal]
+    public function itDoesSomething() {}
+}',
+            '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    #[OneTest]
+    #[Internal]
+    public function testItWorks() {}
+
+    #[TwoTest]
+    #[Internal]
+    public function testItDoesSomething() {}
+}',
+            ['style' => 'annotation'],
+        ];
     }
 }


### PR DESCRIPTION
Partial fix of #6795 