### PR TITLE
DX: make data providers static for fixer's tests

### DIFF
--- a/tests/AbstractDoctrineAnnotationFixerTestCase.php
+++ b/tests/AbstractDoctrineAnnotationFixerTestCase.php
@@ -47,36 +47,36 @@ abstract class AbstractDoctrineAnnotationFixerTestCase extends AbstractFixerTest
      *
      * @return list<array{0: string, 1?: string}>
      */
-    protected function createTestCases(array $commentCases): array
+    protected static function createTestCases(array $commentCases): array
     {
         $cases = [];
         foreach ($commentCases as $commentCase) {
             $cases[] = [
-                $this->withClassDocBlock($commentCase[0]),
-                isset($commentCase[1]) ? $this->withClassDocBlock($commentCase[1]) : null,
+                self::withClassDocBlock($commentCase[0]),
+                isset($commentCase[1]) ? self::withClassDocBlock($commentCase[1]) : null,
             ];
 
             $cases[] = [
-                $this->withPropertyDocBlock($commentCase[0]),
-                isset($commentCase[1]) ? $this->withPropertyDocBlock($commentCase[1]) : null,
+                self::withPropertyDocBlock($commentCase[0]),
+                isset($commentCase[1]) ? self::withPropertyDocBlock($commentCase[1]) : null,
             ];
 
             $cases[] = [
-                $this->withMethodDocBlock($commentCase[0]),
-                isset($commentCase[1]) ? $this->withMethodDocBlock($commentCase[1]) : null,
+                self::withMethodDocBlock($commentCase[0]),
+                isset($commentCase[1]) ? self::withMethodDocBlock($commentCase[1]) : null,
             ];
 
             $cases[] = [
-                $this->withWrongElementDocBlock($commentCase[0]),
+                self::withWrongElementDocBlock($commentCase[0]),
             ];
         }
 
         return $cases;
     }
 
-    private function withClassDocBlock(string $comment): string
+    private static function withClassDocBlock(string $comment): string
     {
-        return $this->with('<?php
+        return self::with('<?php
 
 %s
 class FooClass
@@ -84,9 +84,9 @@ class FooClass
 }', $comment, false);
     }
 
-    private function withPropertyDocBlock(string $comment): string
+    private static function withPropertyDocBlock(string $comment): string
     {
-        return $this->with('<?php
+        return self::with('<?php
 
 class FooClass
 {
@@ -95,9 +95,9 @@ class FooClass
 }', $comment, true);
     }
 
-    private function withMethodDocBlock(string $comment): string
+    private static function withMethodDocBlock(string $comment): string
     {
-        return $this->with('<?php
+        return self::with('<?php
 
 class FooClass
 {
@@ -108,15 +108,15 @@ class FooClass
 }', $comment, true);
     }
 
-    private function withWrongElementDocBlock(string $comment): string
+    private static function withWrongElementDocBlock(string $comment): string
     {
-        return $this->with('<?php
+        return self::with('<?php
 
 %s
 $foo = bar();', $comment, false);
     }
 
-    private function with(string $php, string $comment, bool $indent): string
+    private static function with(string $php, string $comment, bool $indent): string
     {
         $comment = trim($comment);
 

--- a/tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
+++ b/tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
@@ -34,7 +34,7 @@ final class NoAliasFunctionsFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         $defaultSets = [
             '@internal',
@@ -42,7 +42,7 @@ final class NoAliasFunctionsFixerTest extends AbstractFixerTestCase
             '@pg',
         ];
 
-        foreach ($this->provideAllCases() as $set => $cases) {
+        foreach (self::provideAllCases() as $set => $cases) {
             if (\in_array($set, $defaultSets, true)) {
                 yield from $cases;
             } else {
@@ -111,7 +111,7 @@ abstract class A
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithConfigurationCases(): iterable
+    public static function provideFixWithConfigurationCases(): iterable
     {
         yield '@internal' => [
             '<?php
@@ -225,7 +225,7 @@ abstract class A
             ['sets' => ['@exif']],
         ];
 
-        foreach ($this->provideAllCases() as $set => $cases) {
+        foreach (self::provideAllCases() as $set => $cases) {
             foreach ($cases as $case) {
                 yield [
                     $case[0],
@@ -253,7 +253,7 @@ abstract class A
         ];
     }
 
-    private function provideAllCases(): iterable
+    private static function provideAllCases(): iterable
     {
         $reflectionConstant = new \ReflectionClassConstant(\PhpCsFixer\Fixer\Alias\NoAliasFunctionsFixer::class, 'SETS');
 

--- a/tests/Fixer/Basic/EncodingFixerTest.php
+++ b/tests/Fixer/Basic/EncodingFixerTest.php
@@ -33,11 +33,11 @@ final class EncodingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input, $file);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
-        yield $this->prepareTestCase('test-utf8.case1.php', 'test-utf8.case1-bom.php');
+        yield self::prepareTestCase('test-utf8.case1.php', 'test-utf8.case1-bom.php');
 
-        yield $this->prepareTestCase('test-utf8.case2.php', 'test-utf8.case2-bom.php');
+        yield self::prepareTestCase('test-utf8.case2.php', 'test-utf8.case2-bom.php');
 
         yield ['<?php '];
     }
@@ -45,10 +45,10 @@ final class EncodingFixerTest extends AbstractFixerTestCase
     /**
      * @return array{string, string|null, \SplFileInfo}
      */
-    private function prepareTestCase(string $expectedFilename, ?string $inputFilename = null): array
+    private static function prepareTestCase(string $expectedFilename, ?string $inputFilename = null): array
     {
-        $expectedFile = $this->getTestFile(__DIR__.'/../../Fixtures/FixerTest/encoding/'.$expectedFilename);
-        $inputFile = $inputFilename ? $this->getTestFile(__DIR__.'/../../Fixtures/FixerTest/encoding/'.$inputFilename) : null;
+        $expectedFile = self::getTestFile(__DIR__.'/../../Fixtures/FixerTest/encoding/'.$expectedFilename);
+        $inputFile = $inputFilename ? self::getTestFile(__DIR__.'/../../Fixtures/FixerTest/encoding/'.$inputFilename) : null;
 
         return [
             file_get_contents($expectedFile->getRealPath()),

--- a/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
+++ b/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
@@ -47,7 +47,7 @@ final class LowercaseCastFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         $types = ['boolean', 'bool', 'integer', 'int', 'double', 'float', 'float', 'string', 'array', 'object', 'binary'];
 
@@ -56,21 +56,21 @@ final class LowercaseCastFixerTest extends AbstractFixerTestCase
         }
 
         foreach ($types as $from) {
-            foreach ($this->createCasesFor($from) as $case) {
+            foreach (self::createCasesFor($from) as $case) {
                 yield $case;
             }
         }
     }
 
-    public function provideFixDeprecatedCases(): iterable
+    public static function provideFixDeprecatedCases(): iterable
     {
-        return $this->createCasesFor('real');
+        return self::createCasesFor('real');
     }
 
     /**
      * @return iterable<array{0: non-empty-string, 1?: non-empty-string}>
      */
-    private function createCasesFor(string $type): iterable
+    private static function createCasesFor(string $type): iterable
     {
         yield [
             sprintf('<?php $b= (%s)$d;', $type),

--- a/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
+++ b/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
@@ -47,18 +47,18 @@ final class ShortScalarCastFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         foreach (['boolean' => 'bool', 'integer' => 'int', 'double' => 'float', 'binary' => 'string'] as $from => $to) {
-            foreach ($this->createCasesFor($from, $to) as $case) {
+            foreach (self::createCasesFor($from, $to) as $case) {
                 yield $case;
             }
         }
     }
 
-    public function provideFixDeprecatedCases(): iterable
+    public static function provideFixDeprecatedCases(): iterable
     {
-        return $this->createCasesFor('real', 'float');
+        return self::createCasesFor('real', 'float');
     }
 
     /**
@@ -91,7 +91,7 @@ final class ShortScalarCastFixerTest extends AbstractFixerTestCase
     /**
      * @return iterable<array{0: non-empty-string, 1?: non-empty-string}>
      */
-    private function createCasesFor(string $from, string $to): iterable
+    private static function createCasesFor(string $from, string $to): iterable
     {
         yield [
             sprintf('<?php echo ( %s  )$a;', $to),

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -315,12 +315,12 @@ A#
         ];
     }
 
-    public function provideClassesCases(): array
+    public static function provideClassesCases(): array
     {
         return array_merge(
-            $this->provideClassyCases('class'),
-            $this->provideClassyExtendingCases('class'),
-            $this->provideClassyImplementsCases()
+            self::provideClassyCases('class'),
+            self::provideClassyExtendingCases('class'),
+            self::provideClassyImplementsCases()
         );
     }
 
@@ -374,11 +374,11 @@ A#
         ];
     }
 
-    public function provideInterfacesCases(): array
+    public static function provideInterfacesCases(): array
     {
         $cases = array_merge(
-            $this->provideClassyCases('interface'),
-            $this->provideClassyExtendingCases('interface')
+            self::provideClassyCases('interface'),
+            self::provideClassyExtendingCases('interface')
         );
 
         $cases[] = [
@@ -411,9 +411,9 @@ TestInterface3, /**/     TestInterface4   ,
         return $cases;
     }
 
-    public function provideTraitsCases(): array
+    public static function provideTraitsCases(): array
     {
-        return $this->provideClassyCases('trait');
+        return self::provideClassyCases('trait');
     }
 
     /**
@@ -803,7 +803,7 @@ $a = new class implements
         static::assertSame($expected, $result);
     }
 
-    private function provideClassyCases(string $classy): array
+    private static function provideClassyCases(string $classy): array
     {
         return [
             [
@@ -871,7 +871,7 @@ namespace {
         ];
     }
 
-    private function provideClassyExtendingCases(string $classy): array
+    private static function provideClassyExtendingCases(string $classy): array
     {
         return [
             [
@@ -901,7 +901,7 @@ extends
         ];
     }
 
-    private function provideClassyImplementsCases(): array
+    private static function provideClassyImplementsCases(): array
     {
         return [
             [

--- a/tests/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixerTest.php
@@ -36,9 +36,9 @@ final class FinalPublicMethodForAbstractClassFixerTest extends AbstractFixerTest
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
-        $original = $fixed = $this->getClassElementStubs();
+        $original = $fixed = self::getClassElementStubs();
         $fixed = str_replace('public function f1', 'final public function f1', $fixed);
         $fixed = str_replace('public static function f4', 'final public static function f4', $fixed);
         $fixed = str_replace('static public function f7', 'final static public function f7', $fixed);
@@ -103,7 +103,7 @@ final class FinalPublicMethodForAbstractClassFixerTest extends AbstractFixerTest
             'anonymous-class' => [
                 sprintf(
                     '<?php abstract class MyClass { private function test() { $a = new class { %s }; } }',
-                    $this->getClassElementStubs()
+                    self::getClassElementStubs()
                 ),
             ],
             'constant visibility' => [
@@ -116,7 +116,7 @@ final class FinalPublicMethodForAbstractClassFixerTest extends AbstractFixerTest
         ];
     }
 
-    private function getClassElementStubs(): string
+    private static function getClassElementStubs(): string
     {
         return '
             public $a1;

--- a/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
+++ b/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
@@ -33,10 +33,10 @@ final class ProtectedToPrivateFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
-        $attributesAndMethodsOriginal = $this->getAttributesAndMethods(true);
-        $attributesAndMethodsFixed = $this->getAttributesAndMethods(false);
+        $attributesAndMethodsOriginal = self::getAttributesAndMethods(true);
+        $attributesAndMethodsFixed = self::getAttributesAndMethods(false);
 
         return [
             'final-extends' => [
@@ -315,7 +315,7 @@ echo DocumentStats::DRAFT->getStatusName();
         ];
     }
 
-    private function getAttributesAndMethods(bool $original): string
+    private static function getAttributesAndMethods(bool $original): string
     {
         $attributesAndMethodsOriginal = '
 public $v1;

--- a/tests/Fixer/ControlStructure/ControlStructureContinuationPositionFixerTest.php
+++ b/tests/Fixer/ControlStructure/ControlStructureContinuationPositionFixerTest.php
@@ -286,9 +286,9 @@ final class ControlStructureContinuationPositionFixerTest extends AbstractFixerT
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithWindowsLineEndingsCases(): iterable
+    public static function provideFixWithWindowsLineEndingsCases(): iterable
     {
-        foreach ($this->provideFixCases() as $label => $case) {
+        foreach (self::provideFixCases() as $label => $case) {
             yield $label => [
                 Preg::replace('/\n/', "\r\n", $case[0]),
                 isset($case[1]) ? Preg::replace('/\n/', "\r\n", $case[1]) : null,

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -1062,9 +1062,9 @@ switch ($foo) {
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixWithDifferentCommentTextCases(): array
+    public static function provideTestFixWithDifferentCommentTextCases(): array
     {
-        $cases = $this->provideFixCases();
+        $cases = self::provideFixCases();
 
         $replaceCommentText = static function (string $php): string {
             return strtr($php, [
@@ -1120,9 +1120,9 @@ switch ($foo) {
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixWithDifferentLineEndingCases(): iterable
+    public static function provideTestFixWithDifferentLineEndingCases(): iterable
     {
-        foreach ($this->provideFixCases() as $case) {
+        foreach (self::provideFixCases() as $case) {
             $case[0] = str_replace("\n", "\r\n", $case[0]);
 
             if (isset($case[1])) {

--- a/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
@@ -133,7 +133,7 @@ else?><?php echo 5;',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixIfElseIfElseCases(): array
+    public static function provideFixIfElseIfElseCases(): array
     {
         $expected =
             '<?php
@@ -171,7 +171,7 @@ else?><?php echo 5;',
                 }
             ';
 
-        $cases = $this->generateCases($expected, $input);
+        $cases = self::generateCases($expected, $input);
 
         $expected =
             '<?php
@@ -188,7 +188,7 @@ else?><?php echo 5;',
                 }
             ';
 
-        $cases = array_merge($cases, $this->generateCases($expected));
+        $cases = array_merge($cases, self::generateCases($expected));
 
         $expected =
             '<?php
@@ -209,7 +209,7 @@ else?><?php echo 5;',
                 }
             ';
 
-        $cases = array_merge($cases, $this->generateCases($expected));
+        $cases = array_merge($cases, self::generateCases($expected));
 
         $cases[] = [
             '<?php
@@ -257,7 +257,7 @@ else?><?php echo 5;',
         $this->doTest($expected, $input);
     }
 
-    public function provideFixIfElseCases(): iterable
+    public static function provideFixIfElseCases(): iterable
     {
         $expected = '<?php
             while(true) {
@@ -283,7 +283,7 @@ else?><?php echo 5;',
             }
         ';
 
-        yield from $this->generateCases($expected, $input);
+        yield from self::generateCases($expected, $input);
 
         yield [
             '<?php
@@ -711,7 +711,7 @@ else?><?php echo 5;',
         $this->doTest($expected, $input);
     }
 
-    public function provideConditionsWithoutBracesCases(): iterable
+    public static function provideConditionsWithoutBracesCases(): iterable
     {
         $statements = [
             'die;',
@@ -724,7 +724,7 @@ else?><?php echo 5;',
         ];
 
         foreach ($statements as $statement) {
-            yield from $this->generateConditionsWithoutBracesCase($statement);
+            yield from self::generateConditionsWithoutBracesCase($statement);
         }
 
         yield [
@@ -748,9 +748,9 @@ else?><?php echo 5;',
                 return $ret;',
         ];
 
-        yield from $this->generateConditionsWithoutBracesCase('throw new class extends Exception{};');
+        yield from self::generateConditionsWithoutBracesCase('throw new class extends Exception{};');
 
-        yield from $this->generateConditionsWithoutBracesCase('throw new class ($a, 9) extends Exception{ public function z($a, $b){ echo 7;} };');
+        yield from self::generateConditionsWithoutBracesCase('throw new class ($a, 9) extends Exception{ public function z($a, $b){ echo 7;} };');
     }
 
     /**
@@ -763,9 +763,9 @@ else?><?php echo 5;',
         $this->doTest($expected);
     }
 
-    public function provideConditionsWithoutBraces80Cases(): iterable
+    public static function provideConditionsWithoutBraces80Cases(): iterable
     {
-        yield from $this->generateConditionsWithoutBracesCase('$b = $a ?? throw new Exception($i);');
+        yield from self::generateConditionsWithoutBracesCase('$b = $a ?? throw new Exception($i);');
     }
 
     /**
@@ -945,7 +945,7 @@ else?><?php echo 5;',
     /**
      * @return iterable<array{0: non-empty-string, 1?: non-empty-string}>
      */
-    private function generateConditionsWithoutBracesCase(string $statement): iterable
+    private static function generateConditionsWithoutBracesCase(string $statement): iterable
     {
         $ifTemplate = '<?php
             if ($a === false)
@@ -991,7 +991,7 @@ else?><?php echo 5;',
     /**
      * @return array<array<string>>
      */
-    private function generateCases(string $expected, ?string $input = null): array
+    private static function generateCases(string $expected, ?string $input = null): array
     {
         $cases = [];
 

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixerTest.php
@@ -41,9 +41,9 @@ final class DoctrineAnnotationArrayAssignmentFixerTest extends AbstractDoctrineA
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
-        yield from $this->createTestCases([
+        yield from self::createTestCases([
             ['
 /**
  * @Foo
@@ -117,9 +117,9 @@ final class DoctrineAnnotationArrayAssignmentFixerTest extends AbstractDoctrineA
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithColonCases(): iterable
+    public static function provideFixWithColonCases(): iterable
     {
-        yield from $this->createTestCases([
+        yield from self::createTestCases([
             ['
 /**
  * @Foo

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
@@ -33,9 +33,9 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithBracesCases(): iterable
+    public static function provideFixWithBracesCases(): iterable
     {
-        yield from $this->createTestCases([
+        yield from self::createTestCases([
             ['
 /**
  * @Foo()
@@ -288,9 +288,9 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithoutBracesCases(): iterable
+    public static function provideFixWithoutBracesCases(): iterable
     {
-        yield from $this->createTestCases([
+        yield from self::createTestCases([
             ['
 /**
  * Foo.

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
@@ -43,9 +43,9 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
-        $cases = $this->createTestCases([
+        $cases = self::createTestCases([
             ['
 /**
  * Foo.
@@ -362,9 +362,9 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithIndentedMixedLinesCases(): array
+    public static function provideFixWithIndentedMixedLinesCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * Foo.

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
@@ -57,9 +57,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixAll($expected, $input);
     }
 
-    public function provideFixAllCases(): array
+    public static function provideFixAllCases(): array
     {
-        $cases = $this->createTestCases([
+        $cases = self::createTestCases([
             ['
 /**
  * @Foo
@@ -372,9 +372,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixAroundParenthesesOnly($expected, $input);
     }
 
-    public function provideFixAroundParenthesesOnlyCases(): array
+    public static function provideFixAroundParenthesesOnlyCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * @Foo
@@ -626,9 +626,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixAroundCommasOnly($expected, $input);
     }
 
-    public function provideFixAroundCommasOnlyCases(): array
+    public static function provideFixAroundCommasOnlyCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * @Foo
@@ -892,9 +892,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixWithSpaceBeforeArgumentAssignmentOnly($expected, $input);
     }
 
-    public function provideFixWithSpaceBeforeArgumentAssignmentOnlyCases(): array
+    public static function provideFixWithSpaceBeforeArgumentAssignmentOnlyCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * @Foo(foo ="foo", bar ={"foo":"foo", "bar"="bar"})
@@ -940,9 +940,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixWithoutSpaceBeforeArgumentAssignmentOnly($expected, $input);
     }
 
-    public function provideFixWithoutSpaceBeforeArgumentAssignmentOnlyCases(): array
+    public static function provideFixWithoutSpaceBeforeArgumentAssignmentOnlyCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * @Foo(foo="foo", bar={"foo":"foo", "bar"="bar"})
@@ -988,9 +988,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixWithSpaceAfterArgumentAssignmentOnly($expected, $input);
     }
 
-    public function provideFixWithSpaceAfterArgumentAssignmentOnlyCases(): array
+    public static function provideFixWithSpaceAfterArgumentAssignmentOnlyCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * @Foo(foo= "foo", bar= {"foo":"foo", "bar"="bar"})
@@ -1036,9 +1036,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixWithoutSpaceAfterArgumentAssignmentOnly($expected, $input);
     }
 
-    public function provideFixWithoutSpaceAfterArgumentAssignmentOnlyCases(): array
+    public static function provideFixWithoutSpaceAfterArgumentAssignmentOnlyCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * @Foo(foo="foo", bar={"foo":"foo", "bar"="bar"})
@@ -1084,9 +1084,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixWithSpaceBeforeArrayAssignmentEqualOnly($expected, $input);
     }
 
-    public function provideFixWithSpaceBeforeArrayAssignmentEqualOnlyCases(): array
+    public static function provideFixWithSpaceBeforeArrayAssignmentEqualOnlyCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * @Foo(foo="foo", bar={"foo":"foo", "bar" ="bar"})
@@ -1132,9 +1132,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixWithoutSpaceBeforeArrayAssignmentEqualOnly($expected, $input);
     }
 
-    public function provideFixWithoutSpaceBeforeArrayAssignmentEqualOnlyCases(): array
+    public static function provideFixWithoutSpaceBeforeArrayAssignmentEqualOnlyCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * @Foo(foo="foo", bar={"foo":"foo", "bar"="bar"})
@@ -1180,9 +1180,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixWithSpaceAfterArrayAssignmentEqualOnly($expected, $input);
     }
 
-    public function provideFixWithSpaceAfterArrayAssignmentEqualOnlyCases(): array
+    public static function provideFixWithSpaceAfterArrayAssignmentEqualOnlyCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * @Foo(foo="foo", bar={"foo":"foo", "bar"= "bar"})
@@ -1228,9 +1228,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixWithoutSpaceAfterArrayAssignmentEqualOnly($expected, $input);
     }
 
-    public function provideFixWithoutSpaceAfterArrayAssignmentEqualOnlyCases(): array
+    public static function provideFixWithoutSpaceAfterArrayAssignmentEqualOnlyCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * @Foo(foo="foo", bar={"foo":"foo", "bar"="bar"})
@@ -1276,9 +1276,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixWithSpaceBeforeArrayAssignmentColonOnly($expected, $input);
     }
 
-    public function provideFixWithSpaceBeforeArrayAssignmentColonOnlyCases(): array
+    public static function provideFixWithSpaceBeforeArrayAssignmentColonOnlyCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * @Foo(foo="foo", bar={"foo" :"foo", "bar"="bar"})
@@ -1324,9 +1324,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixWithoutSpaceBeforeArrayAssignmentColonOnly($expected, $input);
     }
 
-    public function provideFixWithoutSpaceBeforeArrayAssignmentColonOnlyCases(): array
+    public static function provideFixWithoutSpaceBeforeArrayAssignmentColonOnlyCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * @Foo(foo="foo", bar={"foo":"foo", "bar"="bar"})
@@ -1372,9 +1372,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixWithSpaceAfterArrayAssignmentColonOnly($expected, $input);
     }
 
-    public function provideFixWithSpaceAfterArrayAssignmentColonOnlyCases(): array
+    public static function provideFixWithSpaceAfterArrayAssignmentColonOnlyCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * @Foo(foo="foo", bar={"foo": "foo", "bar"="bar"})
@@ -1420,9 +1420,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
         $this->testFixWithoutSpaceAfterArrayAssignmentColonOnly($expected, $input);
     }
 
-    public function provideFixWithoutSpaceAfterArrayAssignmentColonOnlyCases(): array
+    public static function provideFixWithoutSpaceAfterArrayAssignmentColonOnlyCases(): array
     {
-        return $this->createTestCases([
+        return self::createTestCases([
             ['
 /**
  * @Foo(foo="foo", bar={"foo":"foo", "bar"="bar"})

--- a/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
@@ -327,9 +327,9 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         ];
     }
 
-    public function provideInvertedFixCases(): iterable
+    public static function provideInvertedFixCases(): iterable
     {
-        return TestCaseUtils::swapExpectedInputTestCases($this->provideFixCases());
+        return TestCaseUtils::swapExpectedInputTestCases(self::provideFixCases());
     }
 
     public static function provideNonInverseOnlyFixCases(): iterable
@@ -422,9 +422,9 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         ];
     }
 
-    public function provideInvertedFixPhp74Cases(): iterable
+    public static function provideInvertedFixPhp74Cases(): iterable
     {
-        return TestCaseUtils::swapExpectedInputTestCases($this->provideFixPhp74Cases());
+        return TestCaseUtils::swapExpectedInputTestCases(self::provideFixPhp74Cases());
     }
 
     /**
@@ -503,9 +503,9 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         ];
     }
 
-    public function provideInvertedFix80Cases(): iterable
+    public static function provideInvertedFix80Cases(): iterable
     {
-        return TestCaseUtils::swapExpectedInputTestCases($this->provideFix80Cases());
+        return TestCaseUtils::swapExpectedInputTestCases(self::provideFix80Cases());
     }
 
     /**

--- a/tests/Fixer/ListNotation/ListSyntaxFixerTest.php
+++ b/tests/Fixer/ListNotation/ListSyntaxFixerTest.php
@@ -42,10 +42,10 @@ final class ListSyntaxFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixToLongSyntaxCases(): iterable
+    public static function provideFixToLongSyntaxCases(): iterable
     {
         // reverse testing
-        $shortCases = $this->provideFixToShortSyntaxCases();
+        $shortCases = self::provideFixToShortSyntaxCases();
 
         foreach ($shortCases as $label => $shortCase) {
             if ('messy comments case' === $label) {
@@ -208,9 +208,9 @@ $a;#
         ];
     }
 
-    public function provideFixToLongSyntaxPhp72Cases(): iterable
+    public static function provideFixToLongSyntaxPhp72Cases(): iterable
     {
-        return TestCaseUtils::swapExpectedInputTestCases($this->provideFixToShortSyntaxPhp72Cases());
+        return TestCaseUtils::swapExpectedInputTestCases(self::provideFixToShortSyntaxPhp72Cases());
     }
 
     /**
@@ -249,9 +249,9 @@ $a;#
         ];
     }
 
-    public function provideFixToLongSyntaxPhp73Cases(): iterable
+    public static function provideFixToLongSyntaxPhp73Cases(): iterable
     {
-        return TestCaseUtils::swapExpectedInputTestCases($this->provideFixToShortSyntaxPhp73Cases());
+        return TestCaseUtils::swapExpectedInputTestCases(self::provideFixToShortSyntaxPhp73Cases());
     }
 
     /**

--- a/tests/Fixer/Operator/IncrementStyleFixerTest.php
+++ b/tests/Fixer/Operator/IncrementStyleFixerTest.php
@@ -46,11 +46,11 @@ final class IncrementStyleFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixPostIncrementCases(): array
+    public static function provideFixPostIncrementCases(): array
     {
         return array_map(static function (array $case): array {
             return array_reverse($case);
-        }, $this->provideFixPreIncrementCases());
+        }, self::provideFixPreIncrementCases());
     }
 
     public static function provideFixPreIncrementCases(): array

--- a/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
@@ -48,7 +48,7 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
         }
     }
 
-    public function provideTestFixCases(): array
+    public static function provideTestFixCases(): array
     {
         $cases = [
             ['$sth->assertSame(true, $foo);'],
@@ -141,11 +141,11 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
                     ',
                 ],
             ],
-            $this->generateCases('$this->assert%s%s($a); //%s %s', '$this->assert%s(%s, $a); //%s %s'),
-            $this->generateCases('$this->assert%s%s($a, "%s", "%s");', '$this->assert%s(%s, $a, "%s", "%s");'),
-            $this->generateCases('static::assert%s%s($a); //%s %s', 'static::assert%s(%s, $a); //%s %s'),
-            $this->generateCases('STATIC::assert%s%s($a); //%s %s', 'STATIC::assert%s(%s, $a); //%s %s'),
-            $this->generateCases('self::assert%s%s($a); //%s %s', 'self::assert%s(%s, $a); //%s %s')
+            self::generateCases('$this->assert%s%s($a); //%s %s', '$this->assert%s(%s, $a); //%s %s'),
+            self::generateCases('$this->assert%s%s($a, "%s", "%s");', '$this->assert%s(%s, $a, "%s", "%s");'),
+            self::generateCases('static::assert%s%s($a); //%s %s', 'static::assert%s(%s, $a); //%s %s'),
+            self::generateCases('STATIC::assert%s%s($a); //%s %s', 'STATIC::assert%s(%s, $a); //%s %s'),
+            self::generateCases('self::assert%s%s($a); //%s %s', 'self::assert%s(%s, $a); //%s %s')
         );
     }
 
@@ -205,7 +205,7 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
     /**
      * @return list<array{string, string}>
      */
-    private function generateCases(string $expectedTemplate, string $inputTemplate): array
+    private static function generateCases(string $expectedTemplate, string $inputTemplate): array
     {
         $functionTypes = ['Same' => true, 'NotSame' => false, 'Equals' => true, 'NotEquals' => false];
         $cases = [];

--- a/tests/Fixer/PhpUnit/PhpUnitStrictFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitStrictFixerTest.php
@@ -37,13 +37,13 @@ final class PhpUnitStrictFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideTestFixCases(): iterable
+    public static function provideTestFixCases(): iterable
     {
         yield ['<?php $self->foo();'];
 
         yield [self::generateTest('$self->foo();')];
 
-        foreach ($this->getMethodsMap() as $methodBefore => $methodAfter) {
+        foreach (self::getMethodsMap() as $methodBefore => $methodAfter) {
             yield [self::generateTest("\$sth->{$methodBefore}(1, 1);")];
 
             yield [self::generateTest("\$sth->{$methodAfter}(1, 1);")];
@@ -91,7 +91,7 @@ final class PhpUnitStrictFixerTest extends AbstractFixerTestCase
             ];
         }
 
-        foreach ($this->getMethodsMap() as $methodBefore => $methodAfter) {
+        foreach (self::getMethodsMap() as $methodBefore => $methodAfter) {
             yield [
                 self::generateTest("static::{$methodAfter}(1, 2,);"),
                 self::generateTest("static::{$methodBefore}(1, 2,);"),
@@ -115,11 +115,11 @@ final class PhpUnitStrictFixerTest extends AbstractFixerTestCase
         $this->doTest($expected);
     }
 
-    public function provideTestNoFixWithWrongNumberOfArgumentsCases(): array
+    public static function provideTestNoFixWithWrongNumberOfArgumentsCases(): array
     {
         $cases = [];
 
-        foreach ($this->getMethodsMap() as $candidate => $fix) {
+        foreach (self::getMethodsMap() as $candidate => $fix) {
             $cases[sprintf('do not change call to "%s" without arguments.', $candidate)] = [
                 self::generateTest(sprintf('$this->%s();', $candidate)),
             ];
@@ -151,7 +151,7 @@ final class PhpUnitStrictFixerTest extends AbstractFixerTestCase
     /**
      * @return array<string, string>
      */
-    private function getMethodsMap(): array
+    private static function getMethodsMap(): array
     {
         return [
             'assertAttributeEquals' => 'assertAttributeSame',

--- a/tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
@@ -32,9 +32,9 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
-        return $this->withLongArraySyntaxCases([
+        return self::withLongArraySyntaxCases([
             [
                 <<<'EXPECTED'
 <?php
@@ -863,9 +863,9 @@ INPUT
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithTabsCases(): array
+    public static function provideFixWithTabsCases(): array
     {
-        return $this->withLongArraySyntaxCases([
+        return self::withLongArraySyntaxCases([
             [
                 <<<EXPECTED
 <?php
@@ -956,14 +956,14 @@ class Foo {
      *
      * @return list<array{0: string, 1?: string}>
      */
-    private function withLongArraySyntaxCases(array $cases): array
+    private static function withLongArraySyntaxCases(array $cases): array
     {
         $longSyntaxCases = [];
 
         foreach ($cases as $case) {
-            $case[0] = $this->toLongArraySyntax($case[0]);
+            $case[0] = self::toLongArraySyntax($case[0]);
             if (isset($case[1])) {
-                $case[1] = $this->toLongArraySyntax($case[1]);
+                $case[1] = self::toLongArraySyntax($case[1]);
             }
 
             $longSyntaxCases[] = $case;
@@ -972,7 +972,7 @@ class Foo {
         return array_merge($cases, $longSyntaxCases);
     }
 
-    private function toLongArraySyntax(string $php): string
+    private static function toLongArraySyntax(string $php): string
     {
         return strtr($php, [
             '[' => 'array(',

--- a/tests/Fixer/Whitespace/IndentationTypeFixerTest.php
+++ b/tests/Fixer/Whitespace/IndentationTypeFixerTest.php
@@ -307,10 +307,10 @@ function myFunction() {
         $this->doTest($input, $expected);
     }
 
-    public function provideMessyWhitespacesReversedCases(): array
+    public static function provideMessyWhitespacesReversedCases(): array
     {
         return array_filter(
-            $this->provideMessyWhitespacesCases(),
+            self::provideMessyWhitespacesCases(),
             static function (string $key): bool {
                 return !str_contains($key, 'mix indentation');
             },

--- a/tests/Fixer/Whitespace/LineEndingFixerTest.php
+++ b/tests/Fixer/Whitespace/LineEndingFixerTest.php
@@ -34,9 +34,9 @@ final class LineEndingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public static function provideFixCases(): array
     {
-        $cases = $this->provideCommonCases();
+        $cases = self::provideCommonCases();
 
         $cases[] = [
             "<?php \$b = \" \$a \r\n 123\"; \$a = <<<TEST\nAAAAA \n |\nTEST;\n",
@@ -84,11 +84,11 @@ final class LineEndingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): iterable
+    public static function provideMessyWhitespacesCases(): iterable
     {
         yield from array_map(static function (array $case): array {
             return array_reverse($case);
-        }, $this->provideCommonCases());
+        }, self::provideCommonCases());
 
         yield [
             "<?php \$b = \" \$a \r\n 123\"; \$a = <<<TEST\r\nAAAAA \r\n |\r\nTEST;\r\n",
@@ -101,7 +101,7 @@ final class LineEndingFixerTest extends AbstractFixerTestCase
         ];
     }
 
-    private function provideCommonCases(): array
+    private static function provideCommonCases(): array
     {
         return [
             'T_OPEN_TAG' => [

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -354,7 +354,7 @@ abstract class AbstractFixerTestCase extends TestCase
         return new $fixerClassName();
     }
 
-    protected function getTestFile(string $filename = __FILE__): \SplFileInfo
+    protected static function getTestFile(string $filename = __FILE__): \SplFileInfo
     {
         static $files = [];
 
@@ -385,7 +385,7 @@ abstract class AbstractFixerTestCase extends TestCase
             throw new \InvalidArgumentException('Input parameter must not be equal to expected parameter.');
         }
 
-        $file ??= $this->getTestFile();
+        $file ??= self::getTestFile();
         $fileIsSupported = $this->fixer->supports($file);
 
         if (null !== $input) {


### PR DESCRIPTION
Part 1 of 2 - for fixers it is a very simple change.