### PR TITLE
feature: Add align_multiline_comment rule to @Symfony

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -14,7 +14,7 @@ List of Available Rules
      | Default value: ``'phpdocs_only'``
 
 
-   Part of rule set `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
+   Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Phpdoc\\AlignMultilineCommentFixer <./../src/Fixer/Phpdoc/AlignMultilineCommentFixer.php>`_
 -  `array_indentation <./rules/whitespace/array_indentation.rst>`_

--- a/doc/ruleSets/PhpCsFixer.rst
+++ b/doc/ruleSets/PhpCsFixer.rst
@@ -9,7 +9,6 @@ Rules
 
 - `@PER <./PER.rst>`_
 - `@Symfony <./Symfony.rst>`_
-- `align_multiline_comment <./../rules/phpdoc/align_multiline_comment.rst>`_
 - `array_indentation <./../rules/whitespace/array_indentation.rst>`_
 - `blank_line_before_statement <./../rules/whitespace/blank_line_before_statement.rst>`_
   config:

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -8,6 +8,7 @@ Rules
 -----
 
 - `@PSR12 <./PSR12.rst>`_
+- `align_multiline_comment <./../rules/phpdoc/align_multiline_comment.rst>`_
 - `array_syntax <./../rules/array_notation/array_syntax.rst>`_
 - `backtick_to_shell_exec <./../rules/alias/backtick_to_shell_exec.rst>`_
 - `binary_operator_spaces <./../rules/operator/binary_operator_spaces.rst>`_

--- a/doc/rules/phpdoc/align_multiline_comment.rst
+++ b/doc/rules/phpdoc/align_multiline_comment.rst
@@ -79,7 +79,10 @@ With configuration: ``['comment_type' => 'all_multiline']``.
 Rule sets
 ---------
 
-The rule is part of the following rule set:
+The rule is part of the following rule sets:
 
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``align_multiline_comment`` rule with the default config.
+
+@Symfony
+  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``align_multiline_comment`` rule with the default config.

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -26,7 +26,6 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
         return [
             '@PER' => true,
             '@Symfony' => true,
-            'align_multiline_comment' => true,
             'array_indentation' => true,
             'blank_line_before_statement' => [
                 'statements' => [

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -25,6 +25,7 @@ final class SymfonySet extends AbstractRuleSetDescription
     {
         return [
             '@PSR12' => true,
+            'align_multiline_comment' => true,
             'array_syntax' => true,
             'backtick_to_shell_exec' => true,
             'binary_operator_spaces' => true,


### PR DESCRIPTION
After a discussion with @stof, this rule should be part of the `@Symfony` PHP-CS-Fixer ruleset.
Symfony code base is (almost, see https://github.com/symfony/symfony/pull/49895) following it already