### PR TITLE
feature: Add operator_linebreak rule to @Symfony

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1883,7 +1883,7 @@ List of Available Rules
      | Default value: ``'beginning'``
 
 
-   Part of rule set `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
+   Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Operator\\OperatorLinebreakFixer <./../src/Fixer/Operator/OperatorLinebreakFixer.php>`_
 -  `ordered_class_elements <./rules/class_notation/ordered_class_elements.rst>`_

--- a/doc/ruleSets/PhpCsFixer.rst
+++ b/doc/ruleSets/PhpCsFixer.rst
@@ -39,9 +39,6 @@ Rules
   ``['statements' => ['break', 'clone', 'continue', 'echo_print', 'negative_instanceof', 'others', 'return', 'switch_case', 'yield', 'yield_from']]``
 - `no_useless_else <./../rules/control_structure/no_useless_else.rst>`_
 - `no_useless_return <./../rules/return_notation/no_useless_return.rst>`_
-- `operator_linebreak <./../rules/operator/operator_linebreak.rst>`_
-  config:
-  ``['only_booleans' => true]``
 - `ordered_class_elements <./../rules/class_notation/ordered_class_elements.rst>`_
 - `php_unit_internal_class <./../rules/php_unit/php_unit_internal_class.rst>`_
 - `php_unit_test_class_requires_covers <./../rules/php_unit/php_unit_test_class_requires_covers.rst>`_

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -87,6 +87,9 @@ Rules
 - `no_whitespace_before_comma_in_array <./../rules/array_notation/no_whitespace_before_comma_in_array.rst>`_
 - `normalize_index_brace <./../rules/array_notation/normalize_index_brace.rst>`_
 - `object_operator_without_whitespace <./../rules/operator/object_operator_without_whitespace.rst>`_
+- `operator_linebreak <./../rules/operator/operator_linebreak.rst>`_
+  config:
+  ``['only_booleans' => true]``
 - `ordered_imports <./../rules/import/ordered_imports.rst>`_
   config:
   ``['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha']``

--- a/doc/rules/operator/operator_linebreak.rst
+++ b/doc/rules/operator/operator_linebreak.rst
@@ -66,9 +66,14 @@ With configuration: ``['position' => 'end']``.
 Rule sets
 ---------
 
-The rule is part of the following rule set:
+The rule is part of the following rule sets:
 
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``operator_linebreak`` rule with the config below:
+
+  ``['only_booleans' => true]``
+
+@Symfony
+  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``operator_linebreak`` rule with the config below:
 
   ``['only_booleans' => true]``

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -100,9 +100,6 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
             ],
             'no_useless_else' => true,
             'no_useless_return' => true,
-            'operator_linebreak' => [
-                'only_booleans' => true,
-            ],
             'ordered_class_elements' => true,
             'php_unit_internal_class' => true,
             'php_unit_test_class_requires_covers' => true,

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -134,6 +134,9 @@ final class SymfonySet extends AbstractRuleSetDescription
             'no_whitespace_before_comma_in_array' => true,
             'normalize_index_brace' => true,
             'object_operator_without_whitespace' => true,
+            'operator_linebreak' => [
+                'only_booleans' => true,
+            ],
             'ordered_imports' => [
                 'imports_order' => [
                     'class',


### PR DESCRIPTION
After a discussion with @stof, this rule should be part of the `@Symfony` PHP-CS-Fixer ruleset.
Symfony code base is (almost, see https://github.com/symfony/symfony/pull/49897) following it already