### PR TITLE
DX: Include self_static_accessor fixer in PhpCsFixer set

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2725,6 +2725,8 @@ List of Available Rules
 
    Inside a ``final`` class or anonymous class ``self`` should be preferred to ``static``.
 
+   Part of rule set `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
+
    `Source PhpCsFixer\\Fixer\\ClassNotation\\SelfStaticAccessorFixer <./../src/Fixer/ClassNotation/SelfStaticAccessorFixer.php>`_
 -  `semicolon_after_instruction <./rules/semicolon/semicolon_after_instruction.rst>`_
 

--- a/doc/ruleSets/PhpCsFixer.rst
+++ b/doc/ruleSets/PhpCsFixer.rst
@@ -46,6 +46,7 @@ Rules
 - `phpdoc_types_order <./../rules/phpdoc/phpdoc_types_order.rst>`_
 - `phpdoc_var_annotation_correct_order <./../rules/phpdoc/phpdoc_var_annotation_correct_order.rst>`_
 - `return_assignment <./../rules/return_notation/return_assignment.rst>`_
+- `self_static_accessor <./../rules/class_notation/self_static_accessor.rst>`_
 - `single_line_comment_style <./../rules/comment/single_line_comment_style.rst>`_
 - `whitespace_after_comma_in_array <./../rules/array_notation/whitespace_after_comma_in_array.rst>`_
   config:

--- a/doc/rules/class_notation/self_static_accessor.rst
+++ b/doc/rules/class_notation/self_static_accessor.rst
@@ -81,3 +81,11 @@ Example #4
    +        return self::class;
         }
     };
+
+Rule sets
+---------
+
+The rule is part of the following rule set:
+
+@PhpCsFixer
+  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``self_static_accessor`` rule.

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -43,8 +43,8 @@ final class HelpCommand extends BaseHelpCommand
     public static function toString($value): string
     {
         return \is_array($value)
-            ? static::arrayToString($value)
-            : static::scalarToString($value);
+            ? self::arrayToString($value)
+            : self::scalarToString($value);
     }
 
     /**
@@ -116,12 +116,12 @@ final class HelpCommand extends BaseHelpCommand
 
         foreach ($value as $k => $v) {
             if ($isHash) {
-                $str .= static::scalarToString($k).' => ';
+                $str .= self::scalarToString($k).' => ';
             }
 
             $str .= \is_array($v)
-                ? static::arrayToString($v).', '
-                : static::scalarToString($v).', ';
+                ? self::arrayToString($v).', '
+                : self::scalarToString($v).', ';
         }
 
         return substr($str, 0, -2).']';

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -107,6 +107,7 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
             'phpdoc_types_order' => true,
             'phpdoc_var_annotation_correct_order' => true,
             'return_assignment' => true,
+            'self_static_accessor' => true,
             'single_line_comment_style' => true,
             'single_line_throw' => false,
             'whitespace_after_comma_in_array' => ['ensure_single_space' => true],

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -406,7 +406,7 @@ final class Token
      */
     public function isKeyword(): bool
     {
-        $keywords = static::getKeywords();
+        $keywords = self::getKeywords();
 
         return $this->isArray && isset($keywords[$this->id]);
     }
@@ -428,7 +428,7 @@ final class Token
      */
     public function isMagicConstant(): bool
     {
-        $magicConstants = static::getMagicConstants();
+        $magicConstants = self::getMagicConstants();
 
         return $this->isArray && isset($magicConstants[$this->id]);
     }

--- a/tests/AbstractFixerTest.php
+++ b/tests/AbstractFixerTest.php
@@ -29,16 +29,16 @@ final class AbstractFixerTest extends TestCase
     {
         $fixer = new UnconfigurableFixer();
 
-        static::assertFalse($fixer->isRisky());
-        static::assertTrue($fixer->supports(new \SplFileInfo(__FILE__)));
+        self::assertFalse($fixer->isRisky());
+        self::assertTrue($fixer->supports(new \SplFileInfo(__FILE__)));
     }
 
     public function testConfigureUnconfigurable(): void
     {
         $fixer = new UnconfigurableFixer();
 
-        static::assertSame(0, $fixer->getPriority());
-        static::assertSame('unconfigurable', $fixer->getName());
+        self::assertSame(0, $fixer->getPriority());
+        self::assertSame('unconfigurable', $fixer->getName());
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Cannot configure using Abstract parent, child not implementing "PhpCsFixer\Fixer\ConfigurableFixerInterface".');
@@ -82,8 +82,8 @@ final class AbstractFixerTest extends TestCase
 
         $config = $fixer->getWhitespacesConfig();
 
-        static::assertSame('    ', $config->getIndent());
-        static::assertSame("\n", $config->getLineEnding());
+        self::assertSame('    ', $config->getIndent());
+        self::assertSame("\n", $config->getLineEnding());
 
         $newConfig = new WhitespacesFixerConfig("\t", "\r\n");
 
@@ -91,7 +91,7 @@ final class AbstractFixerTest extends TestCase
 
         $config = $fixer->getWhitespacesConfig();
 
-        static::assertSame("\t", $config->getIndent());
-        static::assertSame("\r\n", $config->getLineEnding());
+        self::assertSame("\t", $config->getIndent());
+        self::assertSame("\r\n", $config->getLineEnding());
     }
 }

--- a/tests/AbstractFunctionReferenceFixerTest.php
+++ b/tests/AbstractFunctionReferenceFixerTest.php
@@ -38,11 +38,11 @@ final class AbstractFunctionReferenceFixerTest extends TestCase
     ): void {
         $fixer = new FunctionReferenceTestFixer();
 
-        static::assertTrue($fixer->isRisky());
+        self::assertTrue($fixer->isRisky());
 
         $tokens = Tokens::fromCode($source);
 
-        static::assertSame(
+        self::assertSame(
             $expected,
             $fixer->findTest(
                 $functionNameToSearch,
@@ -52,7 +52,7 @@ final class AbstractFunctionReferenceFixerTest extends TestCase
             )
         );
 
-        static::assertFalse($tokens->isChanged());
+        self::assertFalse($tokens->isChanged());
     }
 
     public static function provideAbstractFunctionReferenceFixerCases(): array

--- a/tests/AbstractProxyFixerTest.php
+++ b/tests/AbstractProxyFixerTest.php
@@ -33,26 +33,26 @@ final class AbstractProxyFixerTest extends TestCase
     public function testCandidate(): void
     {
         $proxyFixer = $this->buildProxyFixer([new SimpleFixer(true)]);
-        static::assertTrue($proxyFixer->isCandidate(new Tokens()));
+        self::assertTrue($proxyFixer->isCandidate(new Tokens()));
 
         $proxyFixer = $this->buildProxyFixer([new SimpleFixer(false)]);
-        static::assertFalse($proxyFixer->isCandidate(new Tokens()));
+        self::assertFalse($proxyFixer->isCandidate(new Tokens()));
 
         $proxyFixer = $this->buildProxyFixer([
             new SimpleFixer(false),
             new SimpleFixer(true),
         ]);
 
-        static::assertTrue($proxyFixer->isCandidate(new Tokens()));
+        self::assertTrue($proxyFixer->isCandidate(new Tokens()));
     }
 
     public function testRisky(): void
     {
         $proxyFixer = $this->buildProxyFixer([new SimpleFixer(true, false)]);
-        static::assertFalse($proxyFixer->isRisky());
+        self::assertFalse($proxyFixer->isRisky());
 
         $proxyFixer = $this->buildProxyFixer([new SimpleFixer(true, true)]);
-        static::assertTrue($proxyFixer->isRisky());
+        self::assertTrue($proxyFixer->isRisky());
 
         $proxyFixer = $this->buildProxyFixer([
             new SimpleFixer(true, false),
@@ -60,7 +60,7 @@ final class AbstractProxyFixerTest extends TestCase
             new SimpleFixer(true, false),
         ]);
 
-        static::assertTrue($proxyFixer->isRisky());
+        self::assertTrue($proxyFixer->isRisky());
     }
 
     public function testSupports(): void
@@ -68,10 +68,10 @@ final class AbstractProxyFixerTest extends TestCase
         $file = new \SplFileInfo(__FILE__);
 
         $proxyFixer = $this->buildProxyFixer([new SimpleFixer(true, false, false)]);
-        static::assertFalse($proxyFixer->supports($file));
+        self::assertFalse($proxyFixer->supports($file));
 
         $proxyFixer = $this->buildProxyFixer([new SimpleFixer(true, true, true)]);
-        static::assertTrue($proxyFixer->supports($file));
+        self::assertTrue($proxyFixer->supports($file));
 
         $proxyFixer = $this->buildProxyFixer([
             new SimpleFixer(true, false, false),
@@ -79,13 +79,13 @@ final class AbstractProxyFixerTest extends TestCase
             new SimpleFixer(true, false, true),
         ]);
 
-        static::assertTrue($proxyFixer->supports($file));
+        self::assertTrue($proxyFixer->supports($file));
     }
 
     public function testPrioritySingleFixer(): void
     {
         $proxyFixer = $this->buildProxyFixer([new SimpleFixer(true, false, false, 123)]);
-        static::assertSame(123, $proxyFixer->getPriority());
+        self::assertSame(123, $proxyFixer->getPriority());
     }
 
     public function testPriorityMultipleFixersNotSet(): void
@@ -115,7 +115,7 @@ final class AbstractProxyFixerTest extends TestCase
 
         $proxyFixer->setWhitespacesConfig($config);
 
-        static::assertSame($config, $whitespacesAwareFixer->getWhitespacesFixerConfig());
+        self::assertSame($config, $whitespacesAwareFixer->getWhitespacesFixerConfig());
     }
 
     public function testApplyFixInPriorityOrder(): void
@@ -126,8 +126,8 @@ final class AbstractProxyFixerTest extends TestCase
         $proxyFixer = $this->buildProxyFixer([$fixer1, $fixer2]);
         $proxyFixer->fix(new \SplFileInfo(__FILE__), Tokens::fromCode('<?php echo 1;'));
 
-        static::assertSame(2, $fixer1->isFixCalled());
-        static::assertSame(1, $fixer2->isFixCalled());
+        self::assertSame(2, $fixer1->isFixCalled());
+        self::assertSame(1, $fixer2->isFixCalled());
     }
 
     /**

--- a/tests/AutoReview/CiConfigurationTest.php
+++ b/tests/AutoReview/CiConfigurationTest.php
@@ -52,11 +52,11 @@ final class CiConfigurationTest extends TestCase
             self::generateMinorVersionsRange($supportedMinPhp, $supportedMaxPhp)
         );
 
-        static::assertTrue(\count($supportedVersions) > 0);
+        self::assertTrue(\count($supportedVersions) > 0);
 
         $ciVersions = $this->getAllPhpVersionsUsedByCiForTests();
 
-        static::assertNotEmpty($ciVersions);
+        self::assertNotEmpty($ciVersions);
 
         self::assertSupportedPhpVersionsAreCoveredByCiJobs($supportedVersions, $ciVersions);
         self::assertUpcomingPhpVersionIsCoveredByCiJob(end($supportedVersions), $ciVersions);
@@ -73,11 +73,11 @@ final class CiConfigurationTest extends TestCase
             $expectedPhp = (string) ((float) $expectedPhp - 0.1);
         }
 
-        static::assertGreaterThanOrEqual(1, \count($ciVersionsForDeployments));
-        static::assertGreaterThanOrEqual(1, \count($ciVersions));
+        self::assertGreaterThanOrEqual(1, \count($ciVersionsForDeployments));
+        self::assertGreaterThanOrEqual(1, \count($ciVersions));
 
         foreach ($ciVersionsForDeployments as $ciVersionsForDeployment) {
-            static::assertTrue(
+            self::assertTrue(
                 version_compare($expectedPhp, $ciVersionsForDeployment, 'eq'),
                 sprintf('Expects %s to be %s', $ciVersionsForDeployment, $expectedPhp)
             );
@@ -101,7 +101,7 @@ final class CiConfigurationTest extends TestCase
     private static function ensureTraversableContainsIdenticalIsAvailable(): void
     {
         if (!class_exists(TraversableContainsIdentical::class)) {
-            static::markTestSkipped('TraversableContainsIdentical not available.');
+            self::markTestSkipped('TraversableContainsIdentical not available.');
         }
     }
 
@@ -117,7 +117,7 @@ final class CiConfigurationTest extends TestCase
 
         self::ensureTraversableContainsIdenticalIsAvailable();
 
-        static::assertThat($ciVersions, static::logicalOr(
+        self::assertThat($ciVersions, self::logicalOr(
             // if `$lastsupportedVersion` is already a snapshot version
             new TraversableContainsIdentical(sprintf('%.1fsnapshot', $lastSupportedVersion)),
             // if `$lastsupportedVersion` is not snapshot version, expect CI to run snapshot of next PHP version
@@ -138,12 +138,12 @@ final class CiConfigurationTest extends TestCase
         $lastSupportedVersion = array_pop($supportedVersions);
 
         foreach ($supportedVersions as $expectedVersion) {
-            static::assertContains($expectedVersion, $ciVersions);
+            self::assertContains($expectedVersion, $ciVersions);
         }
 
         self::ensureTraversableContainsIdenticalIsAvailable();
 
-        static::assertThat($ciVersions, static::logicalOr(
+        self::assertThat($ciVersions, self::logicalOr(
             new TraversableContainsIdentical($lastSupportedVersion),
             new TraversableContainsIdentical(sprintf('%.1fsnapshot', $lastSupportedVersion))
         ));

--- a/tests/AutoReview/CommandTest.php
+++ b/tests/AutoReview/CommandTest.php
@@ -35,7 +35,7 @@ final class CommandTest extends TestCase
      */
     public function testCommandHasNameConst(Command $command): void
     {
-        static::assertNotNull($command::getDefaultName());
+        self::assertNotNull($command::getDefaultName());
     }
 
     public static function provideCommandHasNameConstCases(): array

--- a/tests/AutoReview/DescribeCommandTest.php
+++ b/tests/AutoReview/DescribeCommandTest.php
@@ -46,7 +46,7 @@ final class DescribeCommandTest extends TestCase
             'name' => $fixerName,
         ]);
 
-        static::assertSame(0, $commandTester->getStatusCode());
+        self::assertSame(0, $commandTester->getStatusCode());
     }
 
     public static function provideDescribeCommandCases(): iterable

--- a/tests/AutoReview/DocumentationTest.php
+++ b/tests/AutoReview/DocumentationTest.php
@@ -47,7 +47,7 @@ final class DocumentationTest extends TestCase
 
         $path = $locator->getFixerDocumentationFilePath($fixer);
 
-        static::assertFileExists($path);
+        self::assertFileExists($path);
 
         $expected = $generator->generateFixerDocumentation($fixer);
         $actual = file_get_contents($path);
@@ -89,7 +89,7 @@ final class DocumentationTest extends TestCase
             $expected
         );
 
-        static::assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     public static function provideFixerCases(): iterable
@@ -114,7 +114,7 @@ final class DocumentationTest extends TestCase
     {
         $generator = new DocumentationLocator();
 
-        static::assertCount(
+        self::assertCount(
             \count($this->getFixers()) + 1,
             (new Finder())->files()->in($generator->getFixersDocumentationDirectoryPath())
         );
@@ -131,7 +131,7 @@ final class DocumentationTest extends TestCase
         foreach (RuleSets::getSetDefinitions() as $name => $definition) {
             $paths[$name] = $path = $locator->getRuleSetsDocumentationFilePath($name);
 
-            static::assertFileEqualsString(
+            self::assertFileEqualsString(
                 $generator->generateRuleSetsDocumentation($definition, $fixers),
                 $path,
                 sprintf('RuleSet documentation is generated (please see CONTRIBUTING.md), file "%s".', $path)
@@ -140,7 +140,7 @@ final class DocumentationTest extends TestCase
 
         $indexFilePath = $locator->getRuleSetsDocumentationIndexFilePath();
 
-        static::assertFileEqualsString(
+        self::assertFileEqualsString(
             $generator->generateRuleSetsDocumentationIndex($paths),
             $indexFilePath,
             sprintf('RuleSet documentation is generated (please CONTRIBUTING.md), file "%s".', $indexFilePath)
@@ -151,7 +151,7 @@ final class DocumentationTest extends TestCase
     {
         $generator = new DocumentationLocator();
 
-        static::assertCount(
+        self::assertCount(
             \count(RuleSets::getSetDefinitions()) + 1,
             (new Finder())->files()->in($generator->getRuleSetsDocumentationDirectoryPath())
         );
@@ -167,7 +167,7 @@ final class DocumentationTest extends TestCase
         $minimumVersionInformation = sprintf('PHP needs to be a minimum version of PHP %s.', $minimumVersion);
         $installationDocPath = realpath(__DIR__.'/../../doc/installation.rst');
 
-        static::assertStringContainsString(
+        self::assertStringContainsString(
             $minimumVersionInformation,
             file_get_contents($installationDocPath),
             sprintf('Files %s needs to contain information "%s"', $installationDocPath, $minimumVersionInformation)
@@ -182,7 +182,7 @@ final class DocumentationTest extends TestCase
         $fixers = $this->getFixers();
         $listingFilePath = $locator->getListingFilePath();
 
-        static::assertFileEqualsString(
+        self::assertFileEqualsString(
             $generator->generateListingDocumentation($fixers),
             $listingFilePath,
             sprintf('Listing documentation is generated (please CONTRIBUTING.md), file "%s".', $listingFilePath)
@@ -191,8 +191,8 @@ final class DocumentationTest extends TestCase
 
     private static function assertFileEqualsString(string $expectedString, string $actualFilePath, string $message = ''): void
     {
-        static::assertFileExists($actualFilePath, $message);
-        static::assertSame($expectedString, file_get_contents($actualFilePath), $message);
+        self::assertFileExists($actualFilePath, $message);
+        self::assertSame($expectedString, file_get_contents($actualFilePath), $message);
     }
 
     /**

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -40,9 +40,9 @@ final class FixerFactoryTest extends TestCase
 
         foreach (self::getFixerWithFixedPosition() as $fixerName => $offset) {
             if ($offset < 0) {
-                static::assertSame($fixerName, $fixers[\count($fixers) + $offset]->getName(), $fixerName);
+                self::assertSame($fixerName, $fixers[\count($fixers) + $offset]->getName(), $fixerName);
             } else {
-                static::assertSame($fixerName, $fixers[$offset]->getName(), $fixerName);
+                self::assertSame($fixerName, $fixers[$offset]->getName(), $fixerName);
             }
         }
     }
@@ -63,7 +63,7 @@ final class FixerFactoryTest extends TestCase
                 foreach ($edges as $edge) {
                     $second = $fixers[$edge];
 
-                    static::assertLessThan($first->getPriority(), $second->getPriority(), sprintf('"%s" should have less priority than "%s"', $edge, $fixerName));
+                    self::assertLessThan($first->getPriority(), $second->getPriority(), sprintf('"%s" should have less priority than "%s"', $edge, $fixerName));
                 }
             }
         }
@@ -119,22 +119,22 @@ final class FixerFactoryTest extends TestCase
             sort($expected);
             sort($actual);
 
-            static::assertSame(
+            self::assertSame(
                 sprintf('Integration of fixers: %s,%s.', $fixerName, $edge),
                 $test->getTitle(),
                 sprintf('Please fix the title in "%s".', $file)
             );
 
-            static::assertCount(2, $rules, sprintf('Only the two rules that are tested for priority should be in the ruleset of "%s".', $file));
+            self::assertCount(2, $rules, sprintf('Only the two rules that are tested for priority should be in the ruleset of "%s".', $file));
 
             foreach ($rules as $name => $config) {
-                static::assertNotFalse($config, sprintf('The rule "%s" in "%s" may not be disabled for the test.', $name, $file));
+                self::assertNotFalse($config, sprintf('The rule "%s" in "%s" may not be disabled for the test.', $name, $file));
             }
 
-            static::assertSame($expected, $actual, sprintf('The ruleset of "%s" must contain the rules for the priority test.', $file));
+            self::assertSame($expected, $actual, sprintf('The ruleset of "%s" must contain the rules for the priority test.', $file));
         }
 
-        static::assertCount(0, $missingIntegrationsTests, sprintf("There shall be an integration test. How do you know that priority set up is good, if there is no integration test to check it?\nMissing:\n- %s", implode("\n- ", $missingIntegrationsTests)));
+        self::assertCount(0, $missingIntegrationsTests, sprintf("There shall be an integration test. How do you know that priority set up is good, if there is no integration test to check it?\nMissing:\n- %s", implode("\n- ", $missingIntegrationsTests)));
     }
 
     public static function provideFixersPriorityCasesHaveIntegrationCases(): iterable
@@ -151,9 +151,9 @@ final class FixerFactoryTest extends TestCase
     {
         $fileName = $file->getFilename();
 
-        static::assertTrue($file->isFile(), sprintf('Expected only files in the priority integration test directory, got "%s".', $fileName));
-        static::assertFalse($file->isLink(), sprintf('No (sym)links expected the priority integration test directory, got "%s".', $fileName));
-        static::assertSame(
+        self::assertTrue($file->isFile(), sprintf('Expected only files in the priority integration test directory, got "%s".', $fileName));
+        self::assertFalse($file->isLink(), sprintf('No (sym)links expected the priority integration test directory, got "%s".', $fileName));
+        self::assertSame(
             1,
             preg_match('#^([a-z][a-z0-9_]*),([a-z][a-z_]*)(?:_\d{1,3})?\.test(-(in|out)\.php)?$#', $fileName, $matches),
             sprintf('File with unexpected name "%s" in the priority integration test directory.', $fileName)
@@ -162,7 +162,7 @@ final class FixerFactoryTest extends TestCase
         [, $fixerName1, $fixerName2] = $matches;
         $graph = self::getFixersPriorityGraph();
 
-        static::assertTrue(
+        self::assertTrue(
             isset($graph[$fixerName1]) && \in_array($fixerName2, $graph[$fixerName1], true),
             sprintf('Missing priority test entry for file "%s".', $fileName)
         );
@@ -182,12 +182,12 @@ final class FixerFactoryTest extends TestCase
         $previous = '';
 
         foreach (self::getFixersPriorityGraph() as $fixerName => $edges) {
-            static::assertLessThan(0, strcmp($previous, $fixerName), sprintf('Not sorted "%s" "%s".', $previous, $fixerName));
+            self::assertLessThan(0, strcmp($previous, $fixerName), sprintf('Not sorted "%s" "%s".', $previous, $fixerName));
 
             $edgesSorted = $edges;
             sort($edgesSorted);
 
-            static::assertSame($edgesSorted, $edges, sprintf('Fixer "%s" edges are not sorted', $fixerName));
+            self::assertSame($edgesSorted, $edges, sprintf('Fixer "%s" edges are not sorted', $fixerName));
             $previous = $fixerName;
         }
     }
@@ -270,7 +270,7 @@ final class FixerFactoryTest extends TestCase
                 $message .= sprintf("\n--------------------------------------------------\n%s\n%s", $fixers[$fixerName]['short_classname'], $issue);
             }
 
-            static::fail($message);
+            self::fail($message);
         }
     }
 
@@ -321,11 +321,11 @@ final class FixerFactoryTest extends TestCase
             if (isset($missing[$knownIssue])) {
                 unset($missing[$knownIssue]);
             } else {
-                static::fail(sprintf('No longer found known issue "%s", please update the set.', $knownIssue));
+                self::fail(sprintf('No longer found known issue "%s", please update the set.', $knownIssue));
             }
         }
 
-        static::assertEmpty($missing, 'Fixers without default priority and without priority tests: "'.implode('", "', array_keys($missing)).'."');
+        self::assertEmpty($missing, 'Fixers without default priority and without priority tests: "'.implode('", "', array_keys($missing)).'."');
     }
 
     /**

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -76,7 +76,7 @@ final class ProjectCodeTest extends TestCase
             static fn (string $class): bool => !class_exists($class) && !trait_exists($class),
         );
 
-        static::assertSame([], $unknownClasses);
+        self::assertSame([], $unknownClasses);
     }
 
     /**
@@ -87,12 +87,12 @@ final class ProjectCodeTest extends TestCase
         $testClassName = 'PhpCsFixer\\Tests'.substr($className, 10).'Test';
 
         if (\in_array($className, self::$classesWithoutTests, true)) {
-            static::assertFalse(class_exists($testClassName), sprintf('Class "%s" already has tests, so it should be removed from "%s::$classesWithoutTests".', $className, __CLASS__));
-            static::markTestIncomplete(sprintf('Class "%s" has no tests yet, please help and add it.', $className));
+            self::assertFalse(class_exists($testClassName), sprintf('Class "%s" already has tests, so it should be removed from "%s::$classesWithoutTests".', $className, __CLASS__));
+            self::markTestIncomplete(sprintf('Class "%s" has no tests yet, please help and add it.', $className));
         }
 
-        static::assertTrue(class_exists($testClassName), sprintf('Expected test class "%s" for "%s" not found.', $testClassName, $className));
-        static::assertTrue(is_subclass_of($testClassName, TestCase::class), sprintf('Expected test class "%s" to be a subclass of "\PhpCsFixer\Tests\TestCase".', $testClassName));
+        self::assertTrue(class_exists($testClassName), sprintf('Expected test class "%s" for "%s" not found.', $testClassName, $className));
+        self::assertTrue(is_subclass_of($testClassName, TestCase::class), sprintf('Expected test class "%s" to be a subclass of "\PhpCsFixer\Tests\TestCase".', $testClassName));
     }
 
     /**
@@ -134,7 +134,7 @@ final class ProjectCodeTest extends TestCase
 
         sort($extraMethods);
 
-        static::assertEmpty(
+        self::assertEmpty(
             $extraMethods,
             sprintf(
                 "Class '%s' should not have public methods that are not part of implemented interfaces.\nViolations:\n%s",
@@ -153,7 +153,7 @@ final class ProjectCodeTest extends TestCase
     {
         $rc = new \ReflectionClass($className);
 
-        static::assertEmpty(
+        self::assertEmpty(
             $rc->getProperties(\ReflectionProperty::IS_PUBLIC),
             sprintf('Class \'%s\' should not have public properties.', $className)
         );
@@ -191,7 +191,7 @@ final class ProjectCodeTest extends TestCase
 
         sort($extraProps);
 
-        static::assertEmpty(
+        self::assertEmpty(
             $extraProps,
             sprintf(
                 "Class '%s' should not have protected properties.\nViolations:\n%s",
@@ -210,7 +210,7 @@ final class ProjectCodeTest extends TestCase
     {
         $rc = new \ReflectionClass($testClassName);
 
-        static::assertTrue(
+        self::assertTrue(
             $rc->isTrait() || $rc->isAbstract() || $rc->isFinal(),
             sprintf('Test class %s should be trait, abstract or final.', $testClassName)
         );
@@ -224,7 +224,7 @@ final class ProjectCodeTest extends TestCase
         $rc = new \ReflectionClass($testClassName);
         $doc = new DocBlock($rc->getDocComment());
 
-        static::assertNotEmpty(
+        self::assertNotEmpty(
             $doc->getAnnotationsOfType('internal'),
             sprintf('Test class %s should have internal annotation.', $testClassName)
         );
@@ -251,7 +251,7 @@ final class ProjectCodeTest extends TestCase
         }
 
         foreach ($publicMethods as $method) {
-            static::assertMatchesRegularExpression(
+            self::assertMatchesRegularExpression(
                 '/^(test|expect|provide|setUpBeforeClass$|tearDownAfterClass$)/',
                 $method->getName(),
                 sprintf('Public method "%s::%s" is not properly named.', $reflectionClass->getName(), $method->getName())
@@ -272,7 +272,7 @@ final class ProjectCodeTest extends TestCase
 
         $dataProviderName = $dataProvider->getName();
 
-        static::assertContains(
+        self::assertContains(
             $dataProviderName,
             $usedDataProviderMethodNames,
             sprintf('Data provider in "%s" with name "%s" is not used.', $dataProvider->getDeclaringClass()->getName(), $dataProviderName)
@@ -288,7 +288,7 @@ final class ProjectCodeTest extends TestCase
 
         $returnType = $dataProvider->getReturnType();
 
-        static::assertInstanceOf(
+        self::assertInstanceOf(
             \ReflectionNamedType::class,
             $returnType,
             sprintf('Data provider in "%s" with name "%s" has no return type.', $dataProvider->getDeclaringClass()->getName(), $dataProviderName)
@@ -296,7 +296,7 @@ final class ProjectCodeTest extends TestCase
 
         $returnTypeName = $returnType->getName();
 
-        static::assertTrue(
+        self::assertTrue(
             'array' === $returnTypeName || 'iterable' === $returnTypeName,
             sprintf('Data provider in "%s" with name "%s" has return type "%s", expected "array" or "iterable".', $dataProvider->getDeclaringClass()->getName(), $dataProviderName, $returnTypeName)
         );
@@ -309,7 +309,7 @@ final class ProjectCodeTest extends TestCase
     {
         $dataProviderName = $dataProvider->getShortName();
 
-        static::assertMatchesRegularExpression('/^provide[A-Z]\S+Cases$/', $dataProviderName, sprintf(
+        self::assertMatchesRegularExpression('/^provide[A-Z]\S+Cases$/', $dataProviderName, sprintf(
             'Data provider in "%s" with name "%s" is not correctly named.',
             $testClassName,
             $dataProviderName
@@ -350,14 +350,14 @@ final class ProjectCodeTest extends TestCase
         }
 
         $doc = $reflectionClass->getDocComment();
-        static::assertNotFalse($doc);
+        self::assertNotFalse($doc);
 
         if (1 === Preg::match('/@coversNothing/', $doc, $matches)) {
             return;
         }
 
         $covers = Preg::match('/@covers (\S*)/', $doc, $matches);
-        static::assertNotFalse($covers, sprintf('Missing @covers in PHPDoc of test class "%s".', $testClassName));
+        self::assertNotFalse($covers, sprintf('Missing @covers in PHPDoc of test class "%s".', $testClassName));
 
         array_shift($matches);
         $class = '\\'.str_replace('PhpCsFixer\Tests\\', 'PhpCsFixer\\', substr($testClassName, 0, -4));
@@ -365,7 +365,7 @@ final class ProjectCodeTest extends TestCase
         $parentClassName = false === $parentClass ? null : '\\'.$parentClass->getName();
 
         foreach ($matches as $match) {
-            static::assertTrue(
+            self::assertTrue(
                 $match === $class || $parentClassName === $match,
                 sprintf('Unexpected @covers "%s" for "%s".', $match, $testClassName)
             );
@@ -395,13 +395,13 @@ final class ProjectCodeTest extends TestCase
 
         $strings = array_unique($strings);
         $message = sprintf('Class %s must not use preg_*, it shall use Preg::* instead.', $className);
-        static::assertNotContains('preg_filter', $strings, $message);
-        static::assertNotContains('preg_grep', $strings, $message);
-        static::assertNotContains('preg_match', $strings, $message);
-        static::assertNotContains('preg_match_all', $strings, $message);
-        static::assertNotContains('preg_replace', $strings, $message);
-        static::assertNotContains('preg_replace_callback', $strings, $message);
-        static::assertNotContains('preg_split', $strings, $message);
+        self::assertNotContains('preg_filter', $strings, $message);
+        self::assertNotContains('preg_grep', $strings, $message);
+        self::assertNotContains('preg_match', $strings, $message);
+        self::assertNotContains('preg_match_all', $strings, $message);
+        self::assertNotContains('preg_replace', $strings, $message);
+        self::assertNotContains('preg_replace_callback', $strings, $message);
+        self::assertNotContains('preg_split', $strings, $message);
     }
 
     /**
@@ -455,7 +455,7 @@ final class ProjectCodeTest extends TestCase
                 continue;
             }
 
-            static::assertLessThan(
+            self::assertLessThan(
                 $expected['input'],
                 $expected['expected'],
                 sprintf('Public method "%s::%s" has parameter \'input\' before \'expected\'.', $reflectionClass->getName(), $method->getName())
@@ -490,7 +490,7 @@ final class ProjectCodeTest extends TestCase
         $tokens = Tokens::fromCode(file_get_contents($file));
         $classyIndex = null;
 
-        static::assertTrue($tokens->isAnyTokenKindsFound(Token::getClassyTokenKinds()), sprintf('File "%s" should contains a classy.', $file));
+        self::assertTrue($tokens->isAnyTokenKindsFound(Token::getClassyTokenKinds()), sprintf('File "%s" should contains a classy.', $file));
 
         $count = \count($tokens);
 
@@ -508,11 +508,11 @@ final class ProjectCodeTest extends TestCase
             }
 
             if (!$tokens[$index]->isGivenKind($headerTypes) && !$tokens[$index]->equalsAny([';', '=', '(', ')'])) {
-                static::fail(sprintf('File "%s" should only contains single classy, found "%s" @ %d.', $file, $tokens[$index]->toJson(), $index));
+                self::fail(sprintf('File "%s" should only contains single classy, found "%s" @ %d.', $file, $tokens[$index]->toJson(), $index));
             }
         }
 
-        static::assertNotNull($classyIndex, sprintf('File "%s" does not contain a classy.', $file));
+        self::assertNotNull($classyIndex, sprintf('File "%s" does not contain a classy.', $file));
 
         $nextTokenOfKind = $tokens->getNextTokenOfKind($classyIndex, ['{']);
 
@@ -522,7 +522,7 @@ final class ProjectCodeTest extends TestCase
 
         $classyEndIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $nextTokenOfKind);
 
-        static::assertNull($tokens->getNextNonWhitespace($classyEndIndex), sprintf('File "%s" should only contains a single classy.', $file));
+        self::assertNull($tokens->getNextNonWhitespace($classyEndIndex), sprintf('File "%s" should only contains a single classy.', $file));
     }
 
     /**
@@ -568,7 +568,7 @@ final class ProjectCodeTest extends TestCase
 
         $extraMethods = array_diff($methodsWithInheritdoc, $allowedMethods);
 
-        static::assertEmpty(
+        self::assertEmpty(
             $extraMethods,
             sprintf(
                 "Class '%s' should not have methods with '@inheritdoc' in PHPDoc that are not inheriting PHPDoc.\nViolations:\n%s",
@@ -684,7 +684,7 @@ final class ProjectCodeTest extends TestCase
     {
         $reflection = new \ReflectionClass($className);
 
-        static::assertTrue($reflection->isSubclassOf(AbstractPhpUnitFixer::class));
+        self::assertTrue($reflection->isSubclassOf(AbstractPhpUnitFixer::class));
     }
 
     public static function providePhpUnitFixerExtendsAbstractPhpUnitFixerCases(): iterable
@@ -728,7 +728,7 @@ final class ProjectCodeTest extends TestCase
 
         foreach ($reflectionClassConstants as $constant) {
             $constantName = $constant->getName();
-            static::assertSame(strtoupper($constantName), $constantName, $className);
+            self::assertSame(strtoupper($constantName), $constantName, $className);
         }
     }
 

--- a/tests/AutoReview/ProjectFixerConfigurationTest.php
+++ b/tests/AutoReview/ProjectFixerConfigurationTest.php
@@ -33,8 +33,8 @@ final class ProjectFixerConfigurationTest extends TestCase
     {
         $config = $this->loadConfig();
 
-        static::assertEmpty($config->getCustomFixers());
-        static::assertNotEmpty($config->getRules());
+        self::assertEmpty($config->getCustomFixers());
+        self::assertNotEmpty($config->getRules());
 
         // call so the fixers get configured to reveal issue (like deprecated configuration used etc.)
         $resolver = new ConfigurationResolver(
@@ -51,7 +51,7 @@ final class ProjectFixerConfigurationTest extends TestCase
     {
         $rules = $rulesSorted = array_keys($this->loadConfig()->getRules());
         sort($rulesSorted);
-        static::assertSame($rulesSorted, $rules, 'Please sort the "rules" in `.php-cs-fixer.dist.php` of this project.');
+        self::assertSame($rulesSorted, $rules, 'Please sort the "rules" in `.php-cs-fixer.dist.php` of this project.');
     }
 
     private function loadConfig(): Config

--- a/tests/AutoReview/ReadmeTest.php
+++ b/tests/AutoReview/ReadmeTest.php
@@ -42,7 +42,7 @@ final class ReadmeTest extends TestCase
         // Unset the file to call __destruct(), closing the file handle.
         $file = null;
 
-        static::assertEqualsCanonicalizing([
+        self::assertEqualsCanonicalizing([
             '    if (\PHP_VERSION_ID === 80000) {'."\n",
             '    if (\PHP_VERSION_ID < 70400 || \PHP_VERSION_ID >= 80300) {'."\n",
         ], $phpVersionIdLines, 'Seems supported PHP versions changed in "./php-cs-fixer" - edit the README.md (and this test file) to match them!');

--- a/tests/AutoReview/TransformerTest.php
+++ b/tests/AutoReview/TransformerTest.php
@@ -35,7 +35,7 @@ final class TransformerTest extends TestCase
      */
     public function testTransformerPriority(TransformerInterface $first, TransformerInterface $second): void
     {
-        static::assertLessThan(
+        self::assertLessThan(
             $first->getPriority(),
             $second->getPriority(),
             sprintf('"%s" should have less priority than "%s"', \get_class($second), \get_class($first))
@@ -67,7 +67,7 @@ final class TransformerTest extends TestCase
             }
         }
 
-        static::fail(sprintf('Transformer "%s" has priority %d but is not in priority test list.', $name, $priority));
+        self::fail(sprintf('Transformer "%s" has priority %d but is not in priority test list.', $name, $priority));
     }
 
     public static function provideTransformerPriorityCases(): array

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -35,14 +35,14 @@ final class CacheTest extends TestCase
     {
         $reflection = new \ReflectionClass(Cache::class);
 
-        static::assertTrue($reflection->isFinal());
+        self::assertTrue($reflection->isFinal());
     }
 
     public function testImplementsCacheInterface(): void
     {
         $reflection = new \ReflectionClass(Cache::class);
 
-        static::assertTrue($reflection->implementsInterface(CacheInterface::class));
+        self::assertTrue($reflection->implementsInterface(CacheInterface::class));
     }
 
     public function testConstructorSetsValues(): void
@@ -51,7 +51,7 @@ final class CacheTest extends TestCase
 
         $cache = new Cache($signature);
 
-        static::assertSame($signature, $cache->getSignature());
+        self::assertSame($signature, $cache->getSignature());
     }
 
     public function testDefaults(): void
@@ -62,8 +62,8 @@ final class CacheTest extends TestCase
 
         $file = 'test.php';
 
-        static::assertFalse($cache->has($file));
-        static::assertNull($cache->get($file));
+        self::assertFalse($cache->has($file));
+        self::assertNull($cache->get($file));
     }
 
     public function testCanSetAndGetValue(): void
@@ -77,8 +77,8 @@ final class CacheTest extends TestCase
 
         $cache->set($file, $hash);
 
-        static::assertTrue($cache->has($file));
-        static::assertSame($hash, $cache->get($file));
+        self::assertTrue($cache->has($file));
+        self::assertSame($hash, $cache->get($file));
     }
 
     public function testCanClearValue(): void
@@ -93,7 +93,7 @@ final class CacheTest extends TestCase
         $cache->set($file, $hash);
         $cache->clear($file);
 
-        static::assertNull($cache->get($file));
+        self::assertNull($cache->get($file));
     }
 
     public function testFromJsonThrowsInvalidArgumentExceptionIfJsonIsInvalid(): void
@@ -153,9 +153,9 @@ final class CacheTest extends TestCase
         $cache->set($file, $hash);
         $cached = Cache::fromJson($cache->toJson());
 
-        static::assertTrue($cached->getSignature()->equals($signature));
-        static::assertTrue($cached->has($file));
-        static::assertSame($hash, $cached->get($file));
+        self::assertTrue($cached->getSignature()->equals($signature));
+        self::assertTrue($cached->has($file));
+        self::assertSame($hash, $cached->get($file));
     }
 
     public static function provideCanConvertToAndFromJsonCases(): array

--- a/tests/Cache/DirectoryTest.php
+++ b/tests/Cache/DirectoryTest.php
@@ -31,14 +31,14 @@ final class DirectoryTest extends TestCase
     {
         $reflection = new \ReflectionClass(Directory::class);
 
-        static::assertTrue($reflection->isFinal());
+        self::assertTrue($reflection->isFinal());
     }
 
     public function testImplementsDirectoryInterface(): void
     {
         $reflection = new \ReflectionClass(Directory::class);
 
-        static::assertTrue($reflection->implementsInterface(DirectoryInterface::class));
+        self::assertTrue($reflection->implementsInterface(DirectoryInterface::class));
     }
 
     public function testGetRelativePathToReturnsFileIfAboveLevelOfDirectoryName(): void
@@ -48,7 +48,7 @@ final class DirectoryTest extends TestCase
 
         $directory = new Directory($directoryName);
 
-        static::assertSame($file, $directory->getRelativePathTo($file));
+        self::assertSame($file, $directory->getRelativePathTo($file));
     }
 
     public function testGetRelativePathToReturnsRelativePathIfWithinDirectoryName(): void
@@ -58,6 +58,6 @@ final class DirectoryTest extends TestCase
 
         $directory = new Directory($directoryName);
 
-        static::assertSame('bar'.\DIRECTORY_SEPARATOR.'hello.php', $directory->getRelativePathTo($file));
+        self::assertSame('bar'.\DIRECTORY_SEPARATOR.'hello.php', $directory->getRelativePathTo($file));
     }
 }

--- a/tests/Cache/FileCacheManagerTest.php
+++ b/tests/Cache/FileCacheManagerTest.php
@@ -35,14 +35,14 @@ final class FileCacheManagerTest extends TestCase
     {
         $reflection = new \ReflectionClass(FileCacheManager::class);
 
-        static::assertTrue($reflection->isFinal());
+        self::assertTrue($reflection->isFinal());
     }
 
     public function testImplementsCacheManagerInterface(): void
     {
         $reflection = new \ReflectionClass(FileCacheManager::class);
 
-        static::assertTrue($reflection->implementsInterface(CacheManagerInterface::class));
+        self::assertTrue($reflection->implementsInterface(CacheManagerInterface::class));
     }
 
     public function testCreatesCacheIfHandlerReturnedNoCache(): void
@@ -143,7 +143,7 @@ final class FileCacheManagerTest extends TestCase
             $signature
         );
 
-        static::assertTrue($manager->needFixing($file, $fileContent));
+        self::assertTrue($manager->needFixing($file, $fileContent));
     }
 
     public function testNeedFixingReturnsTrueIfCachedHashIsDifferent(): void
@@ -175,7 +175,7 @@ final class FileCacheManagerTest extends TestCase
             $signature
         );
 
-        static::assertTrue($manager->needFixing($file, $fileContent));
+        self::assertTrue($manager->needFixing($file, $fileContent));
     }
 
     public function testNeedFixingReturnsFalseIfCachedHashIsIdentical(): void
@@ -206,7 +206,7 @@ final class FileCacheManagerTest extends TestCase
             $signature
         );
 
-        static::assertFalse($manager->needFixing($file, $fileContent));
+        self::assertFalse($manager->needFixing($file, $fileContent));
     }
 
     public function testNeedFixingUsesRelativePathToFile(): void
@@ -244,7 +244,7 @@ final class FileCacheManagerTest extends TestCase
             $directoryProphecy->reveal()
         );
 
-        static::assertTrue($manager->needFixing($file, $fileContent));
+        self::assertTrue($manager->needFixing($file, $fileContent));
     }
 
     public function testSetFileSetsHashOfFileContent(): void

--- a/tests/Cache/FileHandlerTest.php
+++ b/tests/Cache/FileHandlerTest.php
@@ -47,7 +47,7 @@ final class FileHandlerTest extends TestCase
 
         $handler = new FileHandler($file);
 
-        static::assertInstanceOf(\PhpCsFixer\Cache\FileHandlerInterface::class, $handler);
+        self::assertInstanceOf(\PhpCsFixer\Cache\FileHandlerInterface::class, $handler);
     }
 
     public function testConstructorSetsFile(): void
@@ -56,7 +56,7 @@ final class FileHandlerTest extends TestCase
 
         $handler = new FileHandler($file);
 
-        static::assertSame($file, $handler->getFile());
+        self::assertSame($file, $handler->getFile());
     }
 
     public function testReadReturnsNullIfFileDoesNotExist(): void
@@ -65,7 +65,7 @@ final class FileHandlerTest extends TestCase
 
         $handler = new FileHandler($file);
 
-        static::assertNull($handler->read());
+        self::assertNull($handler->read());
     }
 
     public function testReadReturnsNullIfContentCanNotBeDeserialized(): void
@@ -76,7 +76,7 @@ final class FileHandlerTest extends TestCase
 
         $handler = new FileHandler($file);
 
-        static::assertNull($handler->read());
+        self::assertNull($handler->read());
     }
 
     public function testReadReturnsCache(): void
@@ -93,8 +93,8 @@ final class FileHandlerTest extends TestCase
 
         $cached = $handler->read();
 
-        static::assertInstanceOf(\PhpCsFixer\Cache\CacheInterface::class, $cached);
-        static::assertTrue($cached->getSignature()->equals($signature));
+        self::assertInstanceOf(\PhpCsFixer\Cache\CacheInterface::class, $cached);
+        self::assertTrue($cached->getSignature()->equals($signature));
     }
 
     public function testWriteThrowsIOExceptionIfFileCanNotBeWritten(): void
@@ -124,11 +124,11 @@ final class FileHandlerTest extends TestCase
 
         $handler->write($cache);
 
-        static::assertFileExists($file);
+        self::assertFileExists($file);
 
         $actualCacheJson = file_get_contents($file);
 
-        static::assertSame($cache->toJson(), $actualCacheJson);
+        self::assertSame($cache->toJson(), $actualCacheJson);
     }
 
     public function testWriteCacheToDirectory(): void
@@ -150,7 +150,7 @@ final class FileHandlerTest extends TestCase
     {
         $file = __DIR__.'/../Fixtures/cache-file-handler/cache-file';
         if (is_writable($file)) {
-            static::markTestSkipped(sprintf('File "%s" must be not writeable for this tests.', realpath($file)));
+            self::markTestSkipped(sprintf('File "%s" must be not writeable for this tests.', realpath($file)));
         }
 
         $handler = new FileHandler($file);
@@ -169,15 +169,15 @@ final class FileHandlerTest extends TestCase
         $file = __DIR__.'/../Fixtures/cache-file-handler/rw_cache.test';
         @unlink($file);
 
-        static::assertFileDoesNotExist($file);
+        self::assertFileDoesNotExist($file);
 
         $handler = new FileHandler($file);
         $handler->write(new Cache($this->createSignature()));
 
-        static::assertFileExists($file);
-        static::assertTrue(@is_file($file), sprintf('Failed cache "%s" `is_file`.', $file));
-        static::assertTrue(@is_writable($file), sprintf('Failed cache "%s" `is_writable`.', $file));
-        static::assertTrue(@is_readable($file), sprintf('Failed cache "%s" `is_readable`.', $file));
+        self::assertFileExists($file);
+        self::assertTrue(@is_file($file), sprintf('Failed cache "%s" `is_file`.', $file));
+        self::assertTrue(@is_writable($file), sprintf('Failed cache "%s" `is_writable`.', $file));
+        self::assertTrue(@is_readable($file), sprintf('Failed cache "%s" `is_readable`.', $file));
 
         @unlink($file);
     }

--- a/tests/Cache/NullCacheManagerTest.php
+++ b/tests/Cache/NullCacheManagerTest.php
@@ -30,21 +30,21 @@ final class NullCacheManagerTest extends TestCase
     {
         $reflection = new \ReflectionClass(\PhpCsFixer\Cache\NullCacheManager::class);
 
-        static::assertTrue($reflection->isFinal());
+        self::assertTrue($reflection->isFinal());
     }
 
     public function testImplementsCacheManagerInterface(): void
     {
         $reflection = new \ReflectionClass(\PhpCsFixer\Cache\NullCacheManager::class);
 
-        static::assertTrue($reflection->implementsInterface(\PhpCsFixer\Cache\CacheManagerInterface::class));
+        self::assertTrue($reflection->implementsInterface(\PhpCsFixer\Cache\CacheManagerInterface::class));
     }
 
     public function testNeedFixingReturnsTrue(): void
     {
         $manager = new NullCacheManager();
 
-        static::assertTrue($manager->needFixing('foo.php', 'bar'));
+        self::assertTrue($manager->needFixing('foo.php', 'bar'));
 
         $manager->setFile(__FILE__, 'XXX'); // no-op, should not raise an exception
     }

--- a/tests/Cache/SignatureTest.php
+++ b/tests/Cache/SignatureTest.php
@@ -30,14 +30,14 @@ final class SignatureTest extends TestCase
     {
         $reflection = new \ReflectionClass(\PhpCsFixer\Cache\Signature::class);
 
-        static::assertTrue($reflection->isFinal());
+        self::assertTrue($reflection->isFinal());
     }
 
     public function testImplementsSignatureInterface(): void
     {
         $reflection = new \ReflectionClass(\PhpCsFixer\Cache\Signature::class);
 
-        static::assertTrue($reflection->implementsInterface(\PhpCsFixer\Cache\SignatureInterface::class));
+        self::assertTrue($reflection->implementsInterface(\PhpCsFixer\Cache\SignatureInterface::class));
     }
 
     public function testConstructorSetsValues(): void
@@ -50,11 +50,11 @@ final class SignatureTest extends TestCase
 
         $signature = new Signature($php, $version, $indent, $lineEnding, $rules);
 
-        static::assertSame($php, $signature->getPhpVersion());
-        static::assertSame($version, $signature->getFixerVersion());
-        static::assertSame($indent, $signature->getIndent());
-        static::assertSame($lineEnding, $signature->getLineEnding());
-        static::assertSame($rules, $signature->getRules());
+        self::assertSame($php, $signature->getPhpVersion());
+        self::assertSame($version, $signature->getFixerVersion());
+        self::assertSame($indent, $signature->getIndent());
+        self::assertSame($lineEnding, $signature->getLineEnding());
+        self::assertSame($rules, $signature->getRules());
     }
 
     /**
@@ -62,7 +62,7 @@ final class SignatureTest extends TestCase
      */
     public function testEqualsReturnsFalseIfValuesAreNotIdentical(Signature $signature, Signature $anotherSignature): void
     {
-        static::assertFalse($signature->equals($anotherSignature));
+        self::assertFalse($signature->equals($anotherSignature));
     }
 
     public static function provideEqualsReturnsFalseIfValuesAreNotIdenticalCases(): iterable
@@ -112,6 +112,6 @@ final class SignatureTest extends TestCase
         $signature = new Signature($php, $version, $indent, $lineEnding, $rules);
         $anotherSignature = new Signature($php, $version, $indent, $lineEnding, $rules);
 
-        static::assertTrue($signature->equals($anotherSignature));
+        self::assertTrue($signature->equals($anotherSignature));
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -47,7 +47,7 @@ final class ConfigTest extends TestCase
             new ToolInfo()
         );
 
-        static::assertSame(
+        self::assertSame(
             [
                 'cast_spaces' => true,
                 'statement_indentation' => true,
@@ -68,7 +68,7 @@ final class ConfigTest extends TestCase
             new ToolInfo()
         );
 
-        static::assertSame(
+        self::assertSame(
             [
                 'array_syntax' => [
                     'syntax' => 'short',
@@ -115,7 +115,7 @@ final class ConfigTest extends TestCase
                 'verbosity' => OutputInterface::VERBOSITY_VERY_VERBOSE,
             ]
         );
-        static::assertStringMatchesFormat(
+        self::assertStringMatchesFormat(
             sprintf('%%ALoaded config custom_config_test from "%s".%%A', $customConfigFile),
             $commandTester->getDisplay(true)
         );
@@ -130,10 +130,10 @@ final class ConfigTest extends TestCase
             false
         );
 
-        static::assertCount(1, $items);
+        self::assertCount(1, $items);
 
         $item = reset($items);
-        static::assertSame('somefile.php', $item->getFilename());
+        self::assertSame('somefile.php', $item->getFilename());
     }
 
     public function testThatCustomFinderWorks(): void
@@ -148,8 +148,8 @@ final class ConfigTest extends TestCase
             false
         );
 
-        static::assertCount(1, $items);
-        static::assertSame('somefile.php', $items[0]->getFilename());
+        self::assertCount(1, $items);
+        self::assertSame('somefile.php', $items[0]->getFilename());
     }
 
     public function testThatCustomSymfonyFinderWorks(): void
@@ -164,15 +164,15 @@ final class ConfigTest extends TestCase
             false
         );
 
-        static::assertCount(1, $items);
-        static::assertSame('somefile.php', $items[0]->getFilename());
+        self::assertCount(1, $items);
+        self::assertSame('somefile.php', $items[0]->getFilename());
     }
 
     public function testThatCacheFileHasDefaultValue(): void
     {
         $config = new Config();
 
-        static::assertSame('.php-cs-fixer.cache', $config->getCacheFile());
+        self::assertSame('.php-cs-fixer.cache', $config->getCacheFile());
     }
 
     public function testThatCacheFileCanBeMutated(): void
@@ -182,14 +182,14 @@ final class ConfigTest extends TestCase
         $config = new Config();
         $config->setCacheFile($cacheFile);
 
-        static::assertSame($cacheFile, $config->getCacheFile());
+        self::assertSame($cacheFile, $config->getCacheFile());
     }
 
     public function testThatMutatorHasFluentInterface(): void
     {
         $config = new Config();
 
-        static::assertSame($config, $config->setCacheFile('some-directory/some.file'));
+        self::assertSame($config, $config->setCacheFile('some-directory/some.file'));
     }
 
     /**
@@ -203,49 +203,49 @@ final class ConfigTest extends TestCase
         $config = new Config();
         $config->registerCustomFixers($suite);
 
-        static::assertSame($expected, $config->getCustomFixers());
+        self::assertSame($expected, $config->getCustomFixers());
     }
 
     public function testConfigDefault(): void
     {
         $config = new Config();
 
-        static::assertSame('.php-cs-fixer.cache', $config->getCacheFile());
-        static::assertSame([], $config->getCustomFixers());
-        static::assertSame('txt', $config->getFormat());
-        static::assertFalse($config->getHideProgress());
-        static::assertSame('    ', $config->getIndent());
-        static::assertSame("\n", $config->getLineEnding());
-        static::assertSame('default', $config->getName());
-        static::assertNull($config->getPhpExecutable());
-        static::assertFalse($config->getRiskyAllowed());
-        static::assertSame(['@PSR12' => true], $config->getRules());
-        static::assertTrue($config->getUsingCache());
+        self::assertSame('.php-cs-fixer.cache', $config->getCacheFile());
+        self::assertSame([], $config->getCustomFixers());
+        self::assertSame('txt', $config->getFormat());
+        self::assertFalse($config->getHideProgress());
+        self::assertSame('    ', $config->getIndent());
+        self::assertSame("\n", $config->getLineEnding());
+        self::assertSame('default', $config->getName());
+        self::assertNull($config->getPhpExecutable());
+        self::assertFalse($config->getRiskyAllowed());
+        self::assertSame(['@PSR12' => true], $config->getRules());
+        self::assertTrue($config->getUsingCache());
 
         $finder = $config->getFinder();
-        static::assertInstanceOf(Finder::class, $finder);
+        self::assertInstanceOf(Finder::class, $finder);
 
         $config->setFormat('xml');
-        static::assertSame('xml', $config->getFormat());
+        self::assertSame('xml', $config->getFormat());
 
         $config->setHideProgress(true);
-        static::assertTrue($config->getHideProgress());
+        self::assertTrue($config->getHideProgress());
 
         $config->setIndent("\t");
-        static::assertSame("\t", $config->getIndent());
+        self::assertSame("\t", $config->getIndent());
 
         $finder = new Finder();
         $config->setFinder($finder);
-        static::assertSame($finder, $config->getFinder());
+        self::assertSame($finder, $config->getFinder());
 
         $config->setLineEnding("\r\n");
-        static::assertSame("\r\n", $config->getLineEnding());
+        self::assertSame("\r\n", $config->getLineEnding());
 
         $config->setPhpExecutable(null);
-        static::assertNull($config->getPhpExecutable());
+        self::assertNull($config->getPhpExecutable());
 
         $config->setUsingCache(false);
-        static::assertFalse($config->getUsingCache());
+        self::assertFalse($config->getUsingCache());
     }
 
     public static function provideRegisterCustomFixersCases(): array
@@ -266,7 +266,7 @@ final class ConfigTest extends TestCase
         $anonymousConfig = new Config();
         $namedConfig = new Config('foo');
 
-        static::assertSame($anonymousConfig->getName(), 'default');
-        static::assertSame($namedConfig->getName(), 'foo');
+        self::assertSame($anonymousConfig->getName(), 'default');
+        self::assertSame($namedConfig->getName(), 'foo');
     }
 }

--- a/tests/ConfigurationException/InvalidConfigurationExceptionTest.php
+++ b/tests/ConfigurationException/InvalidConfigurationExceptionTest.php
@@ -31,7 +31,7 @@ final class InvalidConfigurationExceptionTest extends TestCase
     {
         $exception = new InvalidConfigurationException('I cannot do that, Dave.');
 
-        static::assertInstanceOf(\InvalidArgumentException::class, $exception);
+        self::assertInstanceOf(\InvalidArgumentException::class, $exception);
     }
 
     public function testDefaults(): void
@@ -40,9 +40,9 @@ final class InvalidConfigurationExceptionTest extends TestCase
 
         $exception = new InvalidConfigurationException($message);
 
-        static::assertSame($message, $exception->getMessage());
-        static::assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_CONFIG, $exception->getCode());
-        static::assertNull($exception->getPrevious());
+        self::assertSame($message, $exception->getMessage());
+        self::assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_CONFIG, $exception->getCode());
+        self::assertNull($exception->getPrevious());
     }
 
     public function testConstructorSetsValues(): void
@@ -57,8 +57,8 @@ final class InvalidConfigurationExceptionTest extends TestCase
             $previous
         );
 
-        static::assertSame($message, $exception->getMessage());
-        static::assertSame($code, $exception->getCode());
-        static::assertSame($previous, $exception->getPrevious());
+        self::assertSame($message, $exception->getMessage());
+        self::assertSame($code, $exception->getCode());
+        self::assertSame($previous, $exception->getPrevious());
     }
 }

--- a/tests/ConfigurationException/InvalidFixerConfigurationExceptionTest.php
+++ b/tests/ConfigurationException/InvalidFixerConfigurationExceptionTest.php
@@ -32,7 +32,7 @@ final class InvalidFixerConfigurationExceptionTest extends TestCase
     {
         $exception = new InvalidFixerConfigurationException('foo', 'I cannot do that, Dave.');
 
-        static::assertInstanceOf(InvalidConfigurationException::class, $exception);
+        self::assertInstanceOf(InvalidConfigurationException::class, $exception);
     }
 
     public function testDefaults(): void
@@ -45,10 +45,10 @@ final class InvalidFixerConfigurationExceptionTest extends TestCase
             $message
         );
 
-        static::assertSame(sprintf('[%s] %s', $fixerName, $message), $exception->getMessage());
-        static::assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
-        static::assertSame($fixerName, $exception->getFixerName());
-        static::assertNull($exception->getPrevious());
+        self::assertSame(sprintf('[%s] %s', $fixerName, $message), $exception->getMessage());
+        self::assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
+        self::assertSame($fixerName, $exception->getFixerName());
+        self::assertNull($exception->getPrevious());
     }
 
     public function testConstructorSetsValues(): void
@@ -63,9 +63,9 @@ final class InvalidFixerConfigurationExceptionTest extends TestCase
             $previous
         );
 
-        static::assertSame(sprintf('[%s] %s', $fixerName, $message), $exception->getMessage());
-        static::assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
-        static::assertSame($fixerName, $exception->getFixerName());
-        static::assertSame($previous, $exception->getPrevious());
+        self::assertSame(sprintf('[%s] %s', $fixerName, $message), $exception->getMessage());
+        self::assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
+        self::assertSame($fixerName, $exception->getFixerName());
+        self::assertSame($previous, $exception->getPrevious());
     }
 }

--- a/tests/ConfigurationException/InvalidForEnvFixerConfigurationExceptionTest.php
+++ b/tests/ConfigurationException/InvalidForEnvFixerConfigurationExceptionTest.php
@@ -36,10 +36,10 @@ final class InvalidForEnvFixerConfigurationExceptionTest extends TestCase
             $message
         );
 
-        static::assertInstanceOf(InvalidFixerConfigurationException::class, $exception);
-        static::assertSame(sprintf('[%s] %s', $fixerName, $message), $exception->getMessage());
-        static::assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
-        static::assertSame($fixerName, $exception->getFixerName());
-        static::assertNull($exception->getPrevious());
+        self::assertInstanceOf(InvalidFixerConfigurationException::class, $exception);
+        self::assertSame(sprintf('[%s] %s', $fixerName, $message), $exception->getMessage());
+        self::assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
+        self::assertSame($fixerName, $exception->getFixerName());
+        self::assertNull($exception->getPrevious());
     }
 }

--- a/tests/ConfigurationException/RequiredFixerConfigurationExceptionTest.php
+++ b/tests/ConfigurationException/RequiredFixerConfigurationExceptionTest.php
@@ -35,7 +35,7 @@ final class RequiredFixerConfigurationExceptionTest extends TestCase
             'I cannot do that, Dave.'
         );
 
-        static::assertInstanceOf(InvalidFixerConfigurationException::class, $exception);
+        self::assertInstanceOf(InvalidFixerConfigurationException::class, $exception);
     }
 
     public function testDefaults(): void
@@ -48,9 +48,9 @@ final class RequiredFixerConfigurationExceptionTest extends TestCase
             $message
         );
 
-        static::assertSame(sprintf('[%s] %s', $fixerName, $message), $exception->getMessage());
-        static::assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
-        static::assertNull($exception->getPrevious());
+        self::assertSame(sprintf('[%s] %s', $fixerName, $message), $exception->getMessage());
+        self::assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
+        self::assertNull($exception->getPrevious());
     }
 
     public function testConstructorSetsValues(): void
@@ -65,8 +65,8 @@ final class RequiredFixerConfigurationExceptionTest extends TestCase
             $previous
         );
 
-        static::assertSame(sprintf('[%s] %s', $fixerName, $message), $exception->getMessage());
-        static::assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
-        static::assertSame($previous, $exception->getPrevious());
+        self::assertSame(sprintf('[%s] %s', $fixerName, $message), $exception->getMessage());
+        self::assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
+        self::assertSame($previous, $exception->getPrevious());
     }
 }

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -30,11 +30,11 @@ final class ApplicationTest extends TestCase
             .' by <comment>Fabien Potencier<\\/comment> and <comment>Dariusz Ruminski<\\/comment>.'
             ."\nPHP runtime: <info>\\d+.\\d+.\\d+(-dev)?<\\/info>$/";
 
-        static::assertMatchesRegularExpression($regex, (new Application())->getLongVersion());
+        self::assertMatchesRegularExpression($regex, (new Application())->getLongVersion());
     }
 
     public function testGetMajorVersion(): void
     {
-        static::assertSame(3, Application::getMajorVersion());
+        self::assertSame(3, Application::getMajorVersion());
     }
 }

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -72,7 +72,7 @@ Fixing examples:
    ----------- end diff -----------
 
 ';
-        static::assertSame($expected, $this->execute('Foo/bar', false)->getDisplay(true));
+        self::assertSame($expected, $this->execute('Foo/bar', false)->getDisplay(true));
     }
 
     public function testExecuteOutputWithDecoration(): void
@@ -113,12 +113,12 @@ Fixing examples:
 ";
         $actual = $this->execute('Foo/bar', true)->getDisplay(true);
 
-        static::assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     public function testExecuteStatusCode(): void
     {
-        static::assertSame(0, $this->execute('Foo/bar', false)->getStatusCode());
+        self::assertSame(0, $this->execute('Foo/bar', false)->getStatusCode());
     }
 
     public function testExecuteWithUnknownRuleName(): void
@@ -208,7 +208,7 @@ Fixing examples:
             ]
         );
 
-        static::assertStringContainsString(\get_class($mock), $commandTester->getDisplay(true));
+        self::assertStringContainsString(\get_class($mock), $commandTester->getDisplay(true));
     }
 
     private function execute(string $name, bool $decorated): CommandTester

--- a/tests/Console/Command/DescribeNameNotFoundExceptionTest.php
+++ b/tests/Console/Command/DescribeNameNotFoundExceptionTest.php
@@ -33,7 +33,7 @@ final class DescribeNameNotFoundExceptionTest extends TestCase
             'weird'
         );
 
-        static::assertInstanceOf(\InvalidArgumentException::class, $exception);
+        self::assertInstanceOf(\InvalidArgumentException::class, $exception);
     }
 
     public function testConstructorSetsValues(): void
@@ -46,7 +46,7 @@ final class DescribeNameNotFoundExceptionTest extends TestCase
             $type
         );
 
-        static::assertSame($name, $exception->getName());
-        static::assertSame($type, $exception->getType());
+        self::assertSame($name, $exception->getName());
+        self::assertSame($type, $exception->getType());
     }
 }

--- a/tests/Console/Command/FixCommandExitStatusCalculatorTest.php
+++ b/tests/Console/Command/FixCommandExitStatusCalculatorTest.php
@@ -34,7 +34,7 @@ final class FixCommandExitStatusCalculatorTest extends TestCase
     {
         $calculator = new FixCommandExitStatusCalculator();
 
-        static::assertSame(
+        self::assertSame(
             $expected,
             $calculator->calculate($isDryRun, $hasChangedFiles, $hasInvalidErrors, $hasExceptionErrors, $hasLintErrorsAfterFixing)
         );

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -37,7 +37,7 @@ final class FixCommandTest extends TestCase
             '--show-progress' => 'none',
         ]);
 
-        static::assertSame(
+        self::assertSame(
             Command::SUCCESS,
             $cmdTester->getStatusCode()
         );

--- a/tests/Console/Command/HelpCommandTest.php
+++ b/tests/Console/Command/HelpCommandTest.php
@@ -33,7 +33,7 @@ final class HelpCommandTest extends TestCase
      */
     public function testToString(string $expected, $input): void
     {
-        static::assertSame($expected, HelpCommand::toString($input));
+        self::assertSame($expected, HelpCommand::toString($input));
     }
 
     public static function provideToStringCases(): iterable
@@ -68,7 +68,7 @@ final class HelpCommandTest extends TestCase
      */
     public function testGetDisplayableAllowedValues($expected, FixerOptionInterface $input): void
     {
-        static::assertSame($expected, HelpCommand::getDisplayableAllowedValues($input));
+        self::assertSame($expected, HelpCommand::getDisplayableAllowedValues($input));
     }
 
     public static function provideGetDisplayableAllowedValuesCases(): iterable

--- a/tests/Console/Command/ListFilesCommandTest.php
+++ b/tests/Console/Command/ListFilesCommandTest.php
@@ -37,8 +37,8 @@ final class ListFilesCommandTest extends TestCase
         // make the test also work on Windows
         $expectedPath = str_replace('/', \DIRECTORY_SEPARATOR, $expectedPath);
 
-        static::assertSame(0, $commandTester->getStatusCode());
-        static::assertSame(escapeshellarg($expectedPath).PHP_EOL, $commandTester->getDisplay());
+        self::assertSame(0, $commandTester->getStatusCode());
+        self::assertSame(escapeshellarg($expectedPath).PHP_EOL, $commandTester->getDisplay());
     }
 
     /**

--- a/tests/Console/Command/ListSetsCommandTest.php
+++ b/tests/Console/Command/ListSetsCommandTest.php
@@ -35,8 +35,8 @@ final class ListSetsCommandTest extends TestCase
         $resultRaw = $commandTester->getDisplay();
 
         $expectedResultStart = ' 1) @DoctrineAnnotation'.PHP_EOL.'      Rules covering Doctrine annotations';
-        static::assertStringStartsWith($expectedResultStart, $resultRaw);
-        static::assertSame(0, $commandTester->getStatusCode());
+        self::assertStringStartsWith($expectedResultStart, $resultRaw);
+        self::assertSame(0, $commandTester->getStatusCode());
     }
 
     public function testListWithJsonFormat(): void
@@ -47,8 +47,8 @@ final class ListSetsCommandTest extends TestCase
 
         $resultRaw = $commandTester->getDisplay();
 
-        static::assertJson($resultRaw);
-        static::assertSame(0, $commandTester->getStatusCode());
+        self::assertJson($resultRaw);
+        self::assertSame(0, $commandTester->getStatusCode());
     }
 
     /**

--- a/tests/Console/Command/SelfUpdateCommandTest.php
+++ b/tests/Console/Command/SelfUpdateCommandTest.php
@@ -78,7 +78,7 @@ final class SelfUpdateCommandTest extends TestCase
         $application = new Application();
         $application->add($command);
 
-        static::assertSame($command, $application->find($name));
+        self::assertSame($command, $application->find($name));
     }
 
     public static function provideCommandNameCases(): array
@@ -130,9 +130,9 @@ final class SelfUpdateCommandTest extends TestCase
 
         $commandTester = $this->execute($command, $input, $decorated);
 
-        static::assertSame($expectedFileContents, file_get_contents($this->getToolPath()));
-        static::assertDisplay($expectedDisplay, $commandTester);
-        static::assertSame(0, $commandTester->getStatusCode());
+        self::assertSame($expectedFileContents, file_get_contents($this->getToolPath()));
+        self::assertDisplay($expectedDisplay, $commandTester);
+        self::assertSame(0, $commandTester->getStatusCode());
     }
 
     public static function provideExecuteCases(): array
@@ -269,11 +269,11 @@ OUTPUT;
 
         $commandTester = $this->execute($command, $input, $decorated);
 
-        static::assertDisplay(
+        self::assertDisplay(
             "\033[37;41mUnable to determine newest version: Foo.\033[39;49m\n",
             $commandTester
         );
-        static::assertSame(1, $commandTester->getStatusCode());
+        self::assertSame(1, $commandTester->getStatusCode());
     }
 
     public static function provideExecuteWhenNotAbleToGetLatestVersionsCases(): array
@@ -315,11 +315,11 @@ OUTPUT;
 
         $commandTester = $this->execute($command, $input, $decorated);
 
-        static::assertDisplay(
+        self::assertDisplay(
             "\033[37;41mSelf-update is available only for PHAR version.\033[39;49m\n",
             $commandTester
         );
-        static::assertSame(1, $commandTester->getStatusCode());
+        self::assertSame(1, $commandTester->getStatusCode());
     }
 
     public static function provideExecuteWhenNotInstalledAsPharCases(): array
@@ -362,7 +362,7 @@ OUTPUT;
             $expectedDisplay = preg_replace("/\033\\[(\\d+;)*\\d+m/", '', $expectedDisplay);
         }
 
-        static::assertSame(
+        self::assertSame(
             $expectedDisplay,
             $commandTester->getDisplay(true)
         );

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -54,7 +54,7 @@ final class ConfigurationResolverTest extends TestCase
             'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
         ], $config);
 
-        static::assertSame('none', $resolver->getProgress());
+        self::assertSame('none', $resolver->getProgress());
     }
 
     public function testResolveProgressWithPositiveConfigAndNegativeOption(): void
@@ -67,7 +67,7 @@ final class ConfigurationResolverTest extends TestCase
             'verbosity' => OutputInterface::VERBOSITY_NORMAL,
         ], $config);
 
-        static::assertSame('none', $resolver->getProgress());
+        self::assertSame('none', $resolver->getProgress());
     }
 
     public function testResolveProgressWithNegativeConfigAndPositiveOption(): void
@@ -80,7 +80,7 @@ final class ConfigurationResolverTest extends TestCase
             'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
         ], $config);
 
-        static::assertSame('dots', $resolver->getProgress());
+        self::assertSame('dots', $resolver->getProgress());
     }
 
     public function testResolveProgressWithNegativeConfigAndNegativeOption(): void
@@ -93,7 +93,7 @@ final class ConfigurationResolverTest extends TestCase
             'verbosity' => OutputInterface::VERBOSITY_NORMAL,
         ], $config);
 
-        static::assertSame('none', $resolver->getProgress());
+        self::assertSame('none', $resolver->getProgress());
     }
 
     /**
@@ -110,7 +110,7 @@ final class ConfigurationResolverTest extends TestCase
             'show-progress' => $progressType,
         ], $config);
 
-        static::assertSame($progressType, $resolver->getProgress());
+        self::assertSame($progressType, $resolver->getProgress());
     }
 
     /**
@@ -127,7 +127,7 @@ final class ConfigurationResolverTest extends TestCase
             'show-progress' => $progressType,
         ], $config);
 
-        static::assertSame($progressType, $resolver->getProgress());
+        self::assertSame($progressType, $resolver->getProgress());
     }
 
     public static function provideProgressTypeCases(): array
@@ -156,8 +156,8 @@ final class ConfigurationResolverTest extends TestCase
     {
         $resolver = $this->createConfigurationResolver([]);
 
-        static::assertNull($resolver->getConfigFile());
-        static::assertInstanceOf(\PhpCsFixer\ConfigInterface::class, $resolver->getConfig());
+        self::assertNull($resolver->getConfigFile());
+        self::assertInstanceOf(\PhpCsFixer\ConfigInterface::class, $resolver->getConfig());
     }
 
     public function testResolveConfigFileByPathOfFile(): void
@@ -166,8 +166,8 @@ final class ConfigurationResolverTest extends TestCase
 
         $resolver = $this->createConfigurationResolver(['path' => [$dir.\DIRECTORY_SEPARATOR.'foo.php']]);
 
-        static::assertSame($dir.\DIRECTORY_SEPARATOR.'.php-cs-fixer.dist.php', $resolver->getConfigFile());
-        static::assertInstanceOf(\Test1Config::class, $resolver->getConfig()); // @phpstan-ignore-line to avoid `Class Test1Config not found.`
+        self::assertSame($dir.\DIRECTORY_SEPARATOR.'.php-cs-fixer.dist.php', $resolver->getConfigFile());
+        self::assertInstanceOf(\Test1Config::class, $resolver->getConfig()); // @phpstan-ignore-line to avoid `Class Test1Config not found.`
     }
 
     public function testResolveConfigFileSpecified(): void
@@ -176,8 +176,8 @@ final class ConfigurationResolverTest extends TestCase
 
         $resolver = $this->createConfigurationResolver(['config' => $file]);
 
-        static::assertSame($file, $resolver->getConfigFile());
-        static::assertInstanceOf(\Test4Config::class, $resolver->getConfig()); // @phpstan-ignore-line to avoid `Class Test4Config not found.`
+        self::assertSame($file, $resolver->getConfigFile());
+        self::assertInstanceOf(\Test4Config::class, $resolver->getConfig()); // @phpstan-ignore-line to avoid `Class Test4Config not found.`
     }
 
     /**
@@ -191,8 +191,8 @@ final class ConfigurationResolverTest extends TestCase
             $cwdPath ?? ''
         );
 
-        static::assertSame($expectedFile, $resolver->getConfigFile());
-        static::assertInstanceOf($expectedClass, $resolver->getConfig());
+        self::assertSame($expectedFile, $resolver->getConfigFile());
+        self::assertInstanceOf($expectedClass, $resolver->getConfig());
     }
 
     public static function provideResolveConfigFileDefaultCases(): array
@@ -277,7 +277,7 @@ final class ConfigurationResolverTest extends TestCase
             'path' => [$dirBase.'case_1/.php-cs-fixer.dist.php', $dirBase.'case_1/foo.php'],
         ]);
 
-        static::assertInstanceOf(\PhpCsFixer\Console\ConfigurationResolver::class, $resolver);
+        self::assertInstanceOf(\PhpCsFixer\Console\ConfigurationResolver::class, $resolver);
     }
 
     /**
@@ -294,7 +294,7 @@ final class ConfigurationResolverTest extends TestCase
             $cwd
         );
 
-        static::assertSame($expectedPaths, $resolver->getPath());
+        self::assertSame($expectedPaths, $resolver->getPath());
     }
 
     public static function providePathCases(): iterable
@@ -389,7 +389,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertCount(1, $resolver->getFinder());
+        self::assertCount(1, $resolver->getFinder());
     }
 
     public function testResolvePathWithFileThatIsExcludedDirectlyIntersectionPathMode(): void
@@ -405,7 +405,7 @@ final class ConfigurationResolverTest extends TestCase
             'path-mode' => 'intersection',
         ], $config);
 
-        static::assertCount(0, $resolver->getFinder());
+        self::assertCount(0, $resolver->getFinder());
     }
 
     public function testResolvePathWithFileThatIsExcludedByDirOverridePathMode(): void
@@ -422,7 +422,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertCount(1, $resolver->getFinder());
+        self::assertCount(1, $resolver->getFinder());
     }
 
     public function testResolvePathWithFileThatIsExcludedByDirIntersectionPathMode(): void
@@ -439,7 +439,7 @@ final class ConfigurationResolverTest extends TestCase
             'path' => [__FILE__],
         ], $config);
 
-        static::assertCount(0, $resolver->getFinder());
+        self::assertCount(0, $resolver->getFinder());
     }
 
     public function testResolvePathWithFileThatIsNotExcluded(): void
@@ -456,7 +456,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertCount(1, $resolver->getFinder());
+        self::assertCount(1, $resolver->getFinder());
     }
 
     /**
@@ -494,7 +494,7 @@ final class ConfigurationResolverTest extends TestCase
         sort($expected);
         sort($intersectionItems);
 
-        static::assertSame($expected, $intersectionItems);
+        self::assertSame($expected, $intersectionItems);
     }
 
     public static function provideResolveIntersectionOfPathsCases(): array
@@ -657,12 +657,12 @@ final class ConfigurationResolverTest extends TestCase
     {
         $resolver = $this->createConfigurationResolver($options);
 
-        static::assertSame($expectedResult, $resolver->configFinderIsOverridden());
+        self::assertSame($expectedResult, $resolver->configFinderIsOverridden());
 
         $resolver = $this->createConfigurationResolver($options);
         $resolver->getFinder();
 
-        static::assertSame($expectedResult, $resolver->configFinderIsOverridden());
+        self::assertSame($expectedResult, $resolver->configFinderIsOverridden());
     }
 
     public static function provideConfigFinderIsOverriddenCases(): array
@@ -727,21 +727,21 @@ final class ConfigurationResolverTest extends TestCase
             'path' => ['-'],
         ]);
 
-        static::assertTrue($resolver->isDryRun());
+        self::assertTrue($resolver->isDryRun());
     }
 
     public function testResolveIsDryRunViaNegativeOption(): void
     {
         $resolver = $this->createConfigurationResolver(['dry-run' => false]);
 
-        static::assertFalse($resolver->isDryRun());
+        self::assertFalse($resolver->isDryRun());
     }
 
     public function testResolveIsDryRunViaPositiveOption(): void
     {
         $resolver = $this->createConfigurationResolver(['dry-run' => true]);
 
-        static::assertTrue($resolver->isDryRun());
+        self::assertTrue($resolver->isDryRun());
     }
 
     /**
@@ -757,7 +757,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertSame($expected, $resolver->getUsingCache());
+        self::assertSame($expected, $resolver->getUsingCache());
     }
 
     public function testResolveUsingCacheWithPositiveConfigAndNoOption(): void
@@ -770,7 +770,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertTrue($resolver->getUsingCache());
+        self::assertTrue($resolver->getUsingCache());
     }
 
     public function testResolveUsingCacheWithNegativeConfigAndNoOption(): void
@@ -783,7 +783,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertFalse($resolver->getUsingCache());
+        self::assertFalse($resolver->getUsingCache());
     }
 
     public function testResolveCacheFileWithoutConfigAndOption(): void
@@ -796,7 +796,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertSame($default, $resolver->getCacheFile());
+        self::assertSame($default, $resolver->getCacheFile());
     }
 
     public function testResolveCacheFileWithConfig(): void
@@ -814,15 +814,15 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertNull($resolver->getCacheFile());
+        self::assertNull($resolver->getCacheFile());
 
         $cacheManager = $resolver->getCacheManager();
 
-        static::assertInstanceOf(NullCacheManager::class, $cacheManager);
+        self::assertInstanceOf(NullCacheManager::class, $cacheManager);
 
         $linter = $resolver->getLinter();
 
-        static::assertInstanceOf(LinterInterface::class, $linter);
+        self::assertInstanceOf(LinterInterface::class, $linter);
     }
 
     public function testResolveCacheFileWithOption(): void
@@ -837,7 +837,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertSame($cacheFile, $resolver->getCacheFile());
+        self::assertSame($cacheFile, $resolver->getCacheFile());
     }
 
     public function testResolveCacheFileWithConfigAndOption(): void
@@ -853,7 +853,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertSame($optionCacheFile, $resolver->getCacheFile());
+        self::assertSame($optionCacheFile, $resolver->getCacheFile());
     }
 
     /**
@@ -869,7 +869,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertSame($expected, $resolver->getRiskyAllowed());
+        self::assertSame($expected, $resolver->getRiskyAllowed());
     }
 
     public function testResolveAllowRiskyWithNegativeConfigAndPositiveOption(): void
@@ -882,7 +882,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertTrue($resolver->getRiskyAllowed());
+        self::assertTrue($resolver->getRiskyAllowed());
     }
 
     public function testResolveAllowRiskyWithNegativeConfigAndNegativeOption(): void
@@ -895,7 +895,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertFalse($resolver->getRiskyAllowed());
+        self::assertFalse($resolver->getRiskyAllowed());
     }
 
     public function testResolveAllowRiskyWithPositiveConfigAndNoOption(): void
@@ -908,7 +908,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertTrue($resolver->getRiskyAllowed());
+        self::assertTrue($resolver->getRiskyAllowed());
     }
 
     public function testResolveAllowRiskyWithNegativeConfigAndNoOption(): void
@@ -921,7 +921,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertFalse($resolver->getRiskyAllowed());
+        self::assertFalse($resolver->getRiskyAllowed());
     }
 
     public function testResolveRulesWithConfig(): void
@@ -937,7 +937,7 @@ final class ConfigurationResolverTest extends TestCase
             $config
         );
 
-        static::assertSameRules(
+        self::assertSameRules(
             [
                 'statement_indentation' => true,
             ],
@@ -949,7 +949,7 @@ final class ConfigurationResolverTest extends TestCase
     {
         $resolver = $this->createConfigurationResolver(['rules' => 'statement_indentation,-strict_comparison']);
 
-        static::assertSameRules(
+        self::assertSameRules(
             [
                 'statement_indentation' => true,
             ],
@@ -1020,7 +1020,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
             $config
         );
 
-        static::assertSameRules(
+        self::assertSameRules(
             [
                 'blank_line_before_statement' => true,
             ],
@@ -1033,11 +1033,11 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         $command = new FixCommand(new ToolInfo());
         $definition = $command->getDefinition();
         $arguments = $definition->getArguments();
-        static::assertCount(1, $arguments, 'Expected one argument, possibly test needs updating.');
-        static::assertArrayHasKey('path', $arguments);
+        self::assertCount(1, $arguments, 'Expected one argument, possibly test needs updating.');
+        self::assertArrayHasKey('path', $arguments);
 
         $options = $definition->getOptions();
-        static::assertSame(
+        self::assertSame(
             ['path-mode', 'allow-risky', 'config', 'dry-run', 'rules', 'using-cache', 'cache-file', 'diff', 'format', 'stop-on-violation', 'show-progress'],
             array_keys($options),
             'Expected options mismatch, possibly test needs updating.'
@@ -1055,14 +1055,14 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
             'stop-on-violation' => true,
         ]);
 
-        static::assertTrue($resolver->shouldStopOnViolation());
-        static::assertTrue($resolver->getRiskyAllowed());
-        static::assertTrue($resolver->isDryRun());
-        static::assertSame(['php_unit_construct' => true], $resolver->getRules());
-        static::assertFalse($resolver->getUsingCache());
-        static::assertNull($resolver->getCacheFile());
-        static::assertInstanceOf(\PhpCsFixer\Differ\UnifiedDiffer::class, $resolver->getDiffer());
-        static::assertSame('json', $resolver->getReporter()->getFormat());
+        self::assertTrue($resolver->shouldStopOnViolation());
+        self::assertTrue($resolver->getRiskyAllowed());
+        self::assertTrue($resolver->isDryRun());
+        self::assertSame(['php_unit_construct' => true], $resolver->getRules());
+        self::assertFalse($resolver->getUsingCache());
+        self::assertNull($resolver->getCacheFile());
+        self::assertInstanceOf(\PhpCsFixer\Differ\UnifiedDiffer::class, $resolver->getDiffer());
+        self::assertSame('json', $resolver->getReporter()->getFormat());
     }
 
     /**
@@ -1076,7 +1076,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
             'diff' => $diffConfig,
         ]);
 
-        static::assertInstanceOf($expected, $resolver->getDiffer());
+        self::assertInstanceOf($expected, $resolver->getDiffer());
     }
 
     public static function provideDifferCases(): array
@@ -1103,11 +1103,11 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
 
         $resolver = $this->createConfigurationResolver(['path' => [$dir.\DIRECTORY_SEPARATOR.'.php-cs-fixer.php']]);
 
-        static::assertTrue($resolver->getRiskyAllowed());
-        static::assertSame(['php_unit_construct' => true], $resolver->getRules());
-        static::assertFalse($resolver->getUsingCache());
-        static::assertNull($resolver->getCacheFile());
-        static::assertSame('xml', $resolver->getReporter()->getFormat());
+        self::assertTrue($resolver->getRiskyAllowed());
+        self::assertSame(['php_unit_construct' => true], $resolver->getRules());
+        self::assertFalse($resolver->getUsingCache());
+        self::assertNull($resolver->getCacheFile());
+        self::assertSame('xml', $resolver->getReporter()->getFormat());
     }
 
     public function testDeprecationOfPassingOtherThanNoOrYes(): void
@@ -1202,7 +1202,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         $resolver = new ConfigurationResolver($config, [], $this->normalizePath('/my/path'), new TestToolInfo());
         $directory = $resolver->getDirectory();
 
-        static::assertSame($expectedPathRelativeToFile, $directory->getRelativePathTo($file));
+        self::assertSame($expectedPathRelativeToFile, $directory->getRelativePathTo($file));
     }
 
     private function normalizePath(string $path): string
@@ -1219,7 +1219,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         ksort($expected);
         ksort($actual);
 
-        static::assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     private static function getFixtureDir(): string

--- a/tests/Console/Output/ErrorOutputTest.php
+++ b/tests/Console/Output/ErrorOutputTest.php
@@ -78,7 +78,7 @@ Files that were not fixed due to errors reported during %s:
             );
         }
 
-        static::assertStringStartsWith($startWith, $displayed);
+        self::assertStringStartsWith($startWith, $displayed);
     }
 
     public static function provideTestCases(): array
@@ -129,13 +129,13 @@ EOT;
 
         $displayed = $this->readFullStreamOutput($output);
 
-        static::assertStringContainsString($fixerName, $displayed);
-        static::assertStringContainsString($diffSpecificContext, $displayed);
+        self::assertStringContainsString($fixerName, $displayed);
+        self::assertStringContainsString($diffSpecificContext, $displayed);
 
-        static::assertStringContainsString($noDiffLintFixerName, $displayed);
+        self::assertStringContainsString($noDiffLintFixerName, $displayed);
 
-        static::assertStringNotContainsString($invalidErrorFixerName, $displayed);
-        static::assertStringNotContainsString($invalidDiff, $displayed);
+        self::assertStringNotContainsString($invalidErrorFixerName, $displayed);
+        self::assertStringNotContainsString($invalidDiff, $displayed);
     }
 
     private function createStreamOutput(int $verbosityLevel): StreamOutput

--- a/tests/Console/Output/ProcessOutputTest.php
+++ b/tests/Console/Output/ProcessOutputTest.php
@@ -52,7 +52,7 @@ final class ProcessOutputTest extends TestCase
             $processOutput->onFixerFileProcessed(new FixerFileProcessedEvent($status));
         });
 
-        static::assertSame($expectedOutput, $output->fetch());
+        self::assertSame($expectedOutput, $output->fetch());
     }
 
     public static function provideProcessProgressOutputCases(): array

--- a/tests/Console/Report/FixReport/CheckstyleReporterTest.php
+++ b/tests/Console/Report/FixReport/CheckstyleReporterTest.php
@@ -135,7 +135,7 @@ XML;
         $formatter = new OutputFormatter();
         $input = $formatter->format($input);
 
-        static::assertThat($input, new XmlMatchesXsd(self::$xsd));
-        static::assertXmlStringEqualsXmlString($expected, $input);
+        self::assertThat($input, new XmlMatchesXsd(self::$xsd));
+        self::assertXmlStringEqualsXmlString($expected, $input);
     }
 }

--- a/tests/Console/Report/FixReport/GitlabReporterTest.php
+++ b/tests/Console/Report/FixReport/GitlabReporterTest.php
@@ -134,6 +134,6 @@ JSON;
 
     protected function assertFormat(string $expected, string $input): void
     {
-        static::assertJsonStringEqualsJsonString($expected, $input);
+        self::assertJsonStringEqualsJsonString($expected, $input);
     }
 }

--- a/tests/Console/Report/FixReport/JsonReporterTest.php
+++ b/tests/Console/Report/FixReport/JsonReporterTest.php
@@ -147,8 +147,8 @@ JSON;
 
     protected function assertFormat(string $expected, string $input): void
     {
-        static::assertJsonSchema($input);
-        static::assertJsonStringEqualsJsonString($expected, $input);
+        self::assertJsonSchema($input);
+        self::assertJsonStringEqualsJsonString($expected, $input);
     }
 
     private static function assertJsonSchema(string $json): void
@@ -163,7 +163,7 @@ JSON;
             (object) ['$ref' => 'file://'.realpath($jsonPath)]
         );
 
-        static::assertTrue(
+        self::assertTrue(
             $validator->isValid(),
             implode(
                 "\n",

--- a/tests/Console/Report/FixReport/JunitReporterTest.php
+++ b/tests/Console/Report/FixReport/JunitReporterTest.php
@@ -170,8 +170,8 @@ XML;
         $formatter = new OutputFormatter();
         $input = $formatter->format($input);
 
-        static::assertThat($input, new XmlMatchesXsd(self::$xsd));
-        static::assertXmlStringEqualsXmlString($expected, $input);
+        self::assertThat($input, new XmlMatchesXsd(self::$xsd));
+        self::assertXmlStringEqualsXmlString($expected, $input);
     }
 
     protected function createReporter(): ReporterInterface

--- a/tests/Console/Report/FixReport/ReportSummaryTest.php
+++ b/tests/Console/Report/FixReport/ReportSummaryTest.php
@@ -49,12 +49,12 @@ final class ReportSummaryTest extends TestCase
             $isDecoratedOutput
         );
 
-        static::assertSame($changed, $reportSummary->getChanged());
-        static::assertSame($filesCount, $reportSummary->getFilesCount());
-        static::assertSame($time, $reportSummary->getTime());
-        static::assertSame($memory, $reportSummary->getMemory());
-        static::assertSame($addAppliedFixers, $reportSummary->shouldAddAppliedFixers());
-        static::assertSame($isDryRun, $reportSummary->isDryRun());
-        static::assertSame($isDecoratedOutput, $reportSummary->isDecoratedOutput());
+        self::assertSame($changed, $reportSummary->getChanged());
+        self::assertSame($filesCount, $reportSummary->getFilesCount());
+        self::assertSame($time, $reportSummary->getTime());
+        self::assertSame($memory, $reportSummary->getMemory());
+        self::assertSame($addAppliedFixers, $reportSummary->shouldAddAppliedFixers());
+        self::assertSame($isDryRun, $reportSummary->isDryRun());
+        self::assertSame($isDecoratedOutput, $reportSummary->isDecoratedOutput());
     }
 }

--- a/tests/Console/Report/FixReport/ReporterFactoryTest.php
+++ b/tests/Console/Report/FixReport/ReporterFactoryTest.php
@@ -32,21 +32,21 @@ final class ReporterFactoryTest extends TestCase
         $builder = new ReporterFactory();
 
         $testInstance = $builder->registerBuiltInReporters();
-        static::assertSame($builder, $testInstance);
+        self::assertSame($builder, $testInstance);
 
         $double = $this->createReporterDouble('r1');
         $testInstance = $builder->registerReporter($double);
-        static::assertSame($builder, $testInstance);
+        self::assertSame($builder, $testInstance);
     }
 
     public function testRegisterBuiltInReports(): void
     {
         $builder = new ReporterFactory();
 
-        static::assertCount(0, $builder->getFormats());
+        self::assertCount(0, $builder->getFormats());
 
         $builder->registerBuiltInReporters();
-        static::assertSame(
+        self::assertSame(
             ['checkstyle', 'gitlab', 'json', 'junit', 'txt', 'xml'],
             $builder->getFormats()
         );
@@ -64,9 +64,9 @@ final class ReporterFactoryTest extends TestCase
         $builder->registerReporter($r2);
         $builder->registerReporter($r3);
 
-        static::assertSame($r1, $builder->getReporter('r1'));
-        static::assertSame($r2, $builder->getReporter('r2'));
-        static::assertSame($r3, $builder->getReporter('r3'));
+        self::assertSame($r1, $builder->getReporter('r1'));
+        self::assertSame($r2, $builder->getReporter('r2'));
+        self::assertSame($r3, $builder->getReporter('r3'));
     }
 
     public function testGetFormats(): void
@@ -81,7 +81,7 @@ final class ReporterFactoryTest extends TestCase
         $builder->registerReporter($r2);
         $builder->registerReporter($r3);
 
-        static::assertSame(['r1', 'r2', 'r3'], $builder->getFormats());
+        self::assertSame(['r1', 'r2', 'r3'], $builder->getFormats());
     }
 
     public function testRegisterReportWithOccupiedFormat(): void

--- a/tests/Console/Report/FixReport/TextReporterTest.php
+++ b/tests/Console/Report/FixReport/TextReporterTest.php
@@ -122,6 +122,6 @@ TEXT
 
     protected function assertFormat(string $expected, string $input): void
     {
-        static::assertSame($expected, $input);
+        self::assertSame($expected, $input);
     }
 }

--- a/tests/Console/Report/FixReport/XmlReporterTest.php
+++ b/tests/Console/Report/FixReport/XmlReporterTest.php
@@ -160,7 +160,7 @@ XML;
         $formatter = new OutputFormatter();
         $input = $formatter->format($input);
 
-        static::assertThat($input, new XmlMatchesXsd(self::$xsd));
-        static::assertXmlStringEqualsXmlString($expected, $input);
+        self::assertThat($input, new XmlMatchesXsd(self::$xsd));
+        self::assertXmlStringEqualsXmlString($expected, $input);
     }
 }

--- a/tests/Console/Report/ListSetsReport/JsonReporterTest.php
+++ b/tests/Console/Report/ListSetsReport/JsonReporterTest.php
@@ -38,8 +38,8 @@ final class JsonReporterTest extends AbstractReporterTestCase
 
     protected function assertFormat(string $expected, string $input): void
     {
-        static::assertJsonSchema($input);
-        static::assertJsonStringEqualsJsonString($expected, $input);
+        self::assertJsonSchema($input);
+        self::assertJsonStringEqualsJsonString($expected, $input);
     }
 
     protected static function createSimpleReport(): string
@@ -72,7 +72,7 @@ final class JsonReporterTest extends AbstractReporterTestCase
             (object) ['$ref' => 'file://'.realpath($jsonPath)]
         );
 
-        static::assertTrue(
+        self::assertTrue(
             $validator->isValid(),
             implode(
                 "\n",

--- a/tests/Console/Report/ListSetsReport/ReportSummaryTest.php
+++ b/tests/Console/Report/ListSetsReport/ReportSummaryTest.php
@@ -36,6 +36,6 @@ final class ReportSummaryTest extends TestCase
             $sets
         );
 
-        static::assertSame($sets, $reportSummary->getSets());
+        self::assertSame($sets, $reportSummary->getSets());
     }
 }

--- a/tests/Console/Report/ListSetsReport/ReporterFactoryTest.php
+++ b/tests/Console/Report/ListSetsReport/ReporterFactoryTest.php
@@ -33,21 +33,21 @@ final class ReporterFactoryTest extends TestCase
         $builder = new ReporterFactory();
 
         $testInstance = $builder->registerBuiltInReporters();
-        static::assertSame($builder, $testInstance);
+        self::assertSame($builder, $testInstance);
 
         $double = $this->createReporterDouble('r1');
         $testInstance = $builder->registerReporter($double);
-        static::assertSame($builder, $testInstance);
+        self::assertSame($builder, $testInstance);
     }
 
     public function testRegisterBuiltInReports(): void
     {
         $builder = new ReporterFactory();
 
-        static::assertCount(0, $builder->getFormats());
+        self::assertCount(0, $builder->getFormats());
 
         $builder->registerBuiltInReporters();
-        static::assertSame(
+        self::assertSame(
             ['json', 'txt'],
             $builder->getFormats()
         );
@@ -65,9 +65,9 @@ final class ReporterFactoryTest extends TestCase
         $builder->registerReporter($r2);
         $builder->registerReporter($r3);
 
-        static::assertSame($r1, $builder->getReporter('r1'));
-        static::assertSame($r2, $builder->getReporter('r2'));
-        static::assertSame($r3, $builder->getReporter('r3'));
+        self::assertSame($r1, $builder->getReporter('r1'));
+        self::assertSame($r2, $builder->getReporter('r2'));
+        self::assertSame($r3, $builder->getReporter('r3'));
     }
 
     public function testGetFormats(): void
@@ -82,7 +82,7 @@ final class ReporterFactoryTest extends TestCase
         $builder->registerReporter($r2);
         $builder->registerReporter($r3);
 
-        static::assertSame(['r1', 'r2', 'r3'], $builder->getFormats());
+        self::assertSame(['r1', 'r2', 'r3'], $builder->getFormats());
     }
 
     public function testRegisterReportWithOccupiedFormat(): void

--- a/tests/Console/Report/ListSetsReport/TextReporterTest.php
+++ b/tests/Console/Report/ListSetsReport/TextReporterTest.php
@@ -38,7 +38,7 @@ final class TextReporterTest extends AbstractReporterTestCase
 
     protected function assertFormat(string $expected, string $input): void
     {
-        static::assertSame($expected, $input);
+        self::assertSame($expected, $input);
     }
 
     protected static function createSimpleReport(): string

--- a/tests/Console/SelfUpdate/NewVersionCheckerTest.php
+++ b/tests/Console/SelfUpdate/NewVersionCheckerTest.php
@@ -29,7 +29,7 @@ final class NewVersionCheckerTest extends TestCase
     {
         $checker = new NewVersionChecker($this->createGithubClientStub());
 
-        static::assertSame('v2.4.1', $checker->getLatestVersion());
+        self::assertSame('v2.4.1', $checker->getLatestVersion());
     }
 
     /**
@@ -39,7 +39,7 @@ final class NewVersionCheckerTest extends TestCase
     {
         $checker = new NewVersionChecker($this->createGithubClientStub());
 
-        static::assertSame($expectedVersion, $checker->getLatestVersionOfMajor($majorVersion));
+        self::assertSame($expectedVersion, $checker->getLatestVersionOfMajor($majorVersion));
     }
 
     public static function provideLatestVersionOfMajorCases(): array
@@ -58,11 +58,11 @@ final class NewVersionCheckerTest extends TestCase
     {
         $checker = new NewVersionChecker($this->createGithubClientStub());
 
-        static::assertSame(
+        self::assertSame(
             $expectedResult,
             $checker->compareVersions($versionA, $versionB)
         );
-        static::assertSame(
+        self::assertSame(
             -$expectedResult,
             $checker->compareVersions($versionB, $versionA)
         );

--- a/tests/Console/WarningsDetectorTest.php
+++ b/tests/Console/WarningsDetectorTest.php
@@ -34,7 +34,7 @@ final class WarningsDetectorTest extends TestCase
         $warningsDetector = new WarningsDetector($toolInfo->reveal());
         $warningsDetector->detectOldVendor();
 
-        static::assertSame([], $warningsDetector->getWarnings());
+        self::assertSame([], $warningsDetector->getWarnings());
     }
 
     public function testDetectOldVendorNotLegacyPackage(): void
@@ -48,7 +48,7 @@ final class WarningsDetectorTest extends TestCase
         $warningsDetector = new WarningsDetector($toolInfo->reveal());
         $warningsDetector->detectOldVendor();
 
-        static::assertSame([], $warningsDetector->getWarnings());
+        self::assertSame([], $warningsDetector->getWarnings());
     }
 
     public function testDetectOldVendorLegacyPackage(): void
@@ -62,7 +62,7 @@ final class WarningsDetectorTest extends TestCase
         $warningsDetector = new WarningsDetector($toolInfo->reveal());
         $warningsDetector->detectOldVendor();
 
-        static::assertSame([
+        self::assertSame([
             'You are running PHP CS Fixer installed with old vendor `fabpot/php-cs-fixer`. Please update to `friendsofphp/php-cs-fixer`.',
             'If you need help while solving warnings, ask at https://gitter.im/PHP-CS-Fixer, we will help you!',
         ], $warningsDetector->getWarnings());

--- a/tests/Differ/DiffConsoleFormatterTest.php
+++ b/tests/Differ/DiffConsoleFormatterTest.php
@@ -32,7 +32,7 @@ final class DiffConsoleFormatterTest extends TestCase
     {
         $diffFormatter = new DiffConsoleFormatter($isDecoratedOutput, $template);
 
-        static::assertSame(
+        self::assertSame(
             str_replace(PHP_EOL, "\n", $expected),
             str_replace(PHP_EOL, "\n", $diffFormatter->format($diff, $lineTemplate))
         );

--- a/tests/Differ/FullDifferTest.php
+++ b/tests/Differ/FullDifferTest.php
@@ -42,6 +42,6 @@ final class FullDifferTest extends AbstractDifferTestCase
 ';
         $differ = new FullDiffer();
 
-        static::assertSame($diff, $differ->diff($this->oldCode(), $this->newCode()));
+        self::assertSame($diff, $differ->diff($this->oldCode(), $this->newCode()));
     }
 }

--- a/tests/Differ/NullDifferTest.php
+++ b/tests/Differ/NullDifferTest.php
@@ -31,6 +31,6 @@ final class NullDifferTest extends AbstractDifferTestCase
 
         $differ = new NullDiffer();
 
-        static::assertSame($diff, $differ->diff($this->oldCode(), $this->newCode()));
+        self::assertSame($diff, $differ->diff($this->oldCode(), $this->newCode()));
     }
 }

--- a/tests/Differ/UnifiedDifferTest.php
+++ b/tests/Differ/UnifiedDifferTest.php
@@ -40,14 +40,14 @@ final class UnifiedDifferTest extends AbstractDifferTestCase
      }
  '.'
 ';
-        static::assertSame($diff, $differ->diff($this->oldCode(), $this->newCode(), new \SplFileInfo($file)));
+        self::assertSame($diff, $differ->diff($this->oldCode(), $this->newCode(), new \SplFileInfo($file)));
     }
 
     public function testDiffAddsQuotes(): void
     {
         $differ = new UnifiedDiffer();
 
-        static::assertSame(
+        self::assertSame(
             '--- "test test test.txt"
 +++ "test test test.txt"
 @@ -1 +1 @@
@@ -62,7 +62,7 @@ final class UnifiedDifferTest extends AbstractDifferTestCase
     {
         $differ = new UnifiedDiffer();
 
-        static::assertSame(
+        self::assertSame(
             '--- Original
 +++ New
 @@ -1 +1 @@

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -95,8 +95,8 @@ final class AnnotationTest extends TestCase
         $doc = new DocBlock(self::$sample);
         $annotation = $doc->getAnnotation($index);
 
-        static::assertSame($content, $annotation->getContent());
-        static::assertSame($content, (string) $annotation);
+        self::assertSame($content, $annotation->getContent());
+        self::assertSame($content, (string) $annotation);
     }
 
     public static function provideGetContentCases(): iterable
@@ -114,7 +114,7 @@ final class AnnotationTest extends TestCase
         $doc = new DocBlock(self::$sample);
         $annotation = $doc->getAnnotation($index);
 
-        static::assertSame($start, $annotation->getStart());
+        self::assertSame($start, $annotation->getStart());
     }
 
     public static function provideStartCases(): iterable
@@ -132,7 +132,7 @@ final class AnnotationTest extends TestCase
         $doc = new DocBlock(self::$sample);
         $annotation = $doc->getAnnotation($index);
 
-        static::assertSame($end, $annotation->getEnd());
+        self::assertSame($end, $annotation->getEnd());
     }
 
     public static function provideEndCases(): iterable
@@ -150,7 +150,7 @@ final class AnnotationTest extends TestCase
         $doc = new DocBlock(self::$sample);
         $annotation = $doc->getAnnotation($index);
 
-        static::assertSame($tag, $annotation->getTag()->getName());
+        self::assertSame($tag, $annotation->getTag()->getName());
     }
 
     public static function provideGetTagCases(): iterable
@@ -169,9 +169,9 @@ final class AnnotationTest extends TestCase
         $annotation = $doc->getAnnotation($index);
 
         $annotation->remove();
-        static::assertSame('', $annotation->getContent());
-        static::assertSame('', $doc->getLine($start)->getContent());
-        static::assertSame('', $doc->getLine($end)->getContent());
+        self::assertSame('', $annotation->getContent());
+        self::assertSame('', $doc->getLine($start)->getContent());
+        self::assertSame('', $doc->getLine($end)->getContent());
     }
 
     public static function provideRemoveCases(): iterable
@@ -190,7 +190,7 @@ final class AnnotationTest extends TestCase
         $annotation = $doc->getAnnotation(0);
 
         $annotation->remove();
-        static::assertSame($expected, $doc->getContent());
+        self::assertSame($expected, $doc->getContent());
     }
 
     public static function provideRemoveEdgeCasesCases(): array
@@ -239,7 +239,7 @@ final class AnnotationTest extends TestCase
     {
         $tag = new Annotation([new Line($input)]);
 
-        static::assertSame($expected, $tag->getTypes());
+        self::assertSame($expected, $tag->getTypes());
     }
 
     public static function provideTypeParsingCases(): array
@@ -459,13 +459,13 @@ final class AnnotationTest extends TestCase
         $line = new Line($input);
         $tag = new Annotation([$line]);
 
-        static::assertSame($expected, $tag->getTypes());
+        self::assertSame($expected, $tag->getTypes());
 
         $tag->setTypes($new);
 
-        static::assertSame($new, $tag->getTypes());
+        self::assertSame($new, $tag->getTypes());
 
-        static::assertSame($output, $line->getContent());
+        self::assertSame($output, $line->getContent());
     }
 
     public static function provideTypesCases(): array
@@ -491,7 +491,7 @@ final class AnnotationTest extends TestCase
         $line = new Line($input);
         $tag = new Annotation([$line]);
 
-        static::assertSame($expected, $tag->getNormalizedTypes());
+        self::assertSame($expected, $tag->getNormalizedTypes());
     }
 
     public static function provideNormalizedTypesCases(): array
@@ -536,8 +536,8 @@ final class AnnotationTest extends TestCase
         $tags = Annotation::getTagsWithTypes();
 
         foreach ($tags as $tag) {
-            static::assertIsString($tag);
-            static::assertNotEmpty($tag);
+            self::assertIsString($tag);
+            self::assertNotEmpty($tag);
         }
     }
 
@@ -551,7 +551,7 @@ final class AnnotationTest extends TestCase
         $annotation = new Annotation([new Line($line)], $namespace, $namespaceUses);
         $result = $annotation->getTypeExpression();
 
-        static::assertSame($expectedCommonType, $result->getCommonType());
+        self::assertSame($expectedCommonType, $result->getCommonType());
     }
 
     public static function provideTypeExpressionCases(): iterable
@@ -572,7 +572,7 @@ final class AnnotationTest extends TestCase
     public function testGetVariableName(string $line, ?string $expectedVariableName): void
     {
         $annotation = new Annotation([new Line($line)]);
-        static::assertSame($expectedVariableName, $annotation->getVariableName());
+        self::assertSame($expectedVariableName, $annotation->getVariableName());
     }
 
     public static function provideGetVariableCases(): iterable

--- a/tests/DocBlock/DocBlockTest.php
+++ b/tests/DocBlock/DocBlockTest.php
@@ -51,15 +51,15 @@ final class DocBlockTest extends TestCase
     {
         $doc = new DocBlock(self::$sample);
 
-        static::assertSame(self::$sample, $doc->getContent());
-        static::assertSame(self::$sample, (string) $doc);
+        self::assertSame(self::$sample, $doc->getContent());
+        self::assertSame(self::$sample, (string) $doc);
     }
 
     public function testEmptyContent(): void
     {
         $doc = new DocBlock('');
 
-        static::assertSame('', $doc->getContent());
+        self::assertSame('', $doc->getContent());
     }
 
     public function testGetLines(): void
@@ -67,14 +67,14 @@ final class DocBlockTest extends TestCase
         $doc = new DocBlock(self::$sample);
         $lines = $doc->getLines();
 
-        static::assertCount(15, $lines);
+        self::assertCount(15, $lines);
 
         foreach ($lines as $index => $line) {
-            static::assertInstanceOf(\PhpCsFixer\DocBlock\Line::class, $line);
-            static::assertSame($doc->getLine($index), $line);
+            self::assertInstanceOf(\PhpCsFixer\DocBlock\Line::class, $line);
+            self::assertSame($doc->getLine($index), $line);
         }
 
-        static::assertEmpty($doc->getLine(15));
+        self::assertEmpty($doc->getLine(15));
     }
 
     public function testGetAnnotations(): void
@@ -82,14 +82,14 @@ final class DocBlockTest extends TestCase
         $doc = new DocBlock(self::$sample);
         $annotations = $doc->getAnnotations();
 
-        static::assertCount(5, $annotations);
+        self::assertCount(5, $annotations);
 
         foreach ($annotations as $index => $annotation) {
-            static::assertInstanceOf(\PhpCsFixer\DocBlock\Annotation::class, $annotation);
-            static::assertSame($doc->getAnnotation($index), $annotation);
+            self::assertInstanceOf(\PhpCsFixer\DocBlock\Annotation::class, $annotation);
+            self::assertSame($doc->getAnnotation($index), $annotation);
         }
 
-        static::assertEmpty($doc->getAnnotation(5));
+        self::assertEmpty($doc->getAnnotation(5));
     }
 
     public function testGetAnnotationsOfTypeParam(): void
@@ -97,7 +97,7 @@ final class DocBlockTest extends TestCase
         $doc = new DocBlock(self::$sample);
         $annotations = $doc->getAnnotationsOfType('param');
 
-        static::assertCount(3, $annotations);
+        self::assertCount(3, $annotations);
 
         $first = '     * @param string $hello
 ';
@@ -107,9 +107,9 @@ final class DocBlockTest extends TestCase
         $third = '     * @param adkjbadjasbdand $asdnjkasd
 ';
 
-        static::assertSame($first, $annotations[0]->getContent());
-        static::assertSame($second, $annotations[1]->getContent());
-        static::assertSame($third, $annotations[2]->getContent());
+        self::assertSame($first, $annotations[0]->getContent());
+        self::assertSame($second, $annotations[1]->getContent());
+        self::assertSame($third, $annotations[2]->getContent());
     }
 
     public function testGetAnnotationsOfTypeThrows(): void
@@ -117,14 +117,14 @@ final class DocBlockTest extends TestCase
         $doc = new DocBlock(self::$sample);
         $annotations = $doc->getAnnotationsOfType('throws');
 
-        static::assertCount(1, $annotations);
+        self::assertCount(1, $annotations);
 
         $content = '     * @throws \Exception asdnjkasd
      * asdasdasdasdasdasdasdasd
      * kasdkasdkbasdasdasdjhbasdhbasjdbjasbdjhb
 ';
 
-        static::assertSame($content, $annotations[0]->getContent());
+        self::assertSame($content, $annotations[0]->getContent());
     }
 
     public function testGetAnnotationsOfTypeReturn(): void
@@ -132,12 +132,12 @@ final class DocBlockTest extends TestCase
         $doc = new DocBlock(self::$sample);
         $annotations = $doc->getAnnotationsOfType('return');
 
-        static::assertCount(1, $annotations);
+        self::assertCount(1, $annotations);
 
         $content = '     * @return void
 ';
 
-        static::assertSame($content, $annotations[0]->getContent());
+        self::assertSame($content, $annotations[0]->getContent());
     }
 
     public function testGetAnnotationsOfTypeFoo(): void
@@ -145,14 +145,14 @@ final class DocBlockTest extends TestCase
         $doc = new DocBlock(self::$sample);
         $annotations = $doc->getAnnotationsOfType('foo');
 
-        static::assertCount(0, $annotations);
+        self::assertCount(0, $annotations);
     }
 
     public function testIsMultiLIne(): void
     {
         $doc = new DocBlock(self::$sample);
 
-        static::assertTrue($doc->isMultiLine());
+        self::assertTrue($doc->isMultiLine());
     }
 
     /**
@@ -167,7 +167,7 @@ final class DocBlockTest extends TestCase
             $outputDocBlock = $inputDocBlock;
         }
 
-        static::assertSame($outputDocBlock, $doc->getContent());
+        self::assertSame($outputDocBlock, $doc->getContent());
     }
 
     public static function provideDocBlocksToConvertToMultiLineCases(): array
@@ -212,7 +212,7 @@ final class DocBlockTest extends TestCase
             $outputDocBlock = $inputDocBlock;
         }
 
-        static::assertSame($outputDocBlock, $doc->getContent());
+        self::assertSame($outputDocBlock, $doc->getContent());
     }
 
     public static function provideDocBlocksToConvertToSingleLineCases(): array

--- a/tests/DocBlock/LineTest.php
+++ b/tests/DocBlock/LineTest.php
@@ -125,8 +125,8 @@ final class LineTest extends TestCase
         $doc = new DocBlock(self::$sample);
         $line = $doc->getLine($pos);
 
-        static::assertSame($content, $line->getContent());
-        static::assertSame($content, (string) $line);
+        self::assertSame($content, $line->getContent());
+        self::assertSame($content, (string) $line);
     }
 
     /**
@@ -137,8 +137,8 @@ final class LineTest extends TestCase
         $doc = new DocBlock(self::$sample);
         $line = $doc->getLine($pos);
 
-        static::assertSame(0 === $pos, $line->isTheStart());
-        static::assertSame(14 === $pos, $line->isTheEnd());
+        self::assertSame(0 === $pos, $line->isTheStart());
+        self::assertSame(14 === $pos, $line->isTheEnd());
     }
 
     public static function provideLinesCases(): iterable
@@ -156,7 +156,7 @@ final class LineTest extends TestCase
         $doc = new DocBlock(self::$sample);
         $line = $doc->getLine($pos);
 
-        static::assertSame($useful, $line->containsUsefulContent());
+        self::assertSame($useful, $line->containsUsefulContent());
     }
 
     public static function provideLinesWithUsefulCases(): iterable
@@ -174,7 +174,7 @@ final class LineTest extends TestCase
         $doc = new DocBlock(self::$sample);
         $line = $doc->getLine($pos);
 
-        static::assertSame($tag, $line->containsATag());
+        self::assertSame($tag, $line->containsATag());
     }
 
     public static function provideLinesWithTagCases(): iterable
@@ -188,18 +188,18 @@ final class LineTest extends TestCase
     {
         $line = new Line("     * @param \$foo Hi!\n");
 
-        static::assertSame("     * @param \$foo Hi!\n", $line->getContent());
+        self::assertSame("     * @param \$foo Hi!\n", $line->getContent());
 
         $line->addBlank();
-        static::assertSame("     * @param \$foo Hi!\n     *\n", $line->getContent());
+        self::assertSame("     * @param \$foo Hi!\n     *\n", $line->getContent());
 
         $line->setContent("\t * test\r\n");
-        static::assertSame("\t * test\r\n", $line->getContent());
+        self::assertSame("\t * test\r\n", $line->getContent());
 
         $line->addBlank();
-        static::assertSame("\t * test\r\n\t *\r\n", $line->getContent());
+        self::assertSame("\t * test\r\n\t *\r\n", $line->getContent());
 
         $line->remove();
-        static::assertSame('', $line->getContent());
+        self::assertSame('', $line->getContent());
     }
 }

--- a/tests/DocBlock/ShortDescriptionTest.php
+++ b/tests/DocBlock/ShortDescriptionTest.php
@@ -33,7 +33,7 @@ final class ShortDescriptionTest extends TestCase
         $doc = new DocBlock($input);
         $shortDescription = new ShortDescription($doc);
 
-        static::assertSame($expected, $shortDescription->getEnd());
+        self::assertSame($expected, $shortDescription->getEnd());
     }
 
     public static function provideGetEndCases(): array

--- a/tests/DocBlock/TagComparatorTest.php
+++ b/tests/DocBlock/TagComparatorTest.php
@@ -41,7 +41,7 @@ final class TagComparatorTest extends TestCase
 
         $this->expectDeprecation('%AMethod PhpCsFixer\DocBlock\TagComparator::shouldBeTogether is deprecated and will be removed in version 4.0.');
 
-        static::assertSame($expected, TagComparator::shouldBeTogether($tag1, $tag2));
+        self::assertSame($expected, TagComparator::shouldBeTogether($tag1, $tag2));
     }
 
     public static function provideComparatorCases(): array
@@ -73,7 +73,7 @@ final class TagComparatorTest extends TestCase
 
         $this->expectDeprecation('%AMethod PhpCsFixer\DocBlock\TagComparator::shouldBeTogether is deprecated and will be removed in version 4.0.');
 
-        static::assertSame(
+        self::assertSame(
             $expected,
             TagComparator::shouldBeTogether($tag1, $tag2, $groups)
         );

--- a/tests/DocBlock/TagTest.php
+++ b/tests/DocBlock/TagTest.php
@@ -34,7 +34,7 @@ final class TagTest extends TestCase
     {
         $tag = new Tag(new Line($input));
 
-        static::assertSame($expected, $tag->getName());
+        self::assertSame($expected, $tag->getName());
 
         if ('other' === $expected) {
             $this->expectException(\RuntimeException::class);
@@ -43,7 +43,7 @@ final class TagTest extends TestCase
 
         $tag->setName($new);
 
-        static::assertSame($new, $tag->getName());
+        self::assertSame($new, $tag->getName());
     }
 
     public static function provideNameCases(): array
@@ -69,7 +69,7 @@ final class TagTest extends TestCase
     {
         $tag = new Tag(new Line($input));
 
-        static::assertSame($expected, $tag->valid());
+        self::assertSame($expected, $tag->valid());
     }
 
     public static function provideValidCases(): array

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -34,7 +34,7 @@ final class TypeExpressionTest extends TestCase
     public function testGetTypes(string $typesExpression, array $expectedTypes): void
     {
         $expression = new TypeExpression($typesExpression, null, []);
-        static::assertSame($expectedTypes, $expression->getTypes());
+        self::assertSame($expectedTypes, $expression->getTypes());
     }
 
     public static function provideGetTypesCases(): iterable
@@ -170,7 +170,7 @@ final class TypeExpressionTest extends TestCase
     public function testGetTypesGlue(string $expectedTypesGlue, string $typesExpression): void
     {
         $expression = new TypeExpression($typesExpression, null, []);
-        static::assertSame($expectedTypesGlue, $expression->getTypesGlue());
+        self::assertSame($expectedTypesGlue, $expression->getTypesGlue());
     }
 
     public static function provideGetTypesGlueCases(): iterable
@@ -190,7 +190,7 @@ final class TypeExpressionTest extends TestCase
     public function testGetCommonType(string $typesExpression, ?string $expectedCommonType, NamespaceAnalysis $namespace = null, array $namespaceUses = []): void
     {
         $expression = new TypeExpression($typesExpression, $namespace, $namespaceUses);
-        static::assertSame($expectedCommonType, $expression->getCommonType());
+        self::assertSame($expectedCommonType, $expression->getCommonType());
     }
 
     public static function provideCommonTypeCases(): iterable
@@ -308,7 +308,7 @@ final class TypeExpressionTest extends TestCase
     public function testAllowsNull(string $typesExpression, bool $expectNullAllowed): void
     {
         $expression = new TypeExpression($typesExpression, null, []);
-        static::assertSame($expectNullAllowed, $expression->allowsNull());
+        self::assertSame($expectNullAllowed, $expression->allowsNull());
     }
 
     public static function provideAllowsNullCases(): iterable
@@ -341,7 +341,7 @@ final class TypeExpressionTest extends TestCase
             return strcasecmp($a->toString(), $b->toString());
         });
 
-        static::assertSame($expectResult, $expression->toString());
+        self::assertSame($expectResult, $expression->toString());
     }
 
     public static function provideSortTypesCases(): iterable

--- a/tests/Doctrine/Annotation/TokenTest.php
+++ b/tests/Doctrine/Annotation/TokenTest.php
@@ -31,8 +31,8 @@ final class TokenTest extends TestCase
     {
         $token = new Token();
 
-        static::assertSame(DocLexer::T_NONE, $token->getType());
-        static::assertSame('', $token->getContent());
+        self::assertSame(DocLexer::T_NONE, $token->getType());
+        self::assertSame('', $token->getContent());
     }
 
     public function testConstructorSetsValues(): void
@@ -45,8 +45,8 @@ final class TokenTest extends TestCase
             $content
         );
 
-        static::assertSame($type, $token->getType());
-        static::assertSame($content, $token->getContent());
+        self::assertSame($type, $token->getType());
+        self::assertSame($content, $token->getContent());
     }
 
     public function testCanModifyType(): void
@@ -57,7 +57,7 @@ final class TokenTest extends TestCase
 
         $token->setType($type);
 
-        static::assertSame($type, $token->getType());
+        self::assertSame($type, $token->getType());
     }
 
     /**
@@ -71,7 +71,7 @@ final class TokenTest extends TestCase
 
         $token->setType($type);
 
-        static::assertTrue($token->isType($types));
+        self::assertTrue($token->isType($types));
     }
 
     public static function provideIsTypeCases(): array
@@ -102,7 +102,7 @@ final class TokenTest extends TestCase
 
         $token->setType($type);
 
-        static::assertFalse($token->isType($types));
+        self::assertFalse($token->isType($types));
     }
 
     public static function provideIsNotTypeCases(): array
@@ -129,7 +129,7 @@ final class TokenTest extends TestCase
 
         $token->setContent($content);
 
-        static::assertSame($content, $token->getContent());
+        self::assertSame($content, $token->getContent());
     }
 
     public function testCanClearContent(): void
@@ -141,6 +141,6 @@ final class TokenTest extends TestCase
         $token->setContent($content);
         $token->clear();
 
-        static::assertSame('', $token->getContent());
+        self::assertSame('', $token->getContent());
     }
 }

--- a/tests/Doctrine/Annotation/TokensTest.php
+++ b/tests/Doctrine/Annotation/TokensTest.php
@@ -32,8 +32,8 @@ final class TokensTest extends TestCase
         $token = new Token([T_DOC_COMMENT, $docComment]);
         $tokens = Tokens::createFromDocComment($token);
 
-        static::assertCount(1, $tokens);
-        static::assertSame($docComment, $tokens->getCode());
+        self::assertCount(1, $tokens);
+        self::assertSame($docComment, $tokens->getCode());
     }
 
     /**

--- a/tests/Error/ErrorTest.php
+++ b/tests/Error/ErrorTest.php
@@ -26,8 +26,8 @@ final class ErrorTest extends TestCase
 {
     public function testThatErrorTypeConstantValuesAreDifferent(): void
     {
-        static::assertNotSame(Error::TYPE_INVALID, Error::TYPE_EXCEPTION);
-        static::assertNotSame(Error::TYPE_EXCEPTION, Error::TYPE_LINT);
+        self::assertNotSame(Error::TYPE_INVALID, Error::TYPE_EXCEPTION);
+        self::assertNotSame(Error::TYPE_EXCEPTION, Error::TYPE_LINT);
     }
 
     public function testConstructorSetsValues(): void
@@ -40,11 +40,11 @@ final class ErrorTest extends TestCase
             $filePath
         );
 
-        static::assertSame($type, $error->getType());
-        static::assertSame($filePath, $error->getFilePath());
-        static::assertNull($error->getSource());
-        static::assertSame([], $error->getAppliedFixers());
-        static::assertNull($error->getDiff());
+        self::assertSame($type, $error->getType());
+        self::assertSame($filePath, $error->getFilePath());
+        self::assertNull($error->getSource());
+        self::assertSame([], $error->getAppliedFixers());
+        self::assertNull($error->getDiff());
     }
 
     public function testConstructorSetsValues2(): void
@@ -63,10 +63,10 @@ final class ErrorTest extends TestCase
             $diff
         );
 
-        static::assertSame($type, $error->getType());
-        static::assertSame($filePath, $error->getFilePath());
-        static::assertSame($source, $error->getSource());
-        static::assertSame($appliedFixers, $error->getAppliedFixers());
-        static::assertSame($diff, $error->getDiff());
+        self::assertSame($type, $error->getType());
+        self::assertSame($filePath, $error->getFilePath());
+        self::assertSame($source, $error->getSource());
+        self::assertSame($appliedFixers, $error->getAppliedFixers());
+        self::assertSame($diff, $error->getDiff());
     }
 }

--- a/tests/Error/ErrorsManagerTest.php
+++ b/tests/Error/ErrorsManagerTest.php
@@ -29,10 +29,10 @@ final class ErrorsManagerTest extends TestCase
     {
         $errorsManager = new ErrorsManager();
 
-        static::assertTrue($errorsManager->isEmpty());
-        static::assertEmpty($errorsManager->getInvalidErrors());
-        static::assertEmpty($errorsManager->getExceptionErrors());
-        static::assertEmpty($errorsManager->getLintErrors());
+        self::assertTrue($errorsManager->isEmpty());
+        self::assertEmpty($errorsManager->getInvalidErrors());
+        self::assertEmpty($errorsManager->getExceptionErrors());
+        self::assertEmpty($errorsManager->getLintErrors());
     }
 
     public function testThatCanReportAndRetrieveInvalidErrors(): void
@@ -46,16 +46,16 @@ final class ErrorsManagerTest extends TestCase
 
         $errorsManager->report($error);
 
-        static::assertFalse($errorsManager->isEmpty());
+        self::assertFalse($errorsManager->isEmpty());
 
         $errors = $errorsManager->getInvalidErrors();
 
-        static::assertIsArray($errors);
-        static::assertCount(1, $errors);
-        static::assertSame($error, array_shift($errors));
+        self::assertIsArray($errors);
+        self::assertCount(1, $errors);
+        self::assertSame($error, array_shift($errors));
 
-        static::assertCount(0, $errorsManager->getExceptionErrors());
-        static::assertCount(0, $errorsManager->getLintErrors());
+        self::assertCount(0, $errorsManager->getExceptionErrors());
+        self::assertCount(0, $errorsManager->getLintErrors());
     }
 
     public function testThatCanReportAndRetrieveExceptionErrors(): void
@@ -69,16 +69,16 @@ final class ErrorsManagerTest extends TestCase
 
         $errorsManager->report($error);
 
-        static::assertFalse($errorsManager->isEmpty());
+        self::assertFalse($errorsManager->isEmpty());
 
         $errors = $errorsManager->getExceptionErrors();
 
-        static::assertIsArray($errors);
-        static::assertCount(1, $errors);
-        static::assertSame($error, array_shift($errors));
+        self::assertIsArray($errors);
+        self::assertCount(1, $errors);
+        self::assertSame($error, array_shift($errors));
 
-        static::assertCount(0, $errorsManager->getInvalidErrors());
-        static::assertCount(0, $errorsManager->getLintErrors());
+        self::assertCount(0, $errorsManager->getInvalidErrors());
+        self::assertCount(0, $errorsManager->getLintErrors());
     }
 
     public function testThatCanReportAndRetrieveInvalidFileErrors(): void
@@ -92,15 +92,15 @@ final class ErrorsManagerTest extends TestCase
 
         $errorsManager->report($error);
 
-        static::assertFalse($errorsManager->isEmpty());
+        self::assertFalse($errorsManager->isEmpty());
 
         $errors = $errorsManager->getLintErrors();
 
-        static::assertIsArray($errors);
-        static::assertCount(1, $errors);
-        static::assertSame($error, array_shift($errors));
+        self::assertIsArray($errors);
+        self::assertCount(1, $errors);
+        self::assertSame($error, array_shift($errors));
 
-        static::assertCount(0, $errorsManager->getInvalidErrors());
-        static::assertCount(0, $errorsManager->getExceptionErrors());
+        self::assertCount(0, $errorsManager->getInvalidErrors());
+        self::assertCount(0, $errorsManager->getExceptionErrors());
     }
 }

--- a/tests/FileReaderTest.php
+++ b/tests/FileReaderTest.php
@@ -41,7 +41,7 @@ final class FileReaderTest extends TestCase
     {
         $instance = FileReader::createSingleton();
 
-        static::assertSame($instance, FileReader::createSingleton());
+        self::assertSame($instance, FileReader::createSingleton());
     }
 
     public function testRead(): void
@@ -52,7 +52,7 @@ final class FileReaderTest extends TestCase
 
         $reader = new FileReader();
 
-        static::assertSame('<?php echo "hi";', $reader->read($fs->url().'/foo.php'));
+        self::assertSame('<?php echo "hi";', $reader->read($fs->url().'/foo.php'));
     }
 
     public function testReadStdinCaches(): void
@@ -62,8 +62,8 @@ final class FileReaderTest extends TestCase
         stream_wrapper_unregister('php');
         stream_wrapper_register('php', StdinFakeStream::class);
 
-        static::assertSame('<?php echo "foo";', $reader->read('php://stdin'));
-        static::assertSame('<?php echo "foo";', $reader->read('php://stdin'));
+        self::assertSame('<?php echo "foo";', $reader->read('php://stdin'));
+        self::assertSame('<?php echo "foo";', $reader->read('php://stdin'));
     }
 
     public function testThrowsExceptionOnFail(): void

--- a/tests/FileRemovalTest.php
+++ b/tests/FileRemovalTest.php
@@ -71,8 +71,8 @@ final class FileRemovalTest extends TestCase
      */
     public function testShutdownRemovesObservedFiles(): void
     {
-        static::assertFileDoesNotExist(sys_get_temp_dir().'/cs_fixer_foo.php');
-        static::assertFileExists(sys_get_temp_dir().'/cs_fixer_bar.php');
+        self::assertFileDoesNotExist(sys_get_temp_dir().'/cs_fixer_foo.php');
+        self::assertFileExists(sys_get_temp_dir().'/cs_fixer_bar.php');
     }
 
     public function testCleanRemovesObservedFiles(): void
@@ -86,9 +86,9 @@ final class FileRemovalTest extends TestCase
 
         $fileRemoval->clean();
 
-        static::assertFileDoesNotExist($fs->url().'/foo.php');
-        static::assertFileDoesNotExist($fs->url().'/baz.php');
-        static::assertFileExists($fs->url().'/bar.php');
+        self::assertFileDoesNotExist($fs->url().'/foo.php');
+        self::assertFileDoesNotExist($fs->url().'/baz.php');
+        self::assertFileExists($fs->url().'/bar.php');
     }
 
     public function testDestructRemovesObservedFiles(): void
@@ -102,9 +102,9 @@ final class FileRemovalTest extends TestCase
 
         $fileRemoval->__destruct();
 
-        static::assertFileDoesNotExist($fs->url().'/foo.php');
-        static::assertFileDoesNotExist($fs->url().'/baz.php');
-        static::assertFileExists($fs->url().'/bar.php');
+        self::assertFileDoesNotExist($fs->url().'/foo.php');
+        self::assertFileDoesNotExist($fs->url().'/baz.php');
+        self::assertFileExists($fs->url().'/bar.php');
     }
 
     public function testDeleteObservedFile(): void
@@ -118,8 +118,8 @@ final class FileRemovalTest extends TestCase
 
         $fileRemoval->delete($fs->url().'/foo.php');
 
-        static::assertFileDoesNotExist($fs->url().'/foo.php');
-        static::assertFileExists($fs->url().'/baz.php');
+        self::assertFileDoesNotExist($fs->url().'/foo.php');
+        self::assertFileExists($fs->url().'/baz.php');
     }
 
     public function testDeleteNonObservedFile(): void
@@ -130,7 +130,7 @@ final class FileRemovalTest extends TestCase
 
         $fileRemoval->delete($fs->url().'/foo.php');
 
-        static::assertFileDoesNotExist($fs->url().'/foo.php');
+        self::assertFileDoesNotExist($fs->url().'/foo.php');
     }
 
     public function testSleep(): void

--- a/tests/FinderTest.php
+++ b/tests/FinderTest.php
@@ -41,7 +41,7 @@ final class FinderTest extends TestCase
             ->ignoreDotFiles(false)
         ;
 
-        static::assertContains(
+        self::assertContains(
             realpath(__DIR__.'/../.php-cs-fixer.dist.php'),
             array_map(
                 function (SplFileInfo $file): string {

--- a/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
+++ b/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
@@ -286,7 +286,7 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
     {
         $this->fixer->configure([]);
 
-        static::assertCandidateTokenType(T_PRINT, $this->fixer);
+        self::assertCandidateTokenType(T_PRINT, $this->fixer);
     }
 
     /**
@@ -329,7 +329,7 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
         $reflectionProperty = new \ReflectionProperty($fixer, 'candidateTokenType');
         $reflectionProperty->setAccessible(true);
 
-        static::assertSame($expected, $reflectionProperty->getValue($fixer));
+        self::assertSame($expected, $reflectionProperty->getValue($fixer));
     }
 
     /**

--- a/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+++ b/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
@@ -50,7 +50,7 @@ final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
         $reflectionProperty = new \ReflectionProperty($this->fixer, 'configuration');
         $reflectionProperty->setAccessible(true);
 
-        static::assertSame(
+        self::assertSame(
             ['replacements' => [
                 'rand' => ['alternativeName' => 'random_int', 'argumentCount' => [0, 2]], ],
             ],

--- a/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
+++ b/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
@@ -39,7 +39,7 @@ final class LowercaseCastFixerTest extends AbstractFixerTestCase
     public function testFix74Deprecated(string $expected, ?string $input = null): void
     {
         if (\PHP_VERSION_ID >= 8_00_00) {
-            static::markTestSkipped('PHP < 8.0 is required.');
+            self::markTestSkipped('PHP < 8.0 is required.');
         }
 
         $this->expectDeprecation('%AThe (real) cast is deprecated, use (float) instead');

--- a/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
+++ b/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
@@ -39,7 +39,7 @@ final class ShortScalarCastFixerTest extends AbstractFixerTestCase
     public function testFix74Deprecated(string $expected, ?string $input = null): void
     {
         if (\PHP_VERSION_ID >= 8_00_00) {
-            static::markTestSkipped('PHP < 8.0 is required.');
+            self::markTestSkipped('PHP < 8.0 is required.');
         }
 
         $this->expectDeprecation('%AThe (real) cast is deprecated, use (float) instead');

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -279,7 +279,7 @@ private $d = 123;
         $method->setAccessible(true);
 
         $result = $method->invoke($this->fixer, $tokens, $index, 0);
-        static::assertSame(
+        self::assertSame(
             $expected,
             $result,
             sprintf('Expected index %d (%s) got index %d (%s).', $expected, $tokens[$expected]->toJson(), $result, $tokens[$result]->toJson())

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -39,10 +39,10 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
 
         $fixer = new ClassDefinitionFixer();
         $fixer->configure($defaultConfig);
-        static::assertConfigurationSame($defaultConfig, $fixer);
+        self::assertConfigurationSame($defaultConfig, $fixer);
 
         $fixer->configure([]);
-        static::assertConfigurationSame($defaultConfig, $fixer);
+        self::assertConfigurationSame($defaultConfig, $fixer);
     }
 
     /**
@@ -434,7 +434,7 @@ TestInterface3, /**/     TestInterface4   ,
         ksort($expected);
         ksort($result);
 
-        static::assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public static function provideClassyDefinitionInfoCases(): array
@@ -784,7 +784,7 @@ $a = new class implements
         $reflectionProperty = new \ReflectionProperty($fixer, 'configuration');
         $reflectionProperty->setAccessible(true);
 
-        static::assertSame($expected, $reflectionProperty->getValue($fixer));
+        self::assertSame($expected, $reflectionProperty->getValue($fixer));
     }
 
     /**
@@ -794,13 +794,13 @@ $a = new class implements
     {
         Tokens::clearCache();
         $tokens = Tokens::fromCode($source);
-        static::assertTrue($tokens[$expected['start']]->isGivenKind([T_IMPLEMENTS, T_EXTENDS]), sprintf('Token must be "implements" or "extends", got "%s".', $tokens[$expected['start']]->getContent()));
+        self::assertTrue($tokens[$expected['start']]->isGivenKind([T_IMPLEMENTS, T_EXTENDS]), sprintf('Token must be "implements" or "extends", got "%s".', $tokens[$expected['start']]->getContent()));
         $method = new \ReflectionMethod($this->fixer, 'getClassyInheritanceInfo');
         $method->setAccessible(true);
 
         $result = $method->invoke($this->fixer, $tokens, $expected['start'], $label);
 
-        static::assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     private static function provideClassyCases(string $classy): array

--- a/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
+++ b/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
@@ -260,16 +260,16 @@ echo 1;
     {
         Tokens::clearCache();
         $tokens = Tokens::fromCode($source);
-        static::assertTrue($tokens[$startIndex]->isComment(), sprintf('Misconfiguration of test, expected comment token at index "%d".', $startIndex));
+        self::assertTrue($tokens[$startIndex]->isComment(), sprintf('Misconfiguration of test, expected comment token at index "%d".', $startIndex));
 
         $method = new \ReflectionMethod($this->fixer, 'getCommentBlock');
         $method->setAccessible(true);
 
         [$foundStart, $foundEnd, $foundIsEmpty] = $method->invoke($this->fixer, $tokens, $startIndex);
 
-        static::assertSame($startIndex, $foundStart, 'Find start index of block failed.');
-        static::assertSame($endIndex, $foundEnd, 'Find end index of block failed.');
-        static::assertSame($isEmpty, $foundIsEmpty, 'Is empty comment block detection failed.');
+        self::assertSame($startIndex, $foundStart, 'Find start index of block failed.');
+        self::assertSame($endIndex, $foundEnd, 'Find end index of block failed.');
+        self::assertSame($isEmpty, $foundIsEmpty, 'Is empty comment block detection failed.');
     }
 
     public static function provideCommentBlockCases(): array

--- a/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
@@ -660,7 +660,7 @@ else?><?php echo 5;',
 
         $result = $method->invoke($this->fixer, $tokens, $index);
 
-        static::assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public static function provideBlockDetectionCases(): array
@@ -781,7 +781,7 @@ else?><?php echo 5;',
         $tokens = Tokens::fromCode($input);
 
         foreach ($indexes as $index => $expected) {
-            static::assertSame(
+            self::assertSame(
                 $expected,
                 $method->invoke($this->fixer, $tokens, $index, 0),
                 sprintf('Failed in condition without braces check for index %d', $index)

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -811,7 +811,7 @@ switch ($a) {
 
     public function testDefinition(): void
     {
-        static::assertInstanceOf(\PhpCsFixer\FixerDefinition\FixerDefinitionInterface::class, $this->fixer->getDefinition());
+        self::assertInstanceOf(\PhpCsFixer\FixerDefinition\FixerDefinitionInterface::class, $this->fixer->getDefinition());
     }
 
     /**

--- a/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
+++ b/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
@@ -293,7 +293,7 @@ final class VoidReturnFixerTest extends AbstractFixerTestCase
 
         $this->fixer->fix($this->getTestFile(), $tokens);
 
-        static::assertNull($this->lintSource($tokens->generateCode()));
+        self::assertNull($this->lintSource($tokens->generateCode()));
     }
 
     public static function provideMethodWillNotCauseSyntaxErrorCases(): iterable

--- a/tests/Fixer/Operator/OperatorLinebreakFixerTest.php
+++ b/tests/Fixer/Operator/OperatorLinebreakFixerTest.php
@@ -39,7 +39,7 @@ final class OperatorLinebreakFixerTest extends AbstractFixerTestCase
 
     public static function provideFixCases(): iterable
     {
-        foreach (static::pairs() as $key => $value) {
+        foreach (self::pairs() as $key => $value) {
             yield sprintf('%s when position is "beginning"', $key) => $value;
 
             yield sprintf('%s when position is "end"', $key) => [

--- a/tests/Fixer/PhpTag/NoClosingTagFixerTest.php
+++ b/tests/Fixer/PhpTag/NoClosingTagFixerTest.php
@@ -37,7 +37,7 @@ final class NoClosingTagFixerTest extends AbstractFixerTestCase
     public function testWithShortOpenTag(string $expected, ?string $input = null): void
     {
         if (!\ini_get('short_open_tag')) {
-            static::markTestSkipped('The short_open_tag option is required to be enabled.');
+            self::markTestSkipped('The short_open_tag option is required to be enabled.');
         }
 
         $this->doTest($expected, $input);

--- a/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
@@ -115,10 +115,10 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
         array_walk(
             $cases,
             static function (&$case): void {
-                $case[0] = static::generateTest($case[0]);
+                $case[0] = self::generateTest($case[0]);
 
                 if (isset($case[1])) {
-                    $case[1] = static::generateTest($case[1]);
+                    $case[1] = self::generateTest($case[1]);
                 }
             }
         );
@@ -169,12 +169,12 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
     {
         return [
             [
-                static::generateTest('$this->assertTrue($a, );'),
-                static::generateTest('$this->assertSame(true, $a, );'),
+                self::generateTest('$this->assertTrue($a, );'),
+                self::generateTest('$this->assertSame(true, $a, );'),
             ],
             [
-                static::generateTest('$this->assertTrue($a, $message , );'),
-                static::generateTest('$this->assertSame(true, $a, $message , );'),
+                self::generateTest('$this->assertTrue($a, $message , );'),
+                self::generateTest('$this->assertSame(true, $a, $message , );'),
             ],
         ];
     }

--- a/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
@@ -265,8 +265,8 @@ final class PhpUnitNamespacedFixerTest extends AbstractFixerTestCase
 
         $this->fixer->fix($this->getTestFile(), $tokens);
 
-        static::assertTrue($tokens->isChanged());
-        static::assertStringNotContainsString('_', $tokens->generateCode());
+        self::assertTrue($tokens->isChanged());
+        self::assertStringNotContainsString('_', $tokens->generateCode());
     }
 
     public static function provideClassIsFixedCases(): iterable

--- a/tests/Fixer/PhpUnit/PhpUnitTargetVersionTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTargetVersionTest.php
@@ -35,7 +35,7 @@ final class PhpUnitTargetVersionTest extends TestCase
             $this->expectException($exception);
         }
 
-        static::assertSame(
+        self::assertSame(
             $expected,
             PhpUnitTargetVersion::fulfills($candidate, $target)
         );

--- a/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
@@ -44,7 +44,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
             }
         }
 
-        static::assertSame([], $missingMethods, sprintf('The following static methods from "%s" are missing from "%s::$staticMethods"', TestCase::class, PhpUnitTestCaseStaticMethodCallsFixer::class));
+        self::assertSame([], $missingMethods, sprintf('The following static methods from "%s" are missing from "%s::$staticMethods"', TestCase::class, PhpUnitTestCaseStaticMethodCallsFixer::class));
     }
 
     public function testWrongConfigTypeForMethodsKey(): void

--- a/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
+++ b/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
@@ -522,7 +522,7 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
     public function testCasesWithShortOpenTag(string $expected, ?string $input = null): void
     {
         if (!\ini_get('short_open_tag')) {
-            static::markTestSkipped('No short tag tests possible.');
+            self::markTestSkipped('No short tag tests possible.');
         }
 
         $this->doTest($expected, $input);

--- a/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
+++ b/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
@@ -103,7 +103,7 @@ A is equal to 5
     public function testOpenWithEcho(): void
     {
         if (!\ini_get('short_open_tag')) {
-            static::markTestSkipped('The short_open_tag option is required to be enabled.');
+            self::markTestSkipped('The short_open_tag option is required to be enabled.');
         }
 
         $this->doTest(

--- a/tests/FixerConfiguration/AliasedFixerOptionBuilderTest.php
+++ b/tests/FixerConfiguration/AliasedFixerOptionBuilderTest.php
@@ -30,25 +30,25 @@ final class AliasedFixerOptionBuilderTest extends TestCase
     public function testSetDefault(): void
     {
         $builder = new AliasedFixerOptionBuilder(new FixerOptionBuilder('foo', 'Bar.'), 'baz');
-        static::assertSame($builder, $builder->setDefault('baz'));
+        self::assertSame($builder, $builder->setDefault('baz'));
     }
 
     public function testSetAllowedTypes(): void
     {
         $builder = new AliasedFixerOptionBuilder(new FixerOptionBuilder('foo', 'Bar.'), 'baz');
-        static::assertSame($builder, $builder->setAllowedTypes(['bool']));
+        self::assertSame($builder, $builder->setAllowedTypes(['bool']));
     }
 
     public function testSetAllowedValues(): void
     {
         $builder = new AliasedFixerOptionBuilder(new FixerOptionBuilder('foo', 'Bar.'), 'baz');
-        static::assertSame($builder, $builder->setAllowedValues(['baz']));
+        self::assertSame($builder, $builder->setAllowedValues(['baz']));
     }
 
     public function testSetNormalizer(): void
     {
         $builder = new AliasedFixerOptionBuilder(new FixerOptionBuilder('foo', 'Bar.'), 'baz');
-        static::assertSame($builder, $builder->setNormalizer(static fn () => null));
+        self::assertSame($builder, $builder->setNormalizer(static fn () => null));
     }
 
     public function testGetOption(): void
@@ -62,13 +62,13 @@ final class AliasedFixerOptionBuilderTest extends TestCase
             ->getOption()
         ;
 
-        static::assertSame('foo', $option->getName());
-        static::assertSame('Bar.', $option->getDescription());
-        static::assertTrue($option->hasDefault());
-        static::assertSame('baz', $option->getDefault());
-        static::assertSame(['bool'], $option->getAllowedTypes());
-        static::assertSame([true, false], $option->getAllowedValues());
-        static::assertInstanceOf(\Closure::class, $option->getNormalizer());
-        static::assertSame('baz', $option->getAlias());
+        self::assertSame('foo', $option->getName());
+        self::assertSame('Bar.', $option->getDescription());
+        self::assertTrue($option->hasDefault());
+        self::assertSame('baz', $option->getDefault());
+        self::assertSame(['bool'], $option->getAllowedTypes());
+        self::assertSame([true, false], $option->getAllowedValues());
+        self::assertInstanceOf(\Closure::class, $option->getNormalizer());
+        self::assertSame('baz', $option->getAlias());
     }
 }

--- a/tests/FixerConfiguration/AliasedFixerOptionTest.php
+++ b/tests/FixerConfiguration/AliasedFixerOptionTest.php
@@ -34,7 +34,7 @@ final class AliasedFixerOptionTest extends TestCase
     {
         $option = new AliasedFixerOption(new FixerOption($name, 'Bar.'), 'baz');
 
-        static::assertSame($name, $option->getName());
+        self::assertSame($name, $option->getName());
     }
 
     public static function provideGetNameCases(): array
@@ -52,7 +52,7 @@ final class AliasedFixerOptionTest extends TestCase
     {
         $option = new AliasedFixerOption(new FixerOption('foo', $description), 'baz');
 
-        static::assertSame($description, $option->getDescription());
+        self::assertSame($description, $option->getDescription());
     }
 
     public static function provideGetDescriptionCases(): array
@@ -68,7 +68,7 @@ final class AliasedFixerOptionTest extends TestCase
      */
     public function testHasDefault(bool $hasDefault, AliasedFixerOption $input): void
     {
-        static::assertSame($hasDefault, $input->hasDefault());
+        self::assertSame($hasDefault, $input->hasDefault());
     }
 
     public static function provideHasDefaultCases(): array
@@ -92,7 +92,7 @@ final class AliasedFixerOptionTest extends TestCase
     {
         $option = new AliasedFixerOption(new FixerOption('foo', 'Bar.', false, $default), 'baz');
 
-        static::assertSame($default, $option->getDefault());
+        self::assertSame($default, $option->getDefault());
     }
 
     public static function provideGetDefaultCases(): array
@@ -121,7 +121,7 @@ final class AliasedFixerOptionTest extends TestCase
     {
         $option = new AliasedFixerOption(new FixerOption('foo', 'Bar.', true, null, $allowedTypes), 'baz');
 
-        static::assertSame($allowedTypes, $option->getAllowedTypes());
+        self::assertSame($allowedTypes, $option->getAllowedTypes());
     }
 
     public static function provideGetAllowedTypesCases(): array
@@ -142,7 +142,7 @@ final class AliasedFixerOptionTest extends TestCase
     {
         $option = new AliasedFixerOption(new FixerOption('foo', 'Bar.', true, null, null, $allowedValues), 'baz');
 
-        static::assertSame($allowedValues, $option->getAllowedValues());
+        self::assertSame($allowedValues, $option->getAllowedValues());
     }
 
     public static function provideGetAllowedValuesCases(): array
@@ -158,19 +158,19 @@ final class AliasedFixerOptionTest extends TestCase
     {
         $option = new AliasedFixerOption(new FixerOption('foo', 'Bar.', true, null, null, [static fn () => true]), 'baz');
         $allowedTypes = $option->getAllowedValues();
-        static::assertIsArray($allowedTypes);
-        static::assertCount(1, $allowedTypes);
-        static::assertArrayHasKey(0, $allowedTypes);
-        static::assertInstanceOf(\Closure::class, $allowedTypes[0]);
+        self::assertIsArray($allowedTypes);
+        self::assertCount(1, $allowedTypes);
+        self::assertArrayHasKey(0, $allowedTypes);
+        self::assertInstanceOf(\Closure::class, $allowedTypes[0]);
     }
 
     public function testGetNormalizers(): void
     {
         $option = new AliasedFixerOption(new FixerOption('foo', 'Bar.'), 'baz');
-        static::assertNull($option->getNormalizer());
+        self::assertNull($option->getNormalizer());
 
         $option = new AliasedFixerOption(new FixerOption('foo', 'Bar.', true, null, null, null, static fn () => null), 'baz');
-        static::assertInstanceOf(\Closure::class, $option->getNormalizer());
+        self::assertInstanceOf(\Closure::class, $option->getNormalizer());
     }
 
     /**
@@ -180,7 +180,7 @@ final class AliasedFixerOptionTest extends TestCase
     {
         $options = new AliasedFixerOption(new FixerOption('foo', 'Bar', true, null, null, null, null), $alias);
 
-        static::assertSame($alias, $options->getAlias());
+        self::assertSame($alias, $options->getAlias());
     }
 
     public static function provideGetAliasCases(): array

--- a/tests/FixerConfiguration/AllowedValueSubsetTest.php
+++ b/tests/FixerConfiguration/AllowedValueSubsetTest.php
@@ -26,7 +26,7 @@ final class AllowedValueSubsetTest extends TestCase
 {
     public function testConstructor(): void
     {
-        static::assertIsCallable(new AllowedValueSubset(['foo', 'bar']));
+        self::assertIsCallable(new AllowedValueSubset(['foo', 'bar']));
     }
 
     public static function provideGetAllowedValuesAreSortedCases(): iterable
@@ -52,7 +52,7 @@ final class AllowedValueSubsetTest extends TestCase
     {
         $subset = new AllowedValueSubset($input);
 
-        static::assertSame($expected, $subset->getAllowedValues());
+        self::assertSame($expected, $subset->getAllowedValues());
     }
 
     /**
@@ -64,7 +64,7 @@ final class AllowedValueSubsetTest extends TestCase
     {
         $subset = new AllowedValueSubset(['foo', 'bar']);
 
-        static::assertSame($expectedResult, $subset($inputValue));
+        self::assertSame($expectedResult, $subset($inputValue));
     }
 
     public static function provideInvokeCases(): array
@@ -131,6 +131,6 @@ final class AllowedValueSubsetTest extends TestCase
 
         $subset = new AllowedValueSubset($values);
 
-        static::assertSame($values, $subset->getAllowedValues());
+        self::assertSame($values, $subset->getAllowedValues());
     }
 }

--- a/tests/FixerConfiguration/DeprecatedFixerOptionTest.php
+++ b/tests/FixerConfiguration/DeprecatedFixerOptionTest.php
@@ -34,8 +34,8 @@ final class DeprecatedFixerOptionTest extends TestCase
             'deprecated'
         );
 
-        static::assertInstanceOf(FixerOptionInterface::class, $option);
-        static::assertInstanceOf(DeprecatedFixerOptionInterface::class, $option);
+        self::assertInstanceOf(FixerOptionInterface::class, $option);
+        self::assertInstanceOf(DeprecatedFixerOptionInterface::class, $option);
     }
 
     public function testGetName(): void
@@ -45,7 +45,7 @@ final class DeprecatedFixerOptionTest extends TestCase
             'deprecated'
         );
 
-        static::assertSame('foo', $option->getName());
+        self::assertSame('foo', $option->getName());
     }
 
     public function testGetDescription(): void
@@ -55,7 +55,7 @@ final class DeprecatedFixerOptionTest extends TestCase
             'deprecated'
         );
 
-        static::assertSame('Foo.', $option->getDescription());
+        self::assertSame('Foo.', $option->getDescription());
     }
 
     /**
@@ -68,7 +68,7 @@ final class DeprecatedFixerOptionTest extends TestCase
             'deprecated'
         );
 
-        static::assertSame(!$isRequired, $option->hasDefault());
+        self::assertSame(!$isRequired, $option->hasDefault());
     }
 
     public static function provideHasDefaultCases(): array
@@ -91,7 +91,7 @@ final class DeprecatedFixerOptionTest extends TestCase
             'deprecated'
         );
 
-        static::assertSame($default, $option->getDefault());
+        self::assertSame($default, $option->getDefault());
     }
 
     public static function provideGetDefaultCases(): array
@@ -111,7 +111,7 @@ final class DeprecatedFixerOptionTest extends TestCase
             'deprecated'
         );
 
-        static::assertSame($allowedTypes, $option->getAllowedTypes());
+        self::assertSame($allowedTypes, $option->getAllowedTypes());
     }
 
     public function testGetAllowedValues(): void
@@ -123,7 +123,7 @@ final class DeprecatedFixerOptionTest extends TestCase
             'deprecated'
         );
 
-        static::assertSame($allowedValues, $option->getAllowedValues());
+        self::assertSame($allowedValues, $option->getAllowedValues());
     }
 
     public function testGetNormalizer(): void
@@ -138,7 +138,7 @@ final class DeprecatedFixerOptionTest extends TestCase
             'deprecated'
         );
 
-        static::assertSame($normalizer, $option->getNormalizer());
+        self::assertSame($normalizer, $option->getNormalizer());
     }
 
     public function testGetDeprecationMessage(): void
@@ -148,6 +148,6 @@ final class DeprecatedFixerOptionTest extends TestCase
             'Use option "bar" instead.'
         );
 
-        static::assertSame('Use option "bar" instead.', $option->getDeprecationMessage());
+        self::assertSame('Use option "bar" instead.', $option->getDeprecationMessage());
     }
 }

--- a/tests/FixerConfiguration/FixerConfigurationResolverTest.php
+++ b/tests/FixerConfiguration/FixerConfigurationResolverTest.php
@@ -71,7 +71,7 @@ final class FixerConfigurationResolverTest extends TestCase
         ];
         $configuration = new FixerConfigurationResolver($options);
 
-        static::assertSame($options, $configuration->getOptions());
+        self::assertSame($options, $configuration->getOptions());
     }
 
     public function testResolve(): void
@@ -79,7 +79,7 @@ final class FixerConfigurationResolverTest extends TestCase
         $configuration = new FixerConfigurationResolver([
             new FixerOption('foo', 'Bar.'),
         ]);
-        static::assertSame(
+        self::assertSame(
             ['foo' => 'bar'],
             $configuration->resolve(['foo' => 'bar'])
         );
@@ -101,7 +101,7 @@ final class FixerConfigurationResolverTest extends TestCase
             new FixerOption('foo', 'Bar.', false, 'baz'),
         ]);
 
-        static::assertSame(
+        self::assertSame(
             ['foo' => 'baz'],
             $configuration->resolve([])
         );
@@ -113,7 +113,7 @@ final class FixerConfigurationResolverTest extends TestCase
             new FixerOption('foo', 'Bar.', true, null, ['int']),
         ]);
 
-        static::assertSame(
+        self::assertSame(
             ['foo' => 1],
             $configuration->resolve(['foo' => 1])
         );
@@ -128,7 +128,7 @@ final class FixerConfigurationResolverTest extends TestCase
             new FixerOption('foo', 'Bar.', true, null, null, [true, false]),
         ]);
 
-        static::assertSame(
+        self::assertSame(
             ['foo' => true],
             $configuration->resolve(['foo' => true])
         );
@@ -143,7 +143,7 @@ final class FixerConfigurationResolverTest extends TestCase
             new FixerOption('foo', 'Bar.', true, null, null, [new AllowedValueSubset(['foo', 'bar'])]),
         ]);
 
-        static::assertSame(
+        self::assertSame(
             ['foo' => ['bar']],
             $configuration->resolve(['foo' => ['bar']])
         );
@@ -170,7 +170,7 @@ final class FixerConfigurationResolverTest extends TestCase
             }),
         ]);
 
-        static::assertSame(
+        self::assertSame(
             ['foo' => 1],
             $configuration->resolve(['foo' => '1'])
         );
@@ -189,7 +189,7 @@ final class FixerConfigurationResolverTest extends TestCase
         } catch (InvalidOptionsException $caught) {
         }
 
-        static::assertSame($exception, $caught);
+        self::assertSame($exception, $caught);
     }
 
     public function testResolveWithAliasedDuplicateConfig(): void

--- a/tests/FixerConfiguration/FixerOptionBuilderTest.php
+++ b/tests/FixerConfiguration/FixerOptionBuilderTest.php
@@ -29,25 +29,25 @@ final class FixerOptionBuilderTest extends TestCase
     public function testSetDefault(): void
     {
         $builder = new FixerOptionBuilder('foo', 'Bar.');
-        static::assertSame($builder, $builder->setDefault('baz'));
+        self::assertSame($builder, $builder->setDefault('baz'));
     }
 
     public function testSetAllowedTypes(): void
     {
         $builder = new FixerOptionBuilder('foo', 'Bar.');
-        static::assertSame($builder, $builder->setAllowedTypes(['bool']));
+        self::assertSame($builder, $builder->setAllowedTypes(['bool']));
     }
 
     public function testSetAllowedValues(): void
     {
         $builder = new FixerOptionBuilder('foo', 'Bar.');
-        static::assertSame($builder, $builder->setAllowedValues(['baz']));
+        self::assertSame($builder, $builder->setAllowedValues(['baz']));
     }
 
     public function testSetNormalizer(): void
     {
         $builder = new FixerOptionBuilder('foo', 'Bar.');
-        static::assertSame($builder, $builder->setNormalizer(static fn () => null));
+        self::assertSame($builder, $builder->setNormalizer(static fn () => null));
     }
 
     public function testGetOption(): void
@@ -61,7 +61,7 @@ final class FixerOptionBuilderTest extends TestCase
             ->getOption()
         ;
 
-        static::assertInstanceOf(FixerOption::class, $regularOption);
+        self::assertInstanceOf(FixerOption::class, $regularOption);
 
         $deprecationOption = $builder
             ->setDefault('baz')
@@ -72,16 +72,16 @@ final class FixerOptionBuilderTest extends TestCase
             ->getOption()
         ;
 
-        static::assertInstanceOf(DeprecatedFixerOption::class, $deprecationOption);
+        self::assertInstanceOf(DeprecatedFixerOption::class, $deprecationOption);
 
         foreach ([$regularOption, $deprecationOption] as $option) {
-            static::assertSame('foo', $option->getName());
-            static::assertSame('Bar.', $option->getDescription());
-            static::assertTrue($option->hasDefault());
-            static::assertSame('baz', $option->getDefault());
-            static::assertSame(['bool'], $option->getAllowedTypes());
-            static::assertSame([true, false], $option->getAllowedValues());
-            static::assertInstanceOf(\Closure::class, $option->getNormalizer());
+            self::assertSame('foo', $option->getName());
+            self::assertSame('Bar.', $option->getDescription());
+            self::assertTrue($option->hasDefault());
+            self::assertSame('baz', $option->getDefault());
+            self::assertSame(['bool'], $option->getAllowedTypes());
+            self::assertSame([true, false], $option->getAllowedValues());
+            self::assertInstanceOf(\Closure::class, $option->getNormalizer());
         }
     }
 }

--- a/tests/FixerConfiguration/FixerOptionTest.php
+++ b/tests/FixerConfiguration/FixerOptionTest.php
@@ -27,28 +27,28 @@ final class FixerOptionTest extends TestCase
     public function testGetName(): void
     {
         $option = new FixerOption('foo', 'Bar.');
-        static::assertSame('foo', $option->getName());
+        self::assertSame('foo', $option->getName());
     }
 
     public function testGetDescription(): void
     {
         $option = new FixerOption('foo', 'Bar.');
-        static::assertSame('Bar.', $option->getDescription());
+        self::assertSame('Bar.', $option->getDescription());
     }
 
     public function testHasDefault(): void
     {
         $option = new FixerOption('foo', 'Bar.');
-        static::assertFalse($option->hasDefault());
+        self::assertFalse($option->hasDefault());
 
         $option = new FixerOption('foo', 'Bar.', false, 'baz');
-        static::assertTrue($option->hasDefault());
+        self::assertTrue($option->hasDefault());
     }
 
     public function testGetDefault(): void
     {
         $option = new FixerOption('foo', 'Bar.', false, 'baz');
-        static::assertSame('baz', $option->getDefault());
+        self::assertSame('baz', $option->getDefault());
     }
 
     public function testGetUndefinedDefault(): void
@@ -63,41 +63,41 @@ final class FixerOptionTest extends TestCase
     public function testGetAllowedTypes(): void
     {
         $option = new FixerOption('foo', 'Bar.');
-        static::assertNull($option->getAllowedTypes());
+        self::assertNull($option->getAllowedTypes());
 
         $option = new FixerOption('foo', 'Bar.', true, null, ['bool']);
-        static::assertSame(['bool'], $option->getAllowedTypes());
+        self::assertSame(['bool'], $option->getAllowedTypes());
 
         $option = new FixerOption('foo', 'Bar.', true, null, ['bool', 'string']);
-        static::assertSame(['bool', 'string'], $option->getAllowedTypes());
+        self::assertSame(['bool', 'string'], $option->getAllowedTypes());
     }
 
     public function testGetAllowedValues(): void
     {
         $option = new FixerOption('foo', 'Bar.');
-        static::assertNull($option->getAllowedValues());
+        self::assertNull($option->getAllowedValues());
 
         $option = new FixerOption('foo', 'Bar.', true, null, null, ['baz']);
-        static::assertSame(['baz'], $option->getAllowedValues());
+        self::assertSame(['baz'], $option->getAllowedValues());
 
         $option = new FixerOption('foo', 'Bar.', true, null, null, ['baz', 'qux']);
-        static::assertSame(['baz', 'qux'], $option->getAllowedValues());
+        self::assertSame(['baz', 'qux'], $option->getAllowedValues());
 
         $option = new FixerOption('foo', 'Bar.', true, null, null, [static fn () => true]);
         $allowedTypes = $option->getAllowedValues();
-        static::assertIsArray($allowedTypes);
-        static::assertCount(1, $allowedTypes);
-        static::assertArrayHasKey(0, $allowedTypes);
-        static::assertInstanceOf(\Closure::class, $allowedTypes[0]);
+        self::assertIsArray($allowedTypes);
+        self::assertCount(1, $allowedTypes);
+        self::assertArrayHasKey(0, $allowedTypes);
+        self::assertInstanceOf(\Closure::class, $allowedTypes[0]);
     }
 
     public function testGetNormalizers(): void
     {
         $option = new FixerOption('foo', 'Bar.');
-        static::assertNull($option->getNormalizer());
+        self::assertNull($option->getNormalizer());
 
         $option = new FixerOption('foo', 'Bar.', true, null, null, null, static fn () => null);
-        static::assertInstanceOf(\Closure::class, $option->getNormalizer());
+        self::assertInstanceOf(\Closure::class, $option->getNormalizer());
     }
 
     public function testRequiredWithDefaultValue(): void

--- a/tests/FixerConfiguration/InvalidOptionsForEnvExceptionTest.php
+++ b/tests/FixerConfiguration/InvalidOptionsForEnvExceptionTest.php
@@ -27,6 +27,6 @@ final class InvalidOptionsForEnvExceptionTest extends TestCase
     public function testInvalidOptionsForEnvException(): void
     {
         $exception = new InvalidOptionsForEnvException();
-        static::assertInstanceOf(\Symfony\Component\OptionsResolver\Exception\InvalidOptionsException::class, $exception);
+        self::assertInstanceOf(\Symfony\Component\OptionsResolver\Exception\InvalidOptionsException::class, $exception);
     }
 }

--- a/tests/FixerDefinition/CodeSampleTest.php
+++ b/tests/FixerDefinition/CodeSampleTest.php
@@ -38,14 +38,14 @@ final class CodeSampleTest extends TestCase
             $configuration
         );
 
-        static::assertSame($code, $codeSample->getCode());
-        static::assertSame($configuration, $codeSample->getConfiguration());
+        self::assertSame($code, $codeSample->getCode());
+        self::assertSame($configuration, $codeSample->getConfiguration());
     }
 
     public function testConfigurationDefaultsToNull(): void
     {
         $codeSample = new CodeSample('<php echo $foo;');
 
-        static::assertNull($codeSample->getConfiguration());
+        self::assertNull($codeSample->getConfiguration());
     }
 }

--- a/tests/FixerDefinition/FileSpecificCodeSampleTest.php
+++ b/tests/FixerDefinition/FileSpecificCodeSampleTest.php
@@ -30,7 +30,7 @@ final class FileSpecificCodeSampleTest extends TestCase
     {
         $sample = new FileSpecificCodeSample(file_get_contents(__FILE__), new \SplFileInfo(__FILE__));
 
-        static::assertInstanceOf(\PhpCsFixer\FixerDefinition\FileSpecificCodeSampleInterface::class, $sample);
+        self::assertInstanceOf(\PhpCsFixer\FixerDefinition\FileSpecificCodeSampleInterface::class, $sample);
     }
 
     public function testDefaults(): void
@@ -43,9 +43,9 @@ final class FileSpecificCodeSampleTest extends TestCase
             $splFileInfo
         );
 
-        static::assertSame($code, $sample->getCode());
-        static::assertSame($splFileInfo, $sample->getSplFileInfo());
-        static::assertNull($sample->getConfiguration());
+        self::assertSame($code, $sample->getCode());
+        self::assertSame($splFileInfo, $sample->getSplFileInfo());
+        self::assertNull($sample->getConfiguration());
     }
 
     public function testConstructorSetsValues(): void
@@ -63,8 +63,8 @@ final class FileSpecificCodeSampleTest extends TestCase
             $configuration
         );
 
-        static::assertSame($code, $sample->getCode());
-        static::assertSame($splFileInfo, $sample->getSplFileInfo());
-        static::assertSame($configuration, $sample->getConfiguration());
+        self::assertSame($code, $sample->getCode());
+        self::assertSame($splFileInfo, $sample->getSplFileInfo());
+        self::assertSame($configuration, $sample->getConfiguration());
     }
 }

--- a/tests/FixerDefinition/FixerDefinitionTest.php
+++ b/tests/FixerDefinition/FixerDefinitionTest.php
@@ -29,7 +29,7 @@ final class FixerDefinitionTest extends TestCase
     {
         $definition = new FixerDefinition('Foo', []);
 
-        static::assertSame('Foo', $definition->getSummary());
+        self::assertSame('Foo', $definition->getSummary());
     }
 
     public function testGetCodeSamples(): void
@@ -41,28 +41,28 @@ final class FixerDefinitionTest extends TestCase
 
         $definition = new FixerDefinition('', $samples);
 
-        static::assertSame($samples, $definition->getCodeSamples());
+        self::assertSame($samples, $definition->getCodeSamples());
     }
 
     public function testGetDescription(): void
     {
         $definition = new FixerDefinition('', []);
 
-        static::assertNull($definition->getDescription());
+        self::assertNull($definition->getDescription());
 
         $definition = new FixerDefinition('', [], 'Foo');
 
-        static::assertSame('Foo', $definition->getDescription());
+        self::assertSame('Foo', $definition->getDescription());
     }
 
     public function testGetRiskyDescription(): void
     {
         $definition = new FixerDefinition('', []);
 
-        static::assertNull($definition->getRiskyDescription());
+        self::assertNull($definition->getRiskyDescription());
 
         $definition = new FixerDefinition('', [], null, 'Foo');
 
-        static::assertSame('Foo', $definition->getRiskyDescription());
+        self::assertSame('Foo', $definition->getRiskyDescription());
     }
 }

--- a/tests/FixerDefinition/VersionSpecificCodeSampleTest.php
+++ b/tests/FixerDefinition/VersionSpecificCodeSampleTest.php
@@ -41,8 +41,8 @@ final class VersionSpecificCodeSampleTest extends TestCase
             $configuration
         );
 
-        static::assertSame($code, $codeSample->getCode());
-        static::assertSame($configuration, $codeSample->getConfiguration());
+        self::assertSame($code, $codeSample->getCode());
+        self::assertSame($configuration, $codeSample->getConfiguration());
     }
 
     public function testConfigurationDefaultsToNull(): void
@@ -52,7 +52,7 @@ final class VersionSpecificCodeSampleTest extends TestCase
             $this->createVersionSpecificationMock()->reveal()
         );
 
-        static::assertNull($codeSample->getConfiguration());
+        self::assertNull($codeSample->getConfiguration());
     }
 
     /**
@@ -72,7 +72,7 @@ final class VersionSpecificCodeSampleTest extends TestCase
             $versionSpecification->reveal()
         );
 
-        static::assertSame($isSatisfied, $codeSample->isSuitableFor($version));
+        self::assertSame($isSatisfied, $codeSample->isSuitableFor($version));
     }
 
     public static function provideIsSuitableForVersionUsesVersionSpecificationCases(): array

--- a/tests/FixerDefinition/VersionSpecificationTest.php
+++ b/tests/FixerDefinition/VersionSpecificationTest.php
@@ -84,7 +84,7 @@ final class VersionSpecificationTest extends TestCase
             $maximum
         );
 
-        static::assertTrue($versionSpecification->isSatisfiedBy($actual));
+        self::assertTrue($versionSpecification->isSatisfiedBy($actual));
     }
 
     public static function provideIsSatisfiedByReturnsTrueCases(): array
@@ -107,7 +107,7 @@ final class VersionSpecificationTest extends TestCase
             $maximum
         );
 
-        static::assertFalse($versionSpecification->isSatisfiedBy($actual));
+        self::assertFalse($versionSpecification->isSatisfiedBy($actual));
     }
 
     public static function provideIsSatisfiedByReturnsFalseCases(): array

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -36,20 +36,20 @@ final class FixerFactoryTest extends TestCase
         $factory = new FixerFactory();
 
         $testInstance = $factory->registerBuiltInFixers();
-        static::assertSame($factory, $testInstance);
+        self::assertSame($factory, $testInstance);
 
         $testInstance = $factory->registerCustomFixers(
             [$this->createFixerDouble('Foo/f1'), $this->createFixerDouble('Foo/f2')]
         );
 
-        static::assertSame($factory, $testInstance);
+        self::assertSame($factory, $testInstance);
 
         $testInstance = $factory->registerFixer(
             $this->createFixerDouble('f3'),
             false
         );
 
-        static::assertSame($factory, $testInstance);
+        self::assertSame($factory, $testInstance);
 
         $ruleSetProphecy = $this->prophesize(RuleSetInterface::class);
         $ruleSetProphecy->getRules()->willReturn([]);
@@ -57,7 +57,7 @@ final class FixerFactoryTest extends TestCase
             $ruleSetProphecy->reveal()
         );
 
-        static::assertSame($factory, $testInstance);
+        self::assertSame($factory, $testInstance);
     }
 
     /**
@@ -88,7 +88,7 @@ final class FixerFactoryTest extends TestCase
 
         sort($fixers);
 
-        static::assertSame($fixerClasses, $fixers);
+        self::assertSame($fixerClasses, $fixers);
     }
 
     /**
@@ -109,7 +109,7 @@ final class FixerFactoryTest extends TestCase
         }
 
         // There are no rules that forces $fxs[1] to be prioritized before $fxs[3]. We should not test against that
-        static::assertSame([$fxs[2], $fxs[0]], \array_slice($factory->getFixers(), 0, 2));
+        self::assertSame([$fxs[2], $fxs[0]], \array_slice($factory->getFixers(), 0, 2));
     }
 
     /**
@@ -128,9 +128,9 @@ final class FixerFactoryTest extends TestCase
         $factory->registerFixer($f1, false);
         $factory->registerCustomFixers([$f2, $f3]);
 
-        static::assertTrue(\in_array($f1, $factory->getFixers(), true));
-        static::assertTrue(\in_array($f2, $factory->getFixers(), true));
-        static::assertTrue(\in_array($f3, $factory->getFixers(), true));
+        self::assertTrue(\in_array($f1, $factory->getFixers(), true));
+        self::assertTrue(\in_array($f2, $factory->getFixers(), true));
+        self::assertTrue(\in_array($f3, $factory->getFixers(), true));
     }
 
     /**
@@ -159,7 +159,7 @@ final class FixerFactoryTest extends TestCase
             ->useRuleSet(new RuleSet([]))
         ;
 
-        static::assertCount(0, $factory->getFixers());
+        self::assertCount(0, $factory->getFixers());
 
         $factory = (new FixerFactory())
             ->registerBuiltInFixers()
@@ -167,8 +167,8 @@ final class FixerFactoryTest extends TestCase
         ;
 
         $fixers = $factory->getFixers();
-        static::assertCount(1, $fixers);
-        static::assertSame('strict_comparison', $fixers[0]->getName());
+        self::assertCount(1, $fixers);
+        self::assertSame('strict_comparison', $fixers[0]->getName());
     }
 
     /**
@@ -237,10 +237,10 @@ final class FixerFactoryTest extends TestCase
         $factory->registerFixer($f1, false);
         $factory->registerCustomFixers([$f2, $f3]);
 
-        static::assertTrue($factory->hasRule('f1'), 'Should have f1 fixer');
-        static::assertTrue($factory->hasRule('Foo/f2'), 'Should have f2 fixer');
-        static::assertTrue($factory->hasRule('Foo/f3'), 'Should have f3 fixer');
-        static::assertFalse($factory->hasRule('dummy'), 'Should not have dummy fixer');
+        self::assertTrue($factory->hasRule('f1'), 'Should have f1 fixer');
+        self::assertTrue($factory->hasRule('Foo/f2'), 'Should have f2 fixer');
+        self::assertTrue($factory->hasRule('Foo/f3'), 'Should have f3 fixer');
+        self::assertFalse($factory->hasRule('dummy'), 'Should not have dummy fixer');
     }
 
     public function testHasRuleWithChangedRuleSet(): void
@@ -252,12 +252,12 @@ final class FixerFactoryTest extends TestCase
         $factory->registerFixer($f1, false);
         $factory->registerFixer($f2, false);
 
-        static::assertTrue($factory->hasRule('f1'), 'Should have f1 fixer');
-        static::assertTrue($factory->hasRule('f2'), 'Should have f2 fixer');
+        self::assertTrue($factory->hasRule('f1'), 'Should have f1 fixer');
+        self::assertTrue($factory->hasRule('f2'), 'Should have f2 fixer');
 
         $factory->useRuleSet(new RuleSet(['f2' => true]));
-        static::assertFalse($factory->hasRule('f1'), 'Should not have f1 fixer');
-        static::assertTrue($factory->hasRule('f2'), 'Should have f2 fixer');
+        self::assertFalse($factory->hasRule('f1'), 'Should not have f1 fixer');
+        self::assertTrue($factory->hasRule('f2'), 'Should have f2 fixer');
     }
 
     /**
@@ -286,7 +286,7 @@ final class FixerFactoryTest extends TestCase
         $factory = new FixerFactory();
         $method = new \ReflectionMethod($factory, 'generateConflictMessage');
         $method->setAccessible(true);
-        static::assertSame(
+        self::assertSame(
             'Rule contains conflicting fixers:
 - "a" with "b"
 - "c" with "d", "e", "f"

--- a/tests/FixerFileProcessedEventTest.php
+++ b/tests/FixerFileProcessedEventTest.php
@@ -28,6 +28,6 @@ final class FixerFileProcessedEventTest extends TestCase
         $status = FixerFileProcessedEvent::STATUS_NO_CHANGES;
         $event = new FixerFileProcessedEvent($status);
 
-        static::assertSame($status, $event->getStatus());
+        self::assertSame($status, $event->getStatus());
     }
 }

--- a/tests/FixerNameValidatorTest.php
+++ b/tests/FixerNameValidatorTest.php
@@ -32,7 +32,7 @@ final class FixerNameValidatorTest extends TestCase
     {
         $validator = new FixerNameValidator();
 
-        static::assertSame($isValid, $validator->isValid($name, $isCustom));
+        self::assertSame($isValid, $validator->isValid($name, $isCustom));
     }
 
     public static function provideIsValidCases(): array

--- a/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
+++ b/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
@@ -46,7 +46,7 @@ final class PhpUnitTestCaseIndicatorTest extends TestCase
      */
     public function testIsPhpUnitClass(bool $expected, Tokens $tokens, int $index): void
     {
-        static::assertSame($expected, $this->indicator->isPhpUnitClass($tokens, $index));
+        self::assertSame($expected, $this->indicator->isPhpUnitClass($tokens, $index));
     }
 
     public static function provideIsPhpUnitClassCases(): iterable
@@ -162,7 +162,7 @@ class Foo extends A implements TestInterface, SomethingElse
         $classes = $this->indicator->findPhpUnitClasses($tokens);
         $classes = iterator_to_array($classes);
 
-        static::assertSame($expectedIndexes, $classes);
+        self::assertSame($expectedIndexes, $classes);
     }
 
     public static function provideFindPhpUnitClassesCases(): iterable

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -58,7 +58,7 @@ final class IntegrationTest extends AbstractIntegrationTestCase
         $settings = $case->getSettings();
 
         if (!isset($settings['isExplicitPriorityCheck'])) {
-            static::markTestIncomplete('Missing `isExplicitPriorityCheck` extension setting.');
+            self::markTestIncomplete('Missing `isExplicitPriorityCheck` extension setting.');
         }
 
         if ($settings['isExplicitPriorityCheck']) {
@@ -68,7 +68,7 @@ final class IntegrationTest extends AbstractIntegrationTestCase
                     'priority'.\DIRECTORY_SEPARATOR.'braces,indentation_type,no_break_comment.test',
                     'priority'.\DIRECTORY_SEPARATOR.'standardize_not_equals,binary_operator_spaces.test',
                 ], true)) {
-                    static::markTestIncomplete(sprintf(
+                    self::markTestIncomplete(sprintf(
                         'Integration test `%s` was defined as explicit priority test, but no priority conflict was detected.'
                         ."\n".'Either integration test needs to be extended or moved from `priority` to `misc`.'
                         ."\n".'But don\'t do it blindly - it deserves investigation!',
@@ -77,7 +77,7 @@ final class IntegrationTest extends AbstractIntegrationTestCase
                 }
             }
 
-            static::assertNotSame(
+            self::assertNotSame(
                 $fixedInputCode,
                 $fixedInputCodeWithReversedFixers,
                 sprintf('Test "%s" in "%s" is expected to be priority check.', $case->getTitle(), $case->getFileName())
@@ -101,7 +101,7 @@ final class IntegrationTest extends AbstractIntegrationTestCase
             }
 
             if (\PHP_VERSION_ID >= $phpUpperLimit) {
-                static::markTestSkipped(sprintf('PHP lower than %d is required for "%s", current "%d".', $phpUpperLimit, $case->getFileName(), \PHP_VERSION_ID));
+                self::markTestSkipped(sprintf('PHP lower than %d is required for "%s", current "%d".', $phpUpperLimit, $case->getFileName(), \PHP_VERSION_ID));
             }
         }
 

--- a/tests/Linter/CachingLinterTest.php
+++ b/tests/Linter/CachingLinterTest.php
@@ -37,7 +37,7 @@ final class CachingLinterTest extends TestCase
 
         $linter = new CachingLinter($sublinter->reveal());
 
-        static::assertSame($isAsync, $linter->isAsync());
+        self::assertSame($isAsync, $linter->isAsync());
     }
 
     public static function provideIsAsyncCases(): array
@@ -66,10 +66,10 @@ final class CachingLinterTest extends TestCase
 
         $linter = new CachingLinter($sublinter->reveal());
 
-        static::assertSame($result1->reveal(), $linter->lintFile($fs->url().'/foo.php'));
-        static::assertSame($result1->reveal(), $linter->lintFile($fs->url().'/foo.php'));
-        static::assertSame($result1->reveal(), $linter->lintFile($fs->url().'/bar.php'));
-        static::assertSame($result2->reveal(), $linter->lintFile($fs->url().'/baz.php'));
+        self::assertSame($result1->reveal(), $linter->lintFile($fs->url().'/foo.php'));
+        self::assertSame($result1->reveal(), $linter->lintFile($fs->url().'/foo.php'));
+        self::assertSame($result1->reveal(), $linter->lintFile($fs->url().'/bar.php'));
+        self::assertSame($result2->reveal(), $linter->lintFile($fs->url().'/baz.php'));
     }
 
     public function testLintSourceIsCalledOnceOnSameContent(): void
@@ -83,8 +83,8 @@ final class CachingLinterTest extends TestCase
 
         $linter = new CachingLinter($sublinter->reveal());
 
-        static::assertSame($result1->reveal(), $linter->lintSource('<?php echo "baz";'));
-        static::assertSame($result1->reveal(), $linter->lintSource('<?php echo "baz";'));
-        static::assertSame($result2->reveal(), $linter->lintSource('<?php echo "foobarbaz";'));
+        self::assertSame($result1->reveal(), $linter->lintSource('<?php echo "baz";'));
+        self::assertSame($result1->reveal(), $linter->lintSource('<?php echo "baz";'));
+        self::assertSame($result2->reveal(), $linter->lintSource('<?php echo "foobarbaz";'));
     }
 }

--- a/tests/Linter/LinterTest.php
+++ b/tests/Linter/LinterTest.php
@@ -28,7 +28,7 @@ final class LinterTest extends AbstractLinterTestCase
 {
     public function testIsAsync(): void
     {
-        static::assertSame(!class_exists(\CompileError::class), $this->createLinter()->isAsync());
+        self::assertSame(!class_exists(\CompileError::class), $this->createLinter()->isAsync());
     }
 
     /**

--- a/tests/Linter/LintingExceptionTest.php
+++ b/tests/Linter/LintingExceptionTest.php
@@ -30,7 +30,7 @@ final class LintingExceptionTest extends TestCase
     {
         $exception = new LintingException();
 
-        static::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(\RuntimeException::class, $exception);
     }
 
     public function testConstructorSetsValues(): void
@@ -45,8 +45,8 @@ final class LintingExceptionTest extends TestCase
             $previous
         );
 
-        static::assertSame($message, $exception->getMessage());
-        static::assertSame($code, $exception->getCode());
-        static::assertSame($previous, $exception->getPrevious());
+        self::assertSame($message, $exception->getMessage());
+        self::assertSame($code, $exception->getCode());
+        self::assertSame($previous, $exception->getPrevious());
     }
 }

--- a/tests/Linter/ProcessLinterProcessBuilderTest.php
+++ b/tests/Linter/ProcessLinterProcessBuilderTest.php
@@ -36,7 +36,7 @@ final class ProcessLinterProcessBuilderTest extends TestCase
     {
         $builder = new ProcessLinterProcessBuilder($executable);
 
-        static::assertSame(
+        self::assertSame(
             $expected,
             $builder->build($file)->getCommandLine()
         );
@@ -52,7 +52,7 @@ final class ProcessLinterProcessBuilderTest extends TestCase
     {
         $builder = new ProcessLinterProcessBuilder($executable);
 
-        static::assertSame(
+        self::assertSame(
             $expected,
             $builder->build($file)->getCommandLine()
         );

--- a/tests/Linter/ProcessLinterTest.php
+++ b/tests/Linter/ProcessLinterTest.php
@@ -29,7 +29,7 @@ final class ProcessLinterTest extends AbstractLinterTestCase
 {
     public function testIsAsync(): void
     {
-        static::assertTrue($this->createLinter()->isAsync());
+        self::assertTrue($this->createLinter()->isAsync());
     }
 
     public function testSleep(): void

--- a/tests/Linter/TokenizerLinterTest.php
+++ b/tests/Linter/TokenizerLinterTest.php
@@ -29,7 +29,7 @@ final class TokenizerLinterTest extends AbstractLinterTestCase
 {
     public function testIsAsync(): void
     {
-        static::assertFalse($this->createLinter()->isAsync());
+        self::assertFalse($this->createLinter()->isAsync());
     }
 
     /**

--- a/tests/Linter/UnavailableLinterExceptionTest.php
+++ b/tests/Linter/UnavailableLinterExceptionTest.php
@@ -30,7 +30,7 @@ final class UnavailableLinterExceptionTest extends TestCase
     {
         $exception = new UnavailableLinterException();
 
-        static::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(\RuntimeException::class, $exception);
     }
 
     public function testConstructorSetsValues(): void
@@ -45,8 +45,8 @@ final class UnavailableLinterExceptionTest extends TestCase
             $previous
         );
 
-        static::assertSame($message, $exception->getMessage());
-        static::assertSame($code, $exception->getCode());
-        static::assertSame($previous, $exception->getPrevious());
+        self::assertSame($message, $exception->getMessage());
+        self::assertSame($code, $exception->getCode());
+        self::assertSame($previous, $exception->getPrevious());
     }
 }

--- a/tests/PharCheckerTest.php
+++ b/tests/PharCheckerTest.php
@@ -26,12 +26,12 @@ final class PharCheckerTest extends TestCase
     public function testPharChecker(): void
     {
         $checker = new PharChecker();
-        static::assertNull($checker->checkFileValidity(__DIR__.'/Fixtures/empty.phar'));
+        self::assertNull($checker->checkFileValidity(__DIR__.'/Fixtures/empty.phar'));
     }
 
     public function testPharCheckerInvalidFile(): void
     {
         $checker = new PharChecker();
-        static::assertStringStartsWith('Failed to create Phar instance.', $checker->checkFileValidity(__FILE__));
+        self::assertStringStartsWith('Failed to create Phar instance.', $checker->checkFileValidity(__FILE__));
     }
 }

--- a/tests/PregExceptionTest.php
+++ b/tests/PregExceptionTest.php
@@ -29,6 +29,6 @@ final class PregExceptionTest extends TestCase
     {
         $exception = new PregException();
 
-        static::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertInstanceOf(\RuntimeException::class, $exception);
     }
 }

--- a/tests/PregTest.php
+++ b/tests/PregTest.php
@@ -42,8 +42,8 @@ final class PregTest extends TestCase
         $expectedResult = preg_match($pattern, $subject, $expectedMatches);
         $actualResult = Preg::match($pattern, $subject, $actualMatches);
 
-        static::assertSame($expectedResult, $actualResult);
-        static::assertSame($expectedMatches, $actualMatches);
+        self::assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedMatches, $actualMatches);
     }
 
     public static function providePatternValidationCases(): iterable
@@ -95,7 +95,7 @@ final class PregTest extends TestCase
         }
 
         if (null !== $expected) {
-            static::assertSame($expected, $actual);
+            self::assertSame($expected, $actual);
 
             return;
         }
@@ -136,7 +136,7 @@ final class PregTest extends TestCase
         }
 
         if (null !== $expected) {
-            static::assertSame((bool) $expected, $actual);
+            self::assertSame((bool) $expected, $actual);
 
             return;
         }
@@ -162,8 +162,8 @@ final class PregTest extends TestCase
         $expectedResult = preg_match_all($pattern, $subject, $expectedMatches);
         $actualResult = Preg::matchAll($pattern, $subject, $actualMatches);
 
-        static::assertSame($expectedResult, $actualResult);
-        static::assertSame($expectedMatches, $actualMatches);
+        self::assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedMatches, $actualMatches);
     }
 
     public function testReplaceFailing(): void
@@ -185,7 +185,7 @@ final class PregTest extends TestCase
         $expectedResult = preg_replace($pattern, 'foo', $subject);
         $actualResult = Preg::replace($pattern, 'foo', $subject);
 
-        static::assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     public function testReplaceCallbackFailing(): void
@@ -209,7 +209,7 @@ final class PregTest extends TestCase
         $expectedResult = preg_replace_callback($pattern, $callback, $subject);
         $actualResult = Preg::replaceCallback($pattern, $callback, $subject);
 
-        static::assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     public static function provideCommonCases(): array
@@ -239,7 +239,7 @@ final class PregTest extends TestCase
         $expectedResult = preg_split($pattern, $subject);
         $actualResult = Preg::split($pattern, $subject);
 
-        static::assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     public function testCorrectnessForUtf8String(): void
@@ -250,8 +250,8 @@ final class PregTest extends TestCase
         Preg::match($pattern, $subject, $methodMatches);
         preg_match($pattern, $subject, $functionMatches);
 
-        static::assertSame(['à'], $methodMatches);
-        static::assertNotSame(['à'], $functionMatches);
+        self::assertSame(['à'], $methodMatches);
+        self::assertNotSame(['à'], $functionMatches);
     }
 
     public function testCorrectnessForNonUtf8String(): void
@@ -262,7 +262,7 @@ final class PregTest extends TestCase
         Preg::match($pattern, $subject, $methodMatches);
         preg_match($pattern, $subject, $functionMatches);
 
-        static::assertSame([\chr(224)], $methodMatches);
-        static::assertNotSame([\chr(224)], $functionMatches);
+        self::assertSame([\chr(224)], $methodMatches);
+        self::assertNotSame([\chr(224)], $functionMatches);
     }
 }

--- a/tests/RuleSet/AbstractMigrationSetDescriptionTest.php
+++ b/tests/RuleSet/AbstractMigrationSetDescriptionTest.php
@@ -38,7 +38,7 @@ final class AbstractMigrationSetDescriptionTest extends TestCase
             }
         };
 
-        static::assertSame('Rules to improve code for PHP 9.9 compatibility.', $set->getDescription());
+        self::assertSame('Rules to improve code for PHP 9.9 compatibility.', $set->getDescription());
     }
 
     public function testGetDescriptionForPhpUnitMigrationSet(): void
@@ -55,7 +55,7 @@ final class AbstractMigrationSetDescriptionTest extends TestCase
             }
         };
 
-        static::assertSame('Rules to improve tests code for PHPUnit 3.0 compatibility.', $set->getDescription());
+        self::assertSame('Rules to improve tests code for PHPUnit 3.0 compatibility.', $set->getDescription());
     }
 
     public function testGetDescriptionForNoneMigrationSet(): void

--- a/tests/RuleSet/AbstractRuleSetDescriptionTest.php
+++ b/tests/RuleSet/AbstractRuleSetDescriptionTest.php
@@ -28,7 +28,7 @@ final class AbstractRuleSetDescriptionTest extends TestCase
     {
         $set = new TestRuleSet();
 
-        static::assertSame('@TestRule', $set->getName());
-        static::assertFalse($set->isRisky());
+        self::assertSame('@TestRule', $set->getName());
+        self::assertFalse($set->isRisky());
     }
 }

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -60,14 +60,14 @@ final class RuleSetTest extends TestCase
             $fixers[$fixer->getName()] = $fixer;
         }
 
-        static::assertArrayHasKey($ruleName, $fixers, sprintf('RuleSet "%s" contains unknown rule.', $setName));
+        self::assertArrayHasKey($ruleName, $fixers, sprintf('RuleSet "%s" contains unknown rule.', $setName));
 
         if (true === $ruleConfig) {
             return; // rule doesn't need configuration.
         }
 
         $fixer = $fixers[$ruleName];
-        static::assertInstanceOf(ConfigurableFixerInterface::class, $fixer, sprintf('RuleSet "%s" contains configuration for rule "%s" which cannot be configured.', $setName, $ruleName));
+        self::assertInstanceOf(ConfigurableFixerInterface::class, $fixer, sprintf('RuleSet "%s" contains configuration for rule "%s" which cannot be configured.', $setName, $ruleName));
 
         try {
             $fixer->configure($ruleConfig); // test fixer accepts the configuration
@@ -105,7 +105,7 @@ final class RuleSetTest extends TestCase
             $defaultConfig[$option->getName()] = $option->getDefault();
         }
 
-        static::assertNotSame(
+        self::assertNotSame(
             $this->sortNestedArray($defaultConfig, $ruleName),
             $this->sortNestedArray($ruleConfig, $ruleName),
             sprintf('Rule "%s" (in RuleSet "%s") has default config passed.', $ruleName, $setName)
@@ -123,7 +123,7 @@ final class RuleSetTest extends TestCase
 
         $fixer = current($factory->getFixers());
 
-        static::assertNotInstanceOf(DeprecatedFixerInterface::class, $fixer, sprintf('RuleSet "%s" contains deprecated rule "%s".', $setName, $ruleName));
+        self::assertNotInstanceOf(DeprecatedFixerInterface::class, $fixer, sprintf('RuleSet "%s" contains deprecated rule "%s".', $setName, $ruleName));
     }
 
     public static function provideAllRulesFromSetsCases(): iterable
@@ -145,7 +145,7 @@ final class RuleSetTest extends TestCase
     {
         $setNames = RuleSets::getSetDefinitionNames();
 
-        static::assertNotEmpty($setNames);
+        self::assertNotEmpty($setNames);
     }
 
     public function testResolveRulesWithInvalidSet(): void
@@ -175,7 +175,7 @@ final class RuleSetTest extends TestCase
             'strict_comparison' => true,
         ]);
 
-        static::assertSameRules(
+        self::assertSameRules(
             [
                 'braces' => true,
                 'full_opening_tag' => true,
@@ -193,7 +193,7 @@ final class RuleSetTest extends TestCase
             'strict_comparison' => true,
         ]);
 
-        static::assertSameRules(
+        self::assertSameRules(
             [
                 'blank_line_after_namespace' => true,
                 'class_definition' => true,
@@ -239,7 +239,7 @@ final class RuleSetTest extends TestCase
             'encoding' => true,
         ]);
 
-        static::assertSameRules(
+        self::assertSameRules(
             [
                 'blank_line_after_namespace' => true,
                 'constant_case' => true,
@@ -289,7 +289,7 @@ final class RuleSetTest extends TestCase
                 ->getFixers()
             ;
         } catch (InvalidForEnvFixerConfigurationException $exception) {
-            static::markTestSkipped($exception->getMessage());
+            self::markTestSkipped($exception->getMessage());
         }
 
         $fixerNames = [];
@@ -299,7 +299,7 @@ final class RuleSetTest extends TestCase
             }
         }
 
-        static::assertCount(
+        self::assertCount(
             0,
             $fixerNames,
             sprintf(
@@ -384,7 +384,7 @@ final class RuleSetTest extends TestCase
             return;
         }
 
-        static::fail(sprintf(
+        self::fail(sprintf(
             '"%s" defines rules the same as it extends from: %s',
             $set->getName(),
             implode(', ', $duplicates),
@@ -403,7 +403,7 @@ final class RuleSetTest extends TestCase
      */
     public function testPhpUnitTargetVersionHasSet(string $version): void
     {
-        static::assertContains(
+        self::assertContains(
             sprintf('@PHPUnit%sMigration:risky', str_replace('.', '', $version)),
             RuleSets::getSetDefinitionNames(),
             sprintf('PHPUnit target version %s is missing its set in %s.', $version, RuleSet::class)
@@ -527,6 +527,6 @@ final class RuleSetTest extends TestCase
         ksort($expected);
         ksort($actual);
 
-        static::assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 }

--- a/tests/RuleSet/RuleSetsTest.php
+++ b/tests/RuleSet/RuleSetsTest.php
@@ -32,7 +32,7 @@ final class RuleSetsTest extends TestCase
 {
     public function testGetSetDefinitionNames(): void
     {
-        static::assertSame(
+        self::assertSame(
             array_keys(RuleSets::getSetDefinitions()),
             RuleSets::getSetDefinitionNames()
         );
@@ -43,10 +43,10 @@ final class RuleSetsTest extends TestCase
         $sets = RuleSets::getSetDefinitions();
 
         foreach ($sets as $name => $set) {
-            static::assertIsString($name);
-            static::assertStringStartsWith('@', $name);
-            static::assertIsArray($set->getRules());
-            static::assertSame($set, RuleSets::getSetDefinition($name));
+            self::assertIsString($name);
+            self::assertStringStartsWith('@', $name);
+            self::assertIsArray($set->getRules());
+            self::assertSame($set, RuleSets::getSetDefinition($name));
         }
     }
 
@@ -86,23 +86,23 @@ final class RuleSetsTest extends TestCase
         ];
 
         if (\in_array($setDefinitionName, $setsWithoutTests, true)) {
-            static::markTestIncomplete(sprintf('Set "%s" has no integration test.', $setDefinitionName));
+            self::markTestIncomplete(sprintf('Set "%s" has no integration test.', $setDefinitionName));
         }
 
         $setDefinitionFileNamePrefix = str_replace(':', '-', $setDefinitionName);
         $dir = __DIR__.'/../../tests/Fixtures/Integration/set';
         $file = sprintf('%s/%s.test', $dir, $setDefinitionFileNamePrefix);
 
-        static::assertFileExists($file);
-        static::assertFileExists(sprintf('%s/%s.test-in.php', $dir, $setDefinitionFileNamePrefix));
-        static::assertFileExists(sprintf('%s/%s.test-out.php', $dir, $setDefinitionFileNamePrefix));
+        self::assertFileExists($file);
+        self::assertFileExists(sprintf('%s/%s.test-in.php', $dir, $setDefinitionFileNamePrefix));
+        self::assertFileExists(sprintf('%s/%s.test-out.php', $dir, $setDefinitionFileNamePrefix));
 
         $template = '--TEST--
 Integration of %s.
 --RULESET--
 {"%s": true}
 ';
-        static::assertStringStartsWith(
+        self::assertStringStartsWith(
             sprintf($template, $setDefinitionName, $setDefinitionName),
             file_get_contents($file)
         );
@@ -113,7 +113,7 @@ Integration of %s.
      */
     public function testBuildInSetDefinitionNames(string $setName): void
     {
-        static::assertStringStartsWith('@', $setName);
+        self::assertStringStartsWith('@', $setName);
     }
 
     /**
@@ -125,7 +125,7 @@ Integration of %s.
         $sortedSetDefinition = $setDefinition;
         $this->sort($sortedSetDefinition);
 
-        static::assertSame($sortedSetDefinition, $setDefinition, sprintf(
+        self::assertSame($sortedSetDefinition, $setDefinition, sprintf(
             'Failed to assert that the set definition for "%s" is sorted by key.',
             $setDefinitionName
         ));
@@ -137,7 +137,7 @@ Integration of %s.
         $sortedSetDefinition = $setDefinition;
         natsort($sortedSetDefinition);
 
-        static::assertSame($sortedSetDefinition, $setDefinition);
+        self::assertSame($sortedSetDefinition, $setDefinition);
     }
 
     public static function provideSetDefinitionNameCases(): array
@@ -159,7 +159,7 @@ Integration of %s.
         foreach ($ruleSet->getRules() as $ruleName => $ruleConfig) {
             $targetVersion = true === $ruleConfig ? $this->getDefaultPHPUnitTargetOfRule($ruleName) : $ruleConfig['target'];
 
-            static::assertPHPUnitVersionIsLargestAllowed($setName, $ruleName, $targetVersion);
+            self::assertPHPUnitVersionIsLargestAllowed($setName, $ruleName, $targetVersion);
         }
     }
 
@@ -205,7 +205,7 @@ Integration of %s.
             }
         );
 
-        static::assertTrue(\in_array($actualTargetVersion, $allowedVersionsForRuleset, true), sprintf(
+        self::assertTrue(\in_array($actualTargetVersion, $allowedVersionsForRuleset, true), sprintf(
             'Rule "%s" (in rule set "%s") has target "%s", but the rule set is not allowing it (allowed are only "%s")',
             $fixer->getName(),
             $setName,
@@ -216,7 +216,7 @@ Integration of %s.
         rsort($allowedVersionsForRuleset);
         $maximumAllowedVersionForRuleset = reset($allowedVersionsForRuleset);
 
-        static::assertSame($maximumAllowedVersionForRuleset, $actualTargetVersion, sprintf(
+        self::assertSame($maximumAllowedVersionForRuleset, $actualTargetVersion, sprintf(
             'Rule "%s" (in rule set "%s") has target "%s", but there is higher available target "%s"',
             $fixer->getName(),
             $setName,

--- a/tests/Runner/FileFilterIteratorTest.php
+++ b/tests/Runner/FileFilterIteratorTest.php
@@ -56,12 +56,12 @@ final class FileFilterIteratorTest extends TestCase
             $cache->reveal()
         );
 
-        static::assertCount(0, $events);
+        self::assertCount(0, $events);
 
         $files = iterator_to_array($filter);
 
-        static::assertCount(1, $files);
-        static::assertSame($fileInfo, reset($files));
+        self::assertCount(1, $files);
+        self::assertSame($fileInfo, reset($files));
     }
 
     public function testEmitSkipEventWhenCacheNeedFixingFalse(): void
@@ -87,14 +87,14 @@ final class FileFilterIteratorTest extends TestCase
             $cache->reveal()
         );
 
-        static::assertCount(0, $filter);
-        static::assertCount(1, $events);
+        self::assertCount(0, $filter);
+        self::assertCount(1, $events);
 
         /** @var FixerFileProcessedEvent $event */
         $event = reset($events);
 
-        static::assertInstanceOf(\PhpCsFixer\FixerFileProcessedEvent::class, $event);
-        static::assertSame(FixerFileProcessedEvent::STATUS_SKIPPED, $event->getStatus());
+        self::assertInstanceOf(\PhpCsFixer\FixerFileProcessedEvent::class, $event);
+        self::assertSame(FixerFileProcessedEvent::STATUS_SKIPPED, $event->getStatus());
     }
 
     public function testIgnoreEmptyFile(): void
@@ -120,14 +120,14 @@ final class FileFilterIteratorTest extends TestCase
             $cache->reveal()
         );
 
-        static::assertCount(0, $filter);
-        static::assertCount(1, $events);
+        self::assertCount(0, $filter);
+        self::assertCount(1, $events);
 
         /** @var FixerFileProcessedEvent $event */
         $event = reset($events);
 
-        static::assertInstanceOf(\PhpCsFixer\FixerFileProcessedEvent::class, $event);
-        static::assertSame(FixerFileProcessedEvent::STATUS_SKIPPED, $event->getStatus());
+        self::assertInstanceOf(\PhpCsFixer\FixerFileProcessedEvent::class, $event);
+        self::assertSame(FixerFileProcessedEvent::STATUS_SKIPPED, $event->getStatus());
     }
 
     public function testIgnore(): void
@@ -149,7 +149,7 @@ final class FileFilterIteratorTest extends TestCase
             $this->prophesize(\PhpCsFixer\Cache\CacheManagerInterface::class)->reveal()
         );
 
-        static::assertCount(0, $filter);
+        self::assertCount(0, $filter);
     }
 
     public function testWithoutDispatcher(): void
@@ -166,7 +166,7 @@ final class FileFilterIteratorTest extends TestCase
             $cache->reveal()
         );
 
-        static::assertCount(0, $filter);
+        self::assertCount(0, $filter);
     }
 
     public function testInvalidIterator(): void
@@ -194,8 +194,8 @@ final class FileFilterIteratorTest extends TestCase
     {
         $link = __DIR__.'/../Fixtures/Test/FileFilterIteratorTest/FileFilterIteratorTest.php.link';
 
-        static::assertTrue(is_link($link), 'Fixture data is no longer correct for this test.');
-        static::assertSame(__FILE__, realpath($link), 'Fixture data is no longer correct for this test.');
+        self::assertTrue(is_link($link), 'Fixture data is no longer correct for this test.');
+        self::assertSame(__FILE__, realpath($link), 'Fixture data is no longer correct for this test.');
 
         $file = new \SplFileInfo(__FILE__);
         $link = new \SplFileInfo($link);
@@ -213,7 +213,7 @@ final class FileFilterIteratorTest extends TestCase
         );
 
         $files = iterator_to_array($filter);
-        static::assertCount(1, $files);
-        static::assertSame($file, reset($files));
+        self::assertCount(1, $files);
+        self::assertSame($file, reset($files));
     }
 }

--- a/tests/Runner/FileLintingIteratorTest.php
+++ b/tests/Runner/FileLintingIteratorTest.php
@@ -37,10 +37,10 @@ final class FileLintingIteratorTest extends TestCase
             $fileLintingIteratorProphecy->reveal()
         );
 
-        static::assertNull($fileLintingIterator->current());
-        static::assertNull($fileLintingIterator->currentLintingResult());
-        static::assertSame($iterator, $fileLintingIterator->getInnerIterator());
-        static::assertFalse($fileLintingIterator->valid());
+        self::assertNull($fileLintingIterator->current());
+        self::assertNull($fileLintingIterator->currentLintingResult());
+        self::assertSame($iterator, $fileLintingIterator->getInnerIterator());
+        self::assertFalse($fileLintingIterator->valid());
     }
 
     public function testFileLintingIterator(): void
@@ -60,7 +60,7 @@ final class FileLintingIteratorTest extends TestCase
 
         // test when not touched current is null
 
-        static::assertNull($fileLintingIterator->currentLintingResult());
+        self::assertNull($fileLintingIterator->currentLintingResult());
 
         // test iterating
 
@@ -81,15 +81,15 @@ final class FileLintingIteratorTest extends TestCase
         $iterations = 0;
 
         foreach ($fileLintingIterator as $lintedFile) {
-            static::assertSame($file, $lintedFile);
-            static::assertSame($lintingResultInterface, $fileLintingIterator->currentLintingResult());
+            self::assertSame($file, $lintedFile);
+            self::assertSame($lintingResultInterface, $fileLintingIterator->currentLintingResult());
             ++$iterations;
         }
 
-        static::assertSame(1, $iterations);
+        self::assertSame(1, $iterations);
 
         $fileLintingIterator->next();
 
-        static::assertNull($fileLintingIterator->currentLintingResult());
+        self::assertNull($fileLintingIterator->currentLintingResult());
     }
 }

--- a/tests/Runner/RunnerTest.php
+++ b/tests/Runner/RunnerTest.php
@@ -80,9 +80,9 @@ final class RunnerTest extends TestCase
 
         $changed = $runner->fix();
 
-        static::assertCount(2, $changed);
-        static::assertSame($expectedChangedInfo, array_pop($changed));
-        static::assertSame($expectedChangedInfo, array_pop($changed));
+        self::assertCount(2, $changed);
+        self::assertSame($expectedChangedInfo, array_pop($changed));
+        self::assertSame($expectedChangedInfo, array_pop($changed));
 
         $path = __DIR__.\DIRECTORY_SEPARATOR.'..'.\DIRECTORY_SEPARATOR.'Fixtures'.\DIRECTORY_SEPARATOR.'FixerTest'.\DIRECTORY_SEPARATOR.'fix';
         $runner = new Runner(
@@ -100,8 +100,8 @@ final class RunnerTest extends TestCase
 
         $changed = $runner->fix();
 
-        static::assertCount(1, $changed);
-        static::assertSame($expectedChangedInfo, array_pop($changed));
+        self::assertCount(1, $changed);
+        self::assertSame($expectedChangedInfo, array_pop($changed));
     }
 
     /**
@@ -129,18 +129,18 @@ final class RunnerTest extends TestCase
         $changed = $runner->fix();
         $pathToInvalidFile = $path.\DIRECTORY_SEPARATOR.'somefile.php';
 
-        static::assertCount(0, $changed);
+        self::assertCount(0, $changed);
 
         $errors = $errorsManager->getInvalidErrors();
 
-        static::assertCount(1, $errors);
+        self::assertCount(1, $errors);
 
         $error = $errors[0];
 
-        static::assertInstanceOf(\PhpCsFixer\Error\Error::class, $error);
+        self::assertInstanceOf(\PhpCsFixer\Error\Error::class, $error);
 
-        static::assertSame(Error::TYPE_INVALID, $error->getType());
-        static::assertSame($pathToInvalidFile, $error->getFilePath());
+        self::assertSame(Error::TYPE_INVALID, $error->getType());
+        self::assertSame($pathToInvalidFile, $error->getFilePath());
     }
 
     /**
@@ -170,6 +170,6 @@ final class RunnerTest extends TestCase
 
         $runner->fix();
 
-        static::assertSame($path, $spy->passedFile->getPath());
+        self::assertSame($path, $spy->passedFile->getPath());
     }
 }

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -48,13 +48,13 @@ final class CiIntegrationTest extends AbstractSmokeTest
         try {
             CommandExecutor::create('composer --version', __DIR__)->getResult();
         } catch (\RuntimeException $e) {
-            static::markTestSkippedOrFail('Missing `composer` env script. Details:'."\n".$e->getMessage());
+            self::markTestSkippedOrFail('Missing `composer` env script. Details:'."\n".$e->getMessage());
         }
 
         try {
             CommandExecutor::create('composer check', __DIR__.'/../..')->getResult();
         } catch (\RuntimeException $e) {
-            static::markTestSkippedOrFail('Composer check failed. Details:'."\n".$e->getMessage());
+            self::markTestSkippedOrFail('Composer check failed. Details:'."\n".$e->getMessage());
         }
 
         try {
@@ -67,7 +67,7 @@ final class CiIntegrationTest extends AbstractSmokeTest
                 'git commit -m "init" -q',
             ]);
         } catch (\RuntimeException $e) {
-            static::markTestSkippedOrFail($e->getMessage());
+            self::markTestSkippedOrFail($e->getMessage());
         }
     }
 
@@ -127,7 +127,7 @@ final class CiIntegrationTest extends AbstractSmokeTest
             'echo "$CHANGED_FILES"',
         ]);
 
-        static::assertSame(implode("\n", $expectedResult1Lines)."\n", $result1->getOutput());
+        self::assertSame(implode("\n", $expectedResult1Lines)."\n", $result1->getOutput());
 
         $result2 = self::executeScript([
             $steps[0],
@@ -137,7 +137,7 @@ final class CiIntegrationTest extends AbstractSmokeTest
             'echo "${EXTRA_ARGS}"',
         ]);
 
-        static::assertSame(implode("\n", $expectedResult2Lines), $result2->getOutput());
+        self::assertSame(implode("\n", $expectedResult2Lines), $result2->getOutput());
 
         $result3 = self::executeScript([
             $steps[0],
@@ -185,15 +185,15 @@ Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Exec
             preg_quote('Legend: .-no changes, F-fixed, S-skipped (cached or empty file), I-invalid file syntax (file ignored), E-error', '/')
         );
 
-        static::assertMatchesRegularExpression($pattern, $result3->getError());
+        self::assertMatchesRegularExpression($pattern, $result3->getError());
 
         preg_match($pattern, $result3->getError(), $matches);
 
-        static::assertArrayHasKey(1, $matches);
-        static::assertSame(substr_count($expectedResult3FilesDots, '.'), substr_count($matches[1], '.'));
-        static::assertSame(substr_count($expectedResult3FilesDots, 'S'), substr_count($matches[1], 'S'));
+        self::assertArrayHasKey(1, $matches);
+        self::assertSame(substr_count($expectedResult3FilesDots, '.'), substr_count($matches[1], '.'));
+        self::assertSame(substr_count($expectedResult3FilesDots, 'S'), substr_count($matches[1], 'S'));
 
-        static::assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '/^\s*Found \d+ of \d+ files that can be fixed in \d+\.\d+ seconds, \d+\.\d+ MB memory used\s*$/',
             $result3->getOutput()
         );

--- a/tests/Smoke/InstallViaComposerTest.php
+++ b/tests/Smoke/InstallViaComposerTest.php
@@ -50,25 +50,25 @@ final class InstallViaComposerTest extends AbstractSmokeTest
         parent::setUpBeforeClass();
 
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            static::markTestIncomplete('This test is broken on Windows');
+            self::markTestIncomplete('This test is broken on Windows');
         }
 
         try {
             CommandExecutor::create('php --version', __DIR__)->getResult();
         } catch (\RuntimeException $e) {
-            static::markTestSkippedOrFail('Missing `php` env script. Details:'."\n".$e->getMessage());
+            self::markTestSkippedOrFail('Missing `php` env script. Details:'."\n".$e->getMessage());
         }
 
         try {
             CommandExecutor::create('composer --version', __DIR__)->getResult();
         } catch (\RuntimeException $e) {
-            static::markTestSkippedOrFail('Missing `composer` env script. Details:'."\n".$e->getMessage());
+            self::markTestSkippedOrFail('Missing `composer` env script. Details:'."\n".$e->getMessage());
         }
 
         try {
             CommandExecutor::create('composer check', __DIR__.'/../..')->getResult();
         } catch (\RuntimeException $e) {
-            static::markTestSkippedOrFail('Composer check failed. Details:'."\n".$e->getMessage());
+            self::markTestSkippedOrFail('Composer check failed. Details:'."\n".$e->getMessage());
         }
     }
 
@@ -97,7 +97,7 @@ final class InstallViaComposerTest extends AbstractSmokeTest
             json_encode($initialComposerFileState, JSON_PRETTY_PRINT)
         );
 
-        static::assertCommandsWork($this->stepsToVerifyInstallation, $tmpPath);
+        self::assertCommandsWork($this->stepsToVerifyInstallation, $tmpPath);
 
         $fs->remove($tmpPath);
     }
@@ -107,7 +107,7 @@ final class InstallViaComposerTest extends AbstractSmokeTest
     {
         // Composer Artifact Repository requires `zip` extension
         if (!\extension_loaded('zip')) {
-            static::markTestSkippedOrFail('No zip extension available.');
+            self::markTestSkippedOrFail('No zip extension available.');
         }
 
         $fs = new Filesystem();
@@ -160,9 +160,9 @@ final class InstallViaComposerTest extends AbstractSmokeTest
             'git rm -r . && rm -rf .git',
         ];
 
-        static::assertCommandsWork($stepsToInitializeArtifact, $cwd);
-        static::assertCommandsWork($stepsToPrepareArtifact, $tmpArtifactPath);
-        static::assertCommandsWork($this->stepsToVerifyInstallation, $tmpPath);
+        self::assertCommandsWork($stepsToInitializeArtifact, $cwd);
+        self::assertCommandsWork($stepsToPrepareArtifact, $tmpArtifactPath);
+        self::assertCommandsWork($this->stepsToVerifyInstallation, $tmpPath);
 
         $fs->remove($tmpPath);
         $fs->remove($tmpArtifactPath);
@@ -174,7 +174,7 @@ final class InstallViaComposerTest extends AbstractSmokeTest
     private static function assertCommandsWork(array $commands, string $cwd): void
     {
         foreach ($commands as $command) {
-            static::assertSame(0, CommandExecutor::create($command, $cwd)->getResult()->getCode());
+            self::assertSame(0, CommandExecutor::create($command, $cwd)->getResult()->getCode());
         }
     }
 }

--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -51,7 +51,7 @@ final class PharTest extends AbstractSmokeTest
         self::$pharName = 'php-cs-fixer.phar';
 
         if (!file_exists(self::$pharCwd.'/'.self::$pharName)) {
-            static::markTestSkippedOrFail('No phar file available.');
+            self::markTestSkippedOrFail('No phar file available.');
         }
     }
 
@@ -60,7 +60,7 @@ final class PharTest extends AbstractSmokeTest
         /** @phpstan-ignore-next-line to avoid `Ternary operator condition is always true|false.` */
         $shouldExpectCodename = Application::VERSION_CODENAME ? 1 : 0;
 
-        static::assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             sprintf("/^PHP CS Fixer (?<version>%s)(?<git_sha> \\([a-z0-9]+\\))?(?<codename> %s){%d}(?<by> by .*)\nPHP runtime: (?<php_version>\\d\\.\\d+\\..*)$/", Application::VERSION, Application::VERSION_CODENAME, $shouldExpectCodename),
             self::executePharCommand('--version')->getOutput()
         );
@@ -79,7 +79,7 @@ final class PharTest extends AbstractSmokeTest
             'name' => 'header_comment',
         ]);
 
-        static::assertSame(
+        self::assertSame(
             $commandTester->getDisplay(),
             self::executePharCommand('describe header_comment')->getOutput()
         );
@@ -87,7 +87,7 @@ final class PharTest extends AbstractSmokeTest
 
     public function testFix(): void
     {
-        static::assertSame(
+        self::assertSame(
             0,
             self::executePharCommand('fix src/Config.php -vvv --dry-run --diff --using-cache=no 2>&1')->getCode()
         );
@@ -95,7 +95,7 @@ final class PharTest extends AbstractSmokeTest
 
     public function testFixHelp(): void
     {
-        static::assertSame(
+        self::assertSame(
             0,
             self::executePharCommand('fix --help')->getCode()
         );

--- a/tests/Smoke/StdinTest.php
+++ b/tests/Smoke/StdinTest.php
@@ -42,7 +42,7 @@ final class StdinTest extends AbstractSmokeTest
         $fileResult = CommandExecutor::create("{$command} {$inputFile}", $cwd)->getResult(false);
         $stdinResult = CommandExecutor::create("{$command} - < {$inputFile}", $cwd)->getResult(false);
 
-        static::assertSame($fileResult->getCode(), $stdinResult->getCode());
+        self::assertSame($fileResult->getCode(), $stdinResult->getCode());
 
         $expectedError = str_replace(
             'Paths from configuration file have been overridden by paths provided as command arguments.'."\n",
@@ -50,7 +50,7 @@ final class StdinTest extends AbstractSmokeTest
             $fileResult->getError()
         );
 
-        static::assertSame($expectedError, $stdinResult->getError());
+        self::assertSame($expectedError, $stdinResult->getError());
 
         $fileResult = $this->unifyFooter($fileResult->getOutput());
 
@@ -66,7 +66,7 @@ final class StdinTest extends AbstractSmokeTest
             $fileResult
         );
 
-        static::assertSame(
+        self::assertSame(
             $fileResult,
             $this->unifyFooter($stdinResult->getOutput())
         );

--- a/tests/StdinFileInfoTest.php
+++ b/tests/StdinFileInfoTest.php
@@ -29,42 +29,42 @@ final class StdinFileInfoTest extends TestCase
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame('php://stdin', (string) $fileInfo);
+        self::assertSame('php://stdin', (string) $fileInfo);
     }
 
     public function testGetRealPath(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame('php://stdin', $fileInfo->getRealPath());
+        self::assertSame('php://stdin', $fileInfo->getRealPath());
     }
 
     public function testGetATime(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame(0, $fileInfo->getATime());
+        self::assertSame(0, $fileInfo->getATime());
     }
 
     public function testGetBasename(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame('stdin.php', $fileInfo->getBasename());
+        self::assertSame('stdin.php', $fileInfo->getBasename());
     }
 
     public function testGetCTime(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame(0, $fileInfo->getCTime());
+        self::assertSame(0, $fileInfo->getCTime());
     }
 
     public function testGetExtension(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame('.php', $fileInfo->getExtension());
+        self::assertSame('.php', $fileInfo->getExtension());
     }
 
     public function testGetFileInfo(): void
@@ -81,49 +81,49 @@ final class StdinFileInfoTest extends TestCase
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame('stdin.php', $fileInfo->getFilename());
+        self::assertSame('stdin.php', $fileInfo->getFilename());
     }
 
     public function testGetGroup(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame(0, $fileInfo->getGroup());
+        self::assertSame(0, $fileInfo->getGroup());
     }
 
     public function testGetInode(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame(0, $fileInfo->getInode());
+        self::assertSame(0, $fileInfo->getInode());
     }
 
     public function testGetLinkTarget(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame('', $fileInfo->getLinkTarget());
+        self::assertSame('', $fileInfo->getLinkTarget());
     }
 
     public function testGetMTime(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame(0, $fileInfo->getMTime());
+        self::assertSame(0, $fileInfo->getMTime());
     }
 
     public function testGetOwner(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame(0, $fileInfo->getOwner());
+        self::assertSame(0, $fileInfo->getOwner());
     }
 
     public function testGetPath(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame('', $fileInfo->getPath());
+        self::assertSame('', $fileInfo->getPath());
     }
 
     public function testGetPathInfo(): void
@@ -140,70 +140,70 @@ final class StdinFileInfoTest extends TestCase
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame('stdin.php', $fileInfo->getPathname());
+        self::assertSame('stdin.php', $fileInfo->getPathname());
     }
 
     public function testGetPerms(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame(0, $fileInfo->getPerms());
+        self::assertSame(0, $fileInfo->getPerms());
     }
 
     public function testGetSize(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame(0, $fileInfo->getSize());
+        self::assertSame(0, $fileInfo->getSize());
     }
 
     public function testGetType(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertSame('file', $fileInfo->getType());
+        self::assertSame('file', $fileInfo->getType());
     }
 
     public function testIsDir(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertFalse($fileInfo->isDir());
+        self::assertFalse($fileInfo->isDir());
     }
 
     public function testIsExecutable(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertFalse($fileInfo->isExecutable());
+        self::assertFalse($fileInfo->isExecutable());
     }
 
     public function testIsFile(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertTrue($fileInfo->isFile());
+        self::assertTrue($fileInfo->isFile());
     }
 
     public function testIsLink(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertFalse($fileInfo->isLink());
+        self::assertFalse($fileInfo->isLink());
     }
 
     public function testIsReadable(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertTrue($fileInfo->isReadable());
+        self::assertTrue($fileInfo->isReadable());
     }
 
     public function testIsWritable(): void
     {
         $fileInfo = new StdinFileInfo();
 
-        static::assertFalse($fileInfo->isWritable());
+        self::assertFalse($fileInfo->isWritable());
     }
 
     public function testOpenFile(): void

--- a/tests/TextDiffTest.php
+++ b/tests/TextDiffTest.php
@@ -52,14 +52,14 @@ final class TextDiffTest extends TestCase
         );
 
         if ($isDecorated !== $commandTester->getOutput()->isDecorated()) {
-            static::markTestSkipped(sprintf('Output should %sbe decorated.', $isDecorated ? '' : 'not '));
+            self::markTestSkipped(sprintf('Output should %sbe decorated.', $isDecorated ? '' : 'not '));
         }
 
         if ($isDecorated !== $commandTester->getOutput()->getFormatter()->isDecorated()) {
-            static::markTestSkipped(sprintf('Formatter should %sbe decorated.', $isDecorated ? '' : 'not '));
+            self::markTestSkipped(sprintf('Formatter should %sbe decorated.', $isDecorated ? '' : 'not '));
         }
 
-        static::assertStringMatchesFormat($expected, $commandTester->getDisplay(false));
+        self::assertStringMatchesFormat($expected, $commandTester->getDisplay(false));
     }
 
     public static function provideDiffReportingCases(): iterable
@@ -94,7 +94,7 @@ TEST;
         $formats = $factory->registerBuiltInReporters()->getFormats();
         sort($formats);
 
-        static::assertSame(
+        self::assertSame(
             ['checkstyle', 'gitlab', 'json', 'junit', 'txt', 'xml'],
             $formats
         );

--- a/tests/Tokenizer/AbstractTransformerTest.php
+++ b/tests/Tokenizer/AbstractTransformerTest.php
@@ -28,14 +28,14 @@ final class AbstractTransformerTest extends TestCase
     {
         $transformer = new FooTransformer();
 
-        static::assertSame(0, $transformer->getPriority());
-        static::assertSame('foo', $transformer->getName());
+        self::assertSame(0, $transformer->getPriority());
+        self::assertSame('foo', $transformer->getName());
     }
 
     public function testCustomTokens(): void
     {
         $transformer = new FooTransformer();
 
-        static::assertSame([], $transformer->getCustomTokens());
+        self::assertSame([], $transformer->getCustomTokens());
     }
 }

--- a/tests/Tokenizer/Analyzer/AlternativeSyntaxAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/AlternativeSyntaxAnalyzerTest.php
@@ -35,7 +35,7 @@ final class AlternativeSyntaxAnalyzerTest extends TestCase
         $tokens = Tokens::fromCode($source);
 
         for ($index = $tokens->count() - 1; $index >= 0; --$index) {
-            static::assertSame(
+            self::assertSame(
                 \in_array($index, $expectedPositives, true),
                 (new AlternativeSyntaxAnalyzer())->belongsToAlternativeSyntax($tokens, $index),
                 '@ index: '.$index
@@ -93,7 +93,7 @@ final class AlternativeSyntaxAnalyzerTest extends TestCase
     {
         $analyzer = new AlternativeSyntaxAnalyzer();
 
-        static::assertSame(
+        self::assertSame(
             $expectedResult,
             $analyzer->findAlternativeSyntaxBlockEnd(
                 Tokens::fromCode($code),

--- a/tests/Tokenizer/Analyzer/Analysis/ArgumentAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/ArgumentAnalysisTest.php
@@ -30,37 +30,37 @@ final class ArgumentAnalysisTest extends TestCase
     public function testName(): void
     {
         $analysis = new ArgumentAnalysis('$name', 1, null, null);
-        static::assertSame('$name', $analysis->getName());
-        static::assertSame(1, $analysis->getNameIndex());
+        self::assertSame('$name', $analysis->getName());
+        self::assertSame(1, $analysis->getNameIndex());
     }
 
     public function testDefault(): void
     {
         $analysis = new ArgumentAnalysis('$name', 1, 'default', null);
-        static::assertTrue($analysis->hasDefault());
-        static::assertSame('default', $analysis->getDefault());
+        self::assertTrue($analysis->hasDefault());
+        self::assertSame('default', $analysis->getDefault());
     }
 
     public function testNoDefaultFound(): void
     {
         $analysis = new ArgumentAnalysis('$name', 1, null, null);
-        static::assertFalse($analysis->hasDefault());
-        static::assertNull($analysis->getDefault());
+        self::assertFalse($analysis->hasDefault());
+        self::assertNull($analysis->getDefault());
     }
 
     public function testType(): void
     {
         $analysis = new ArgumentAnalysis('$name', 1, null, new TypeAnalysis('string', 1, 4));
-        static::assertTrue($analysis->hasTypeAnalysis());
-        static::assertSame('string', $analysis->getTypeAnalysis()->getName());
-        static::assertSame(1, $analysis->getTypeAnalysis()->getStartIndex());
-        static::assertSame(4, $analysis->getTypeAnalysis()->getEndIndex());
+        self::assertTrue($analysis->hasTypeAnalysis());
+        self::assertSame('string', $analysis->getTypeAnalysis()->getName());
+        self::assertSame(1, $analysis->getTypeAnalysis()->getStartIndex());
+        self::assertSame(4, $analysis->getTypeAnalysis()->getEndIndex());
     }
 
     public function testNoTypeFound(): void
     {
         $analysis = new ArgumentAnalysis('$name', 1, null, null);
-        static::assertFalse($analysis->hasDefault());
-        static::assertNull($analysis->getDefault());
+        self::assertFalse($analysis->hasDefault());
+        self::assertNull($analysis->getDefault());
     }
 }

--- a/tests/Tokenizer/Analyzer/Analysis/CaseAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/CaseAnalysisTest.php
@@ -28,7 +28,7 @@ final class CaseAnalysisTest extends TestCase
     {
         $analysis = new CaseAnalysis(12, 20);
 
-        static::assertSame(12, $analysis->getIndex());
-        static::assertSame(20, $analysis->getColonIndex());
+        self::assertSame(12, $analysis->getIndex());
+        self::assertSame(20, $analysis->getColonIndex());
     }
 }

--- a/tests/Tokenizer/Analyzer/Analysis/DefaultAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/DefaultAnalysisTest.php
@@ -28,7 +28,7 @@ final class DefaultAnalysisTest extends TestCase
     {
         $analysis = new DefaultAnalysis(15, 16);
 
-        static::assertSame(15, $analysis->getIndex());
-        static::assertSame(16, $analysis->getColonIndex());
+        self::assertSame(15, $analysis->getIndex());
+        self::assertSame(16, $analysis->getColonIndex());
     }
 }

--- a/tests/Tokenizer/Analyzer/Analysis/EnumAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/EnumAnalysisTest.php
@@ -29,10 +29,10 @@ final class EnumAnalysisTest extends TestCase
     {
         $analysis = new EnumAnalysis(10, 11, 15, []);
 
-        static::assertSame(10, $analysis->getIndex());
-        static::assertSame(11, $analysis->getOpenIndex());
-        static::assertSame(15, $analysis->getCloseIndex());
-        static::assertSame([], $analysis->getCases());
+        self::assertSame(10, $analysis->getIndex());
+        self::assertSame(11, $analysis->getOpenIndex());
+        self::assertSame(15, $analysis->getCloseIndex());
+        self::assertSame([], $analysis->getCases());
     }
 
     public function testEnumAnalysis2(): void
@@ -41,9 +41,9 @@ final class EnumAnalysisTest extends TestCase
 
         $analysis = new EnumAnalysis(15, 17, 190, [$caseAnalysis]);
 
-        static::assertSame(15, $analysis->getIndex());
-        static::assertSame(17, $analysis->getOpenIndex());
-        static::assertSame(190, $analysis->getCloseIndex());
-        static::assertSame([$caseAnalysis], $analysis->getCases());
+        self::assertSame(15, $analysis->getIndex());
+        self::assertSame(17, $analysis->getOpenIndex());
+        self::assertSame(190, $analysis->getCloseIndex());
+        self::assertSame([$caseAnalysis], $analysis->getCases());
     }
 }

--- a/tests/Tokenizer/Analyzer/Analysis/MatchAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/MatchAnalysisTest.php
@@ -29,10 +29,10 @@ final class MatchAnalysisTest extends TestCase
     {
         $analysis = new MatchAnalysis(10, 11, 15, null);
 
-        static::assertSame(10, $analysis->getIndex());
-        static::assertSame(11, $analysis->getOpenIndex());
-        static::assertSame(15, $analysis->getCloseIndex());
-        static::assertNull($analysis->getDefaultAnalysis());
+        self::assertSame(10, $analysis->getIndex());
+        self::assertSame(11, $analysis->getOpenIndex());
+        self::assertSame(15, $analysis->getCloseIndex());
+        self::assertNull($analysis->getDefaultAnalysis());
     }
 
     public function testMatchAnalysis2(): void
@@ -41,9 +41,9 @@ final class MatchAnalysisTest extends TestCase
 
         $analysis = new MatchAnalysis(22, 26, 290, $defaultAnalysis);
 
-        static::assertSame(22, $analysis->getIndex());
-        static::assertSame(26, $analysis->getOpenIndex());
-        static::assertSame(290, $analysis->getCloseIndex());
-        static::assertSame($defaultAnalysis, $analysis->getDefaultAnalysis());
+        self::assertSame(22, $analysis->getIndex());
+        self::assertSame(26, $analysis->getOpenIndex());
+        self::assertSame(290, $analysis->getCloseIndex());
+        self::assertSame($defaultAnalysis, $analysis->getDefaultAnalysis());
     }
 }

--- a/tests/Tokenizer/Analyzer/Analysis/NamespaceAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/NamespaceAnalysisTest.php
@@ -29,43 +29,43 @@ final class NamespaceAnalysisTest extends TestCase
     public function testFullName(): void
     {
         $analysis = new NamespaceAnalysis('Full\NamespaceName', 'NamespaceName', 1, 2, 1, 10);
-        static::assertSame('Full\NamespaceName', $analysis->getFullName());
+        self::assertSame('Full\NamespaceName', $analysis->getFullName());
     }
 
     public function testShortName(): void
     {
         $analysis = new NamespaceAnalysis('Full\NamespaceName', 'NamespaceName', 1, 2, 1, 10);
-        static::assertSame('NamespaceName', $analysis->getShortName());
-        static::assertFalse($analysis->isGlobalNamespace());
+        self::assertSame('NamespaceName', $analysis->getShortName());
+        self::assertFalse($analysis->isGlobalNamespace());
     }
 
     public function testStartIndex(): void
     {
         $analysis = new NamespaceAnalysis('Full\NamespaceName', 'NamespaceName', 1, 2, 1, 10);
-        static::assertSame(1, $analysis->getStartIndex());
+        self::assertSame(1, $analysis->getStartIndex());
     }
 
     public function testEndIndex(): void
     {
         $analysis = new NamespaceAnalysis('Full\NamespaceName', 'NamespaceName', 1, 2, 1, 10);
-        static::assertSame(2, $analysis->getEndIndex());
+        self::assertSame(2, $analysis->getEndIndex());
     }
 
     public function testScopeStartIndex(): void
     {
         $analysis = new NamespaceAnalysis('Full\NamespaceName', 'NamespaceName', 1, 2, 1, 10);
-        static::assertSame(1, $analysis->getScopeStartIndex());
+        self::assertSame(1, $analysis->getScopeStartIndex());
     }
 
     public function testScopeEndIndex(): void
     {
         $analysis = new NamespaceAnalysis('Full\NamespaceName', 'NamespaceName', 1, 2, 1, 10);
-        static::assertSame(10, $analysis->getScopeEndIndex());
+        self::assertSame(10, $analysis->getScopeEndIndex());
     }
 
     public function testGlobal(): void
     {
         $analysis = new NamespaceAnalysis('', '', 1, 2, 1, 10);
-        static::assertTrue($analysis->isGlobalNamespace());
+        self::assertTrue($analysis->isGlobalNamespace());
     }
 }

--- a/tests/Tokenizer/Analyzer/Analysis/NamespaceUseAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/NamespaceUseAnalysisTest.php
@@ -29,34 +29,34 @@ final class NamespaceUseAnalysisTest extends TestCase
     public function testFullName(): void
     {
         $analysis = new NamespaceUseAnalysis('Full\NamespaceName', 'NamespaceName', false, 11, 21, NamespaceUseAnalysis::TYPE_CLASS);
-        static::assertSame('Full\NamespaceName', $analysis->getFullName());
+        self::assertSame('Full\NamespaceName', $analysis->getFullName());
     }
 
     public function testAliased(): void
     {
         $analysis = new NamespaceUseAnalysis('Full\NamespaceName', 'NamespaceName', false, 12, 22, NamespaceUseAnalysis::TYPE_CLASS);
-        static::assertFalse($analysis->isAliased());
+        self::assertFalse($analysis->isAliased());
 
         $analysis = new NamespaceUseAnalysis('Full\NamespaceName', 'NamespaceName', true, 1, 2, NamespaceUseAnalysis::TYPE_CLASS);
-        static::assertTrue($analysis->isAliased());
+        self::assertTrue($analysis->isAliased());
     }
 
     public function testShortName(): void
     {
         $analysis = new NamespaceUseAnalysis('Full\NamespaceName', 'NamespaceName', false, 1, 2, NamespaceUseAnalysis::TYPE_CLASS);
-        static::assertSame('NamespaceName', $analysis->getShortName());
+        self::assertSame('NamespaceName', $analysis->getShortName());
     }
 
     public function testStartIndex(): void
     {
         $analysis = new NamespaceUseAnalysis('Full\NamespaceName', 'NamespaceName', false, 1, 2, NamespaceUseAnalysis::TYPE_CLASS);
-        static::assertSame(1, $analysis->getStartIndex());
+        self::assertSame(1, $analysis->getStartIndex());
     }
 
     public function testEndIndex(): void
     {
         $analysis = new NamespaceUseAnalysis('Full\NamespaceName', 'NamespaceName', false, 1, 72, NamespaceUseAnalysis::TYPE_CLASS);
-        static::assertSame(72, $analysis->getEndIndex());
+        self::assertSame(72, $analysis->getEndIndex());
     }
 
     public function testTypeCheck(): void
@@ -65,19 +65,19 @@ final class NamespaceUseAnalysisTest extends TestCase
         $function = new NamespaceUseAnalysis('Foo\Bar', 'Baz', false, 1, 2, NamespaceUseAnalysis::TYPE_FUNCTION);
         $constant = new NamespaceUseAnalysis('Foo\Bar', 'Baz', false, 1, 2, NamespaceUseAnalysis::TYPE_CONSTANT);
 
-        static::assertTrue($class->isClass());
-        static::assertFalse($class->isFunction());
-        static::assertFalse($class->isConstant());
-        static::assertSame(NamespaceUseAnalysis::TYPE_CLASS, $class->getType());
+        self::assertTrue($class->isClass());
+        self::assertFalse($class->isFunction());
+        self::assertFalse($class->isConstant());
+        self::assertSame(NamespaceUseAnalysis::TYPE_CLASS, $class->getType());
 
-        static::assertFalse($function->isClass());
-        static::assertTrue($function->isFunction());
-        static::assertFalse($function->isConstant());
-        static::assertSame(NamespaceUseAnalysis::TYPE_FUNCTION, $function->getType());
+        self::assertFalse($function->isClass());
+        self::assertTrue($function->isFunction());
+        self::assertFalse($function->isConstant());
+        self::assertSame(NamespaceUseAnalysis::TYPE_FUNCTION, $function->getType());
 
-        static::assertFalse($constant->isClass());
-        static::assertFalse($constant->isFunction());
-        static::assertTrue($constant->isConstant());
-        static::assertSame(NamespaceUseAnalysis::TYPE_CONSTANT, $constant->getType());
+        self::assertFalse($constant->isClass());
+        self::assertFalse($constant->isFunction());
+        self::assertTrue($constant->isConstant());
+        self::assertSame(NamespaceUseAnalysis::TYPE_CONSTANT, $constant->getType());
     }
 }

--- a/tests/Tokenizer/Analyzer/Analysis/SwitchAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/SwitchAnalysisTest.php
@@ -32,11 +32,11 @@ final class SwitchAnalysisTest extends TestCase
     {
         $analysis = new SwitchAnalysis(10, 11, 15, [], null);
 
-        static::assertSame(10, $analysis->getIndex());
-        static::assertSame(11, $analysis->getOpenIndex());
-        static::assertSame(15, $analysis->getCloseIndex());
-        static::assertSame([], $analysis->getCases());
-        static::assertNull($analysis->getDefaultAnalysis());
+        self::assertSame(10, $analysis->getIndex());
+        self::assertSame(11, $analysis->getOpenIndex());
+        self::assertSame(15, $analysis->getCloseIndex());
+        self::assertSame([], $analysis->getCases());
+        self::assertNull($analysis->getDefaultAnalysis());
     }
 
     public function testSwitchAnalysis2(): void
@@ -46,10 +46,10 @@ final class SwitchAnalysisTest extends TestCase
 
         $analysis = new SwitchAnalysis(15, 17, 190, [$caseAnalysis], $defaultAnalysis);
 
-        static::assertSame(15, $analysis->getIndex());
-        static::assertSame(17, $analysis->getOpenIndex());
-        static::assertSame(190, $analysis->getCloseIndex());
-        static::assertSame([$caseAnalysis], $analysis->getCases());
-        static::assertSame($defaultAnalysis, $analysis->getDefaultAnalysis());
+        self::assertSame(15, $analysis->getIndex());
+        self::assertSame(17, $analysis->getOpenIndex());
+        self::assertSame(190, $analysis->getCloseIndex());
+        self::assertSame([$caseAnalysis], $analysis->getCases());
+        self::assertSame($defaultAnalysis, $analysis->getDefaultAnalysis());
     }
 }

--- a/tests/Tokenizer/Analyzer/Analysis/TypeAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/TypeAnalysisTest.php
@@ -29,24 +29,24 @@ final class TypeAnalysisTest extends TestCase
     public function testName(): void
     {
         $analysis = new TypeAnalysis('string', 1, 2);
-        static::assertSame('string', $analysis->getName());
-        static::assertFalse($analysis->isNullable());
+        self::assertSame('string', $analysis->getName());
+        self::assertFalse($analysis->isNullable());
 
         $analysis = new TypeAnalysis('?\foo\bar', 1, 2);
-        static::assertSame('\foo\bar', $analysis->getName());
-        static::assertTrue($analysis->isNullable());
+        self::assertSame('\foo\bar', $analysis->getName());
+        self::assertTrue($analysis->isNullable());
     }
 
     public function testStartIndex(): void
     {
         $analysis = new TypeAnalysis('string', 10, 20);
-        static::assertSame(10, $analysis->getStartIndex());
+        self::assertSame(10, $analysis->getStartIndex());
     }
 
     public function testEndIndex(): void
     {
         $analysis = new TypeAnalysis('string', 1, 27);
-        static::assertSame(27, $analysis->getEndIndex());
+        self::assertSame(27, $analysis->getEndIndex());
     }
 
     /**
@@ -55,7 +55,7 @@ final class TypeAnalysisTest extends TestCase
     public function testReserved(string $type, bool $expected): void
     {
         $analysis = new TypeAnalysis($type, 1, 2);
-        static::assertSame($expected, $analysis->isReservedType());
+        self::assertSame($expected, $analysis->isReservedType());
     }
 
     public static function provideReservedCases(): array

--- a/tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
@@ -39,8 +39,8 @@ final class ArgumentsAnalyzerTest extends TestCase
         $tokens = Tokens::fromCode($code);
         $analyzer = new ArgumentsAnalyzer();
 
-        static::assertSame(\count($arguments), $analyzer->countArguments($tokens, $openIndex, $closeIndex));
-        static::assertSame($arguments, $analyzer->getArguments($tokens, $openIndex, $closeIndex));
+        self::assertSame(\count($arguments), $analyzer->countArguments($tokens, $openIndex, $closeIndex));
+        self::assertSame($arguments, $analyzer->getArguments($tokens, $openIndex, $closeIndex));
     }
 
     public static function provideArgumentsCases(): iterable
@@ -99,8 +99,8 @@ final class ArgumentsAnalyzerTest extends TestCase
         $tokens = Tokens::fromCode($code);
         $analyzer = new ArgumentsAnalyzer();
 
-        static::assertSame(\count($arguments), $analyzer->countArguments($tokens, $openIndex, $closeIndex));
-        static::assertSame($arguments, $analyzer->getArguments($tokens, $openIndex, $closeIndex));
+        self::assertSame(\count($arguments), $analyzer->countArguments($tokens, $openIndex, $closeIndex));
+        self::assertSame($arguments, $analyzer->getArguments($tokens, $openIndex, $closeIndex));
     }
 
     public static function provideArguments80Cases(): iterable
@@ -128,8 +128,8 @@ final class ArgumentsAnalyzerTest extends TestCase
         $tokens = Tokens::fromCode($code);
         $analyzer = new ArgumentsAnalyzer();
 
-        static::assertSame(\count($arguments), $analyzer->countArguments($tokens, $openIndex, $closeIndex));
-        static::assertSame($arguments, $analyzer->getArguments($tokens, $openIndex, $closeIndex));
+        self::assertSame(\count($arguments), $analyzer->countArguments($tokens, $openIndex, $closeIndex));
+        self::assertSame($arguments, $analyzer->getArguments($tokens, $openIndex, $closeIndex));
     }
 
     public static function provideArguments81Cases(): iterable
@@ -362,25 +362,25 @@ class Foo
 
     private static function assertArgumentAnalysis(ArgumentAnalysis $expected, ArgumentAnalysis $actual): void
     {
-        static::assertSame($expected->getDefault(), $actual->getDefault(), 'Default.');
-        static::assertSame($expected->getName(), $actual->getName(), 'Name.');
-        static::assertSame($expected->getNameIndex(), $actual->getNameIndex(), 'Name index.');
-        static::assertSame($expected->hasDefault(), $actual->hasDefault(), 'Has default.');
-        static::assertSame($expected->hasTypeAnalysis(), $actual->hasTypeAnalysis(), 'Has type analysis.');
+        self::assertSame($expected->getDefault(), $actual->getDefault(), 'Default.');
+        self::assertSame($expected->getName(), $actual->getName(), 'Name.');
+        self::assertSame($expected->getNameIndex(), $actual->getNameIndex(), 'Name index.');
+        self::assertSame($expected->hasDefault(), $actual->hasDefault(), 'Has default.');
+        self::assertSame($expected->hasTypeAnalysis(), $actual->hasTypeAnalysis(), 'Has type analysis.');
 
         if ($expected->hasTypeAnalysis()) {
             $expectedTypeAnalysis = $expected->getTypeAnalysis();
             $actualTypeAnalysis = $actual->getTypeAnalysis();
 
-            static::assertSame($expectedTypeAnalysis->getEndIndex(), $actualTypeAnalysis->getEndIndex(), 'Type analysis end index.');
-            static::assertSame($expectedTypeAnalysis->getName(), $actualTypeAnalysis->getName(), 'Type analysis name.');
-            static::assertSame($expectedTypeAnalysis->getStartIndex(), $actualTypeAnalysis->getStartIndex(), 'Type analysis start index.');
-            static::assertSame($expectedTypeAnalysis->isNullable(), $actualTypeAnalysis->isNullable(), 'Type analysis nullable.');
-            static::assertSame($expectedTypeAnalysis->isReservedType(), $actualTypeAnalysis->isReservedType(), 'Type analysis reserved type.');
+            self::assertSame($expectedTypeAnalysis->getEndIndex(), $actualTypeAnalysis->getEndIndex(), 'Type analysis end index.');
+            self::assertSame($expectedTypeAnalysis->getName(), $actualTypeAnalysis->getName(), 'Type analysis name.');
+            self::assertSame($expectedTypeAnalysis->getStartIndex(), $actualTypeAnalysis->getStartIndex(), 'Type analysis start index.');
+            self::assertSame($expectedTypeAnalysis->isNullable(), $actualTypeAnalysis->isNullable(), 'Type analysis nullable.');
+            self::assertSame($expectedTypeAnalysis->isReservedType(), $actualTypeAnalysis->isReservedType(), 'Type analysis reserved type.');
         } else {
-            static::assertNull($actual->getTypeAnalysis());
+            self::assertNull($actual->getTypeAnalysis());
         }
 
-        static::assertSame(serialize($expected), serialize($actual));
+        self::assertSame(serialize($expected), serialize($actual));
     }
 }

--- a/tests/Tokenizer/Analyzer/AttributeAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/AttributeAnalyzerTest.php
@@ -32,7 +32,7 @@ final class AttributeAnalyzerTest extends TestCase
     {
         $tokens = Tokens::fromCode('<?php class Foo { private $bar; }');
         foreach ($tokens as $index => $token) {
-            static::assertFalse(AttributeAnalyzer::isAttribute($tokens, $index));
+            self::assertFalse(AttributeAnalyzer::isAttribute($tokens, $index));
         }
     }
 
@@ -48,16 +48,16 @@ final class AttributeAnalyzerTest extends TestCase
         foreach ($tokens as $index => $token) {
             if ($token->equals([T_STRING, 'Foo'])) {
                 if (isset($testedIndex)) {
-                    static::fail('Test is run against index of "Foo", multiple occurrences found.');
+                    self::fail('Test is run against index of "Foo", multiple occurrences found.');
                 }
                 $testedIndex = $index;
             }
         }
         if (!isset($testedIndex)) {
-            static::fail('Test is run against index of "Foo", but it was not found in the code.');
+            self::fail('Test is run against index of "Foo", but it was not found in the code.');
         }
 
-        static::assertSame($isInAttribute, AttributeAnalyzer::isAttribute($tokens, $testedIndex));
+        self::assertSame($isInAttribute, AttributeAnalyzer::isAttribute($tokens, $testedIndex));
     }
 
     /**

--- a/tests/Tokenizer/Analyzer/BlocksAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/BlocksAnalyzerTest.php
@@ -35,7 +35,7 @@ final class BlocksAnalyzerTest extends TestCase
         $tokens = Tokens::fromCode($code);
         $analyzer = new BlocksAnalyzer();
 
-        static::assertTrue($analyzer->isBlock($tokens, $openIndex, $closeIndex));
+        self::assertTrue($analyzer->isBlock($tokens, $openIndex, $closeIndex));
     }
 
     public static function provideBlocksCases(): array
@@ -64,7 +64,7 @@ final class BlocksAnalyzerTest extends TestCase
         $tokens = Tokens::fromCode($code);
         $analyzer = new BlocksAnalyzer();
 
-        static::assertSame($isBlock, $analyzer->isBlock($tokens, $openIndex, $closeIndex));
+        self::assertSame($isBlock, $analyzer->isBlock($tokens, $openIndex, $closeIndex));
     }
 
     public static function provideNonBlocksCases(): array

--- a/tests/Tokenizer/Analyzer/ClassyAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ClassyAnalyzerTest.php
@@ -217,7 +217,7 @@ final class ClassyAnalyzerTest extends TestCase
         $analyzer = new ClassyAnalyzer();
 
         foreach ($expected as $index => $isClassy) {
-            static::assertSame($isClassy, $analyzer->isClassyInvocation($tokens, $index), sprintf('Token at index %d should match the expected value "%s".', $index, true === $isClassy ? 'true' : 'false'));
+            self::assertSame($isClassy, $analyzer->isClassyInvocation($tokens, $index), sprintf('Token at index %d should match the expected value "%s".', $index, true === $isClassy ? 'true' : 'false'));
         }
     }
 }

--- a/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
@@ -48,8 +48,8 @@ final class CommentsAnalyzerTest extends TestCase
         $tokens = Tokens::fromCode($code);
         $analyzer = new CommentsAnalyzer();
 
-        static::assertSame($borders, $analyzer->getCommentBlockIndices($tokens, $index));
-        static::assertFalse($analyzer->isHeaderComment($tokens, $index));
+        self::assertSame($borders, $analyzer->getCommentBlockIndices($tokens, $index));
+        self::assertFalse($analyzer->isHeaderComment($tokens, $index));
     }
 
     public static function provideCommentsCases(): array
@@ -165,7 +165,7 @@ $bar;',
         $tokens = Tokens::fromCode($code);
         $analyzer = new CommentsAnalyzer();
 
-        static::assertTrue($analyzer->isHeaderComment($tokens, $index));
+        self::assertTrue($analyzer->isHeaderComment($tokens, $index));
     }
 
     public static function provideHeaderCommentCases(): array
@@ -187,7 +187,7 @@ $bar;',
         $tokens = Tokens::fromCode($code);
         $analyzer = new CommentsAnalyzer();
 
-        static::assertFalse($analyzer->isHeaderComment($tokens, $index));
+        self::assertFalse($analyzer->isHeaderComment($tokens, $index));
     }
 
     public static function provideNotHeaderCommentCases(): array
@@ -221,7 +221,7 @@ $bar;',
         $index = $tokens->getNextTokenOfKind(0, [[T_COMMENT], [T_DOC_COMMENT]]);
         $analyzer = new CommentsAnalyzer();
 
-        static::assertTrue($analyzer->isBeforeStructuralElement($tokens, $index));
+        self::assertTrue($analyzer->isBeforeStructuralElement($tokens, $index));
     }
 
     public static function providePhpdocCandidateCases(): array
@@ -274,7 +274,7 @@ $bar;',
         $index = $tokens->getNextTokenOfKind(0, [[T_COMMENT], [T_DOC_COMMENT]]);
         $analyzer = new CommentsAnalyzer();
 
-        static::assertFalse($analyzer->isBeforeStructuralElement($tokens, $index));
+        self::assertFalse($analyzer->isBeforeStructuralElement($tokens, $index));
     }
 
     public static function provideNotPhpdocCandidateCases(): array
@@ -297,7 +297,7 @@ $bar;',
         $tokens = Tokens::fromCode('<?php /* @var int $x */ [$x] = [2];');
         $analyzer = new CommentsAnalyzer();
 
-        static::assertTrue($analyzer->isHeaderComment($tokens, 1));
+        self::assertTrue($analyzer->isHeaderComment($tokens, 1));
     }
 
     public function testNotPhpdocCandidate71(): void
@@ -305,7 +305,7 @@ $bar;',
         $tokens = Tokens::fromCode('<?php /* @var int $a */ [$b] = [2];');
         $analyzer = new CommentsAnalyzer();
 
-        static::assertFalse($analyzer->isBeforeStructuralElement($tokens, 1));
+        self::assertFalse($analyzer->isBeforeStructuralElement($tokens, 1));
     }
 
     /**
@@ -317,7 +317,7 @@ $bar;',
         $index = $tokens->getNextTokenOfKind(0, [[T_COMMENT], [T_DOC_COMMENT]]);
         $analyzer = new CommentsAnalyzer();
 
-        static::assertTrue($analyzer->isBeforeStructuralElement($tokens, $index));
+        self::assertTrue($analyzer->isBeforeStructuralElement($tokens, $index));
     }
 
     public static function providePhpdocCandidatePhp74Cases(): array
@@ -338,7 +338,7 @@ $bar;',
         $index = $tokens->getNextTokenOfKind(0, [[T_COMMENT], [T_DOC_COMMENT]]);
         $analyzer = new CommentsAnalyzer();
 
-        static::assertTrue($analyzer->isBeforeStructuralElement($tokens, $index));
+        self::assertTrue($analyzer->isBeforeStructuralElement($tokens, $index));
     }
 
     public static function providePhpdocCandidatePhp80Cases(): array
@@ -364,7 +364,7 @@ Class MyAnnotation3 {}'],
         $index = $tokens->getNextTokenOfKind(0, [[T_COMMENT], [T_DOC_COMMENT]]);
         $analyzer = new CommentsAnalyzer();
 
-        static::assertTrue($analyzer->isBeforeStructuralElement($tokens, $index));
+        self::assertTrue($analyzer->isBeforeStructuralElement($tokens, $index));
     }
 
     public static function providePhpdocCandidatePhp81Cases(): iterable

--- a/tests/Tokenizer/Analyzer/ControlCaseStructuresAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ControlCaseStructuresAnalyzerTest.php
@@ -41,7 +41,7 @@ final class ControlCaseStructuresAnalyzerTest extends TestCase
         $tokens = Tokens::fromCode($source);
         $analyses = iterator_to_array(ControlCaseStructuresAnalyzer::findControlStructures($tokens, [T_SWITCH]));
 
-        static::assertCount(\count($expectedAnalyses), $analyses);
+        self::assertCount(\count($expectedAnalyses), $analyses);
 
         foreach ($expectedAnalyses as $index => $expectedAnalysis) {
             self::assertAnalysis($expectedAnalysis, $analyses[$index]);
@@ -332,7 +332,7 @@ endswitch ?>',
         $tokens = Tokens::fromCode($source);
         $analyses = iterator_to_array(ControlCaseStructuresAnalyzer::findControlStructures($tokens, $types));
 
-        static::assertCount(\count($expectedAnalyses), $analyses);
+        self::assertCount(\count($expectedAnalyses), $analyses);
 
         foreach ($expectedAnalyses as $index => $expectedAnalysis) {
             self::assertAnalysis($expectedAnalysis, $analyses[$index]);
@@ -413,25 +413,25 @@ $expressionResult = match ($condition) {
         $serializeActual = serialize($analysis);
 
         if ($serializeExpected === $serializeActual) {
-            static::assertTrue(true);
+            self::assertTrue(true);
 
             return;
         }
 
-        static::assertSame($expectedAnalysis->getIndex(), $analysis->getIndex(), 'index');
-        static::assertSame($expectedAnalysis->getOpenIndex(), $analysis->getOpenIndex(), 'open index');
-        static::assertSame($expectedAnalysis->getCloseIndex(), $analysis->getCloseIndex(), 'close index');
-        static::assertInstanceOf(\get_class($expectedAnalysis), $analysis);
+        self::assertSame($expectedAnalysis->getIndex(), $analysis->getIndex(), 'index');
+        self::assertSame($expectedAnalysis->getOpenIndex(), $analysis->getOpenIndex(), 'open index');
+        self::assertSame($expectedAnalysis->getCloseIndex(), $analysis->getCloseIndex(), 'close index');
+        self::assertInstanceOf(\get_class($expectedAnalysis), $analysis);
 
         if ($expectedAnalysis instanceof MatchAnalysis || $expectedAnalysis instanceof SwitchAnalysis) {
             $expectedDefault = $expectedAnalysis->getDefaultAnalysis();
             $actualDefault = $analysis->getDefaultAnalysis(); // @phpstan-ignore-line already type checked against expected
 
             if (null === $expectedDefault) {
-                static::assertNull($actualDefault, 'default not null');
+                self::assertNull($actualDefault, 'default not null');
             } else {
-                static::assertSame($expectedDefault->getIndex(), $actualDefault->getIndex(), 'default index');
-                static::assertSame($expectedDefault->getColonIndex(), $actualDefault->getColonIndex(), 'default colon index');
+                self::assertSame($expectedDefault->getIndex(), $actualDefault->getIndex(), 'default index');
+                self::assertSame($expectedDefault->getColonIndex(), $actualDefault->getColonIndex(), 'default colon index');
             }
         }
 
@@ -439,14 +439,14 @@ $expressionResult = match ($condition) {
             $expectedCases = $expectedAnalysis->getCases();
             $actualCases = $analysis->getCases(); // @phpstan-ignore-line already type checked against expected
 
-            static::assertCount(\count($expectedCases), $actualCases);
+            self::assertCount(\count($expectedCases), $actualCases);
 
             foreach ($expectedCases as $i => $expectedCase) {
-                static::assertSame($expectedCase->getIndex(), $actualCases[$i]->getIndex(), 'case index');
-                static::assertSame($expectedCase->getColonIndex(), $actualCases[$i]->getColonIndex(), 'case colon index');
+                self::assertSame($expectedCase->getIndex(), $actualCases[$i]->getIndex(), 'case index');
+                self::assertSame($expectedCase->getColonIndex(), $actualCases[$i]->getColonIndex(), 'case colon index');
             }
         }
 
-        static::assertSame($serializeExpected, $serializeActual);
+        self::assertSame($serializeExpected, $serializeActual);
     }
 }

--- a/tests/Tokenizer/Analyzer/DataProviderAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/DataProviderAnalyzerTest.php
@@ -38,7 +38,7 @@ final class DataProviderAnalyzerTest extends TestCase
         }
         $analyzer = new DataProviderAnalyzer();
 
-        static::assertSame(serialize($expected), serialize($analyzer->getDataProviders($tokens, $startIndex, $endIndex)));
+        self::assertSame(serialize($expected), serialize($analyzer->getDataProviders($tokens, $startIndex, $endIndex)));
     }
 
     /**

--- a/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
@@ -377,7 +377,7 @@ class(){};
         $tokens = Tokens::fromCode($code);
         $analyzer = new FunctionsAnalyzer();
 
-        static::assertSame(serialize($expected), serialize($analyzer->getFunctionArguments($tokens, $methodIndex)));
+        self::assertSame(serialize($expected), serialize($analyzer->getFunctionArguments($tokens, $methodIndex)));
     }
 
     /**
@@ -389,7 +389,7 @@ class(){};
         $analyzer = new FunctionsAnalyzer();
         $actual = $analyzer->getFunctionReturnType($tokens, $methodIndex);
 
-        static::assertSame(serialize($expected), serialize($actual));
+        self::assertSame(serialize($expected), serialize($actual));
     }
 
     public static function provideFunctionsWithArgumentsCases(): iterable
@@ -624,7 +624,7 @@ class(){};
         $tokens = Tokens::fromCode($code);
         $analyzer = new FunctionsAnalyzer();
 
-        static::assertSame($isTheSameClassCall, $analyzer->isTheSameClassCall($tokens, $index));
+        self::assertSame($isTheSameClassCall, $analyzer->isTheSameClassCall($tokens, $index));
     }
 
     public static function provideIsTheSameClassCallCases(): iterable
@@ -710,7 +710,7 @@ class(){};
         $tokens = Tokens::fromCode($code);
         $analyzer = new FunctionsAnalyzer();
 
-        static::assertSame(serialize($expected), serialize($analyzer->getFunctionArguments($tokens, $methodIndex)));
+        self::assertSame(serialize($expected), serialize($analyzer->getFunctionArguments($tokens, $methodIndex)));
     }
 
     public static function provideFunctionsWithArgumentsPhp80Cases(): iterable
@@ -755,7 +755,7 @@ class(){};
             }
         }
 
-        static::assertSame(
+        self::assertSame(
             $expectedIndices,
             $actualIndices,
             sprintf(

--- a/tests/Tokenizer/Analyzer/GotoLabelAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/GotoLabelAnalyzerTest.php
@@ -36,7 +36,7 @@ final class GotoLabelAnalyzerTest extends TestCase
         $analyzer = new GotoLabelAnalyzer();
 
         foreach ($tokens as $index => $isClassy) {
-            static::assertSame(
+            self::assertSame(
                 \in_array($index, $expectedTrue, true),
                 $analyzer->belongsToGoToLabel($tokens, $index)
             );

--- a/tests/Tokenizer/Analyzer/NamespaceUsesAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/NamespaceUsesAnalyzerTest.php
@@ -39,7 +39,7 @@ final class NamespaceUsesAnalyzerTest extends TestCase
         $tokens = Tokens::fromCode($code);
         $analyzer = new NamespaceUsesAnalyzer();
 
-        static::assertSame(
+        self::assertSame(
             serialize($expected),
             serialize($analyzer->getDeclarationsFromTokens($tokens))
         );
@@ -168,7 +168,7 @@ final class NamespaceUsesAnalyzerTest extends TestCase
         $tokens = Tokens::fromCode($code);
         $analyzer = new NamespaceUsesAnalyzer();
 
-        static::assertSame(
+        self::assertSame(
             serialize($expected),
             serialize($analyzer->getDeclarationsInNamespace($tokens, $namespace))
         );

--- a/tests/Tokenizer/Analyzer/NamespacesAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/NamespacesAnalyzerTest.php
@@ -38,7 +38,7 @@ final class NamespacesAnalyzerTest extends TestCase
         $tokens = Tokens::fromCode($code);
         $analyzer = new NamespacesAnalyzer();
 
-        static::assertSame(
+        self::assertSame(
             serialize($expected),
             serialize($analyzer->getDeclarations($tokens))
         );
@@ -96,7 +96,7 @@ final class NamespacesAnalyzerTest extends TestCase
         $tokens = Tokens::fromCode($code);
         $analyzer = new NamespacesAnalyzer();
 
-        static::assertSame(
+        self::assertSame(
             serialize($expected),
             serialize($analyzer->getNamespaceAt($tokens, $index))
         );

--- a/tests/Tokenizer/Analyzer/RangeAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/RangeAnalyzerTest.php
@@ -35,7 +35,7 @@ final class RangeAnalyzerTest extends TestCase
     {
         $tokens = Tokens::fromCode($code);
 
-        static::assertSame($expected, RangeAnalyzer::rangeEqualsRange($tokens, $range1, $range2));
+        self::assertSame($expected, RangeAnalyzer::rangeEqualsRange($tokens, $range1, $range2));
     }
 
     public static function provideRangeEqualsRangeCases(): iterable
@@ -102,7 +102,7 @@ final class RangeAnalyzerTest extends TestCase
         ];
 
         foreach ($ranges as [$range1, $range2]) {
-            static::assertTrue(RangeAnalyzer::rangeEqualsRange($tokens, $range1, $range2));
+            self::assertTrue(RangeAnalyzer::rangeEqualsRange($tokens, $range1, $range2));
         }
     }
 }

--- a/tests/Tokenizer/Analyzer/ReferenceAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ReferenceAnalyzerTest.php
@@ -31,7 +31,7 @@ final class ReferenceAnalyzerTest extends TestCase
     {
         $analyzer = new ReferenceAnalyzer();
 
-        static::assertFalse($analyzer->isReference(Tokens::fromCode('<?php $foo;$bar;$baz;'), 3));
+        self::assertFalse($analyzer->isReference(Tokens::fromCode('<?php $foo;$bar;$baz;'), 3));
     }
 
     public function testReferenceAndNonReferenceTogether(): void
@@ -40,8 +40,8 @@ final class ReferenceAnalyzerTest extends TestCase
 
         $tokens = Tokens::fromCode('<?php function foo(&$bar = BAZ & QUX) {};');
 
-        static::assertTrue($analyzer->isReference($tokens, 5));
-        static::assertFalse($analyzer->isReference($tokens, 12));
+        self::assertTrue($analyzer->isReference($tokens, 5));
+        self::assertFalse($analyzer->isReference($tokens, 12));
     }
 
     /**
@@ -156,7 +156,7 @@ class Foo {
 
         foreach ($tokens as $index => $token) {
             if ('&' === $token->getContent()) {
-                static::assertSame($expected, $analyzer->isReference($tokens, $index));
+                self::assertSame($expected, $analyzer->isReference($tokens, $index));
             }
         }
     }

--- a/tests/Tokenizer/Analyzer/WhitespacesAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/WhitespacesAnalyzerTest.php
@@ -32,7 +32,7 @@ final class WhitespacesAnalyzerTest extends TestCase
     {
         $tokens = Tokens::fromCode($code);
 
-        static::assertSame($indent, WhitespacesAnalyzer::detectIndent($tokens, $index));
+        self::assertSame($indent, WhitespacesAnalyzer::detectIndent($tokens, $index));
     }
 
     public static function provideIndentCases(): iterable

--- a/tests/Tokenizer/CTTest.php
+++ b/tests/Tokenizer/CTTest.php
@@ -29,7 +29,7 @@ final class CTTest extends TestCase
     public function testUniqueValues(): void
     {
         $constants = $this->getConstants();
-        static::assertSame($constants, array_flip(array_flip($constants)), 'Values of CT::T_* constants must be unique.');
+        self::assertSame($constants, array_flip(array_flip($constants)), 'Values of CT::T_* constants must be unique.');
     }
 
     /**
@@ -37,12 +37,12 @@ final class CTTest extends TestCase
      */
     public function testHas(string $name, int $value): void
     {
-        static::assertTrue(CT::has($value));
+        self::assertTrue(CT::has($value));
     }
 
     public function testHasNotExists(): void
     {
-        static::assertFalse(CT::has(123));
+        self::assertFalse(CT::has(123));
     }
 
     /**
@@ -50,7 +50,7 @@ final class CTTest extends TestCase
      */
     public function testGetName(string $name, int $value): void
     {
-        static::assertSame('CT::'.$name, CT::getName($value));
+        self::assertSame('CT::'.$name, CT::getName($value));
     }
 
     public function testGetNameNotExists(): void
@@ -66,8 +66,8 @@ final class CTTest extends TestCase
      */
     public function testConstants(string $name, int $value): void
     {
-        static::assertGreaterThan(10000, $value);
-        static::assertFalse(\defined($name), 'The CT name must not use native T_* name.');
+        self::assertGreaterThan(10000, $value);
+        self::assertFalse(\defined($name), 'The CT name must not use native T_* name.');
     }
 
     public static function provideConstantsCases(): iterable

--- a/tests/Tokenizer/CodeHasherTest.php
+++ b/tests/Tokenizer/CodeHasherTest.php
@@ -26,7 +26,7 @@ final class CodeHasherTest extends TestCase
 {
     public function testCodeHasher(): void
     {
-        static::assertSame('d9de49676ba2316990a5acd04c8418e8', CodeHasher::calculateCodeHash('<?php echo 1;'));
-        static::assertSame('d9de49676ba2316990a5acd04c8418e8', CodeHasher::calculateCodeHash('<?php echo 1;')); // calling twice, hashes should always be the same when the input doesn't change.
+        self::assertSame('d9de49676ba2316990a5acd04c8418e8', CodeHasher::calculateCodeHash('<?php echo 1;'));
+        self::assertSame('d9de49676ba2316990a5acd04c8418e8', CodeHasher::calculateCodeHash('<?php echo 1;')); // calling twice, hashes should always be the same when the input doesn't change.
     }
 }

--- a/tests/Tokenizer/TokenTest.php
+++ b/tests/Tokenizer/TokenTest.php
@@ -57,14 +57,14 @@ final class TokenTest extends TestCase
 
     public function testGetPrototype(): void
     {
-        static::assertSame(self::getBraceTokenPrototype(), self::getBraceToken()->getPrototype());
-        static::assertSame(self::getForeachTokenPrototype(), self::getForeachToken()->getPrototype());
+        self::assertSame(self::getBraceTokenPrototype(), self::getBraceToken()->getPrototype());
+        self::assertSame(self::getForeachTokenPrototype(), self::getForeachToken()->getPrototype());
     }
 
     public function testIsArray(): void
     {
-        static::assertFalse(self::getBraceToken()->isArray());
-        static::assertTrue(self::getForeachToken()->isArray());
+        self::assertFalse(self::getBraceToken()->isArray());
+        self::assertTrue(self::getForeachToken()->isArray());
     }
 
     /**
@@ -72,7 +72,7 @@ final class TokenTest extends TestCase
      */
     public function testIsCast(Token $token, bool $isCast): void
     {
-        static::assertSame($isCast, $token->isCast());
+        self::assertSame($isCast, $token->isCast());
     }
 
     public static function provideIsCastCases(): array
@@ -95,7 +95,7 @@ final class TokenTest extends TestCase
      */
     public function testIsClassy(Token $token, bool $isClassy): void
     {
-        static::assertSame($isClassy, $token->isClassy());
+        self::assertSame($isClassy, $token->isClassy());
     }
 
     public static function provideIsClassyCases(): array
@@ -116,7 +116,7 @@ final class TokenTest extends TestCase
     {
         $enumToken = new Token([T_ENUM, 'enum', 1]);
 
-        static::assertTrue($enumToken->isClassy());
+        self::assertTrue($enumToken->isClassy());
     }
 
     /**
@@ -124,7 +124,7 @@ final class TokenTest extends TestCase
      */
     public function testIsComment(Token $token, bool $isComment): void
     {
-        static::assertSame($isComment, $token->isComment());
+        self::assertSame($isComment, $token->isComment());
     }
 
     public static function provideIsCommentCases(): iterable
@@ -147,7 +147,7 @@ final class TokenTest extends TestCase
      */
     public function testIsObjectOperator(Token $token, bool $isObjectOperator): void
     {
-        static::assertSame($isObjectOperator, $token->isObjectOperator());
+        self::assertSame($isObjectOperator, $token->isObjectOperator());
     }
 
     public static function provideIsObjectOperatorCases(): iterable
@@ -170,23 +170,23 @@ final class TokenTest extends TestCase
         $braceToken = self::getBraceToken();
         $foreachToken = self::getForeachToken();
 
-        static::assertFalse($braceToken->isGivenKind(T_FOR));
-        static::assertFalse($braceToken->isGivenKind(T_FOREACH));
-        static::assertFalse($braceToken->isGivenKind([T_FOR]));
-        static::assertFalse($braceToken->isGivenKind([T_FOREACH]));
-        static::assertFalse($braceToken->isGivenKind([T_FOR, T_FOREACH]));
+        self::assertFalse($braceToken->isGivenKind(T_FOR));
+        self::assertFalse($braceToken->isGivenKind(T_FOREACH));
+        self::assertFalse($braceToken->isGivenKind([T_FOR]));
+        self::assertFalse($braceToken->isGivenKind([T_FOREACH]));
+        self::assertFalse($braceToken->isGivenKind([T_FOR, T_FOREACH]));
 
-        static::assertFalse($foreachToken->isGivenKind(T_FOR));
-        static::assertTrue($foreachToken->isGivenKind(T_FOREACH));
-        static::assertFalse($foreachToken->isGivenKind([T_FOR]));
-        static::assertTrue($foreachToken->isGivenKind([T_FOREACH]));
-        static::assertTrue($foreachToken->isGivenKind([T_FOR, T_FOREACH]));
+        self::assertFalse($foreachToken->isGivenKind(T_FOR));
+        self::assertTrue($foreachToken->isGivenKind(T_FOREACH));
+        self::assertFalse($foreachToken->isGivenKind([T_FOR]));
+        self::assertTrue($foreachToken->isGivenKind([T_FOREACH]));
+        self::assertTrue($foreachToken->isGivenKind([T_FOR, T_FOREACH]));
     }
 
     public function testIsKeywords(): void
     {
-        static::assertTrue(self::getForeachToken()->isKeyword());
-        static::assertFalse(self::getBraceToken()->isKeyword());
+        self::assertTrue(self::getForeachToken()->isKeyword());
+        self::assertFalse(self::getBraceToken()->isKeyword());
     }
 
     /**
@@ -200,7 +200,7 @@ final class TokenTest extends TestCase
             null === $tokenId ? $content : [$tokenId, $content]
         );
 
-        static::assertSame($isConstant, $token->isMagicConstant());
+        self::assertSame($isConstant, $token->isMagicConstant());
     }
 
     public static function provideMagicConstantCases(): iterable
@@ -232,7 +232,7 @@ final class TokenTest extends TestCase
      */
     public function testIsNativeConstant(Token $token, bool $isNativeConstant): void
     {
-        static::assertSame($isNativeConstant, $token->isNativeConstant());
+        self::assertSame($isNativeConstant, $token->isNativeConstant());
     }
 
     public static function provideIsNativeConstantCases(): array
@@ -254,10 +254,10 @@ final class TokenTest extends TestCase
     public function testIsWhitespace(Token $token, bool $isWhitespace, ?string $whitespaces = null): void
     {
         if (null !== $whitespaces) {
-            static::assertSame($isWhitespace, $token->isWhitespace($whitespaces));
+            self::assertSame($isWhitespace, $token->isWhitespace($whitespaces));
         } else {
-            static::assertSame($isWhitespace, $token->isWhitespace(null));
-            static::assertSame($isWhitespace, $token->isWhitespace());
+            self::assertSame($isWhitespace, $token->isWhitespace(null));
+            self::assertSame($isWhitespace, $token->isWhitespace());
         }
     }
 
@@ -289,9 +289,9 @@ final class TokenTest extends TestCase
         }
 
         $token = new Token($prototype);
-        static::assertSame($expectedId, $token->getId());
-        static::assertSame($expectedContent, $token->getContent());
-        static::assertSame($expectedIsArray, $token->isArray());
+        self::assertSame($expectedId, $token->getId());
+        self::assertSame($expectedContent, $token->getContent());
+        self::assertSame($expectedIsArray, $token->isArray());
     }
 
     public static function provideCreatingTokenCases(): array
@@ -309,8 +309,8 @@ final class TokenTest extends TestCase
     {
         $token = new Token([T_FUNCTION, 'function', 1]);
 
-        static::assertTrue($token->equals([T_FUNCTION, 'function']));
-        static::assertFalse($token->equals([T_FUNCTION, 'Function']));
+        self::assertTrue($token->equals([T_FUNCTION, 'function']));
+        self::assertFalse($token->equals([T_FUNCTION, 'Function']));
     }
 
     /**
@@ -320,7 +320,7 @@ final class TokenTest extends TestCase
      */
     public function testEquals(Token $token, bool $equals, $other, bool $caseSensitive = true): void
     {
-        static::assertSame($equals, $token->equals($other, $caseSensitive));
+        self::assertSame($equals, $token->equals($other, $caseSensitive));
     }
 
     public static function provideEqualsCases(): iterable
@@ -395,8 +395,8 @@ final class TokenTest extends TestCase
     {
         $token = new Token([T_FUNCTION, 'function', 1]);
 
-        static::assertTrue($token->equalsAny([[T_FUNCTION, 'function']]));
-        static::assertFalse($token->equalsAny([[T_FUNCTION, 'Function']]));
+        self::assertTrue($token->equalsAny([[T_FUNCTION, 'function']]));
+        self::assertFalse($token->equalsAny([[T_FUNCTION, 'Function']]));
     }
 
     /**
@@ -408,7 +408,7 @@ final class TokenTest extends TestCase
     {
         $token = new Token([T_FUNCTION, 'function', 1]);
 
-        static::assertSame($equalsAny, $token->equalsAny($other, $caseSensitive));
+        self::assertSame($equalsAny, $token->equalsAny($other, $caseSensitive));
     }
 
     public static function provideEqualsAnyCases(): iterable
@@ -440,7 +440,7 @@ final class TokenTest extends TestCase
      */
     public function testIsKeyCaseSensitive(bool $isKeyCaseSensitive, $caseSensitive, int $key): void
     {
-        static::assertSame($isKeyCaseSensitive, Token::isKeyCaseSensitive($caseSensitive, $key));
+        self::assertSame($isKeyCaseSensitive, Token::isKeyCaseSensitive($caseSensitive, $key));
     }
 
     public static function provideIsKeyCaseSensitiveCases(): iterable
@@ -475,7 +475,7 @@ final class TokenTest extends TestCase
      */
     public function testTokenGetNameForId(?string $expected, int $id): void
     {
-        static::assertSame($expected, Token::getNameForId($id));
+        self::assertSame($expected, Token::getNameForId($id));
     }
 
     public static function provideTokenGetNameCases(): array
@@ -501,7 +501,7 @@ final class TokenTest extends TestCase
      */
     public function testGetName(Token $token, ?string $expected = null): void
     {
-        static::assertSame($expected, $token->getName());
+        self::assertSame($expected, $token->getName());
     }
 
     public static function provideGetNameCases(): iterable
@@ -529,7 +529,7 @@ final class TokenTest extends TestCase
      */
     public function testToArray(Token $token, array $expected): void
     {
-        static::assertSame($expected, $token->toArray());
+        self::assertSame($expected, $token->toArray());
     }
 
     public static function provideToArrayCases(): iterable
@@ -571,9 +571,9 @@ final class TokenTest extends TestCase
     public function testGetClassyTokenKinds(): void
     {
         if (\defined('T_ENUM')) {
-            static::assertSame([T_CLASS, T_TRAIT, T_INTERFACE, T_ENUM], Token::getClassyTokenKinds());
+            self::assertSame([T_CLASS, T_TRAIT, T_INTERFACE, T_ENUM], Token::getClassyTokenKinds());
         } else {
-            static::assertSame([T_CLASS, T_TRAIT, T_INTERFACE], Token::getClassyTokenKinds());
+            self::assertSame([T_CLASS, T_TRAIT, T_INTERFACE], Token::getClassyTokenKinds());
         }
     }
 

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -48,7 +48,7 @@ final class TokensAnalyzerTest extends TestCase
 
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 
-        static::assertSame(
+        self::assertSame(
             $expectedElements,
             $tokensAnalyzer->getClassyElements()
         );
@@ -210,7 +210,7 @@ PHP;
         $tokensAnalyzer = new TokensAnalyzer($tokens);
         $elements = $tokensAnalyzer->getClassyElements();
 
-        static::assertSame(
+        self::assertSame(
             [
                 11 => [
                     'classIndex' => 1,
@@ -264,7 +264,7 @@ PHP;
         $tokensAnalyzer = new TokensAnalyzer($tokens);
         $elements = $tokensAnalyzer->getClassyElements();
 
-        static::assertSame(
+        self::assertSame(
             [
                 9 => [
                     'classIndex' => 1,
@@ -377,7 +377,7 @@ PHP;
         $tokensAnalyzer = new TokensAnalyzer($tokens);
         $elements = $tokensAnalyzer->getClassyElements();
 
-        static::assertSame(
+        self::assertSame(
             [
                 9 => [
                     'classIndex' => 1,
@@ -479,7 +479,7 @@ PHP;
             ];
         }
 
-        static::assertSame($expected, $elements);
+        self::assertSame($expected, $elements);
     }
 
     /**
@@ -503,7 +503,7 @@ PHP;
             }
         );
 
-        static::assertSame($expected, $elements);
+        self::assertSame($expected, $elements);
     }
 
     public static function provideGetClassyElements81Cases(): iterable
@@ -689,7 +689,7 @@ enum Foo: string
             },
         );
 
-        static::assertSame($expected, $elements);
+        self::assertSame($expected, $elements);
     }
 
     public static function provideGetClassyElements82Cases(): iterable
@@ -726,7 +726,7 @@ enum Foo: string
         $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
 
         foreach ($expected as $index => $expectedValue) {
-            static::assertSame($expectedValue, $tokensAnalyzer->isAnonymousClass($index));
+            self::assertSame($expectedValue, $tokensAnalyzer->isAnonymousClass($index));
         }
     }
 
@@ -792,7 +792,7 @@ enum Foo: string
         $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
 
         foreach ($expected as $index => $isLambda) {
-            static::assertSame($isLambda, $tokensAnalyzer->isLambda($index));
+            self::assertSame($isLambda, $tokensAnalyzer->isLambda($index));
         }
     }
 
@@ -892,7 +892,7 @@ preg_replace_callback(
         $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
 
         foreach ($expected as $index => $expectedValue) {
-            static::assertSame($expectedValue, $tokensAnalyzer->isLambda($index));
+            self::assertSame($expectedValue, $tokensAnalyzer->isLambda($index));
         }
     }
 
@@ -921,7 +921,7 @@ preg_replace_callback(
         $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
 
         foreach ($expected as $index => $expectedValue) {
-            static::assertSame($expectedValue, $tokensAnalyzer->isLambda($index));
+            self::assertSame($expectedValue, $tokensAnalyzer->isLambda($index));
         }
     }
 
@@ -1369,7 +1369,7 @@ abstract class Baz
                 continue;
             }
 
-            static::assertFalse($tokensAnalyzer->isConstantInvocation($index));
+            self::assertFalse($tokensAnalyzer->isConstantInvocation($index));
         }
     }
 
@@ -1383,11 +1383,11 @@ abstract class Baz
         $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
 
         foreach ($expected as $index => $isUnary) {
-            static::assertSame($isUnary, $tokensAnalyzer->isUnarySuccessorOperator($index));
+            self::assertSame($isUnary, $tokensAnalyzer->isUnarySuccessorOperator($index));
 
             if ($isUnary) {
-                static::assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
-                static::assertFalse($tokensAnalyzer->isBinaryOperator($index));
+                self::assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
+                self::assertFalse($tokensAnalyzer->isBinaryOperator($index));
             }
         }
     }
@@ -1444,11 +1444,11 @@ abstract class Baz
         $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
 
         foreach ($expected as $index => $isUnary) {
-            static::assertSame($isUnary, $tokensAnalyzer->isUnaryPredecessorOperator($index));
+            self::assertSame($isUnary, $tokensAnalyzer->isUnaryPredecessorOperator($index));
 
             if ($isUnary) {
-                static::assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
-                static::assertFalse($tokensAnalyzer->isBinaryOperator($index));
+                self::assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
+                self::assertFalse($tokensAnalyzer->isBinaryOperator($index));
             }
         }
     }
@@ -1529,11 +1529,11 @@ abstract class Baz
         $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
 
         foreach ($expected as $index => $isBinary) {
-            static::assertSame($isBinary, $tokensAnalyzer->isBinaryOperator($index));
+            self::assertSame($isBinary, $tokensAnalyzer->isBinaryOperator($index));
 
             if ($isBinary) {
-                static::assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
-                static::assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
+                self::assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
+                self::assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
             }
         }
     }
@@ -1701,8 +1701,8 @@ $b;',
         $tokens = Tokens::fromCode($source);
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 
-        static::assertTrue($tokensAnalyzer->isArray($tokenIndex), 'Expected to be an array.');
-        static::assertSame($isMultiLineArray, $tokensAnalyzer->isArrayMultiLine($tokenIndex), sprintf('Expected %sto be a multiline array', $isMultiLineArray ? '' : 'not '));
+        self::assertTrue($tokensAnalyzer->isArray($tokenIndex), 'Expected to be an array.');
+        self::assertSame($isMultiLineArray, $tokensAnalyzer->isArrayMultiLine($tokenIndex), sprintf('Expected %sto be a multiline array', $isMultiLineArray ? '' : 'not '));
     }
 
     public static function provideIsArrayCases(): array
@@ -1780,7 +1780,7 @@ $b;',
         foreach ($tokens as $index => $token) {
             $expect = \in_array($index, $tokenIndexes, true);
 
-            static::assertSame(
+            self::assertSame(
                 $expect,
                 $tokensAnalyzer->isArray($index),
                 sprintf('Expected %sarray, got @ %d "%s".', $expect ? '' : 'no ', $index, var_export($token, true))
@@ -1814,11 +1814,11 @@ $b;',
         $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
 
         foreach ($expected as $index => $isBinary) {
-            static::assertSame($isBinary, $tokensAnalyzer->isBinaryOperator($index));
+            self::assertSame($isBinary, $tokensAnalyzer->isBinaryOperator($index));
 
             if ($isBinary) {
-                static::assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
-                static::assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
+                self::assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
+                self::assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
             }
         }
     }
@@ -1848,11 +1848,11 @@ $b;',
         $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
 
         foreach ($expected as $index => $isBinary) {
-            static::assertSame($isBinary, $tokensAnalyzer->isBinaryOperator($index));
+            self::assertSame($isBinary, $tokensAnalyzer->isBinaryOperator($index));
 
             if ($isBinary) {
-                static::assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
-                static::assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
+                self::assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
+                self::assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
             }
         }
     }
@@ -1897,11 +1897,11 @@ $b;',
         $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
 
         foreach ($expected as $index => $isBinary) {
-            static::assertSame($isBinary, $tokensAnalyzer->isBinaryOperator($index));
+            self::assertSame($isBinary, $tokensAnalyzer->isBinaryOperator($index));
 
             if ($isBinary) {
-                static::assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
-                static::assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
+                self::assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
+                self::assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
             }
         }
     }
@@ -1928,10 +1928,10 @@ $b;',
 
         foreach ($tokens as $index => $token) {
             $isBinary = isset($expected[$index]);
-            static::assertSame($isBinary, $tokensAnalyzer->isBinaryOperator($index));
+            self::assertSame($isBinary, $tokensAnalyzer->isBinaryOperator($index));
             if ($isBinary) {
-                static::assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
-                static::assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
+                self::assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
+                self::assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
             }
         }
     }
@@ -1969,7 +1969,7 @@ $b;',
         $tokens = Tokens::fromCode($source);
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 
-        static::assertFalse($tokensAnalyzer->isArray($tokenIndex));
+        self::assertFalse($tokensAnalyzer->isArray($tokenIndex));
     }
 
     /**
@@ -2011,7 +2011,7 @@ $b;',
         $tokens = Tokens::fromCode($source);
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 
-        static::assertSame($isBlockMultiline, $tokensAnalyzer->isBlockMultiline($tokens, $tokenIndex));
+        self::assertSame($isBlockMultiline, $tokensAnalyzer->isBlockMultiline($tokens, $tokenIndex));
     }
 
     public static function provideIsBlockMultilineCases(): iterable
@@ -2059,7 +2059,7 @@ $b;',
         $tokensAnalyzer = new TokensAnalyzer($tokens);
         $attributes = $tokensAnalyzer->getMethodAttributes($index);
 
-        static::assertSame($expected, $attributes);
+        self::assertSame($expected, $attributes);
     }
 
     public static function provideGetFunctionPropertiesCases(): array
@@ -2188,7 +2188,7 @@ SRC;
                 continue;
             }
 
-            static::assertSame(
+            self::assertSame(
                 $expected[$index],
                 $tokensAnalyzer->isWhilePartOfDoWhile($index),
                 sprintf('Expected token at index "%d" to be detected as %sa "do-while"-loop.', $index, true === $expected[$index] ? '' : 'not ')
@@ -2206,7 +2206,7 @@ SRC;
         $tokens = Tokens::fromCode($input);
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 
-        static::assertSame($expected, $tokensAnalyzer->getImportUseIndexes($perNamespace));
+        self::assertSame($expected, $tokensAnalyzer->getImportUseIndexes($perNamespace));
     }
 
     public static function provideGetImportUseIndexesCases(): array
@@ -2343,7 +2343,7 @@ class MyTestWithAnonymousClass extends TestCase
         $tokensAnalyzer = new TokensAnalyzer($tokens);
         $elements = $tokensAnalyzer->getClassyElements();
 
-        static::assertSame([
+        self::assertSame([
             13 => [
                 'classIndex' => 1,
                 'token' => $tokens[13],
@@ -2390,7 +2390,7 @@ class MyTestWithAnonymousClass extends TestCase
         $tokens = Tokens::fromCode($source);
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 
-        static::assertSame($expected, $tokensAnalyzer->isSuperGlobal($index));
+        self::assertSame($expected, $tokensAnalyzer->isSuperGlobal($index));
     }
 
     public static function provideIsSuperGlobalCases(): array
@@ -2447,7 +2447,7 @@ class MyTestWithAnonymousClass extends TestCase
         $tokens = Tokens::fromCode($source);
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 
-        static::assertSame($expectedModifiers, $tokensAnalyzer->getClassyModifiers($index));
+        self::assertSame($expectedModifiers, $tokensAnalyzer->getClassyModifiers($index));
     }
 
     public static function provideGetClassyModifiersCases(): iterable
@@ -2477,7 +2477,7 @@ class MyTestWithAnonymousClass extends TestCase
         $tokens = Tokens::fromCode($source);
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 
-        static::assertSame($expectedModifiers, $tokensAnalyzer->getClassyModifiers($index));
+        self::assertSame($expectedModifiers, $tokensAnalyzer->getClassyModifiers($index));
     }
 
     public static function provideGetClassyModifiersOnPhp82Cases(): iterable
@@ -2542,7 +2542,7 @@ class MyTestWithAnonymousClass extends TestCase
     {
         $tokens = Tokens::fromCode($source);
 
-        static::assertCount(
+        self::assertCount(
             $tokens->countTokenKind(T_STRING),
             $expected,
             'All T_STRING tokens must be tested'
@@ -2551,7 +2551,7 @@ class MyTestWithAnonymousClass extends TestCase
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 
         foreach ($expected as $index => $expectedValue) {
-            static::assertSame(
+            self::assertSame(
                 $expectedValue,
                 $tokensAnalyzer->isConstantInvocation($index),
                 sprintf('Token at index '.$index.' should match the expected value (%s).', $expectedValue ? 'true' : 'false')

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -44,7 +44,7 @@ final class TokensTest extends TestCase
 
         $tokens = Tokens::fromCode($code);
 
-        static::assertSame($countBefore, $tokens->count());
+        self::assertSame($countBefore, $tokens->count());
     }
 
     /**
@@ -64,7 +64,7 @@ final class TokensTest extends TestCase
     ): void {
         $tokens = Tokens::fromCode($source);
 
-        static::assertEqualsTokensArray(
+        self::assertEqualsTokensArray(
             $expected,
             $tokens->findSequence(
                 $sequence,
@@ -338,10 +338,10 @@ PHP;
         $tokens->clearRange($fooIndex, $barIndex - 1);
 
         $newPublicIndexes = array_keys($tokens->findGivenKind(T_PUBLIC));
-        static::assertSame($barIndex, reset($newPublicIndexes));
+        self::assertSame($barIndex, reset($newPublicIndexes));
 
         for ($i = $fooIndex; $i < $barIndex; ++$i) {
-            static::assertTrue($tokens[$i]->isWhitespace());
+            self::assertTrue($tokens[$i]->isWhitespace());
         }
     }
 
@@ -351,7 +351,7 @@ PHP;
     public function testMonolithicPhpDetection(bool $isMonolithic, string $source): void
     {
         $tokens = Tokens::fromCode($source);
-        static::assertSame($isMonolithic, $tokens->isMonolithicPhp());
+        self::assertSame($isMonolithic, $tokens->isMonolithicPhp());
     }
 
     public static function provideMonolithicPhpDetectionCases(): iterable
@@ -453,17 +453,17 @@ EOF;
 
         $tokens = Tokens::fromCode($code);
 
-        static::assertTrue($tokens->isTokenKindFound(T_CLASS));
-        static::assertTrue($tokens->isTokenKindFound(T_RETURN));
-        static::assertFalse($tokens->isTokenKindFound(T_INTERFACE));
-        static::assertFalse($tokens->isTokenKindFound(T_ARRAY));
+        self::assertTrue($tokens->isTokenKindFound(T_CLASS));
+        self::assertTrue($tokens->isTokenKindFound(T_RETURN));
+        self::assertFalse($tokens->isTokenKindFound(T_INTERFACE));
+        self::assertFalse($tokens->isTokenKindFound(T_ARRAY));
 
-        static::assertTrue($tokens->isAllTokenKindsFound([T_CLASS, T_RETURN]));
-        static::assertFalse($tokens->isAllTokenKindsFound([T_CLASS, T_INTERFACE]));
+        self::assertTrue($tokens->isAllTokenKindsFound([T_CLASS, T_RETURN]));
+        self::assertFalse($tokens->isAllTokenKindsFound([T_CLASS, T_INTERFACE]));
 
-        static::assertTrue($tokens->isAnyTokenKindsFound([T_CLASS, T_RETURN]));
-        static::assertTrue($tokens->isAnyTokenKindsFound([T_CLASS, T_INTERFACE]));
-        static::assertFalse($tokens->isAnyTokenKindsFound([T_INTERFACE, T_ARRAY]));
+        self::assertTrue($tokens->isAnyTokenKindsFound([T_CLASS, T_RETURN]));
+        self::assertTrue($tokens->isAnyTokenKindsFound([T_CLASS, T_INTERFACE]));
+        self::assertFalse($tokens->isAnyTokenKindsFound([T_INTERFACE, T_ARRAY]));
     }
 
     public function testFindGivenKind(): void
@@ -487,36 +487,36 @@ PHP;
 
         /** @var Token[] $found */
         $found = $tokens->findGivenKind(T_CLASS);
-        static::assertCount(1, $found);
-        static::assertArrayHasKey(1, $found);
-        static::assertSame(T_CLASS, $found[1]->getId());
+        self::assertCount(1, $found);
+        self::assertArrayHasKey(1, $found);
+        self::assertSame(T_CLASS, $found[1]->getId());
 
         $found = $tokens->findGivenKind([T_CLASS, T_FUNCTION]);
-        static::assertCount(2, $found);
-        static::assertArrayHasKey(T_CLASS, $found);
-        static::assertIsArray($found[T_CLASS]);
-        static::assertCount(1, $found[T_CLASS]);
-        static::assertArrayHasKey(1, $found[T_CLASS]);
-        static::assertSame(T_CLASS, $found[T_CLASS][1]->getId());
+        self::assertCount(2, $found);
+        self::assertArrayHasKey(T_CLASS, $found);
+        self::assertIsArray($found[T_CLASS]);
+        self::assertCount(1, $found[T_CLASS]);
+        self::assertArrayHasKey(1, $found[T_CLASS]);
+        self::assertSame(T_CLASS, $found[T_CLASS][1]->getId());
 
-        static::assertArrayHasKey(T_FUNCTION, $found);
-        static::assertIsArray($found[T_FUNCTION]);
-        static::assertCount(2, $found[T_FUNCTION]);
-        static::assertArrayHasKey(9, $found[T_FUNCTION]);
-        static::assertSame(T_FUNCTION, $found[T_FUNCTION][9]->getId());
-        static::assertArrayHasKey(26, $found[T_FUNCTION]);
-        static::assertSame(T_FUNCTION, $found[T_FUNCTION][26]->getId());
+        self::assertArrayHasKey(T_FUNCTION, $found);
+        self::assertIsArray($found[T_FUNCTION]);
+        self::assertCount(2, $found[T_FUNCTION]);
+        self::assertArrayHasKey(9, $found[T_FUNCTION]);
+        self::assertSame(T_FUNCTION, $found[T_FUNCTION][9]->getId());
+        self::assertArrayHasKey(26, $found[T_FUNCTION]);
+        self::assertSame(T_FUNCTION, $found[T_FUNCTION][26]->getId());
 
         // test offset and limits of the search
         $found = $tokens->findGivenKind([T_CLASS, T_FUNCTION], 10);
-        static::assertCount(0, $found[T_CLASS]);
-        static::assertCount(1, $found[T_FUNCTION]);
-        static::assertArrayHasKey(26, $found[T_FUNCTION]);
+        self::assertCount(0, $found[T_CLASS]);
+        self::assertCount(1, $found[T_FUNCTION]);
+        self::assertArrayHasKey(26, $found[T_FUNCTION]);
 
         $found = $tokens->findGivenKind([T_CLASS, T_FUNCTION], 2, 10);
-        static::assertCount(0, $found[T_CLASS]);
-        static::assertCount(1, $found[T_FUNCTION]);
-        static::assertArrayHasKey(9, $found[T_FUNCTION]);
+        self::assertCount(0, $found[T_CLASS]);
+        self::assertCount(1, $found[T_FUNCTION]);
+        self::assertArrayHasKey(9, $found[T_FUNCTION]);
     }
 
     /**
@@ -648,12 +648,12 @@ PHP;
         Tokens::clearCache();
         $tokens = Tokens::fromCode($source);
         if (1 === $direction) {
-            static::assertSame($expectedIndex, $tokens->getNextTokenOfKind($index, $findTokens, $caseSensitive));
+            self::assertSame($expectedIndex, $tokens->getNextTokenOfKind($index, $findTokens, $caseSensitive));
         } else {
-            static::assertSame($expectedIndex, $tokens->getPrevTokenOfKind($index, $findTokens, $caseSensitive));
+            self::assertSame($expectedIndex, $tokens->getPrevTokenOfKind($index, $findTokens, $caseSensitive));
         }
 
-        static::assertSame($expectedIndex, $tokens->getTokenOfKindSibling($index, $direction, $findTokens, $caseSensitive));
+        self::assertSame($expectedIndex, $tokens->getTokenOfKindSibling($index, $direction, $findTokens, $caseSensitive));
     }
 
     public static function provideTokenOfKindSiblingCases(): array
@@ -692,7 +692,7 @@ PHP;
      */
     public function testFindBlockEnd(int $expectedIndex, string $source, int $type, int $searchIndex): void
     {
-        static::assertFindBlockEnd($expectedIndex, $source, $type, $searchIndex);
+        self::assertFindBlockEnd($expectedIndex, $source, $type, $searchIndex);
     }
 
     public static function provideFindBlockEndCases(): array
@@ -723,7 +723,7 @@ PHP;
      */
     public function testFindBlockEnd80(int $expectedIndex, string $source, int $type, int $searchIndex): void
     {
-        static::assertFindBlockEnd($expectedIndex, $source, $type, $searchIndex);
+        self::assertFindBlockEnd($expectedIndex, $source, $type, $searchIndex);
     }
 
     public static function provideFindBlockEnd80Cases(): array
@@ -750,7 +750,7 @@ PHP;
      */
     public function testFindBlockEnd82(int $expectedIndex, string $source, int $type, int $searchIndex): void
     {
-        static::assertFindBlockEnd($expectedIndex, $source, $type, $searchIndex);
+        self::assertFindBlockEnd($expectedIndex, $source, $type, $searchIndex);
     }
 
     public static function provideFindBlockEnd82Cases(): iterable
@@ -806,7 +806,7 @@ PHP;
         Tokens::clearCache();
         $tokens = Tokens::fromCode('<?php foo(1, 2);');
 
-        static::assertSame(7, $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, 2));
+        self::assertSame(7, $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, 2));
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/^Invalid param \$startIndex - not a proper block "start"\.$/');
@@ -819,7 +819,7 @@ PHP;
         Tokens::clearCache();
         $tokens = Tokens::fromCode('<?php foo(1, 2);');
 
-        static::assertSame(2, $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, 7));
+        self::assertSame(2, $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, 7));
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/^Invalid param \$startIndex - not a proper block "end"\.$/');
@@ -832,8 +832,8 @@ PHP;
         $code = '';
         $tokens = Tokens::fromCode($code);
 
-        static::assertCount(0, $tokens);
-        static::assertFalse($tokens->isTokenKindFound(T_OPEN_TAG));
+        self::assertCount(0, $tokens);
+        self::assertFalse($tokens->isTokenKindFound(T_OPEN_TAG));
     }
 
     public function testEmptyTokensMultiple(): void
@@ -841,16 +841,16 @@ PHP;
         $code = '';
 
         $tokens = Tokens::fromCode($code);
-        static::assertFalse($tokens->isChanged());
+        self::assertFalse($tokens->isChanged());
 
         $tokens->insertAt(0, new Token([T_WHITESPACE, ' ']));
-        static::assertCount(1, $tokens);
-        static::assertFalse($tokens->isTokenKindFound(T_OPEN_TAG));
-        static::assertTrue($tokens->isChanged());
+        self::assertCount(1, $tokens);
+        self::assertFalse($tokens->isTokenKindFound(T_OPEN_TAG));
+        self::assertTrue($tokens->isChanged());
 
         $tokens2 = Tokens::fromCode($code);
-        static::assertCount(0, $tokens2);
-        static::assertFalse($tokens->isTokenKindFound(T_OPEN_TAG));
+        self::assertCount(0, $tokens2);
+        self::assertFalse($tokens->isTokenKindFound(T_OPEN_TAG));
     }
 
     public function testFromArray(): void
@@ -860,15 +860,15 @@ PHP;
         $tokens1 = Tokens::fromCode($code);
         $tokens2 = Tokens::fromArray($tokens1->toArray());
 
-        static::assertTrue($tokens1->isTokenKindFound(T_OPEN_TAG));
-        static::assertTrue($tokens2->isTokenKindFound(T_OPEN_TAG));
-        static::assertSame($tokens1->getCodeHash(), $tokens2->getCodeHash());
+        self::assertTrue($tokens1->isTokenKindFound(T_OPEN_TAG));
+        self::assertTrue($tokens2->isTokenKindFound(T_OPEN_TAG));
+        self::assertSame($tokens1->getCodeHash(), $tokens2->getCodeHash());
     }
 
     public function testFromArrayEmpty(): void
     {
         $tokens = Tokens::fromArray([]);
-        static::assertFalse($tokens->isTokenKindFound(T_OPEN_TAG));
+        self::assertFalse($tokens->isTokenKindFound(T_OPEN_TAG));
     }
 
     /**
@@ -878,7 +878,7 @@ PHP;
     {
         $tokens = Tokens::fromArray([$token]);
         Tokens::clearCache();
-        static::assertSame($isEmpty, $tokens->isEmptyAt(0), $token->toJson());
+        self::assertSame($isEmpty, $tokens->isEmptyAt(0), $token->toJson());
     }
 
     public static function provideIsEmptyCases(): array
@@ -897,15 +897,15 @@ PHP;
 
         $tokensClone = clone $tokens;
 
-        static::assertTrue($tokens->isTokenKindFound(T_OPEN_TAG));
-        static::assertTrue($tokensClone->isTokenKindFound(T_OPEN_TAG));
+        self::assertTrue($tokens->isTokenKindFound(T_OPEN_TAG));
+        self::assertTrue($tokensClone->isTokenKindFound(T_OPEN_TAG));
 
         $count = \count($tokens);
-        static::assertCount($count, $tokensClone);
+        self::assertCount($count, $tokensClone);
 
         for ($i = 0; $i < $count; ++$i) {
-            static::assertTrue($tokens[$i]->equals($tokensClone[$i]));
-            static::assertNotSame($tokens[$i], $tokensClone[$i]);
+            self::assertTrue($tokens[$i]->equals($tokensClone[$i]));
+            self::assertNotSame($tokens[$i], $tokensClone[$i]);
         }
     }
 
@@ -917,7 +917,7 @@ PHP;
         $tokens = Tokens::fromCode($input);
         $tokens->ensureWhitespaceAtIndex($index, $offset, $whiteSpace);
         $tokens->clearEmptyTokens();
-        static::assertTokens(Tokens::fromCode($expected), $tokens);
+        self::assertTokens(Tokens::fromCode($expected), $tokens);
     }
 
     public static function provideEnsureWhitespaceAtIndexCases(): array
@@ -1063,12 +1063,12 @@ echo $a;',
             ]
         );
 
-        static::assertTrue($tokens->isChanged());
+        self::assertTrue($tokens->isChanged());
 
         $expected = Tokens::fromCode(sprintf($template, 'private $name;'));
-        static::assertFalse($expected->isChanged());
+        self::assertFalse($expected->isChanged());
 
-        static::assertTokens($expected, $tokens);
+        self::assertTokens($expected, $tokens);
     }
 
     /**
@@ -1081,7 +1081,7 @@ echo $a;',
         $tokens = Tokens::fromCode($input ?? $expected);
         $tokens->removeLeadingWhitespace($index, $whitespaces);
 
-        static::assertSame($expected, $tokens->generateCode());
+        self::assertSame($expected, $tokens->generateCode());
     }
 
     public static function provideRemoveLeadingWhitespaceCases(): array
@@ -1147,7 +1147,7 @@ echo $a;',
         $tokens = Tokens::fromCode($input ?? $expected);
         $tokens->removeTrailingWhitespace($index, $whitespaces);
 
-        static::assertSame($expected, $tokens->generateCode());
+        self::assertSame($expected, $tokens->generateCode());
     }
 
     public static function provideRemoveTrailingWhitespaceCases(): iterable
@@ -1170,7 +1170,7 @@ echo $a;',
         $tokens->removeLeadingWhitespace(3);
 
         $tokens->clearEmptyTokens();
-        static::assertTokens(Tokens::fromCode("<?php\nMY_INDEX_IS_THREE;foo();"), $tokens);
+        self::assertTokens(Tokens::fromCode("<?php\nMY_INDEX_IS_THREE;foo();"), $tokens);
     }
 
     public function testRemovingTrailingWhitespaceWithEmptyTokenInCollection(): void
@@ -1182,7 +1182,7 @@ echo $a;',
         $tokens->removeTrailingWhitespace(1);
 
         $tokens->clearEmptyTokens();
-        static::assertTokens(Tokens::fromCode("<?php\nMY_INDEX_IS_ONE;foo();"), $tokens);
+        self::assertTokens(Tokens::fromCode("<?php\nMY_INDEX_IS_ONE;foo();"), $tokens);
     }
 
     /**
@@ -1197,8 +1197,8 @@ echo $a;',
 
         $tokens->removeLeadingWhitespace(4);
 
-        static::assertSame($originalCount, $tokens->count());
-        static::assertSame(
+        self::assertSame($originalCount, $tokens->count());
+        self::assertSame(
             '<?php
                                     // Foo
 $bar;',
@@ -1218,8 +1218,8 @@ $bar;',
 
         $tokens->removeTrailingWhitespace(2);
 
-        static::assertSame($originalCount, $tokens->count());
-        static::assertSame(
+        self::assertSame($originalCount, $tokens->count());
+        self::assertSame(
             '<?php
                                     // Foo
 $bar;',
@@ -1235,7 +1235,7 @@ $bar;',
     public function testDetectBlockType(?array $expected, string $code, int $index): void
     {
         $tokens = Tokens::fromCode($code);
-        static::assertSame($expected, Tokens::detectBlockType($tokens[$index]));
+        self::assertSame($expected, Tokens::detectBlockType($tokens[$index]));
     }
 
     public static function provideDetectBlockTypeCases(): iterable
@@ -1280,7 +1280,7 @@ $bar;',
         $tokens->overrideRange($indexStart, $indexEnd, $items);
         $tokens->clearEmptyTokens();
 
-        static::assertTokens(Tokens::fromArray($expected), $tokens);
+        self::assertTokens(Tokens::fromArray($expected), $tokens);
     }
 
     /**
@@ -1295,7 +1295,7 @@ $bar;',
         $tokens->overrideRange($indexStart, $indexEnd, $items);
         $tokens->clearEmptyTokens();
 
-        static::assertTokens(Tokens::fromArray($expected), $tokens);
+        self::assertTokens(Tokens::fromArray($expected), $tokens);
     }
 
     public static function provideOverrideRangeCases(): iterable
@@ -1394,7 +1394,7 @@ $bar;',
     public function testInitialChangedState(): void
     {
         $tokens = Tokens::fromCode("<?php\n");
-        static::assertFalse($tokens->isChanged());
+        self::assertFalse($tokens->isChanged());
 
         $tokens = Tokens::fromArray(
             [
@@ -1403,7 +1403,7 @@ $bar;',
                 new Token(';'),
             ]
         );
-        static::assertFalse($tokens->isChanged());
+        self::assertFalse($tokens->isChanged());
     }
 
     /**
@@ -1416,7 +1416,7 @@ $bar;',
         Tokens::clearCache();
         $tokens = Tokens::fromCode($source);
 
-        static::assertSame($expectIndex, $tokens->getMeaningfulTokenSibling($index, $direction));
+        self::assertSame($expectIndex, $tokens->getMeaningfulTokenSibling($index, $direction));
     }
 
     public static function provideGetMeaningfulTokenSiblingCases(): iterable
@@ -1463,7 +1463,7 @@ EOF;
             16 => $slices,
             6 => $slices,
         ]);
-        static::assertTokens(Tokens::fromCode($expected), $tokens);
+        self::assertTokens(Tokens::fromCode($expected), $tokens);
     }
 
     public static function provideInsertSlicesAtMultiplePlacesCases(): iterable
@@ -1506,15 +1506,15 @@ EOF
     {
         $tokens = Tokens::fromCode('<?php echo 1234567890;');
 
-        static::assertFalse($tokens->isChanged());
-        static::assertFalse($tokens->isTokenKindFound(T_COMMENT));
-        static::assertSame(5, $tokens->getSize());
+        self::assertFalse($tokens->isChanged());
+        self::assertFalse($tokens->isTokenKindFound(T_COMMENT));
+        self::assertSame(5, $tokens->getSize());
 
         $tokens->insertSlices([1 => new Token([T_COMMENT, '/* comment */'])]);
 
-        static::assertTrue($tokens->isChanged());
-        static::assertTrue($tokens->isTokenKindFound(T_COMMENT));
-        static::assertSame(6, $tokens->getSize());
+        self::assertTrue($tokens->isChanged());
+        self::assertTrue($tokens->isTokenKindFound(T_COMMENT));
+        self::assertSame(6, $tokens->getSize());
     }
 
     /**
@@ -1525,7 +1525,7 @@ EOF
     public function testInsertSlices(Tokens $expected, Tokens $tokens, array $slices): void
     {
         $tokens->insertSlices($slices);
-        static::assertTokens($expected, $tokens);
+        self::assertTokens($expected, $tokens);
     }
 
     public static function provideInsertSlicesCases(): iterable
@@ -1634,7 +1634,7 @@ EOF
         $tokens = $this->getBlockEdgeCachingTestTokens();
 
         $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, 5);
-        static::assertSame(9, $endIndex);
+        self::assertSame(9, $endIndex);
 
         $tokens->offsetSet(5, new Token('('));
         $tokens->offsetSet(9, new Token('('));
@@ -1650,15 +1650,15 @@ EOF
         $tokens = $this->getBlockEdgeCachingTestTokens();
 
         $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, 5);
-        static::assertSame(9, $endIndex);
+        self::assertSame(9, $endIndex);
 
         $tokens->clearAt(7); // note: offsetUnset doesn't work here
         $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, 5);
-        static::assertSame(9, $endIndex);
+        self::assertSame(9, $endIndex);
 
         $tokens->clearEmptyTokens();
         $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, 5);
-        static::assertSame(8, $endIndex);
+        self::assertSame(8, $endIndex);
     }
 
     public function testBlockEdgeCachingInsertSlices(): void
@@ -1666,12 +1666,12 @@ EOF
         $tokens = $this->getBlockEdgeCachingTestTokens();
 
         $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, 5);
-        static::assertSame(9, $endIndex);
+        self::assertSame(9, $endIndex);
 
         $tokens->insertSlices([6 => [new Token([T_COMMENT, '/* A */'])], new Token([T_COMMENT, '/* B */'])]);
 
         $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, 5);
-        static::assertSame(11, $endIndex);
+        self::assertSame(11, $endIndex);
     }
 
     private function getBlockEdgeCachingTestTokens(): Tokens
@@ -1702,22 +1702,22 @@ EOF
         Tokens::clearCache();
         $tokens = Tokens::fromCode($source);
 
-        static::assertSame($expectedIndex, $tokens->findBlockEnd($type, $searchIndex));
-        static::assertSame($searchIndex, $tokens->findBlockStart($type, $expectedIndex));
+        self::assertSame($expectedIndex, $tokens->findBlockEnd($type, $searchIndex));
+        self::assertSame($searchIndex, $tokens->findBlockStart($type, $expectedIndex));
 
         $detectedType = Tokens::detectBlockType($tokens[$searchIndex]);
-        static::assertIsArray($detectedType);
-        static::assertArrayHasKey('type', $detectedType);
-        static::assertArrayHasKey('isStart', $detectedType);
-        static::assertSame($type, $detectedType['type']);
-        static::assertTrue($detectedType['isStart']);
+        self::assertIsArray($detectedType);
+        self::assertArrayHasKey('type', $detectedType);
+        self::assertArrayHasKey('isStart', $detectedType);
+        self::assertSame($type, $detectedType['type']);
+        self::assertTrue($detectedType['isStart']);
 
         $detectedType = Tokens::detectBlockType($tokens[$expectedIndex]);
-        static::assertIsArray($detectedType);
-        static::assertArrayHasKey('type', $detectedType);
-        static::assertArrayHasKey('isStart', $detectedType);
-        static::assertSame($type, $detectedType['type']);
-        static::assertFalse($detectedType['isStart']);
+        self::assertIsArray($detectedType);
+        self::assertArrayHasKey('type', $detectedType);
+        self::assertArrayHasKey('isStart', $detectedType);
+        self::assertSame($type, $detectedType['type']);
+        self::assertFalse($detectedType['isStart']);
     }
 
     /**
@@ -1727,19 +1727,19 @@ EOF
     private static function assertEqualsTokensArray(array $expected = null, array $input = null): void
     {
         if (null === $expected) {
-            static::assertNull($input);
+            self::assertNull($input);
 
             return;
         }
 
         if (null === $input) {
-            static::fail('While "input" is <null>, "expected" is not.');
+            self::fail('While "input" is <null>, "expected" is not.');
         }
 
-        static::assertSame(array_keys($expected), array_keys($input), 'Both arrays need to have same keys.');
+        self::assertSame(array_keys($expected), array_keys($input), 'Both arrays need to have same keys.');
 
         foreach ($expected as $index => $expectedToken) {
-            static::assertTrue(
+            self::assertTrue(
                 $expectedToken->equals($input[$index]),
                 sprintf('The token at index %d should be %s, got %s', $index, $expectedToken->toJson(), $input[$index]->toJson())
             );
@@ -1758,12 +1758,12 @@ EOF
             $tokens->clearTokenAndMergeSurroundingWhitespace($index);
         }
 
-        static::assertSame(\count($expected), $tokens->count());
+        self::assertSame(\count($expected), $tokens->count());
         foreach ($expected as $index => $expectedToken) {
             $token = $tokens[$index];
             $expectedPrototype = $expectedToken->getPrototype();
 
-            static::assertTrue($token->equals($expectedPrototype), sprintf('The token at index %d should be %s, got %s', $index, json_encode($expectedPrototype), $token->toJson()));
+            self::assertTrue($token->equals($expectedPrototype), sprintf('The token at index %d should be %s, got %s', $index, json_encode($expectedPrototype), $token->toJson()));
         }
     }
 }

--- a/tests/Tokenizer/Transformer/AttributeTransformerTest.php
+++ b/tests/Tokenizer/Transformer/AttributeTransformerTest.php
@@ -183,7 +183,7 @@ class User
         Tokens::clearCache();
 
         foreach (Tokens::fromCode($source) as $token) {
-            static::assertFalse($token->isGivenKind([
+            self::assertFalse($token->isGivenKind([
                 CT::T_ATTRIBUTE_CLOSE,
             ]));
         }

--- a/tests/Tokenizer/Transformer/ConstructorPromotionTransformerTest.php
+++ b/tests/Tokenizer/Transformer/ConstructorPromotionTransformerTest.php
@@ -118,7 +118,7 @@ class Point {
         Tokens::clearCache();
 
         foreach (Tokens::fromCode($code) as $token) {
-            static::assertFalse($token->isGivenKind([
+            self::assertFalse($token->isGivenKind([
                 CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC,
                 CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED,
                 CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE,

--- a/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php
@@ -50,13 +50,13 @@ final class NameQualifiedTransformerTest extends AbstractTransformerTestCase
             $this->transformer->process($tokens, $tokens[$i], $i);
         }
 
-        static::assertTokens($expectedTokens, $tokens);
+        self::assertTokens($expectedTokens, $tokens);
 
         if (null === $input) {
-            static::assertFalse($tokens->isChanged());
+            self::assertFalse($tokens->isChanged());
         } else {
             self::testProcess($expected);
-            static::assertTrue($tokens->isChanged());
+            self::assertTrue($tokens->isChanged());
         }
     }
 
@@ -161,7 +161,7 @@ final class NameQualifiedTransformerTest extends AbstractTransformerTestCase
      */
     public function testPriority(array $expected, string $source): void
     {
-        static::assertTokens(Tokens::fromArray($expected), Tokens::fromCode($source));
+        self::assertTokens(Tokens::fromArray($expected), Tokens::fromCode($source));
     }
 
     public static function providePriorityCases(): iterable

--- a/tests/Tokenizer/Transformer/NamedArgumentTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NamedArgumentTransformerTest.php
@@ -92,7 +92,7 @@ final class NamedArgumentTransformerTest extends AbstractTransformerTestCase
      */
     public function testDoNotChange(string $source): void
     {
-        static::assertNotChange($source);
+        self::assertNotChange($source);
     }
 
     public static function provideDoNotChangeCases(): iterable
@@ -145,7 +145,7 @@ final class NamedArgumentTransformerTest extends AbstractTransformerTestCase
         Tokens::clearCache();
 
         foreach (Tokens::fromCode($source) as $token) {
-            static::assertFalse($token->isGivenKind([
+            self::assertFalse($token->isGivenKind([
                 CT::T_NAMED_ARGUMENT_NAME,
                 CT::T_NAMED_ARGUMENT_COLON,
             ]));

--- a/tests/Tokenizer/Transformer/SquareBraceTransformerTest.php
+++ b/tests/Tokenizer/Transformer/SquareBraceTransformerTest.php
@@ -42,12 +42,12 @@ final class SquareBraceTransformerTest extends AbstractTransformerTestCase
 
         $tokens = Tokens::fromCode($source);
         foreach ($inspectIndexes as $index) {
-            static::assertTrue($tokens->offsetExists($index), sprintf('Index %d does not exist.', $index));
+            self::assertTrue($tokens->offsetExists($index), sprintf('Index %d does not exist.', $index));
         }
 
         foreach ($tokens as $index => $token) {
             if (\in_array($index, $inspectIndexes, true)) {
-                static::assertSame('[', $tokens[$index]->getContent(), sprintf('Token @ index %d must have content \']\'', $index));
+                self::assertSame('[', $tokens[$index]->getContent(), sprintf('Token @ index %d must have content \']\'', $index));
                 $exp = $expected;
             } elseif ('[' === $tokens[$index]->getContent()) {
                 $exp = !$expected;
@@ -55,7 +55,7 @@ final class SquareBraceTransformerTest extends AbstractTransformerTestCase
                 continue;
             }
 
-            static::assertSame(
+            self::assertSame(
                 $expected,
                 $method->invoke($transformer, $tokens, $index),
                 sprintf('Excepted token "%s" @ index %d %sto be detected as short array.', $tokens[$index]->toJson(), $index, $exp ? '' : 'not ')

--- a/tests/Tokenizer/Transformer/WhitespacyCommentTransformerTest.php
+++ b/tests/Tokenizer/Transformer/WhitespacyCommentTransformerTest.php
@@ -38,8 +38,8 @@ final class WhitespacyCommentTransformerTest extends AbstractTransformerTestCase
         foreach ($expectedTokens as $index => $expectedToken) {
             $token = $tokens[$index];
 
-            static::assertSame($expectedToken[1], $token->getContent());
-            static::assertSame($expectedToken[0], $token->getId());
+            self::assertSame($expectedToken[1], $token->getContent());
+            self::assertSame($expectedToken[0], $token->getId());
         }
     }
 

--- a/tests/Tokenizer/TransformersTest.php
+++ b/tests/Tokenizer/TransformersTest.php
@@ -37,8 +37,8 @@ final class TransformersTest extends TestCase
         $tokens = Tokens::fromCode($input);
 
         foreach ($expectedTokenKinds as $index => $expected) {
-            static::assertTrue($tokens->offsetExists($index));
-            static::assertTrue($tokens[$index]->isGivenKind($expected));
+            self::assertTrue($tokens->offsetExists($index));
+            self::assertTrue($tokens[$index]->isGivenKind($expected));
         }
     }
 

--- a/tests/ToolInfoTest.php
+++ b/tests/ToolInfoTest.php
@@ -27,19 +27,19 @@ final class ToolInfoTest extends TestCase
     public function testGetVersion(): void
     {
         $toolInfo = new ToolInfo();
-        static::assertStringStartsWith(Application::VERSION, $toolInfo->getVersion());
+        self::assertStringStartsWith(Application::VERSION, $toolInfo->getVersion());
     }
 
     public function testIsInstallAsPhar(): void
     {
         $toolInfo = new ToolInfo();
-        static::assertFalse($toolInfo->isInstalledAsPhar());
+        self::assertFalse($toolInfo->isInstalledAsPhar());
     }
 
     public function testIsInstalledByComposer(): void
     {
         $toolInfo = new ToolInfo();
-        static::assertFalse($toolInfo->isInstalledByComposer());
+        self::assertFalse($toolInfo->isInstalledByComposer());
     }
 
     public function testGetComposerVersionThrowsExceptionIfOutsideComposerScope(): void
@@ -54,7 +54,7 @@ final class ToolInfoTest extends TestCase
     public function testGetPharDownloadUri(): void
     {
         $toolInfo = new ToolInfo();
-        static::assertSame(
+        self::assertSame(
             'https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/foo/php-cs-fixer.phar',
             $toolInfo->getPharDownloadUri('foo')
         );

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -55,10 +55,10 @@ final class UtilsTest extends TestCase
     public function testCamelCaseToUnderscore(string $expected, string $input = null): void
     {
         if (null !== $input) {
-            static::assertSame($expected, Utils::camelCaseToUnderscore($input));
+            self::assertSame($expected, Utils::camelCaseToUnderscore($input));
         }
 
-        static::assertSame($expected, Utils::camelCaseToUnderscore($expected));
+        self::assertSame($expected, Utils::camelCaseToUnderscore($expected));
     }
 
     public static function provideCamelCaseToUnderscoreCases(): array
@@ -123,7 +123,7 @@ final class UtilsTest extends TestCase
     {
         $token = new Token($input);
 
-        static::assertSame($spaces, Utils::calculateTrailingWhitespaceIndent($token));
+        self::assertSame($spaces, Utils::calculateTrailingWhitespaceIndent($token));
     }
 
     public static function provideCalculateTrailingWhitespaceIndentCases(): array
@@ -160,7 +160,7 @@ final class UtilsTest extends TestCase
         callable $getComparableValueCallback,
         callable $compareValuesCallback
     ): void {
-        static::assertSame(
+        self::assertSame(
             $expected,
             Utils::stableSort($elements, $getComparableValueCallback, $compareValuesCallback)
         );
@@ -205,7 +205,7 @@ final class UtilsTest extends TestCase
             $this->createFixerDouble('f4', -10),
         ];
 
-        static::assertSame(
+        self::assertSame(
             [
                 $fixers[2],
                 $fixers[0],
@@ -230,7 +230,7 @@ final class UtilsTest extends TestCase
      */
     public function testNaturalLanguageJoinWithBackticks(string $joined, array $names): void
     {
-        static::assertSame($joined, Utils::naturalLanguageJoinWithBackticks($names));
+        self::assertSame($joined, Utils::naturalLanguageJoinWithBackticks($names));
     }
 
     public static function provideNaturalLanguageJoinWithBackticksCases(): array
@@ -264,7 +264,7 @@ final class UtilsTest extends TestCase
         Utils::triggerDeprecation(new \DomainException($message));
 
         $triggered = Utils::getTriggeredDeprecations();
-        static::assertContains($message, $triggered);
+        self::assertContains($message, $triggered);
     }
 
     public function testTriggerDeprecationWhenFutureModeIsOn(): void
@@ -280,11 +280,11 @@ final class UtilsTest extends TestCase
         } catch (\Exception $futureModeException) {
         }
 
-        static::assertInstanceOf(\RuntimeException::class, $futureModeException);
-        static::assertSame($exception, $futureModeException->getPrevious());
+        self::assertInstanceOf(\RuntimeException::class, $futureModeException);
+        self::assertSame($exception, $futureModeException->getPrevious());
 
         $triggered = Utils::getTriggeredDeprecations();
-        static::assertNotContains($message, $triggered);
+        self::assertNotContains($message, $triggered);
     }
 
     private function createFixerDouble(string $name, int $priority): FixerInterface

--- a/tests/WhitespacesFixerConfigTest.php
+++ b/tests/WhitespacesFixerConfigTest.php
@@ -37,8 +37,8 @@ final class WhitespacesFixerConfigTest extends TestCase
 
         $config = new WhitespacesFixerConfig($indent, $lineEnding);
 
-        static::assertSame($indent, $config->getIndent());
-        static::assertSame($lineEnding, $config->getLineEnding());
+        self::assertSame($indent, $config->getIndent());
+        self::assertSame($lineEnding, $config->getLineEnding());
     }
 
     public static function provideTestCases(): array

--- a/tests/WordMatcherTest.php
+++ b/tests/WordMatcherTest.php
@@ -33,7 +33,7 @@ final class WordMatcherTest extends TestCase
     public function testMatch(?string $expected, string $needle, array $candidates): void
     {
         $matcher = new WordMatcher($candidates);
-        static::assertSame($expected, $matcher->match($needle));
+        self::assertSame($expected, $matcher->match($needle));
     }
 
     public static function provideMatchCases(): array


### PR DESCRIPTION
PHPStorm underlines all of these `static::` calls in tests and I thought it would be good to include this fixer in the `PhpCsFixer` ruleset to keep the code clean from such redundant usage 🙂. Let me know what you think.