### PR TITLE
DX: Use ParaUnit to speed up tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
             execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
 
           - operating-system: 'ubuntu-20.04'
+            php-version: '8.0'
+
+          - operating-system: 'ubuntu-20.04'
             php-version: '8.1'
             job-description: 'with Symfony ^6'
             execute-flex-with-symfony-version: '^6.1' # explicit check for Symfony 6.x compatibility

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
             execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
 
           - operating-system: 'ubuntu-20.04'
-            php-version: '8.0'
+            php-version: '8.1'
             job-description: 'with Symfony ^6'
-            execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
+            execute-flex-with-symfony-version: '^6.1' # explicit check for Symfony 6.x compatibility
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
+        run: vendor/bin/paratest ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
             php-version: '8.2'
             job-description: 'with calculating code coverage'
             calculate-code-coverage: 'yes'
-            phpunit-flags: '--testsuite coverage --exclude-group covers-nothing --coverage-clover build/logs/clover.xml'
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.2'
@@ -146,10 +145,15 @@ jobs:
         run: sed 's/enforceTimeLimit="true"/enforceTimeLimit="false"/g' phpunit.xml.dist > phpunit.xml
 
       - name: Run tests
+        if: matrix.calculate-code-coverage != 'yes'
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paratest ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
+        run: vendor/bin/paraunit run ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
+
+      - name: Collect code coverage
+        if: matrix.calculate-code-coverage == 'yes'
+        run: vendor/bin/paraunit coverage --testsuite coverage --exclude-group covers-nothing --clover build/logs/clover.xml
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,8 @@ jobs:
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.0'
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '8.1'
             job-description: 'with Symfony ^6'
-            execute-flex-with-symfony-version: '^6.1' # explicit check for Symfony 6.x compatibility
+            execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.1'

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/stopwatch": "^5.4 || ^6.0"
     },
     "require-dev": {
-        "brianium/paratest": "^6.9",
+        "facile-it/paraunit": "^1.3 || ^2.0",
         "justinrainbow/json-schema": "^5.2",
         "keradus/cli-executor": "^2.0",
         "mikey179/vfsstream": "^1.6.11",

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "symfony/stopwatch": "^5.4 || ^6.0"
     },
     "require-dev": {
+        "brianium/paratest": "^6.9",
         "justinrainbow/json-schema": "^5.2",
         "keradus/cli-executor": "^2.0",
         "mikey179/vfsstream": "^1.6.11",


### PR DESCRIPTION
Currently test suites in Github Actions take ages. This PR's goal is reducing time needed for running test suite(s).

Initially started with ParaTest, but after encountering problems with test loader I've changed to ParaUnit.

[Benchmark](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6883#issuecomment-1613530274):
|  | Process Lint | Fast Lint |
| ------------- | ------------- | ------------- |
| PHPUnit | 00:26:54 😩 | 00:00:56 | 
| ParaUnit | 00:04:48 | 00:00:28 ❤️ |