### PR TITLE
feature: [CurlyBracesPositionFixer] Handle constructors with promoted properties

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -372,6 +372,10 @@ List of Available Rules
      | Allow anonymous functions to have opening and closing braces on the same line.
      | Allowed types: ``bool``
      | Default value: ``true``
+   - | ``allow_single_line_constructors``
+     | Allow constructors to have opening and closing braces on the same line (helpful e.g. when using promoted properties).
+     | Allowed types: ``bool``
+     | Default value: ``true``
 
 
    Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_

--- a/doc/rules/basic/curly_braces_position.rst
+++ b/doc/rules/basic/curly_braces_position.rst
@@ -70,6 +70,16 @@ Allowed types: ``bool``
 
 Default value: ``true``
 
+``allow_single_line_constructors``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Allow constructors to have opening and closing braces on the same line (helpful
+e.g. when using promoted properties).
+
+Allowed types: ``bool``
+
+Default value: ``true``
+
 Examples
 --------
 

--- a/src/Fixer/Basic/CurlyBracesPositionFixer.php
+++ b/src/Fixer/Basic/CurlyBracesPositionFixer.php
@@ -388,6 +388,10 @@ $bar = function () { $result = true;
                 ->setAllowedTypes(['bool'])
                 ->setDefault(true)
                 ->getOption(),
+            (new FixerOptionBuilder('allow_single_line_constructors', 'Allow constructors to have opening and closing braces on the same line (helpful e.g. when using promoted properties).'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(true)
+                ->getOption(),
         ]);
     }
 

--- a/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
+++ b/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
@@ -778,6 +778,89 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                     }
                 }',
         ];
+
+        yield 'constructor with promoted properties and empty body' => [
+            '<?php
+                class Foo
+                {
+                    function __construct(
+                        private $foo
+                    ) {}
+                }',
+            '<?php
+                class Foo
+                {
+                    function __construct(
+                        private $foo
+                    )
+                    {
+
+
+                    }
+                }',
+        ];
+
+        yield 'constructor with promoted properties and line comment in the body' => [
+            '<?php
+                class Foo
+                {
+                    function __construct(
+                        private $foo
+                    ) {} // Foo
+                }',
+            '<?php
+                class Foo
+                {
+                    function __construct(
+                        private $foo
+                    )
+                    {
+                        // Foo
+                    }
+                }',
+        ];
+
+        yield 'constructor with promoted properties and block comment in the body' => [
+            '<?php
+                class Foo
+                {
+                    function __construct(
+                        private $foo
+                    ) {} /* Foo */
+                }',
+            '<?php
+                class Foo
+                {
+                    function __construct(
+                        private $foo
+                    )
+                    {
+                        /* Foo */
+                    }
+                }',
+        ];
+
+        yield 'constructor with promoted properties and additional logic in the body' => [
+            '<?php
+                class Foo
+                {
+                    function __construct(
+                        private Bar $bar
+                    ) {
+                        $bar->baz();
+                    }
+                }',
+            '<?php
+                class Foo
+                {
+                    function __construct(
+                        private Bar $bar
+                    )
+                    {
+                        $bar->baz();
+                    }
+                }',
+        ];
     }
 
     /**


### PR DESCRIPTION
Currently Fixer messes with constructors that have promoted properties and empty body (reported by @mabdullahsari). Imagine:

```php
final class FooController
{
    public function __construct(private readonly ResponseFactory $response) {}
}
```

Applying `curly_braces_position` makes such change:

```diff
-    public function __construct(private readonly ResponseFactory $response) {}
+    public function __construct(private readonly ResponseFactory $response)
+    {
+    }
```

This PR aims to provide support for such constructors, to leave braces in the same line.

I'll be glad if @julienfalque could help with this, because I started to work on it but got stuck 😅.