### PR TITLE
DX: Use Fast Linter by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,11 @@ jobs:
             execute-deployment: 'yes'
 
           - operating-system: 'ubuntu-20.04'
+            php-version: '8.2'
+            job-description: 'with process linter'
+            FAST_LINT_TEST_CASES: 'no'
+
+          - operating-system: 'ubuntu-20.04'
             php-version: '8.3'
             PHP_CS_FIXER_IGNORE_ENV: 1
             composer-flags: '--ignore-platform-req=PHP'
@@ -60,7 +65,6 @@ jobs:
           - operating-system: 'windows-latest'
             php-version: '8.2'
             job-description: 'on Windows'
-            FAST_LINT_TEST_CASES: 1
 
           - operating-system: 'macos-latest'
             php-version: '8.2'
@@ -133,7 +137,7 @@ jobs:
       - name: Run tests
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
-          FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
+          FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES || 1 }}
         run: vendor/bin/phpunit ${{ matrix.phpunit-flags }}
 
       - name: Upload coverage results to Coveralls

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -41,7 +41,7 @@
     <php>
         <ini name="zend.enable_gc" value="0"/>
         <ini name="memory_limit" value="10G"/>
-        <env name="FAST_LINT_TEST_CASES" value="0"/>
+        <env name="FAST_LINT_TEST_CASES" value="1"/>
         <env name="PHP_CS_FIXER_TEST_ALLOW_SKIPPING_SMOKE_TESTS" value="1"/>
     </php>
 </phpunit>

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -461,7 +461,9 @@ abstract class AbstractFixerTestCase extends TestCase
 
         if (null === $linter) {
             $linter = new CachingLinter(
-                getenv('FAST_LINT_TEST_CASES') ? new Linter() : new ProcessLinter()
+                filter_var(getenv('FAST_LINT_TEST_CASES'), FILTER_VALIDATE_BOOLEAN)
+                    ? new Linter()
+                    : new ProcessLinter()
             );
         }
 

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -362,7 +362,9 @@ abstract class AbstractIntegrationTestCase extends TestCase
 
         if (null === $linter) {
             $linter = new CachingLinter(
-                getenv('FAST_LINT_TEST_CASES') ? new Linter() : new ProcessLinter()
+                filter_var(getenv('FAST_LINT_TEST_CASES'), FILTER_VALIDATE_BOOLEAN)
+                    ? new Linter()
+                    : new ProcessLinter()
             );
         }
 


### PR DESCRIPTION
Alternative approach to #6883 for speeding up CI - use fast linter by default, run one additional job with previous linter.