### PR TITLE
bug: Fix FullyQualifiedStrictTypesFixer common prefix bug

### DIFF
--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -152,13 +152,15 @@ class SomeClass
         $namespaceNameLength = \strlen($namespaceName);
         $types = $this->getTypes($tokens, $typeStartIndex, $type->getEndIndex());
 
+        $prefix = $namespaceName ? '\\'.$namespaceName.'\\' : '\\';
         foreach ($types as $typeName => [$startIndex, $endIndex]) {
-            if (!str_starts_with($typeName, '\\')) {
+            $typeNameLower = strtolower($typeName);
+            if (!str_starts_with($typeNameLower, $prefix)) {
                 continue; // no shorter type possible
             }
 
             $typeName = substr($typeName, 1);
-            $typeNameLower = strtolower($typeName);
+            $typeNameLower = substr($typeNameLower, 1);
 
             if (isset($uses[$typeNameLower])) {
                 // if the type without leading "\" equals any of the full "uses" long names, it can be replaced with the short one

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -103,6 +103,11 @@ namespace A\B\C\D
             '<?php use \A\Exception; function foo(Exception $e) {}',
             '<?php use \A\Exception; function foo(\A\Exception $e) {}',
         ];
+
+        yield 'common prefix' => [
+            '<?php namespace Foo; function foo(\FooBar $v): \FooBar {}',
+            null,
+        ];
     }
 
     /**


### PR DESCRIPTION
The `fully_qualified_strict_types` rule had a bug when a class in the root namespace was used, and that class had a common prefix with the current namespace.

For example, this input:

```php
<?php

namespace Foo;

function foo(\FooBar $v): \FooBar {}
```

would be transformed into:

```php
<?php

namespace Foo;

function foo(ar $v): ar {}
```

This change fixes the bug.