### PR TITLE
bug: PhpUnitMockShortWillReturnFixer - fix for trailing commas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }}
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }} tests/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixerTest.php
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }} tests/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixerTest.php
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }}
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php
@@ -126,6 +126,11 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             $tokens->clearTokenAndMergeSurroundingWhitespace($functionToRemoveIndex);
             $tokens->clearTokenAndMergeSurroundingWhitespace($openingBraceIndex);
             $tokens->clearTokenAndMergeSurroundingWhitespace($closingBraceIndex);
+
+            $commaAfterClosingBraceIndex = $tokens->getNextMeaningfulToken($closingBraceIndex);
+            if ($tokens[$commaAfterClosingBraceIndex]->equals(',')) {
+                $tokens->clearTokenAndMergeSurroundingWhitespace($commaAfterClosingBraceIndex);
+            }
         }
     }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixerTest.php
@@ -267,7 +267,7 @@ class FooTest extends TestCase {
                 '<?php
 class FooTest extends TestCase {
     public function testFoo() {
-        $someMock->method("someMethod")->willReturn( 10 ,  , );
+        $someMock->method("someMethod")->willReturn( 10 ,   );
     }
 }',
                 '<?php

--- a/tests/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixerTest.php
@@ -263,6 +263,20 @@ class FooTest extends TestCase {
     }
 }',
             ],
+            'with trailing commas' => [
+                '<?php
+class FooTest extends TestCase {
+    public function testFoo() {
+        $someMock->method("someMethod")->willReturn( 10 ,  , );
+    }
+}',
+                '<?php
+class FooTest extends TestCase {
+    public function testFoo() {
+        $someMock->method("someMethod")->will($this->returnValue( 10 , ) , );
+    }
+}',
+            ],
         ];
     }
 

--- a/tests/Fixtures/Integration/misc/php_unit_mock_short_will_return,trailing_comma_in_multiline.test
+++ b/tests/Fixtures/Integration/misc/php_unit_mock_short_will_return,trailing_comma_in_multiline.test
@@ -1,0 +1,33 @@
+--TEST--
+Integration of fixers: php_unit_mock_short_will_return,trailing_comma_in_multiline.
+--RULESET--
+{"php_unit_mock_short_will_return": true, "trailing_comma_in_multiline": {"elements": ["arguments"]}}
+--EXPECT--
+<?php
+class FooTest extends TestCase
+{
+    public function test(): void
+    {
+        $service->method('some')->willReturnCallback(
+            
+                function (mixed $event) {
+                },
+            
+        );
+    }
+}
+
+--INPUT--
+<?php
+class FooTest extends TestCase
+{
+    public function test(): void
+    {
+        $service->method('some')->will(
+            $this->returnCallback(
+                function (mixed $event) {
+                }
+            )
+        );
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6896