### PR TITLE
Fix #6904 and update test cases for HeaderCommentFixer

### DIFF
--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -118,7 +118,13 @@ echo 1;
      */
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isMonolithicPhp();
+        if (0 === $tokens->count()) {
+            return false;
+        }
+
+        $firstToken = $tokens[0];
+
+        return $firstToken->isGivenKind([T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO]);
     }
 
     /**

--- a/tests/Fixer/Comment/HeaderCommentFixerTest.php
+++ b/tests/Fixer/Comment/HeaderCommentFixerTest.php
@@ -552,28 +552,6 @@ declare(strict_types=1) ?>',
             [
                 [
                     'header' => 'tmp',
-                    'location' => 'after_declare_strict',
-                ],
-                '#!/usr/bin/env php
-<?php
-declare(strict_types=1);
-
-/*
- * tmp
- */
-
-namespace A\B;
-
-echo 1;',
-                '#!/usr/bin/env php
-<?php
-declare(strict_types=1);namespace A\B;
-
-echo 1;',
-            ],
-            [
-                [
-                    'header' => 'tmp',
                     'location' => 'after_open',
                 ],
                 'Short mixed file A
@@ -731,7 +709,8 @@ echo 1;'
             ['<?= 1?>'],
             ["<?= 1?><?php\n"],
             ["<?= 1?>\n<?php\n"],
-            ["<?php\n// comment 1\n?><?php\n// comment 2\n"],
+            ["#!/usr/bin/env php\n<?php\ndeclare(strict_types=1);\n\n/*\n* tmp\n*/\n\nnamespace A\\B;\n\necho 1;"],
+            ['<!DOCTYPE html>\n<html lang="en">\n<head>\n  <meta charset="UTF-8">\n  <meta http-equiv="X-UA-Compatible" content="IE=edge">\n  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n  <title>Document</title>\n</head>\n<body>\n  \n</body>\n</html>'],
         ];
     }
 


### PR DESCRIPTION
Hiya!

This fixes #6904, which I opened and was summarily invited to try contributing a fix.

I've made changes to the HeaderCommentFixer to address an issue I noticed (in aforementioned #6904) where it wouldn't work with PHP files that have stdout outside of the PHP code. The previous implementation relied on the isMonolithicPhp() method, which checked for monolithic PHP code and didn't allow any content outside the PHP code blocks.

To fix this issue, I've modified the isCandidate() method in the HeaderCommentFixer class. Instead of using the isMonolithicPhp() method, the new implementation checks if the first token in the file is an opening PHP tag. This allows the fixer to work with PHP files that start with an opening PHP tag, even if there is content outside of the PHP code.

I've also made changes to the test cases in HeaderCommentFixerTest.php. I removed test cases that were no longer relevant due to the updated implementation, specifically those that relied on checking isMonolithicPhp. I moved one one of those to the "doesn't touch" test, and added a boilerplate HTML in there to address any possible future regressions for a bug I noticed and fixed while updating the implementation.

Things checked:

- Files without any PHP: DON'T TOUCH
- Files with PHP in the middle: DON'T TOUCH
- Files with an opening PHP tag at position 0, but `T_INLINE_HTML` tokens somewhere after that: FIX
- All other existing test cases have been reverified.
- Shebang on line 1 for running a file as PHP still seems to be ignored correctly by the tokenizer (as it is in the PHP interpreter as well) so there's no regression there that I can see

Have at it, @Wirone :) Let me know if you want additional tests added or anything like that.