### PR TITLE
bug: False positive on used imports when docblock includes it with mismatching case

### DIFF
--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -185,7 +185,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
 
             if ($token->isComment()
                 && Preg::match(
-                    '/(?<![[:alnum:]\$])(?<!\\\\)'.$import->getShortName().'(?![[:alnum:]])/i',
+                    '/(?<![[:alnum:]\$])(?<!\\\\)'.$import->getShortName().'(?![[:alnum:]])/',
                     $token->getContent()
                 )
             ) {

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -708,6 +708,11 @@ use Baz;
             ],
             'with_case_insensitive_matches_in_comments' => [
                 '<?php
+
+//foo
+#bar
+/*baz*/',
+                '<?php
 use Foo;
 use Bar;
 use Baz;
@@ -796,6 +801,8 @@ EOF
 class Foo extends \PHPUnit_Framework_TestCase
 {
     /**
+     * The exception is thrown when foo = bar
+     *
      * @expectedException \Exception
      */
     public function testBar()
@@ -810,6 +817,8 @@ use Some\Exception;
 class Foo extends \PHPUnit_Framework_TestCase
 {
     /**
+     * The exception is thrown when foo = bar
+     *
      * @expectedException \Exception
      */
     public function testBar()


### PR DESCRIPTION
Partially addressing #2814.

---

I see this issue crop up about once a week if not more.

There are two tests in `PHP-CS-Fixer`, one that asserted case-sensitive matching in docblocks, and one that asserted case-insensitive matching in docblock. The result from both is that the imports are retained, albeit unused.

I understand the correct capitalisation of a class name should be treated as a direct reference to the class, and thus it is used. However, the incorrect capitalisation of a class name should not be treated as a direct reference to the class, and thus it should be removed as an import.

**Frequency**

Single-word class names are extremely common in PHP. For example `Illuminate\Support\Collection`, `Illuminate\Http\Request`, `Illuminate\Http\Response`, `Illuminate\Support\Facades\File`,  `App\Models\User`, `App\Models\Role`, `App\Models\Product`, `App\Models\Invoice`.

Mentioning these single-word class names in their abstract sense will be extremely common if you're planning on (or are) using the class in your code. For example, _"do something if the invoice has no product attached"_ references `Invoice` and `Product` as of currently.

If you never end up using the class(es) that you imported, or you end up refactoring the code and remove those classes but retain lowercase reference to the class(es) in docblock comments, then you'll be faced with this issue.

So it's quite easy: First you add a single-word class name, then talk about the abstract idea, then remove (or never add the class to your code) then run php-cs-fixer.

**Example Issue + Example Fix**

```diff
<?php

use App\Models\User;
use App\Models\Role;

class Something
{
    /**
    * Do something as the authorised user depending on their role
    * 
    * See Role for more info
    */
    public function doSomething(): void
    {
        //
    }
}
```

Before this PR, the above would have no change applied. The `User` import would remain imported as `user` is found in the doblock.

After this PR, the below would occur:

```diff
<?php

- use App\Models\User;
use App\Models\Role;

class Something
{
    /**
    * Do something as the authorised user depending on their role
    * 
    * See Role for more info
    */
    public function doSomething(): void
    {
        //
    }
}
```

Note: correct capitalisation of `Role` which is likely to be a reference to the `Role` class is retained.

**Bug or feature?**

I don't know about the thousands of other developers who use php-cs-fixer, but I would expect the import to be removed as it is in no way used in the code. If you want it retained, use the correct capitalisation.

**Impact**

Low impact as this only affects files where the imported class is ONLY referenced using incorrect capitalisation. So, the class is not used in any code, for any type hints, and is only referenced in a capitalisation that really doesn't correlate to the class at all.