### PR TITLE
DX: add cache related tests

### DIFF
--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1174,6 +1174,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
     {
         return [
             [null, '/my/path/my/file', 'path/my/file'],
+            ['/my/path/.php-cs-fixer.cache', '/my/path/my/file', 'my/file'],
             ['/my/path2/dir/.php-cs-fixer.cache', '/my/path2/dir/dir2/file', 'dir2/file'],
             ['dir/.php-cs-fixer.cache', '/my/path/dir/dir3/file', 'dir3/file'],
         ];

--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -101,8 +101,48 @@ final class PharTest extends AbstractSmokeTest
         );
     }
 
+    public static function provideCacheCases(): iterable
+    {
+        yield ['yes'];
+    }
+
+    /**
+     * @dataProvider provideCacheCases
+     */
+    public function testCache(string $usingCache): void
+    {
+        try {
+            $json = self::executePharCommand(sprintf(
+                'fix %s --dry-run --format=json --rules=\'%s\' --using-cache=%s',
+                __FILE__,
+                json_encode(['concat_space' => ['spacing' => 'one']]),
+                $usingCache,
+            ))->getOutput();
+
+            static::assertJson($json);
+
+            $report = json_decode($json, true);
+            static::assertIsArray($report);
+            static::assertArrayHasKey('files', $report);
+            static::assertCount(1, $report['files']);
+            static::assertArrayHasKey(0, $report['files']);
+
+            static::assertSame(
+                'tests/Smoke/PharTest.php',
+                $report['files'][0]['name'],
+            );
+        } catch (\Throwable $exception) {
+            throw $exception;
+        } finally {
+            $cacheFile = __DIR__.'/../../.php-cs-fixer.cache';
+            if (file_exists($cacheFile)) {
+                unlink($cacheFile);
+            }
+        }
+    }
+
     private static function executePharCommand(string $params): CliResult
     {
-        return CommandExecutor::create('php '.self::$pharName.' '.$params, self::$pharCwd)->getResult();
+        return CommandExecutor::create('php '.self::$pharName.' '.$params, self::$pharCwd)->getResult(false);
     }
 }

--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -101,15 +101,15 @@ final class PharTest extends AbstractSmokeTest
         );
     }
 
-    public static function provideCacheCases(): iterable
+    public static function provideReportCases(): iterable
     {
         yield ['yes'];
     }
 
     /**
-     * @dataProvider provideCacheCases
+     * @dataProvider provideReportCases
      */
-    public function testCache(string $usingCache): void
+    public function testReport(string $usingCache): void
     {
         try {
             $json = self::executePharCommand(sprintf(


### PR DESCRIPTION
Extracted from/for https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6915 to separately add already passing tests.

Clearly `provideReportCases` is missing the obvious, other case, but surprisingly, adding it now will make a test fail (because of exactly https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6789) - it will be demonstrated in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6915 after this one gets merged.