### PR TITLE
docs: improve code samples for MultilineWhitespaceBeforeSemicolonsFixer

### DIFF
--- a/doc/rules/semicolon/multiline_whitespace_before_semicolons.rst
+++ b/doc/rules/semicolon/multiline_whitespace_before_semicolons.rst
@@ -31,7 +31,7 @@ Example #1
    --- Original
    +++ New
     <?php
-    function foo () {
+    function foo() {
    -    return 1 + 2
    -        ;
    +    return 1 + 2;
@@ -47,12 +47,11 @@ With configuration: ``['strategy' => 'new_line_for_chained_calls']``.
    --- Original
    +++ New
     <?php
-                            $this->method1()
-                                ->method2()
-   -                            ->method(3);
-   +                            ->method(3)
+    $object->method1()
+        ->method2()
+   -    ->method(3);
+   +    ->method(3)
    +;
-                        ?>
 
 Rule sets
 ---------

--- a/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+++ b/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
@@ -54,7 +54,7 @@ final class MultilineWhitespaceBeforeSemicolonsFixer extends AbstractFixer imple
             [
                 new CodeSample(
                     '<?php
-function foo () {
+function foo() {
     return 1 + 2
         ;
 }
@@ -62,10 +62,9 @@ function foo () {
                 ),
                 new CodeSample(
                     '<?php
-                        $this->method1()
-                            ->method2()
-                            ->method(3);
-                    ?>
+$object->method1()
+    ->method2()
+    ->method(3);
 ',
                     ['strategy' => self::STRATEGY_NEW_LINE_FOR_CHAINED_CALLS]
                 ),


### PR DESCRIPTION
[Current ones](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.16.0/doc/rules/semicolon/multiline_whitespace_before_semicolons.rst#examples) are looking at least "unusual".