### PR TITLE
feature: PhpUnitInternalClassFixer - add empty line before PHPDoc

### DIFF
--- a/doc/rules/php_unit/php_unit_internal_class.rst
+++ b/doc/rules/php_unit/php_unit_internal_class.rst
@@ -29,6 +29,7 @@ Example #1
    --- Original
    +++ New
     <?php
+   +
    +/**
    + * @internal
    + */

--- a/doc/rules/php_unit/php_unit_size_class.rst
+++ b/doc/rules/php_unit/php_unit_size_class.rst
@@ -36,6 +36,7 @@ Example #1
    --- Original
    +++ New
     <?php
+   +
    +/**
    + * @small
    + */
@@ -51,6 +52,7 @@ With configuration: ``['group' => 'medium']``.
    --- Original
    +++ New
     <?php
+   +
    +/**
    + * @medium
    + */

--- a/src/Fixer/AbstractPhpUnitFixer.php
+++ b/src/Fixer/AbstractPhpUnitFixer.php
@@ -77,7 +77,6 @@ abstract class AbstractPhpUnitFixer extends AbstractFixer
         Tokens $tokens,
         int $index,
         string $annotation,
-        bool $addWithEmptyLineBeforePhpdoc,
         bool $addWithEmptyLineBeforeAnnotation,
         array $preventingAnnotations
     ): void {
@@ -86,7 +85,7 @@ abstract class AbstractPhpUnitFixer extends AbstractFixer
         if ($this->isPHPDoc($tokens, $docBlockIndex)) {
             $this->updateDocBlockIfNeeded($tokens, $docBlockIndex, $annotation, $addWithEmptyLineBeforeAnnotation, $preventingAnnotations);
         } else {
-            $this->createDocBlock($tokens, $docBlockIndex, $annotation, $addWithEmptyLineBeforePhpdoc);
+            $this->createDocBlock($tokens, $docBlockIndex, $annotation);
         }
     }
 
@@ -95,7 +94,7 @@ abstract class AbstractPhpUnitFixer extends AbstractFixer
         return $tokens[$index]->isGivenKind(T_DOC_COMMENT);
     }
 
-    private function createDocBlock(Tokens $tokens, int $docBlockIndex, string $annotation, bool $addWithEmptyLineBeforePhpdoc): void
+    private function createDocBlock(Tokens $tokens, int $docBlockIndex, string $annotation): void
     {
         $lineEnd = $this->whitespacesConfig->getLineEnding();
         $originalIndent = WhitespacesAnalyzer::detectIndent($tokens, $tokens->getNextNonWhitespace($docBlockIndex));
@@ -106,7 +105,7 @@ abstract class AbstractPhpUnitFixer extends AbstractFixer
         $index = $tokens->getNextMeaningfulToken($docBlockIndex);
         $tokens->insertAt($index, $toInsert);
 
-        if ($addWithEmptyLineBeforePhpdoc && !$tokens[$index - 1]->isGivenKind(T_WHITESPACE)) {
+        if (!$tokens[$index - 1]->isGivenKind(T_WHITESPACE)) {
             $extraNewLines = $this->whitespacesConfig->getLineEnding();
 
             if (!$tokens[$index - 1]->isGivenKind(T_OPEN_TAG)) {

--- a/src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
@@ -84,7 +84,6 @@ final class PhpUnitInternalClassFixer extends AbstractPhpUnitFixer implements Wh
             $tokens,
             $classIndex,
             'internal',
-            false,
             true,
             ['internal']
         );

--- a/src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
@@ -69,7 +69,6 @@ final class PhpUnitSizeClassFixer extends AbstractPhpUnitFixer implements Whites
             $tokens,
             $classIndex,
             $this->configuration['group'],
-            false,
             true,
             self::SIZES
         );

--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -65,7 +65,6 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             $tokens,
             $classIndex,
             'coversNothing',
-            true,
             false,
             [
                 'covers',

--- a/tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
@@ -512,6 +512,7 @@ final readonly class Test extends TestCase
 
         yield [
             '<?php
+
 /**
  * @internal
  */

--- a/tests/Fixtures/Integration/priority/php_unit_internal_class,final_internal_class.test
+++ b/tests/Fixtures/Integration/priority/php_unit_internal_class,final_internal_class.test
@@ -4,6 +4,7 @@ Integration of fixers: php_unit_internal_class,final_internal_class.
 {"php_unit_internal_class": true, "final_internal_class": true}
 --EXPECT--
 <?php
+
 /**
  * @internal
  */


### PR DESCRIPTION
Follow up to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6756