### PR TITLE
DX: Apply `self_static_accessor` fixer to the project (again)

### DIFF
--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -119,15 +119,15 @@ final class PharTest extends AbstractSmokeTest
                 $usingCache,
             ))->getOutput();
 
-            static::assertJson($json);
+            self::assertJson($json);
 
             $report = json_decode($json, true);
-            static::assertIsArray($report);
-            static::assertArrayHasKey('files', $report);
-            static::assertCount(1, $report['files']);
-            static::assertArrayHasKey(0, $report['files']);
+            self::assertIsArray($report);
+            self::assertArrayHasKey('files', $report);
+            self::assertCount(1, $report['files']);
+            self::assertArrayHasKey(0, $report['files']);
 
-            static::assertSame(
+            self::assertSame(
                 'tests/Smoke/PharTest.php',
                 $report['files'][0]['name'],
             );


### PR DESCRIPTION
I am used to "Merge Result Pipelines" in Gitlab, so when CI is green it's OK to merge... But here I did not handle merging order properly and after #6916 my #6882 had to be rebased. So here's the fix 😅.