### PR TITLE
minor: do not add empty line in PHPDoc when adding annotation in PHPUnit class

### DIFF
--- a/src/Fixer/AbstractPhpUnitFixer.php
+++ b/src/Fixer/AbstractPhpUnitFixer.php
@@ -77,13 +77,12 @@ abstract class AbstractPhpUnitFixer extends AbstractFixer
         Tokens $tokens,
         int $index,
         string $annotation,
-        bool $addWithEmptyLineBeforeAnnotation,
         array $preventingAnnotations
     ): void {
         $docBlockIndex = $this->getDocBlockIndex($tokens, $index);
 
         if ($this->isPHPDoc($tokens, $docBlockIndex)) {
-            $this->updateDocBlockIfNeeded($tokens, $docBlockIndex, $annotation, $addWithEmptyLineBeforeAnnotation, $preventingAnnotations);
+            $this->updateDocBlockIfNeeded($tokens, $docBlockIndex, $annotation, $preventingAnnotations);
         } else {
             $this->createDocBlock($tokens, $docBlockIndex, $annotation);
         }
@@ -125,7 +124,6 @@ abstract class AbstractPhpUnitFixer extends AbstractFixer
         Tokens $tokens,
         int $docBlockIndex,
         string $annotation,
-        bool $addWithEmptyLineBeforeAnnotation,
         array $preventingAnnotations
     ): void {
         $doc = new DocBlock($tokens[$docBlockIndex]->getContent());
@@ -135,7 +133,7 @@ abstract class AbstractPhpUnitFixer extends AbstractFixer
             }
         }
         $doc = $this->makeDocBlockMultiLineIfNeeded($doc, $tokens, $docBlockIndex, $annotation);
-        $lines = $this->addInternalAnnotation($doc, $tokens, $docBlockIndex, $annotation, $addWithEmptyLineBeforeAnnotation);
+        $lines = $this->addInternalAnnotation($doc, $tokens, $docBlockIndex, $annotation);
         $lines = implode('', $lines);
 
         $tokens[$docBlockIndex] = new Token([T_DOC_COMMENT, $lines]);
@@ -144,13 +142,12 @@ abstract class AbstractPhpUnitFixer extends AbstractFixer
     /**
      * @return array<Line>
      */
-    private function addInternalAnnotation(DocBlock $docBlock, Tokens $tokens, int $docBlockIndex, string $annotation, bool $addWithEmptyLineBeforeAnnotation): array
+    private function addInternalAnnotation(DocBlock $docBlock, Tokens $tokens, int $docBlockIndex, string $annotation): array
     {
         $lines = $docBlock->getLines();
         $originalIndent = WhitespacesAnalyzer::detectIndent($tokens, $docBlockIndex);
         $lineEnd = $this->whitespacesConfig->getLineEnding();
-        $extraLine = $addWithEmptyLineBeforeAnnotation ? $lineEnd.$originalIndent.' *' : '';
-        array_splice($lines, -1, 0, $originalIndent.' *'.$extraLine.' @'.$annotation.$lineEnd);
+        array_splice($lines, -1, 0, $originalIndent.' * @'.$annotation.$lineEnd);
 
         return $lines;
     }

--- a/src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
@@ -84,7 +84,6 @@ final class PhpUnitInternalClassFixer extends AbstractPhpUnitFixer implements Wh
             $tokens,
             $classIndex,
             'internal',
-            true,
             ['internal']
         );
     }

--- a/src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
@@ -69,7 +69,6 @@ final class PhpUnitSizeClassFixer extends AbstractPhpUnitFixer implements Whites
             $tokens,
             $classIndex,
             $this->configuration['group'],
-            true,
             self::SIZES
         );
     }

--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -65,7 +65,6 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             $tokens,
             $classIndex,
             'coversNothing',
-            false,
             [
                 'covers',
                 'coversDefaultClass',

--- a/tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
@@ -69,7 +69,6 @@ class Test extends TestCase
 
 /**
  * @coversNothing
- *
  * @internal
  */
 class Test extends TestCase
@@ -141,7 +140,6 @@ if (class_exists("Foo\Bar")) {
      *
      *
      * @covers \Other\Class
-     *
      * @internal
      */
     class Test Extends TestCase
@@ -173,7 +171,6 @@ if (class_exists("Foo\Bar")) {
 	 *
 	 *
 	 * @covers \Other\Class
-	 *
 	 * @internal
 	 */
 	class Test Extends TestCase
@@ -201,7 +198,6 @@ if (class_exists("Foo\Bar")) {
 
 /**
  * @coversNothing
- *
  *
  *
  *
@@ -260,7 +256,6 @@ class Test extends TestCase
 
 /**
  * @coversNothing
- *
  * @internal
  */
 class Test extends TestCase
@@ -414,7 +409,6 @@ class Test extends TestCase
 
             /**
              * @coversNothing
-             *
              * @internal
              */
             #[SimpleTest]
@@ -461,7 +455,6 @@ class Test extends TestCase
 
             /**
              * @coversNothing
-             *
              * @internal
              */
             #[SimpleTest]

--- a/tests/Fixer/PhpUnit/PhpUnitSizeClassFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitSizeClassFixerTest.php
@@ -88,7 +88,6 @@ class Test extends TestCase
 
 /**
  * @coversNothing
- *
  * @small
  */
 class Test extends TestCase
@@ -160,7 +159,6 @@ if (class_exists("Foo\Bar")) {
      *
      *
      * @covers \Other\Class
-     *
      * @small
      */
     class Test Extends TestCase
@@ -188,7 +186,6 @@ if (class_exists("Foo\Bar")) {
 
 /**
  * @coversNothing
- *
  *
  *
  *
@@ -247,7 +244,6 @@ class Test extends TestCase
 
 /**
  * @coversNothing
- *
  * @small
  */
 class Test extends TestCase
@@ -357,7 +353,6 @@ class Test3 extends TestCase
 
             /**
              * @coversNothing
-             *
              * @small
              */
             #[SimpleTest]
@@ -406,7 +401,6 @@ class Test3 extends TestCase
 
             /**
              * @coversNothing
-             *
              * @small
              */
             #[SimpleTest]


### PR DESCRIPTION
There is `PhpdocSeparationFixer` to handle separating tags.