### PR TITLE
bug: MultilineWhitespaceBeforeSemicolonsFixer - fix for discovering multi line calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }} tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }} tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+++ b/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
@@ -24,7 +24,6 @@ use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Analyzer\WhitespacesAnalyzer;
-use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -122,7 +121,7 @@ $object->method1()
             $previousIndex = $index - 1;
             $previous = $tokens[$previousIndex];
 
-            $indent = $this->findWhitespaceBeforeFirstCall($index - 1, $tokens);
+            $indent = $this->findWhitespaceBeforeFirstCall($index, $tokens);
             if (self::STRATEGY_NEW_LINE_FOR_CHAINED_CALLS === $this->configuration['strategy'] && null !== $indent) {
                 if ($previous->isWhitespace() && $previous->getContent() === $lineEnding.$indent) {
                     continue;
@@ -206,7 +205,7 @@ $object->method1()
     }
 
     /**
-     * Checks if the semicolon closes a chained call and returns the whitespace of the first call at $index.
+     * Checks if the semicolon closes a multiline call and returns the whitespace of the first call at $index.
      * i.e. it will return the whitespace marked with '____' in the example underneath.
      *
      * ..
@@ -217,73 +216,32 @@ $object->method1()
     private function findWhitespaceBeforeFirstCall(int $index, Tokens $tokens): ?string
     {
         $lineEnding = $this->whitespacesConfig->getLineEnding();
-        $chained = false;
+        $isMultilineCall = false;
 
-        // skip whitespace between semicolon and closed bracket
-        while ($tokens[$index]->isWhitespace() || $tokens[$index]->isComment()) {
-            --$index;
-        }
-        do {
-            // semicolon followed by a closing bracket?
+        $prevIndex = $tokens->getPrevMeaningfulToken($index);
+
+        while (!$tokens[$prevIndex]->equalsAny([';', '{', '}', [T_OPEN_TAG], [T_ELSE]])) {
+            $index = $prevIndex;
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
+
             if ($tokens[$index]->equals(')')) {
-                // find opening bracket
-                $openingBrackets = 1;
-                for (--$index; $index > 0; --$index) {
-                    if ($tokens[$index]->equals(')')) {
-                        ++$openingBrackets;
+                $prevIndex = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
 
-                        continue;
-                    }
+                continue;
+            }
 
-                    if ($tokens[$index]->equals('(')) {
-                        if (1 === $openingBrackets) {
-                            break;
-                        }
-                        --$openingBrackets;
+            if ($tokens[$index]->isObjectOperator() || $tokens[$index]->isGivenKind(T_DOUBLE_COLON)) {
+                while ($tokens[--$index]->isWhitespace() || $tokens[$index]->isComment()) {
+                    if (false !== strstr($tokens[$index]->getContent(), $lineEnding)) {
+                        $isMultilineCall = true;
+
+                        break;
                     }
                 }
-                --$index;
+                $prevIndex = $index;
             }
+        }
 
-            // method name
-            if (!$tokens[$index]->isGivenKind(T_STRING)) {
-                if (!$tokens[$index]->isGivenKind(CT::T_DYNAMIC_PROP_BRACE_CLOSE)) {
-                    return null;
-                }
-                // find opening curly bracket
-                $openingCurlyBrackets = 1;
-                for (--$index; $index > 0; --$index) {
-                    if ($tokens[$index]->isGivenKind(CT::T_DYNAMIC_PROP_BRACE_CLOSE)) {
-                        ++$openingCurlyBrackets;
-
-                        continue;
-                    }
-
-                    if ($tokens[$index]->isGivenKind(CT::T_DYNAMIC_PROP_BRACE_OPEN)) {
-                        if (1 === $openingCurlyBrackets) {
-                            break;
-                        }
-                        --$openingCurlyBrackets;
-                    }
-                }
-            }
-
-            // ->, ?-> or ::
-            if (!$tokens[--$index]->isObjectOperator() && !$tokens[$index]->isGivenKind(T_DOUBLE_COLON)) {
-                return null;
-            }
-
-            while ($tokens[--$index]->isWhitespace() || $tokens[$index]->isComment()) {
-                if (false !== strstr($tokens[$index]->getContent(), $lineEnding)) {
-                    $chained = true;
-                }
-            }
-
-            while ($tokens[$index]->isGivenKind(T_STRING) && $tokens[$index - 1]->isGivenKind(T_NS_SEPARATOR) || $tokens[$index]->isGivenKind(T_NS_SEPARATOR) && $tokens[$index - 1]->isGivenKind(T_STRING)) {
-                --$index;
-            }
-        } while (!($tokens[$index]->isGivenKind([T_VARIABLE, T_STRING, T_NS_SEPARATOR]) && $tokens[$index - 1]->isGivenKind([T_WHITESPACE, T_OPEN_TAG]) || $tokens[$index]->isGivenKind([CT::T_BRACE_CLASS_INSTANTIATION_CLOSE])));
-
-        return $chained ? WhitespacesAnalyzer::detectIndent($tokens, $index) : null;
+        return $isMultilineCall ? WhitespacesAnalyzer::detectIndent($tokens, $index) : null;
     }
 }

--- a/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
+++ b/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
@@ -1016,6 +1016,32 @@ $this
 ;
 ',
             ],
+            [
+                '<?php
+                    foo("bar")
+                        ->method1()
+                        ->method2()
+                    ;
+                ?>',
+                '<?php
+                    foo("bar")
+                        ->method1()
+                        ->method2();
+                ?>',
+            ],
+            [
+                '<?php
+                    $result = $arrayOfAwesomeObjects["most awesome object"]
+                        ->method1()
+                        ->method2()
+                    ;
+                ?>',
+                '<?php
+                    $result = $arrayOfAwesomeObjects["most awesome object"]
+                        ->method1()
+                        ->method2();
+                ?>',
+            ],
         ];
     }
 

--- a/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
+++ b/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
@@ -1022,12 +1022,12 @@ $this
                         ->method1()
                         ->method2()
                     ;
-                ?>',
+                ',
                 '<?php
                     foo("bar")
                         ->method1()
                         ->method2();
-                ?>',
+                ',
             ],
             [
                 '<?php
@@ -1035,12 +1035,21 @@ $this
                         ->method1()
                         ->method2()
                     ;
-                ?>',
+                ',
                 '<?php
                     $result = $arrayOfAwesomeObjects["most awesome object"]
                         ->method1()
                         ->method2();
-                ?>',
+                ',
+            ],
+            [
+                '<?php
+                    $foo;
+                    $bar = [
+                        1 => 2,
+                        3 => $baz->method(),
+                    ];
+                ',
             ],
         ];
     }


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6886

For this bugfix let's focus on detecting start of the "chained" call, and carry on the fact that for the fixer "chained" means actually "multiline" and discuss it separately to establish what should be changed by the fixer.