### PR TITLE
DX: cancel running builds on subsequent pushes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read # to fetch code (actions/checkout)
 
+concurrency:
+  group: tests-${{ github.head_ref || github.run_id }} # will be canceled on subsequent pushes in pull requests but not branches
+  cancel-in-progress: true
+
 jobs:
   tests:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 concurrency:
-  group: tests-${{ github.head_ref || github.run_id }} # will be canceled on subsequent pushes in pull requests but not branches
+  group: ci-${{ github.head_ref || github.run_id }} # will be canceled on subsequent pushes in pull requests but not branches
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -6,6 +6,10 @@ on:
 
 permissions:
   contents: read # to fetch code (actions/checkout)
+  
+concurrency:
+  group: sca-${{ github.head_ref || github.run_id }} # will be canceled on subsequent pushes in pull requests but not branches
+  cancel-in-progress: true
 
 jobs:
   tests:

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read # to fetch code (actions/checkout)
-  
+
 concurrency:
   group: sca-${{ github.head_ref || github.run_id }} # will be canceled on subsequent pushes in pull requests but not branches
   cancel-in-progress: true


### PR DESCRIPTION
since the CI pipeline is pretty slow/takes a lot of time, I want to propose to skip in-progress jobs after a new commit is pushed to a PR.

that way we don't build up a long queue of jobs but keep only the most recent one per PR