### PR TITLE
DX: Mark Tokens::getNamespaceDeclarations as @internal

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -1172,6 +1172,8 @@ class Tokens extends \SplFixedArray
     }
 
     /**
+     * @internal This is performance-related workaround for lack of proper DI, may be removed at some point
+     *
      * @return list<NamespaceAnalysis>
      */
     public function getNamespaceDeclarations(): array


### PR DESCRIPTION
Following team discussion, let's mark it as internal to not include it in public API.