### PR TITLE
minor: align NoSuperfluousPhpdocTagsFixer with actual Symfony configuration

### DIFF
--- a/doc/ruleSets/PhpCsFixer.rst
+++ b/doc/ruleSets/PhpCsFixer.rst
@@ -32,6 +32,9 @@ Rules
   config:
   ``['tokens' => ['attribute', 'break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use']]``
 - `no_superfluous_elseif <./../rules/control_structure/no_superfluous_elseif.rst>`_
+- `no_superfluous_phpdoc_tags <./../rules/phpdoc/no_superfluous_phpdoc_tags.rst>`_
+  config:
+  ``['allow_mixed' => true, 'allow_unused_params' => true]``
 - `no_unneeded_control_parentheses <./../rules/control_structure/no_unneeded_control_parentheses.rst>`_
   config:
   ``['statements' => ['break', 'clone', 'continue', 'echo_print', 'negative_instanceof', 'others', 'return', 'switch_case', 'yield', 'yield_from']]``

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -73,7 +73,7 @@ Rules
 - `no_spaces_around_offset <./../rules/whitespace/no_spaces_around_offset.rst>`_
 - `no_superfluous_phpdoc_tags <./../rules/phpdoc/no_superfluous_phpdoc_tags.rst>`_
   config:
-  ``['allow_mixed' => true, 'allow_unused_params' => true]``
+  ``['remove_inheritdoc' => true]``
 - `no_trailing_comma_in_singleline <./../rules/basic/no_trailing_comma_in_singleline.rst>`_
 - `no_unneeded_control_parentheses <./../rules/control_structure/no_unneeded_control_parentheses.rst>`_
   config:

--- a/doc/rules/phpdoc/no_superfluous_phpdoc_tags.rst
+++ b/doc/rules/phpdoc/no_superfluous_phpdoc_tags.rst
@@ -128,4 +128,4 @@ The rule is part of the following rule sets:
 @Symfony
   Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``no_superfluous_phpdoc_tags`` rule with the config below:
 
-  ``['allow_mixed' => true, 'allow_unused_params' => true]``
+  ``['remove_inheritdoc' => true]``

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -82,6 +82,10 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
                 ],
             ],
             'no_superfluous_elseif' => true,
+            'no_superfluous_phpdoc_tags' => [
+                'allow_mixed' => true,
+                'allow_unused_params' => true,
+            ],
             'no_unneeded_control_parentheses' => [
                 'statements' => [
                     'break',

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -108,8 +108,7 @@ final class SymfonySet extends AbstractRuleSetDescription
             'no_singleline_whitespace_before_semicolons' => true,
             'no_spaces_around_offset' => true,
             'no_superfluous_phpdoc_tags' => [
-                'allow_mixed' => true,
-                'allow_unused_params' => true,
+                'remove_inheritdoc' => true,
             ],
             'no_trailing_comma_in_singleline' => true,
             'no_unneeded_control_parentheses' => [


### PR DESCRIPTION
Ruleset `@Symfony` should not need to be updated for the actual Symfony's coding standards as it is tight now: https://github.com/symfony/symfony/blob/v6.2.10/.php-cs-fixer.dist.php#L34

@keradus @SpacePossum @julienfalque @localheinz  @Wirone what do you think about updating ruleset `@PhpCsFixer` to the same config as `@Symfony`?