### PR TITLE
bug: Fix `return_assignment` not formatting when variables are used in `catch` and `finally`

### DIFF
--- a/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+++ b/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -510,7 +510,7 @@ final class ReturnAssignmentFixer extends AbstractFixer
         }
 
         $finallyIndex = $nextIndex;
-        if (null === $finallyIndex || $finallyIndex >= $functionCloseIndex) {
+        if ($finallyIndex >= $functionCloseIndex) {
             return false;
         }
         $finallyOpenIndex = $tokens->getNextTokenOfKind($finallyIndex, ['{']);

--- a/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+++ b/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -276,13 +276,16 @@ final class ReturnAssignmentFixer extends AbstractFixer
             }
 
             // Check if there is a finally block and if the variable is used in it
-            $finallyIndex = $tokens->getNextTokenOfKind($endReturnVarIndex, [[T_FINALLY]]);
-            if ($finallyIndex && $finallyIndex < $functionCloseIndex) {
-                $finallyOpenIndex = $tokens->getNextTokenOfKind($finallyIndex, ['{']);
-                $finallyCloseIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $finallyOpenIndex);
-                $varIndex = $tokens->getNextTokenOfKind($finallyOpenIndex, [$tokens[$returnVarIndex]]);
-                if ($varIndex && $varIndex < $finallyCloseIndex) {
-                    continue;
+            $tryIndex = $tokens->getPrevTokenOfKind($returnVarIndex, [[T_TRY]]);
+            if (null !== $tryIndex && $tryIndex > $functionOpenIndex && $tryIndex < $functionCloseIndex) {
+                $finallyIndex = $tokens->getNextTokenOfKind($endReturnVarIndex, [[T_FINALLY]]);
+                if (null !== $finallyIndex && $finallyIndex < $functionCloseIndex) {
+                    $finallyOpenIndex = $tokens->getNextTokenOfKind($finallyIndex, ['{']);
+                    $finallyCloseIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $finallyOpenIndex);
+                    $varIndex = $tokens->getNextTokenOfKind($finallyOpenIndex, [$tokens[$returnVarIndex]]);
+                    if ($varIndex && $varIndex < $finallyCloseIndex) {
+                        continue;
+                    }
                 }
             }
 

--- a/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+++ b/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -480,13 +480,14 @@ final class ReturnAssignmentFixer extends AbstractFixer
         $tryOpenIndex = $tokens->getNextTokenOfKind($tryIndex, ['{']);
         $tryCloseIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $tryOpenIndex);
 
-        // Find finally
+        // Find catch or finally
         $nextIndex = $tokens->getNextMeaningfulToken($tryCloseIndex);
         if (null === $nextIndex) {
             return false;
         }
 
-        if ($tokens[$nextIndex]->isGivenKind(T_CATCH)) {
+        // Find catches
+        while ($tokens[$nextIndex]->isGivenKind(T_CATCH)) {
             $catchOpenIndex = $tokens->getNextTokenOfKind($nextIndex, ['{']);
             $catchCloseIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $catchOpenIndex);
 

--- a/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+++ b/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -474,7 +474,7 @@ final class ReturnAssignmentFixer extends AbstractFixer
     {
         // Find try
         $tryIndex = $tokens->getPrevTokenOfKind($returnVarIndex, [[T_TRY]]);
-        if (null === $tryIndex || $tryIndex <= $functionOpenIndex || $tryIndex >= $functionCloseIndex) {
+        if (null === $tryIndex || $tryIndex <= $functionOpenIndex) {
             return false;
         }
         $tryOpenIndex = $tokens->getNextTokenOfKind($tryIndex, ['{']);

--- a/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+++ b/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -275,6 +275,17 @@ final class ReturnAssignmentFixer extends AbstractFixer
                 continue;
             }
 
+            // Check if there is a finally block and if the variable is used in it
+            $finallyIndex = $tokens->getNextTokenOfKind($endReturnVarIndex, [[T_FINALLY]]);
+            if ($finallyIndex && $finallyIndex < $functionCloseIndex) {
+                $finallyOpenIndex = $tokens->getNextTokenOfKind($finallyIndex, ['{']);
+                $finallyCloseIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $finallyOpenIndex);
+                $varIndex = $tokens->getNextTokenOfKind($finallyOpenIndex, [$tokens[$returnVarIndex]]);
+                if ($varIndex && $varIndex < $finallyCloseIndex) {
+                    continue;
+                }
+            }
+
             // Note: here we are @ "[;{}] $a = [^;{<? ? >] ; return $a;"
             $inserted += $this->simplifyReturnStatement(
                 $tokens,

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -656,7 +656,7 @@ var names are case-insensitive */ return $a   ;}
                 }
                 ',
             ],
-            'try catch2' => [
+            'multiple try/catch blocks separated with conditional return' => [
                 '<?php
                 function foo()
                 {
@@ -702,7 +702,7 @@ var names are case-insensitive */ return $a   ;}
                 }
                 ',
             ],
-            'try finally' => [
+            'try/catch/finally' => [
                 '<?php
                 function foo()
                 {
@@ -742,7 +742,7 @@ var names are case-insensitive */ return $a   ;}
                 }
                 ',
             ],
-            'try finally2' => [
+            'multiple try/catch separated with conditional return, with finally block' => [
                 '<?php
                 function foo()
                 {
@@ -1149,7 +1149,7 @@ var_dump($a); // $a = 2 here _╯°□°╯︵┻━┻
                 }
                 ',
             ],
-            'try finally' => [
+            'try/catch/finally' => [
                 '<?php
                 function add($a, $b): mixed
                 {
@@ -1179,6 +1179,60 @@ var_dump($a); // $a = 2 here _╯°□°╯︵┻━┻
                     }
                 }',
             ],
+            'try/catch/finally with some comments' => [
+                '<?php
+                function add($a, $b): mixed
+                {
+                    try {
+                        $result = $a + $b;
+
+                        return $result;
+                    } /* foo */ catch /** bar */ (\LogicException $th) {
+                        throw $th;
+                    }
+                    // Or maybe this....
+                    catch (\RuntimeException $th) {
+                        throw $th;
+                    }
+                    # Print the result anyway
+                    finally {
+                        echo \'result:\', $result, \PHP_EOL;
+                    }
+                }
+                ',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDoNotFix80Cases
+     *
+     * @requires PHP 8.0
+     */
+    public function testDoNotFix80(string $expected): void
+    {
+        $this->doTest($expected);
+    }
+
+    public static function provideDoNotFix80Cases(): iterable
+    {
+        yield 'try with non-capturing catch block' => [
+            '<?php
+                function add($a, $b): mixed
+                {
+                    try {
+                        $result = $a + $b;
+
+                        return $result;
+                    }
+                    catch (\Throwable) {
+                        noop();
+                    }
+                    finally {
+                        echo \'result:\', $result, \PHP_EOL;
+                    }
+                }
+                ',
         ];
     }
 

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -620,6 +620,88 @@ var names are case-insensitive */ return $a   ;}
                     }
                 ',
             ],
+            'try catch' => [
+                '<?php
+                function foo()
+                {
+                    if (isSomeContiotion()) {
+                        return getSomeResult();
+                    }
+
+                    try {
+                        $result = getResult();
+
+                        return $result;
+                    } catch (\Throwable $exception) {
+                        baz($result ?? null);
+                    }
+                }
+                ',
+                '<?php
+                function foo()
+                {
+                    if (isSomeContiotion()) {
+                        $result = getSomeResult();
+
+                        return $result;
+                    }
+
+                    try {
+                        $result = getResult();
+
+                        return $result;
+                    } catch (\Throwable $exception) {
+                        baz($result ?? null);
+                    }
+                }
+                ',
+            ],
+            'try catch2' => [
+                '<?php
+                function foo()
+                {
+                    try {
+                        return getResult();
+                    } catch (\Throwable $exception) {
+                        error_log($exception->getMessage());
+                    }
+
+                    if (isSomeContiotion()) {
+                        return getSomeResult();
+                    }
+
+                    try {
+                        $result = $a + $b;
+                        return $result;
+                    } catch (\Throwable $th) {
+                        var_dump($result ?? null);
+                    }
+                }
+                ',
+                '<?php
+                function foo()
+                {
+                    try {
+                        $result = getResult();
+                        return $result;
+                    } catch (\Throwable $exception) {
+                        error_log($exception->getMessage());
+                    }
+
+                    if (isSomeContiotion()) {
+                        $result = getSomeResult();
+                        return $result;
+                    }
+
+                    try {
+                        $result = $a + $b;
+                        return $result;
+                    } catch (\Throwable $th) {
+                        var_dump($result ?? null);
+                    }
+                }
+                ',
+            ],
             'try finally' => [
                 '<?php
                 function foo()
@@ -656,6 +738,56 @@ var names are case-insensitive */ return $a   ;}
                         error_log($exception->getMessage());
                     } finally {
                         baz($result);
+                    }
+                }
+                ',
+            ],
+            'try finally2' => [
+                '<?php
+                function foo()
+                {
+                    try {
+                        return getResult();
+                    } catch (\Throwable $exception) {
+                        error_log($exception->getMessage());
+                    }
+
+                    if (isSomeContiotion()) {
+                        return getSomeResult();
+                    }
+
+                    try {
+                        $result = $a + $b;
+                        return $result;
+                    } catch (\Throwable $th) {
+                        throw $th;
+                    } finally {
+                        echo "result:", $result, \PHP_EOL;
+                    }
+                }
+                ',
+                '<?php
+                function foo()
+                {
+                    try {
+                        $result = getResult();
+                        return $result;
+                    } catch (\Throwable $exception) {
+                        error_log($exception->getMessage());
+                    }
+
+                    if (isSomeContiotion()) {
+                        $result = getSomeResult();
+                        return $result;
+                    }
+
+                    try {
+                        $result = $a + $b;
+                        return $result;
+                    } catch (\Throwable $th) {
+                        throw $th;
+                    } finally {
+                        echo "result:", $result, \PHP_EOL;
                     }
                 }
                 ',

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -620,6 +620,46 @@ var names are case-insensitive */ return $a   ;}
                     }
                 ',
             ],
+            'try finally' => [
+                '<?php
+                function foo()
+                {
+                    if (isSomeContiotion()) {
+                        return getSomeResult();
+                    }
+                
+                    try {
+                        $result = getResult();
+                
+                        return $result;
+                    } catch (\Throwable $exception) {
+                        error_log($exception->getMessage());
+                    } finally {
+                        baz($result);
+                    }
+                }
+                ',
+                '<?php
+                function foo()
+                {
+                    if (isSomeContiotion()) {
+                        $result = getSomeResult();
+                
+                        return $result;
+                    }
+                
+                    try {
+                        $result = getResult();
+                
+                        return $result;
+                    } catch (\Throwable $exception) {
+                        error_log($exception->getMessage());
+                    } finally {
+                        baz($result);
+                    }
+                }
+                '
+            ],
         ];
     }
 

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -1170,14 +1170,14 @@ var_dump($a); // $a = 2 here _╯°□°╯︵┻━┻
                 function foo() {
                     try {
                         $bar = bar();
-                
+
                         return $bar;
                     } catch (\LogicException $e) {
                         echo "catch ... ";
                     } catch (\RuntimeException $e) {
                         echo $bar;
                     }
-                }'
+                }',
             ],
         ];
     }

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -627,10 +627,10 @@ var names are case-insensitive */ return $a   ;}
                     if (isSomeContiotion()) {
                         return getSomeResult();
                     }
-                
+
                     try {
                         $result = getResult();
-                
+
                         return $result;
                     } catch (\Throwable $exception) {
                         error_log($exception->getMessage());
@@ -644,13 +644,13 @@ var names are case-insensitive */ return $a   ;}
                 {
                     if (isSomeContiotion()) {
                         $result = getSomeResult();
-                
+
                         return $result;
                     }
-                
+
                     try {
                         $result = getResult();
-                
+
                         return $result;
                     } catch (\Throwable $exception) {
                         error_log($exception->getMessage());
@@ -658,7 +658,7 @@ var names are case-insensitive */ return $a   ;}
                         baz($result);
                     }
                 }
-                '
+                ',
             ],
         ];
     }

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -1165,6 +1165,20 @@ var_dump($a); // $a = 2 here _╯°□°╯︵┻━┻
                 }
                 ',
             ],
+            'try finally2' => [
+                '<?php
+                function foo() {
+                    try {
+                        $bar = bar();
+                
+                        return $bar;
+                    } catch (\LogicException $e) {
+                        echo "catch ... ";
+                    } catch (\RuntimeException $e) {
+                        echo $bar;
+                    }
+                }'
+            ],
         ];
     }
 

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -977,6 +977,22 @@ var_dump($a); // $a = 2 here _╯°□°╯︵┻━┻
                 }
                 ',
             ],
+            'try finally' => [
+                '<?php
+                function add($a, $b): mixed
+                {
+                    try {
+                        $result = $a + $b;
+
+                        return $result;
+                    } catch (\Throwable $th) {
+                        throw $th;
+                    } finally {
+                        echo \'result:\', $result, \PHP_EOL;
+                    }
+                }
+                ',
+            ],
         ];
     }
 

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -624,7 +624,7 @@ var names are case-insensitive */ return $a   ;}
                 '<?php
                 function foo()
                 {
-                    if (isSomeContiotion()) {
+                    if (isSomeCondition()) {
                         return getSomeResult();
                     }
 
@@ -640,7 +640,7 @@ var names are case-insensitive */ return $a   ;}
                 '<?php
                 function foo()
                 {
-                    if (isSomeContiotion()) {
+                    if (isSomeCondition()) {
                         $result = getSomeResult();
 
                         return $result;
@@ -666,7 +666,7 @@ var names are case-insensitive */ return $a   ;}
                         error_log($exception->getMessage());
                     }
 
-                    if (isSomeContiotion()) {
+                    if (isSomeCondition()) {
                         return getSomeResult();
                     }
 
@@ -688,7 +688,7 @@ var names are case-insensitive */ return $a   ;}
                         error_log($exception->getMessage());
                     }
 
-                    if (isSomeContiotion()) {
+                    if (isSomeCondition()) {
                         $result = getSomeResult();
                         return $result;
                     }
@@ -706,7 +706,7 @@ var names are case-insensitive */ return $a   ;}
                 '<?php
                 function foo()
                 {
-                    if (isSomeContiotion()) {
+                    if (isSomeCondition()) {
                         return getSomeResult();
                     }
 
@@ -724,7 +724,7 @@ var names are case-insensitive */ return $a   ;}
                 '<?php
                 function foo()
                 {
-                    if (isSomeContiotion()) {
+                    if (isSomeCondition()) {
                         $result = getSomeResult();
 
                         return $result;
@@ -752,7 +752,7 @@ var names are case-insensitive */ return $a   ;}
                         error_log($exception->getMessage());
                     }
 
-                    if (isSomeContiotion()) {
+                    if (isSomeCondition()) {
                         return getSomeResult();
                     }
 
@@ -776,7 +776,7 @@ var names are case-insensitive */ return $a   ;}
                         error_log($exception->getMessage());
                     }
 
-                    if (isSomeContiotion()) {
+                    if (isSomeCondition()) {
                         $result = getSomeResult();
                         return $result;
                     }

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -1165,7 +1165,7 @@ var_dump($a); // $a = 2 here _╯°□°╯︵┻━┻
                 }
                 ',
             ],
-            'try finally2' => [
+            'try with multiple catch blocks' => [
                 '<?php
                 function foo() {
                     try {


### PR DESCRIPTION
fix #6691