### PR TITLE
bug: Fix non-parenthesized callable return type parse

### DIFF
--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -57,7 +57,7 @@ final class TypeExpression
                     \h*\)
                     (?:
                         \h*\:\h*
-                        (?<callable_return>(?&types))
+                        (?<callable_return>(?&type))
                     )?
                 )
                 |
@@ -88,7 +88,7 @@ final class TypeExpression
                     (?i)
                     null | true | false
                     | -?(?:\d+(?:\.\d*)?|\.\d+) # all sorts of numbers with or without minus, e.g.: 1, 1.1, 1., .1, -1
-                    | \'(?:[^\'\\\\]|\\\\.)+?\' | "(?:[^"\\\\]|\\\\.)+?"
+                    | \'(?:[^\'\\\\]|\\\\.)*?\' | "(?:[^"\\\\]|\\\\.)*?"
                     | [@$]?(?:this | self | static)
                     (?-i)
                 )

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -405,8 +405,13 @@ final class TypeExpressionTest extends TestCase
         ];
 
         yield 'simple in callable return type' => [
-            'callable(): string|float',
-            'callable(): string|float',
+            'callable(): (string|float)',
+            'callable(): (float|string)',
+        ];
+
+        yield 'callable with union return type and within union itself' => [
+            'callable(): (string|float)|bool',
+            'bool|callable(): (float|string)',
         ];
 
         yield 'simple in closure argument' => [
@@ -420,13 +425,23 @@ final class TypeExpressionTest extends TestCase
         ];
 
         yield 'simple in closure return type' => [
-            'Closure(): string|float',
-            'Closure(): string|float',
+            'Closure(): (string|float)',
+            'Closure(): (float|string)',
+        ];
+
+        yield 'closure with union return type and within union itself' => [
+            'Closure(): (string|float)|bool',
+            'bool|Closure(): (float|string)',
         ];
 
         yield 'with multiple nesting levels' => [
-            'array{0: Foo<int|bool>|Bar<callable(string|float|array<int|bool>): Foo|Bar>}',
-            'array{0: Bar<Bar|callable(array<bool|int>|float|string): Foo>|Foo<bool|int>}',
+            'array{0: Foo<int|bool>|Bar<callable(string|float|array<int|bool>): (Foo|Bar)>}',
+            'array{0: Bar<callable(array<bool|int>|float|string): (Bar|Foo)>|Foo<bool|int>}',
+        ];
+
+        yield 'with multiple nesting levels and callable within union' => [
+            'array{0: Foo<int|bool>|Bar<callable(string|float|array<int|bool>): (Foo|Bar)|Baz>}',
+            'array{0: Bar<Baz|callable(array<bool|int>|float|string): (Bar|Foo)>|Foo<bool|int>}',
         ];
 
         yield 'nullable generic' => [
@@ -435,13 +450,15 @@ final class TypeExpressionTest extends TestCase
         ];
 
         yield 'nullable callable' => [
-            '?callable(Foo|Bar): Foo|Bar',
-            '?callable(Bar|Foo): Foo|Bar',
+            '?callable(Foo|Bar): (Foo|Bar)',
+            '?callable(Bar|Foo): (Bar|Foo)',
         ];
 
-        yield 'nullable callable and union' => [
-            '?callable(Foo|Bar): (Foo|Bar)|Bar',
-            '?callable(Bar|Foo): (Bar|Foo)|Bar',
+        // This union type makes no sense in general (it should be `Bar|callable|null`)
+        // but let's ensure nullable types are also sorted.
+        yield 'nullable callable with union return type and within union itself' => [
+            '?callable(Foo|Bar): (Foo|Bar)|?Bar',
+            '?Bar|?callable(Bar|Foo): (Bar|Foo)',
         ];
 
         yield 'nullable array shape' => [

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -156,6 +156,8 @@ final class TypeExpressionTest extends TestCase
 
         yield ['\\Closure(string|int, bool): bool', ['\\Closure(string|int, bool): bool']];
 
+        yield ['\\Closure(float|int): (bool|int)', ['\\Closure(float|int): (bool|int)']];
+
         yield ['array  <  int   , callable  (  string  )  :   bool  >', ['array  <  int   , callable  (  string  )  :   bool  >']];
 
         yield ['(int)', ['(int)']];
@@ -404,7 +406,7 @@ final class TypeExpressionTest extends TestCase
 
         yield 'simple in callable return type' => [
             'callable(): string|float',
-            'callable(): float|string',
+            'callable(): string|float',
         ];
 
         yield 'simple in closure argument' => [
@@ -419,12 +421,12 @@ final class TypeExpressionTest extends TestCase
 
         yield 'simple in closure return type' => [
             'Closure(): string|float',
-            'Closure(): float|string',
+            'Closure(): string|float',
         ];
 
         yield 'with multiple nesting levels' => [
             'array{0: Foo<int|bool>|Bar<callable(string|float|array<int|bool>): Foo|Bar>}',
-            'array{0: Bar<callable(array<bool|int>|float|string): Bar|Foo>|Foo<bool|int>}',
+            'array{0: Bar<Bar|callable(array<bool|int>|float|string): Foo>|Foo<bool|int>}',
         ];
 
         yield 'nullable generic' => [
@@ -434,7 +436,7 @@ final class TypeExpressionTest extends TestCase
 
         yield 'nullable callable' => [
             '?callable(Foo|Bar): Foo|Bar',
-            '?callable(Bar|Foo): Bar|Foo',
+            '?callable(Bar|Foo): Foo|Bar',
         ];
 
         yield 'nullable array shape' => [

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -35,6 +35,17 @@ final class TypeExpressionTest extends TestCase
     {
         $expression = new TypeExpression($typesExpression, null, []);
         self::assertSame($expectedTypes, $expression->getTypes());
+
+        $unionTestNs = '__UnionTest__';
+        $unionExpression = new TypeExpression(
+            $unionTestNs.'\\A|'.$typesExpression.'|'.$unionTestNs.'\\Z',
+            null,
+            []
+        );
+        self::assertSame(
+            [$unionTestNs.'\\A', ...$expectedTypes, $unionTestNs.'\\Z'],
+            [...$unionExpression->getTypes()]
+        );
     }
 
     public static function provideGetTypesCases(): iterable

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -439,6 +439,11 @@ final class TypeExpressionTest extends TestCase
             '?callable(Bar|Foo): Foo|Bar',
         ];
 
+        yield 'nullable callable and union' => [
+            '?callable(Foo|Bar): (Foo|Bar)|Bar',
+            '?callable(Bar|Foo): (Bar|Foo)|Bar',
+        ];
+
         yield 'nullable array shape' => [
             '?array{0: Foo|Bar}',
             '?array{0: Bar|Foo}',


### PR DESCRIPTION
`\Closure: int|float` must be parsed as `(\Closure: int) | float`

Parenthesized type can be parsed as of https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6796.

`TypeExpressionTest::testGetTypes` is improved to test if the type is really split/parsed as expected.

Also fix empty string parse (`''`, `""`).