### PR TITLE
bug: Fix array/object shape phpdoc type parse

### DIFF
--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -35,10 +35,10 @@ final class TypeExpression
             (?<nullable>\??)
             (?:
                 (?<object_like_array>
-                    (?<object_like_array_start>array\h*\{)
+                    (?<object_like_array_start>(array|object)\h*\{)
                         (?<object_like_array_keys>
                             (?<object_like_array_key>
-                                \h*[^?:\h]+\h*\??\h*:\h*(?&types)
+                                \h*(?:(?:(?&constant)|(?&name))\h*\??\h*:\h*)?(?&types)
                             )
                             (?:\h*,(?&object_like_array_key))*
                         )
@@ -422,7 +422,7 @@ final class TypeExpression
     {
         while ('' !== $value) {
             Preg::match(
-                '{(?<_start>^.+?:\h*)'.self::REGEX_TYPES.'\h*(?:,|$)}x',
+                '{(?<_start>^(?:.+?:)?\h*)'.self::REGEX_TYPES.'\h*(?:,|$)}x',
                 $value,
                 $matches
             );
@@ -433,7 +433,7 @@ final class TypeExpression
             ];
 
             $newValue = Preg::replace(
-                '/^.+?:\h*'.preg_quote($matches['types'], '/').'(\h*\,\h*)?/',
+                '/^(?:.+?:)?\h*'.preg_quote($matches['types'], '/').'(\h*\,\h*)?/',
                 '',
                 $value
             );

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -42,7 +42,7 @@ final class TypeExpression
                                 (?<object_like_array_inner_value>(?&types))
                             )
                             (?:\h*,\h*(?&object_like_array_inner))*
-                        )
+                        )?
                     \h*\}
                 )
                 |
@@ -346,7 +346,7 @@ final class TypeExpression
         if ('' !== ($matches['object_like_array'] ?? '')) {
             $this->parseObjectLikeArrayInnerTypes(
                 $index + \strlen($matches['object_like_array_start']),
-                $matches['object_like_array_inners']
+                $matches['object_like_array_inners'] ?? ''
             );
 
             return;

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -204,7 +204,7 @@ class Tokens extends \SplFixedArray
     }
 
     /**
-     * @return array<self::BLOCK_TYPE_*, array<'start'|'end', string|array{int, string}>>
+     * @return array<self::BLOCK_TYPE_*, array<'end'|'start', array{int, string}|string>>
      */
     public static function getBlockEdgeDefinitions(): array
     {
@@ -535,9 +535,9 @@ class Tokens extends \SplFixedArray
      *
      * This method is shorthand for getTokenOfKindSibling method.
      *
-     * @param int $index token index
+     * @param int                           $index         token index
      * @param list<array{int}|string|Token> $tokens        possible tokens
-     * @param bool $caseSensitive perform a case sensitive comparison
+     * @param bool                          $caseSensitive perform a case sensitive comparison
      */
     public function getNextTokenOfKind(int $index, array $tokens = [], bool $caseSensitive = true): ?int
     {
@@ -583,9 +583,9 @@ class Tokens extends \SplFixedArray
      * Get index for closest previous token of given kind.
      * This method is shorthand for getTokenOfKindSibling method.
      *
-     * @param int $index token index
+     * @param int                           $index         token index
      * @param list<array{int}|string|Token> $tokens        possible tokens
-     * @param bool $caseSensitive perform a case sensitive comparison
+     * @param bool                          $caseSensitive perform a case sensitive comparison
      */
     public function getPrevTokenOfKind(int $index, array $tokens = [], bool $caseSensitive = true): ?int
     {
@@ -595,10 +595,10 @@ class Tokens extends \SplFixedArray
     /**
      * Get index for closest sibling token of given kind.
      *
-     * @param int  $index     token index
-     * @param -1|1 $direction
-     * @param list<array{int}|string|Token> $tokens possible tokens
-     * @param bool $caseSensitive perform a case sensitive comparison
+     * @param int                           $index         token index
+     * @param -1|1                          $direction
+     * @param list<array{int}|string|Token> $tokens        possible tokens
+     * @param bool                          $caseSensitive perform a case sensitive comparison
      */
     public function getTokenOfKindSibling(int $index, int $direction, array $tokens = [], bool $caseSensitive = true): ?int
     {
@@ -626,9 +626,9 @@ class Tokens extends \SplFixedArray
     /**
      * Get index for closest sibling token not of given kind.
      *
-     * @param int  $index     token index
-     * @param -1|1 $direction
-     * @param list<array{int}|string|Token> $tokens possible tokens
+     * @param int                           $index     token index
+     * @param -1|1                          $direction
+     * @param list<array{int}|string|Token> $tokens    possible tokens
      */
     public function getTokenNotOfKindSibling(int $index, int $direction, array $tokens = []): ?int
     {

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -439,6 +439,11 @@ final class TypeExpressionTest extends TestCase
             'array{0: Bar<callable(array<bool|int>|float|string): Bar|Foo>|Foo<bool|int>}',
         ];
 
+        yield 'complex type with Closure with $this' => [
+            'array<string, string|array{ string|\Closure(mixed, string, $this): (int|float) }>|false',
+            'array<string, array{ \Closure(mixed, string, $this): (float|int)|string }|string>|false',
+        ];
+
         yield 'nullable generic' => [
             '?array<Foo|Bar>',
             '?array<Bar|Foo>',

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -390,6 +390,16 @@ final class TypeExpressionTest extends TestCase
             'array{bool|int}',
         ];
 
+        yield 'array shape with multiple colons - array shape' => [
+            'array{array{x:int|bool}, a:array{x:int|bool}}',
+            'array{array{x:bool|int}, a:array{x:bool|int}}',
+        ];
+
+        yield 'array shape with multiple colons - callable' => [
+            'array{array{x:int|bool}, int|bool, callable(): void}',
+            'array{array{x:bool|int}, bool|int, callable(): void}',
+        ];
+
         yield 'simple in callable argument' => [
             'callable(int|bool)',
             'callable(bool|int)',

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -111,6 +111,10 @@ final class TypeExpressionTest extends TestCase
 
         yield ['array { a : int | string , b ? : A<B, C> }', ['array { a : int | string , b ? : A<B, C> }']];
 
+        yield ['array{bool, int}', ['array{bool, int}']];
+
+        yield ['object{ bool, foo2: int }', ['object{ bool, foo2: int }']];
+
         yield ['callable(string)', ['callable(string)']];
 
         yield ['callable(string): bool', ['callable(string): bool']];
@@ -379,6 +383,11 @@ final class TypeExpressionTest extends TestCase
         yield 'simple in array shape with multiple keys' => [
             'array{0: int|bool, "foo": int|bool}',
             'array{0: bool|int, "foo": bool|int}',
+        ];
+
+        yield 'simple in array shape with implicit key' => [
+            'array{int|bool}',
+            'array{bool|int}',
         ];
 
         yield 'simple in callable argument' => [

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -103,6 +103,10 @@ final class TypeExpressionTest extends TestCase
 
         yield ['A & B', ['A', 'B']];
 
+        yield ['array{}', ['array{}']];
+
+        yield ['object{ }', ['object{ }']];
+
         yield ['array{1: bool, 2: bool}', ['array{1: bool, 2: bool}']];
 
         yield ['array{a: int|string, b?: bool}', ['array{a: int|string, b?: bool}']];

--- a/tests/Fixer/Basic/EncodingFixerTest.php
+++ b/tests/Fixer/Basic/EncodingFixerTest.php
@@ -43,7 +43,7 @@ final class EncodingFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @return array{string, string|null, \SplFileInfo}
+     * @return array{string, null|string, \SplFileInfo}
      */
     private static function prepareTestCase(string $expectedFilename, ?string $inputFilename = null): array
     {

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -623,8 +623,8 @@ PHP;
     }
 
     /**
-     * @param ?int $expectedIndex
-     * @param -1|1 $direction
+     * @param ?int                          $expectedIndex
+     * @param -1|1                          $direction
      * @param list<array{int}|string|Token> $findTokens
      *
      * @dataProvider provideTokenOfKindSiblingCases


### PR DESCRIPTION
- fix array shape parse with implicit key
- fix array shape parse with no value (`array{}`)
- add support for object shapes
- fix shape parsing when multiple colons are present (previously parsed by `[^?:\h]+\h*\??\h*:\h*`/`.+?:\h*`, now parsed by the actual grammar)

array shape key grammar: https://github.com/phpstan/phpdoc-parser/blob/1.20.4/doc/grammars/type.abnf#L70