### PR TITLE
DX: improve test method names to avoid confusion

### DIFF
--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -4125,16 +4125,16 @@ declare   (   ticks   =   1   )   {
     /**
      * @param array<string, mixed> $configuration
      *
-     * @dataProvider provideFix70Cases
+     * @dataProvider provideFixCases
      */
-    public function testFix70(string $expected, ?string $input = null, array $configuration = []): void
+    public function testFix(string $expected, ?string $input = null, array $configuration = []): void
     {
         $this->fixer->configure($configuration);
 
         $this->doTest($expected, $input);
     }
 
-    public static function provideFix70Cases(): iterable
+    public static function provideFixCases(): iterable
     {
         return [
             [

--- a/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
+++ b/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
@@ -26,7 +26,7 @@ final class LowercaseCastFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix74(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
+++ b/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
@@ -26,7 +26,7 @@ final class ShortScalarCastFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix74(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -29,7 +29,7 @@ final class ClassAttributesSeparationFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFixCases(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Operator/AssignNullCoalescingToCoalesceEqualFixerTest.php
+++ b/tests/Fixer/Operator/AssignNullCoalescingToCoalesceEqualFixerTest.php
@@ -24,14 +24,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class AssignNullCoalescingToCoalesceEqualFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideFix74Cases
+     * @dataProvider provideFixCases
      */
-    public function testFix74(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFix74Cases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'simple' => [
             '<?php $a ??= 1;',


### PR DESCRIPTION
These are leftovers since the fixer was supporting PHP 5.6 and those methods had `@requires` annotation for PHPUnit.