### PR TITLE
bug: Fix `TypeExpression::allowsNull()` with nullable

### DIFF
--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -250,6 +250,8 @@ final class TypeExpression
 
             if (isset($aliases[$type])) {
                 $type = $aliases[$type];
+            } elseif (str_starts_with($type, '?')) {
+                $type = substr($type, 1);
             } elseif (1 === Preg::match('/\[\]$/', $type)) {
                 $type = 'array';
             } elseif (1 === Preg::match('/^(.+?)</', $type, $matches)) {

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -254,7 +254,7 @@ final class TypeExpression
 
             if (1 === Preg::match('/\[\h*\]$/', $type)) {
                 $type = 'array';
-            } elseif (1 === Preg::match('/^(.+?)\h*</', $type, $matches)) {
+            } elseif (1 === Preg::match('/^(.+?)\h*[<{(]/', $type, $matches)) {
                 $type = $matches[1];
             }
 

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -252,12 +252,14 @@ final class TypeExpression
                 $type = substr($type, 1);
             }
 
-            if (isset($aliases[$type])) {
-                $type = $aliases[$type];
-            } elseif (1 === Preg::match('/\[\]$/', $type)) {
+            if (1 === Preg::match('/\[\]$/', $type)) {
                 $type = 'array';
             } elseif (1 === Preg::match('/^(.+?)</', $type, $matches)) {
                 $type = $matches[1];
+            }
+
+            if (isset($aliases[$type])) {
+                $type = $aliases[$type];
             }
 
             if (null === $mainType || $type === $mainType) {
@@ -550,6 +552,7 @@ final class TypeExpression
             'double' => 'float',
             'false' => 'bool',
             'integer' => 'int',
+            'list' => 'array',
             'real' => 'float',
             'true' => 'bool',
         ];

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -252,9 +252,9 @@ final class TypeExpression
                 $type = substr($type, 1);
             }
 
-            if (1 === Preg::match('/\[\]$/', $type)) {
+            if (1 === Preg::match('/\[\h*\]$/', $type)) {
                 $type = 'array';
-            } elseif (1 === Preg::match('/^(.+?)</', $type, $matches)) {
+            } elseif (1 === Preg::match('/^(.+?)\h*</', $type, $matches)) {
                 $type = $matches[1];
             }
 

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -248,10 +248,12 @@ final class TypeExpression
                 continue;
             }
 
+            if (str_starts_with($type, '?')) {
+                $type = substr($type, 1);
+            }
+
             if (isset($aliases[$type])) {
                 $type = $aliases[$type];
-            } elseif (str_starts_with($type, '?')) {
-                $type = substr($type, 1);
             } elseif (1 === Preg::match('/\[\]$/', $type)) {
                 $type = 'array';
             } elseif (1 === Preg::match('/^(.+?)</', $type, $matches)) {

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -275,7 +275,7 @@ final class TypeExpression
     public function allowsNull(): bool
     {
         foreach ($this->getTypes() as $type) {
-            if (\in_array($type, ['null', 'mixed'], true)) {
+            if (\in_array($type, ['null', 'mixed'], true) || str_starts_with($type, '?')) {
                 return true;
             }
         }

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -366,6 +366,12 @@ final class TypeExpressionTest extends TestCase
 
         yield ['Collection<int, string>', 'Collection'];
 
+        yield ['array{string}', 'array'];
+
+        yield ['array { 1: string, \Closure(): void }', 'array'];
+
+        yield ['Closure(): void', 'Closure'];
+
         yield ['array<int, string>|iterable<int, string>', 'iterable'];
 
         yield ['int[]|string[]', 'array'];

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -368,6 +368,8 @@ final class TypeExpressionTest extends TestCase
 
         yield ['?int', 'int'];
 
+        yield ['?array<Foo>', 'array'];
+
         yield ['void', 'void'];
 
         yield ['never', 'never'];

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -420,7 +420,7 @@ final class TypeExpressionTest extends TestCase
 
         yield ['?int', true];
 
-        yield ['bool|?\Closure(): void', true];
+        yield ['?\Closure(): void', true];
     }
 
     /**

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -346,6 +346,8 @@ final class TypeExpressionTest extends TestCase
 
         yield ['array<int, string>', 'array'];
 
+        yield ['list<int>', 'array'];
+
         yield ['iterable<string>', 'iterable'];
 
         yield ['iterable<int, string>', 'iterable'];
@@ -369,6 +371,8 @@ final class TypeExpressionTest extends TestCase
         yield ['?int', 'int'];
 
         yield ['?array<Foo>', 'array'];
+
+        yield ['?list<Foo>', 'array'];
 
         yield ['void', 'void'];
 

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -366,6 +366,8 @@ final class TypeExpressionTest extends TestCase
 
         yield ['null|int', 'int'];
 
+        yield ['?int', 'int'];
+
         yield ['void', 'void'];
 
         yield ['never', 'never'];

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -330,6 +330,10 @@ final class TypeExpressionTest extends TestCase
 
         yield ['array[][]', 'array'];
 
+        yield ['bool [ ]', 'array'];
+
+        yield ['bool [ ][ ]', 'array'];
+
         yield ['array|iterable', 'iterable'];
 
         yield ['iterable|array', 'iterable'];
@@ -345,6 +349,8 @@ final class TypeExpressionTest extends TestCase
         yield ['array<string>', 'array'];
 
         yield ['array<int, string>', 'array'];
+
+        yield ['array < string >', 'array'];
 
         yield ['list<int>', 'array'];
 

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -417,6 +417,10 @@ final class TypeExpressionTest extends TestCase
         yield ['bool', false];
 
         yield ['string', false];
+
+        yield ['?int', true];
+
+        yield ['bool|?\Closure(): void', true];
     }
 
     /**

--- a/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
@@ -296,6 +296,10 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
                 '<?php /** @param null|Foo $foo */ function my_foo(?Foo $foo) {}',
                 '<?php /** @param null|Foo $foo */ function my_foo($foo) {}',
             ],
+            'nullable with ? notation in phpDoc' => [
+                '<?php /** @param ?Foo $foo */ function my_foo(?Foo $foo) {}',
+                '<?php /** @param ?Foo $foo */ function my_foo($foo) {}',
+            ],
             'array and iterable param' => [
                 '<?php /** @param Foo[]|iterable $foo */ function my_foo(iterable $foo) {}',
                 '<?php /** @param Foo[]|iterable $foo */ function my_foo($foo) {}',

--- a/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
@@ -146,6 +146,10 @@ final class PhpdocToPropertyTypeFixerTest extends AbstractFixerTestCase
                 '<?php class Foo { /** @var null|Bar */ private ?Bar $foo; }',
                 '<?php class Foo { /** @var null|Bar */ private $foo; }',
             ],
+            'nullable type with ? notation in phpDoc' => [
+                '<?php class Foo { /** @var ?Bar */ private ?Bar $foo; }',
+                '<?php class Foo { /** @var ?Bar */ private $foo; }',
+            ],
             'nullable type reverse order' => [
                 '<?php class Foo { /** @var Bar|null */ private ?Bar $foo; }',
                 '<?php class Foo { /** @var Bar|null */ private $foo; }',

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -203,6 +203,10 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
                 '<?php /** @return null|Bar */ function my_foo(): ?Bar {}',
                 '<?php /** @return null|Bar */ function my_foo() {}',
             ],
+            'nullable type with ? notation in phpDoc' => [
+                '<?php /** @return ?Bar */ function my_foo(): ?Bar {}',
+                '<?php /** @return ?Bar */ function my_foo() {}',
+            ],
             'nullable type reverse order' => [
                 '<?php /** @return Bar|null */ function my_foo(): ?Bar {}',
                 '<?php /** @return Bar|null */ function my_foo() {}',


### PR DESCRIPTION
No test failed after the fix... But `allowsNull` method name implies it should work with nullable phpdoc?