### PR TITLE
feature: Introduce `NullableTypeDeclarationFixer`

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1869,6 +1869,19 @@ List of Available Rules
    Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PER-CS1.0 <./ruleSets/PER-CS1.0.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Whitespace\\NoWhitespaceInBlankLineFixer <./../src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php>`_
+-  `nullable_type_declaration <./rules/language_construct/nullable_type_declaration.rst>`_
+
+   Nullable single type declaration should be standardised using configured syntax.
+
+   Configuration options:
+
+   - | ``syntax``
+     | Whether to use question mark (`?`) or explicit `null` union for nullable type.
+     | Allowed values: ``'question_mark'`` and ``'union'``
+     | Default value: ``'question_mark'``
+
+
+   `Source PhpCsFixer\\Fixer\\LanguageConstruct\\NullableTypeDeclarationFixer <./../src/Fixer/LanguageConstruct/NullableTypeDeclarationFixer.php>`_
 -  `nullable_type_declaration_for_default_null_value <./rules/function_notation/nullable_type_declaration_for_default_null_value.rst>`_
 
    Adds or removes ``?`` before single type declarations or ``|null`` at the end of union types when parameters have a default ``null`` value.

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -471,6 +471,9 @@ Language Construct
 - `no_unset_on_property <./language_construct/no_unset_on_property.rst>`_ *(risky)*
 
   Properties should be set to ``null`` instead of using ``unset``.
+- `nullable_type_declaration <./language_construct/nullable_type_declaration.rst>`_
+
+  Nullable single type declaration should be standardised using configured syntax.
 - `single_space_after_construct <./language_construct/single_space_after_construct.rst>`_ *(deprecated)*
 
   Ensures a single space after language constructs.

--- a/doc/rules/language_construct/nullable_type_declaration.rst
+++ b/doc/rules/language_construct/nullable_type_declaration.rst
@@ -1,0 +1,68 @@
+==================================
+Rule ``nullable_type_declaration``
+==================================
+
+Nullable single type declaration should be standardised using configured syntax.
+
+Configuration
+-------------
+
+``syntax``
+~~~~~~~~~~
+
+Whether to use question mark (``?``) or explicit ``null`` union for nullable
+type.
+
+Allowed values: ``'question_mark'`` and ``'union'``
+
+Default value: ``'question_mark'``
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+*Default* configuration.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -function bar(null|int $value, null|\Closure $callable): void {}
+   +function bar(?int $value, ?\Closure $callable): void {}
+
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['syntax' => 'union']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -function baz(?int $value, ?\stdClass $obj, ?array $config): ?int {}
+   +function baz(null|int $value, null|\stdClass $obj, null|array $config): null|int {}
+
+Example #3
+~~~~~~~~~~
+
+With configuration: ``['syntax' => 'question_mark']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    class ValueObject
+    {
+   -    public null|string $name;
+   +    public ?string $name;
+        public ?int $count;
+   -    public null|bool $internal;
+   -    public null|\Closure $callback;
+   +    public ?bool $internal;
+   +    public ?\Closure $callback;
+    }

--- a/src/Fixer/ClassNotation/OrderedTypesFixer.php
+++ b/src/Fixer/ClassNotation/OrderedTypesFixer.php
@@ -86,7 +86,7 @@ interface Bar
      * {@inheritdoc}
      *
      * Must run before TypesSpacesFixer.
-     * Must run after NullableTypeDeclarationForDefaultNullValueFixer.
+     * Must run after NullableTypeDeclarationFixer, NullableTypeDeclarationForDefaultNullValueFixer.
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php
+++ b/src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php
@@ -79,11 +79,11 @@ final class NullableTypeDeclarationForDefaultNullValueFixer extends AbstractFixe
     /**
      * {@inheritdoc}
      *
-     * Must run before NoUnreachableDefaultArgumentValueFixer, OrderedTypesFixer.
+     * Must run before NoUnreachableDefaultArgumentValueFixer, NullableTypeDeclarationFixer, OrderedTypesFixer.
      */
     public function getPriority(): int
     {
-        return 1;
+        return 3;
     }
 
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface

--- a/src/Fixer/LanguageConstruct/NullableTypeDeclarationFixer.php
+++ b/src/Fixer/LanguageConstruct/NullableTypeDeclarationFixer.php
@@ -1,0 +1,335 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\LanguageConstruct;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Preg;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\TypeAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+
+/**
+ * @author John Paul E. Balandan, CPA <paulbalandan@gmail.com>
+ */
+final class NullableTypeDeclarationFixer extends AbstractFixer implements ConfigurableFixerInterface
+{
+    private const OPTION_SYNTAX_UNION = 'union';
+    private const OPTION_SYNTAX_QUESTION_MARK = 'question_mark';
+
+    private int $candidateTokenKind;
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Nullable single type declaration should be standardised using configured syntax.',
+            [
+                new VersionSpecificCodeSample(
+                    "<?php\nfunction bar(null|int \$value, null|\\Closure \$callable): void {}\n",
+                    new VersionSpecification(8_00_00)
+                ),
+                new VersionSpecificCodeSample(
+                    "<?php\nfunction baz(?int \$value, ?\\stdClass \$obj, ?array \$config): ?int {}\n",
+                    new VersionSpecification(8_00_00),
+                    ['syntax' => self::OPTION_SYNTAX_UNION]
+                ),
+                new VersionSpecificCodeSample(
+                    '<?php
+class ValueObject
+{
+    public null|string $name;
+    public ?int $count;
+    public null|bool $internal;
+    public null|\Closure $callback;
+}
+',
+                    new VersionSpecification(8_00_00),
+                    ['syntax' => self::OPTION_SYNTAX_QUESTION_MARK]
+                ),
+            ]
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return \PHP_VERSION_ID >= 8_00_00 && $tokens->isTokenKindFound($this->candidateTokenKind);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Must run before OrderedTypesFixer, TypesSpacesFixer.
+     * Must run after NullableTypeDeclarationForDefaultNullValueFixer, SingleSpaceAroundConstructFixer.
+     */
+    public function getPriority(): int
+    {
+        return 2;
+    }
+
+    public function configure(array $configuration): void
+    {
+        parent::configure($configuration);
+
+        $this->candidateTokenKind = self::OPTION_SYNTAX_QUESTION_MARK === $this->configuration['syntax']
+            ? CT::T_TYPE_ALTERNATION // `|` -> `?`
+            : CT::T_NULLABLE_TYPE; // `?` -> `|`
+    }
+
+    protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('syntax', 'Whether to use question mark (`?`) or explicit `null` union for nullable type.'))
+                ->setAllowedValues([self::OPTION_SYNTAX_UNION, self::OPTION_SYNTAX_QUESTION_MARK])
+                ->setDefault(self::OPTION_SYNTAX_QUESTION_MARK)
+                ->getOption(),
+        ]);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        $functionsAnalyzer = new FunctionsAnalyzer();
+
+        foreach (array_reverse($this->getElements($tokens), true) as $index => $type) {
+            if ('property' === $type) {
+                $this->normalizePropertyType($tokens, $index);
+
+                continue;
+            }
+
+            // fix return before arguments
+            $this->normalizeMethodReturnType($functionsAnalyzer, $tokens, $index);
+            $this->normalizeMethodArgumentType($functionsAnalyzer, $tokens, $index);
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     *
+     * @phpstan-return array<int, 'method'|'property'>
+     */
+    private function getElements(Tokens $tokens): array
+    {
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+
+        $elements = array_map(
+            static fn (array $element): string => $element['type'],
+            array_filter(
+                $tokensAnalyzer->getClassyElements(),
+                static fn (array $element): bool => \in_array($element['type'], ['method', 'property'], true)
+            )
+        );
+
+        foreach ($tokens as $index => $token) {
+            if (
+                $token->isGivenKind(T_FN)
+                || ($token->isGivenKind(T_FUNCTION) && !isset($elements[$index]))
+            ) {
+                $elements[$index] = 'method';
+            }
+        }
+
+        return $elements;
+    }
+
+    private function collectTypeAnalysis(Tokens $tokens, int $startIndex, int $endIndex): ?TypeAnalysis
+    {
+        $type = '';
+        $typeStartIndex = $tokens->getNextMeaningfulToken($startIndex);
+        $typeEndIndex = $typeStartIndex;
+
+        for ($i = $typeStartIndex; $i < $endIndex; ++$i) {
+            if ($tokens[$i]->isWhitespace() || $tokens[$i]->isComment()) {
+                continue;
+            }
+
+            $type .= $tokens[$i]->getContent();
+            $typeEndIndex = $i;
+        }
+
+        return '' !== $type ? new TypeAnalysis($type, $typeStartIndex, $typeEndIndex) : null;
+    }
+
+    private function isTypeNormalizable(TypeAnalysis $typeAnalysis): bool
+    {
+        if (!$typeAnalysis->isNullable()) {
+            return false;
+        }
+
+        $type = $typeAnalysis->getName();
+
+        if (str_contains($type, '&')) {
+            return false; // skip DNF types
+        }
+
+        if (!str_contains($type, '|')) {
+            return true;
+        }
+
+        return str_contains($type, '|')
+            && 1 === substr_count($type, '|')
+            && 1 === Preg::match('/(?:\|null$|^null\|)/i', $type);
+    }
+
+    private function normalizePropertyType(Tokens $tokens, int $index): void
+    {
+        $propertyEndIndex = $index;
+        $propertyModifiers = [T_PRIVATE, T_PROTECTED, T_PUBLIC, T_STATIC, T_VAR];
+
+        if (\defined('T_READONLY')) {
+            $propertyModifiers[] = T_READONLY; // @TODO: Drop condition when PHP 8.1+ is required
+        }
+
+        do {
+            $index = $tokens->getPrevMeaningfulToken($index);
+        } while (!$tokens[$index]->isGivenKind($propertyModifiers));
+
+        $propertyType = $this->collectTypeAnalysis($tokens, $index, $propertyEndIndex);
+
+        if (null === $propertyType || !$this->isTypeNormalizable($propertyType)) {
+            return;
+        }
+
+        $this->normalizeNullableType($tokens, $propertyType);
+    }
+
+    private function normalizeMethodArgumentType(FunctionsAnalyzer $functionsAnalyzer, Tokens $tokens, int $index): void
+    {
+        foreach (array_reverse($functionsAnalyzer->getFunctionArguments($tokens, $index), true) as $argumentInfo) {
+            $argumentType = $argumentInfo->getTypeAnalysis();
+
+            if (null === $argumentType || !$this->isTypeNormalizable($argumentType)) {
+                continue;
+            }
+
+            $this->normalizeNullableType($tokens, $argumentType);
+        }
+    }
+
+    private function normalizeMethodReturnType(FunctionsAnalyzer $functionsAnalyzer, Tokens $tokens, int $index): void
+    {
+        $returnType = $functionsAnalyzer->getFunctionReturnType($tokens, $index);
+
+        if (null === $returnType || !$this->isTypeNormalizable($returnType)) {
+            return;
+        }
+
+        $this->normalizeNullableType($tokens, $returnType);
+    }
+
+    private function normalizeNullableType(Tokens $tokens, TypeAnalysis $typeAnalysis): void
+    {
+        $type = $typeAnalysis->getName();
+
+        if (!str_contains($type, '|') && !str_contains($type, '&')) {
+            $type = ($typeAnalysis->isNullable() ? '?' : '').$type;
+        }
+
+        $isQuestionMarkSyntax = self::OPTION_SYNTAX_QUESTION_MARK === $this->configuration['syntax'];
+
+        if ($isQuestionMarkSyntax) {
+            $normalizedType = $this->convertToNullableType($type);
+            $normalizedTypeAsString = implode('', $normalizedType);
+        } else {
+            $normalizedType = $this->convertToExplicitUnionType($type);
+            $normalizedTypeAsString = implode('|', $normalizedType);
+        }
+
+        if ($normalizedTypeAsString === $type) {
+            return; // nothing to fix
+        }
+
+        $tokens->overrideRange(
+            $typeAnalysis->getStartIndex(),
+            $typeAnalysis->getEndIndex(),
+            $this->createTypeDeclarationTokens($normalizedType, $isQuestionMarkSyntax)
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function convertToNullableType(string $type): array
+    {
+        if (str_starts_with($type, '?')) {
+            return [$type]; // no need to convert; already fixed
+        }
+
+        return ['?', Preg::replace('/(?:\|null$|^null\|)/i', '', $type)];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function convertToExplicitUnionType(string $type): array
+    {
+        if (str_contains($type, '|')) {
+            return [$type]; // no need to convert; already fixed
+        }
+
+        return ['null', substr($type, 1)];
+    }
+
+    /**
+     * @param list<string> $types
+     *
+     * @return list<Token>
+     */
+    private function createTypeDeclarationTokens(array $types, bool $isQuestionMarkSyntax): array
+    {
+        static $specialTypes = [
+            '?' => [CT::T_NULLABLE_TYPE, '?'],
+            'array' => [CT::T_ARRAY_TYPEHINT, 'array'],
+            'callable' => [T_CALLABLE, 'callable'],
+            'static' => [T_STATIC, 'static'],
+        ];
+
+        $count = \count($types);
+        $newTokens = [];
+
+        foreach ($types as $index => $type) {
+            if (isset($specialTypes[$type])) {
+                $newTokens[] = new Token($specialTypes[$type]);
+            } else {
+                foreach (explode('\\', $type) as $nsIndex => $value) {
+                    if (0 === $nsIndex && '' === $value) {
+                        continue;
+                    }
+
+                    if ($nsIndex > 0) {
+                        $newTokens[] = new Token([T_NS_SEPARATOR, '\\']);
+                    }
+
+                    $newTokens[] = new Token([T_STRING, $value]);
+                }
+            }
+
+            if ($index <= $count - 2 && !$isQuestionMarkSyntax) {
+                $newTokens[] = new Token([CT::T_TYPE_ALTERNATION, '|']);
+            }
+        }
+
+        return $newTokens;
+    }
+}

--- a/src/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixer.php
@@ -255,7 +255,7 @@ yield  from  baz();
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesFixer, FunctionDeclarationFixer.
+     * Must run before BracesFixer, FunctionDeclarationFixer, NullableTypeDeclarationFixer.
      * Must run after ModernizeStrposFixer.
      */
     public function getPriority(): int

--- a/src/Fixer/Whitespace/TypesSpacesFixer.php
+++ b/src/Fixer/Whitespace/TypesSpacesFixer.php
@@ -63,7 +63,7 @@ final class TypesSpacesFixer extends AbstractFixer implements ConfigurableFixerI
     /**
      * {@inheritdoc}
      *
-     * Must run after OrderedTypesFixer.
+     * Must run after NullableTypeDeclarationFixer, OrderedTypesFixer.
      */
     public function getPriority(): int
     {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -653,8 +653,13 @@ final class FixerFactoryTest extends TestCase
                 'no_extra_blank_lines',
                 'no_spaces_inside_parenthesis',
             ],
+            'nullable_type_declaration' => [
+                'ordered_types',
+                'types_spaces',
+            ],
             'nullable_type_declaration_for_default_null_value' => [
                 'no_unreachable_default_argument_value',
+                'nullable_type_declaration',
                 'ordered_types',
             ],
             'ordered_class_elements' => [
@@ -815,6 +820,7 @@ final class FixerFactoryTest extends TestCase
             'single_space_around_construct' => [
                 'braces',
                 'function_declaration',
+                'nullable_type_declaration',
             ],
             'single_trait_insert_per_statement' => [
                 'braces',

--- a/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
@@ -101,11 +101,11 @@ class Dto
     }
 
     /**
-     * @dataProvider provideFixWithUseExplicitNullCases
+     * @dataProvider provideFixWithUnionSyntaxCases
      *
      * @requires PHP 8.0
      */
-    public function testFixWithUseExplicitNull(string $expected, ?string $input = null): void
+    public function testFixWithUnionSyntax(string $expected, ?string $input = null): void
     {
         $this->fixer->configure(['syntax' => 'union']);
 
@@ -115,7 +115,7 @@ class Dto
     /**
      * @return iterable<string, array<int, null|string>>
      */
-    public static function provideFixWithUseExplicitNullCases(): iterable
+    public static function provideFixWithUnionSyntaxCases(): iterable
     {
         yield 'scalar with null' => [
             "<?php\nfunction foo(null|int \$bar): void {}\n",
@@ -228,7 +228,7 @@ class Qux
 ',
         ];
 
-        yield 'readonly property and use explicit null' => [
+        yield 'readonly property with union syntax expected' => [
             '<?php
 class Qux
 {

--- a/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\LanguageConstruct;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author John Paul E. Balandan, CPA <paulbalandan@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\LanguageConstruct\NullableTypeDeclarationFixer
+ */
+final class NullableTypeDeclarationFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideDefaultFixCases
+     *
+     * @requires PHP 8.0
+     */
+    public function testDefaultFix(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string, array<int, null|string>>
+     */
+    public static function provideDefaultFixCases(): iterable
+    {
+        yield 'scalar with null' => [
+            "<?php\nfunction foo(?int \$bar): void {}\n",
+            "<?php\nfunction foo(int|null \$bar): void {}\n",
+        ];
+
+        yield 'class with null' => [
+            "<?php\nfunction bar(?\\stdClass \$crate): int {}\n",
+            "<?php\nfunction bar(null | \\stdClass \$crate): int {}\n",
+        ];
+
+        yield 'static null' => [
+            '<?php
+class Foo
+{
+    public function bar(?array $config = null): ?static {}
+}
+',
+            '<?php
+class Foo
+{
+    public function bar(null|array $config = null): null|static {}
+}
+',
+        ];
+
+        yield 'multiple parameters' => [
+            "<?php\nfunction baz(?Foo \$foo, int|string \$value, ?array \$config = null): ?int {}\n",
+            "<?php\nfunction baz(null|Foo \$foo, int|string \$value, null|array \$config = null): int|null {}\n",
+        ];
+
+        yield 'class properties' => [
+            '<?php
+class Dto
+{
+    public ?string $name;
+    public ?array $parameters;
+    public ?int $count;
+    public ?Closure $callable;
+}
+',
+            '<?php
+class Dto
+{
+    public null|string $name;
+    public array|null $parameters;
+    public int|null $count;
+    public null|Closure $callable;
+}
+',
+        ];
+
+        yield 'skips more than two atomic types' => [
+            "<?php\nstatic fn (int|null|string \$bar): bool => true;\n",
+        ];
+
+        yield 'skips already fixed' => [
+            "<?php\n\$bar = function (?string \$input): int {};\n",
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithUseExplicitNullCases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFixWithUseExplicitNull(string $expected, ?string $input = null): void
+    {
+        $this->fixer->configure(['syntax' => 'union']);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string, array<int, null|string>>
+     */
+    public static function provideFixWithUseExplicitNullCases(): iterable
+    {
+        yield 'scalar with null' => [
+            "<?php\nfunction foo(null|int \$bar): void {}\n",
+            "<?php\nfunction foo(?int \$bar): void {}\n",
+        ];
+
+        yield 'class with null' => [
+            "<?php\nfunction bar(null|\\stdClass \$crate): int {}\n",
+            "<?php\nfunction bar(?\\stdClass \$crate): int {}\n",
+        ];
+
+        yield 'static null' => [
+            '<?php
+class Foo
+{
+    public function bar(null|array $config = null): null|static {}
+}
+',
+            '<?php
+class Foo
+{
+    public function bar(?array $config = null): ?static {}
+}
+',
+        ];
+
+        yield 'multiple parameters' => [
+            "<?php\nfunction baz(null|Foo \$foo, int|string \$value, null|array \$config = null): null|int {}\n",
+            "<?php\nfunction baz(?Foo \$foo, int|string \$value, ?array \$config = null): ?int {}\n",
+        ];
+
+        yield 'class properties' => [
+            '<?php
+class Dto
+{
+    public null|\Closure $callable;
+    public null|string $name;
+    public null|array $parameters;
+    public null|int $count;
+}
+',
+            '<?php
+class Dto
+{
+    public ?\Closure $callable;
+    public ?string $name;
+    public ?array $parameters;
+    public ?int $count;
+}
+',
+        ];
+
+        yield 'space after ?' => [
+            '<?php
+class Foo
+{
+    private null|int $x;
+
+    public static function from(null|int $x): null|static {}
+}
+',
+            '<?php
+class Foo
+{
+    private ? int $x;
+
+    public static function from(?  int $x): ? static {}
+}
+',
+        ];
+
+        yield 'skips already fixed' => [
+            "<?php\n\$bar = function (null | string \$input): int {};\n",
+        ];
+    }
+
+    /**
+     * @param null|array<string, string> $config
+     *
+     * @dataProvider provideFixPhp81Cases
+     *
+     * @requires PHP 8.1
+     */
+    public function testFixPhp81(string $expected, ?string $input = null, ?array $config = null): void
+    {
+        if (null !== $config) {
+            $this->fixer->configure($config);
+        }
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string, array<int, null|array<string, string>|string>>
+     */
+    public static function provideFixPhp81Cases(): iterable
+    {
+        yield 'readonly property' => [
+            '<?php
+class Qux
+{
+    public readonly ?int $baz;
+}
+',
+            '<?php
+class Qux
+{
+    public readonly int|null $baz;
+}
+',
+        ];
+
+        yield 'readonly property and use explicit null' => [
+            '<?php
+class Qux
+{
+    public readonly null|int $baz;
+}
+',
+            '<?php
+class Qux
+{
+    public readonly ?int $baz;
+}
+',
+            ['syntax' => 'union'],
+        ];
+    }
+
+    /**
+     * @param null|array<string, string> $config
+     *
+     * @dataProvider provideFixPhp82Cases
+     *
+     * @requires PHP 8.2
+     */
+    public function testFixPhp82(string $expected, ?string $input = null, ?array $config = null): void
+    {
+        if (null !== $config) {
+            $this->fixer->configure($config);
+        }
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string, array<int, null|array<string, string>|string>>
+     */
+    public static function provideFixPhp82Cases(): iterable
+    {
+        yield 'skips DNF types' => [
+            '<?php
+class Infinite
+{
+    private static (A&B)|null $dft;
+}
+',
+        ];
+    }
+}

--- a/tests/Fixtures/Integration/misc/nullable_type_declaration,nullable_type_declaration_for_default_null_value,ordered_types.test
+++ b/tests/Fixtures/Integration/misc/nullable_type_declaration,nullable_type_declaration_for_default_null_value,ordered_types.test
@@ -1,0 +1,25 @@
+--TEST--
+Integration of fixers: nullable_type_declaration,nullable_type_declaration_for_default_null_value,ordered_types.
+--RULESET--
+{
+    "nullable_type_declaration": {"syntax": "union"},
+    "nullable_type_declaration_for_default_null_value": {"use_nullable_type_declaration": true},
+    "ordered_types": {"null_adjustment": "always_last"}
+}
+--REQUIREMENTS--
+{"php": 80000}
+--EXPECT--
+<?php
+
+function intel(array|null $config = null): array|null
+{
+    return $config;
+}
+
+--INPUT--
+<?php
+
+function intel(array $config = null): ?array
+{
+    return $config;
+}

--- a/tests/Fixtures/Integration/priority/nullable_type_declaration,ordered_types.test
+++ b/tests/Fixtures/Integration/priority/nullable_type_declaration,ordered_types.test
@@ -1,0 +1,13 @@
+--TEST--
+Integration of fixers: nullable_type_declaration,ordered_types.
+--RULESET--
+{"nullable_type_declaration": {"syntax": "union"}, "ordered_types": {"null_adjustment": "always_last"}}
+--REQUIREMENTS--
+{"php": 80000}
+--EXPECT--
+<?php
+function intel(array|null $config) {}
+
+--INPUT--
+<?php
+function intel(?array $config) {}

--- a/tests/Fixtures/Integration/priority/nullable_type_declaration,types_spaces.test
+++ b/tests/Fixtures/Integration/priority/nullable_type_declaration,types_spaces.test
@@ -1,0 +1,13 @@
+--TEST--
+Integration of fixers: nullable_type_declaration,types_spaces.
+--RULESET--
+{"nullable_type_declaration": {"syntax": "union"}, "types_spaces": {"space": "single"}}
+--REQUIREMENTS--
+{"php": 80000}
+--EXPECT--
+<?php
+function bar(null | \Traversable $iterator): int | null {}
+
+--INPUT--
+<?php
+function bar(?\Traversable $iterator): int|null {}

--- a/tests/Fixtures/Integration/priority/nullable_type_declaration_for_default_null_value,nullable_type_declaration.test
+++ b/tests/Fixtures/Integration/priority/nullable_type_declaration_for_default_null_value,nullable_type_declaration.test
@@ -1,0 +1,15 @@
+--TEST--
+Integration of fixers: nullable_type_declaration_for_default_null_value,nullable_type_declaration.
+--RULESET--
+{"nullable_type_declaration_for_default_null_value": true, "nullable_type_declaration": {"syntax": "union"}}
+--REQUIREMENTS--
+{"php": 80000}
+--EXPECT--
+<?php
+
+function bar(null|string $foo = null): void {}
+
+--INPUT--
+<?php
+
+function bar(string $foo = null): void {}

--- a/tests/Fixtures/Integration/priority/single_space_around_construct,nullable_type_declaration.test
+++ b/tests/Fixtures/Integration/priority/single_space_around_construct,nullable_type_declaration.test
@@ -1,0 +1,25 @@
+--TEST--
+Integration of fixers: single_space_around_construct,nullable_type_declaration.
+--RULESET--
+{"single_space_around_construct": true, "nullable_type_declaration": {"syntax": "union"}}
+--REQUIREMENTS--
+{"php": 80000}
+--EXPECT--
+<?php
+class Foo
+{
+    public null|int $a;
+    protected null|array $b;
+    private null|string $c;
+    private static null|bool $d;
+}
+
+--INPUT--
+<?php
+class Foo
+{
+    public?int $a;
+    protected?array $b;
+    private?string $c;
+    private static?bool $d;
+}


### PR DESCRIPTION
Closes #5651 
Alternative to #6980 

- [x] ~Needs #6995 in order to pass integration test with `single_space_around_construct`~

```console
$ php php-cs-fixer describe nullable_type_declaration
Description of nullable_type_declaration rule.
Single base type declaration should be marked nullable by using the configured syntax.

Fixer is configurable using following option:
* syntax ('use_explicit_null', 'use_question_mark'): whether to use question mark (`?`) or explicit `null` union for nullable type; defaults to 'use_question_mark'

Fixing examples:
 * Example #1. Fixing with the default configuration.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,2 +1,2 @@
    <?php
   -function bar(null|int $value, null|\Closure $callable): void {}
   +function bar(?int $value, ?\Closure $callable): void {}

   ----------- end diff -----------

 * Example #2. Fixing with configuration: ['syntax' => 'use_explicit_null'].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,2 +1,2 @@
    <?php
   -function baz(?int $value, ?\stdClass $obj, ?array $config): ?int {}
   +function baz(null|int $value, null|\stdClass $obj, null|array $config): null|int {}

   ----------- end diff -----------

 * Example #3. Fixing with configuration: ['syntax' => 'use_question_mark'].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,8 +1,8 @@
    <?php
    class ValueObject
    {
   -    public null|string $name;
   +    public ?string $name;
        public ?int $count;
   -    public null|bool $internal;
   -    public null|\Closure $callback;
   +    public ?bool $internal;
   +    public ?\Closure $callback;
    }

   ----------- end diff -----------
```