### PR TITLE
DX: Invalidate cache on fixers' code change (allow cache for local development)

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Cache;
 
+use PhpCsFixer\Cache\Signature\ConfigSignature;
+use PhpCsFixer\Cache\Signature\ConfigSignatureInterface;
 use PhpCsFixer\Utils;
 
 /**
@@ -23,19 +25,19 @@ use PhpCsFixer\Utils;
  */
 final class Cache implements CacheInterface
 {
-    private SignatureInterface $signature;
+    private ConfigSignatureInterface $signature;
 
     /**
      * @var array<string, string>
      */
     private array $hashes = [];
 
-    public function __construct(SignatureInterface $signature)
+    public function __construct(ConfigSignatureInterface $signature)
     {
         $this->signature = $signature;
     }
 
-    public function getSignature(): SignatureInterface
+    public function getSignature(): ConfigSignatureInterface
     {
         return $this->signature;
     }
@@ -118,7 +120,7 @@ final class Cache implements CacheInterface
             ));
         }
 
-        $signature = new Signature(
+        $signature = new ConfigSignature(
             $data['php'],
             $data['version'],
             $data['indent'],

--- a/src/Cache/CacheInterface.php
+++ b/src/Cache/CacheInterface.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Cache;
 
+use PhpCsFixer\Cache\Signature\ConfigSignatureInterface;
+
 /**
  * @author Andreas Möller <am@localheinz.com>
  *
@@ -21,7 +23,7 @@ namespace PhpCsFixer\Cache;
  */
 interface CacheInterface
 {
-    public function getSignature(): SignatureInterface;
+    public function getSignature(): ConfigSignatureInterface;
 
     public function has(string $file): bool;
 

--- a/src/Cache/FileCacheManager.php
+++ b/src/Cache/FileCacheManager.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Cache;
 
+use PhpCsFixer\Cache\Signature\ConfigSignatureInterface;
+
 /**
  * Class supports caching information about state of fixing files.
  *
@@ -36,7 +38,7 @@ final class FileCacheManager implements CacheManagerInterface
 
     private FileHandlerInterface $handler;
 
-    private SignatureInterface $signature;
+    private ConfigSignatureInterface $signature;
 
     private bool $isDryRun;
 
@@ -53,7 +55,7 @@ final class FileCacheManager implements CacheManagerInterface
 
     public function __construct(
         FileHandlerInterface $handler,
-        SignatureInterface $signature,
+        ConfigSignatureInterface $signature,
         bool $isDryRun = false,
         ?DirectoryInterface $cacheDirectory = null
     ) {

--- a/src/Cache/Signature/ConfigSignature.php
+++ b/src/Cache/Signature/ConfigSignature.php
@@ -29,21 +29,20 @@ final class ConfigSignature implements ConfigSignatureInterface
 
     private string $lineEnding;
 
-    /**
-     * @var array<string, array<string, mixed>|bool>
-     */
-    private array $rules;
+    private RulesSignature $rules;
 
-    /**
-     * @param array<string, array<string, mixed>|bool> $rules
-     */
-    public function __construct(string $phpVersion, string $fixerVersion, string $indent, string $lineEnding, array $rules)
-    {
+    public function __construct(
+        string $phpVersion,
+        string $fixerVersion,
+        string $indent,
+        string $lineEnding,
+        RulesSignature $rules
+    ) {
         $this->phpVersion = $phpVersion;
         $this->fixerVersion = $fixerVersion;
         $this->indent = $indent;
         $this->lineEnding = $lineEnding;
-        $this->rules = self::makeJsonEncodable($rules);
+        $this->rules = $rules;
     }
 
     public function getPhpVersion(): string
@@ -66,6 +65,14 @@ final class ConfigSignature implements ConfigSignatureInterface
         return $this->lineEnding;
     }
 
+    public function getRulesSignature(): RulesSignature
+    {
+        return $this->rules;
+    }
+
+    /**
+     * @return array<string, array{hash: string, config: array<string, mixed>|bool}>
+     */
     public function getRules(): array
     {
         return array_map(
@@ -83,6 +90,6 @@ final class ConfigSignature implements ConfigSignatureInterface
             && $this->fixerVersion === $signature->getFixerVersion()
             && $this->indent === $signature->getIndent()
             && $this->lineEnding === $signature->getLineEnding()
-            && $this->rules === $signature->getRules();
+            && $this->rules->equals($signature->getRulesSignature());
     }
 }

--- a/src/Cache/Signature/ConfigSignature.php
+++ b/src/Cache/Signature/ConfigSignature.php
@@ -68,7 +68,13 @@ final class ConfigSignature implements ConfigSignatureInterface
 
     public function getRules(): array
     {
-        return $this->rules;
+        return array_map(
+            static fn (FixerSignature $signature) => [
+                'hash' => $signature->getContentHash(),
+                'config' => $signature->getConfig(),
+            ],
+            $this->rules->getFixerSignatures()
+        );
     }
 
     public function equals(ConfigSignatureInterface $signature): bool
@@ -78,21 +84,5 @@ final class ConfigSignature implements ConfigSignatureInterface
             && $this->indent === $signature->getIndent()
             && $this->lineEnding === $signature->getLineEnding()
             && $this->rules === $signature->getRules();
-    }
-
-    /**
-     * @param array<string, array<string, mixed>|bool> $data
-     *
-     * @return array<string, array<string, mixed>|bool>
-     */
-    private static function makeJsonEncodable(array $data): array
-    {
-        array_walk_recursive($data, static function (&$item): void {
-            if (\is_string($item) && !mb_detect_encoding($item, 'utf-8', true)) {
-                $item = base64_encode($item);
-            }
-        });
-
-        return $data;
     }
 }

--- a/src/Cache/Signature/ConfigSignature.php
+++ b/src/Cache/Signature/ConfigSignature.php
@@ -12,14 +12,14 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace PhpCsFixer\Cache;
+namespace PhpCsFixer\Cache\Signature;
 
 /**
  * @author Andreas Möller <am@localheinz.com>
  *
  * @internal
  */
-final class Signature implements SignatureInterface
+final class ConfigSignature implements ConfigSignatureInterface
 {
     private string $phpVersion;
 
@@ -71,7 +71,7 @@ final class Signature implements SignatureInterface
         return $this->rules;
     }
 
-    public function equals(SignatureInterface $signature): bool
+    public function equals(ConfigSignatureInterface $signature): bool
     {
         return $this->phpVersion === $signature->getPhpVersion()
             && $this->fixerVersion === $signature->getFixerVersion()

--- a/src/Cache/Signature/ConfigSignatureInterface.php
+++ b/src/Cache/Signature/ConfigSignatureInterface.php
@@ -29,8 +29,10 @@ interface ConfigSignatureInterface
 
     public function getLineEnding(): string;
 
+    public function getRulesSignature(): RulesSignature;
+
     /**
-     * @return array<string, array<string, mixed>|bool>
+     * @return array<string, array{hash: string, config: array<string, mixed>|bool}>
      */
     public function getRules(): array;
 

--- a/src/Cache/Signature/ConfigSignatureInterface.php
+++ b/src/Cache/Signature/ConfigSignatureInterface.php
@@ -12,14 +12,14 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace PhpCsFixer\Cache;
+namespace PhpCsFixer\Cache\Signature;
 
 /**
  * @author Andreas Möller <am@localheinz.com>
  *
  * @internal
  */
-interface SignatureInterface
+interface ConfigSignatureInterface
 {
     public function getPhpVersion(): string;
 

--- a/src/Cache/Signature/FixerSignature.php
+++ b/src/Cache/Signature/FixerSignature.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Cache\Signature;
+
+use PhpCsFixer\Fixer\FixerInterface;
+
+final class FixerSignature
+{
+    private string $name;
+    private string $contentHash;
+
+    /**
+     * @var array<string, mixed>|bool
+     */
+    private $config;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param array<string, mixed>|bool $config
+     */
+    public static function fromInstance(FixerInterface $fixer, $config): self
+    {
+        $signature = new self();
+        $signature->name = $fixer->getName();
+        $signature->contentHash = md5(file_get_contents((new \ReflectionClass($fixer))->getFileName()));
+        $signature->config = \is_array($config) ? self::makeJsonEncodable($config) : $config;
+
+        return $signature;
+    }
+
+    /**
+     * @param array<string, mixed>|bool $config
+     */
+    public static function fromRawValues(string $name, string $contentHash, $config): self
+    {
+        $signature = new self();
+        $signature->name = $name;
+        $signature->contentHash = $contentHash;
+        $signature->config = \is_array($config) ? self::makeJsonEncodable($config) : $config;
+
+        return $signature;
+    }
+
+    public function equals(self $signature): bool
+    {
+        return $this->contentHash === $signature->getContentHash();
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getContentHash(): string
+    {
+        return $this->contentHash;
+    }
+
+    /**
+     * @return array<string, mixed>|bool
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>|bool> $data
+     *
+     * @return array<string, array<string, mixed>|bool>
+     */
+    private static function makeJsonEncodable(array $data): array
+    {
+        array_walk_recursive($data, static function (&$item): void {
+            if (\is_string($item) && !mb_detect_encoding($item, 'utf-8', true)) {
+                $item = base64_encode($item);
+            }
+        });
+
+        return $data;
+    }
+}

--- a/src/Cache/Signature/FixerSignature.php
+++ b/src/Cache/Signature/FixerSignature.php
@@ -56,11 +56,6 @@ final class FixerSignature
         return $signature;
     }
 
-    public function equals(self $signature): bool
-    {
-        return $this->contentHash === $signature->getContentHash();
-    }
-
     public function getName(): string
     {
         return $this->name;

--- a/src/Cache/Signature/RulesSignature.php
+++ b/src/Cache/Signature/RulesSignature.php
@@ -47,7 +47,7 @@ final class RulesSignature
 
     public function equals(self $signature): bool
     {
-        return $this->hash === $signature->getHash();
+        return $this->hash === $signature->hash;
     }
 
     /**

--- a/src/Cache/Signature/RulesSignature.php
+++ b/src/Cache/Signature/RulesSignature.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Cache\Signature;
+
+final class RulesSignature
+{
+    /**
+     * @var array<string, FixerSignature>
+     */
+    private array $fixerSignatures = [];
+    private string $hash;
+
+    public function __construct(FixerSignature ...$fixerSignatures)
+    {
+        foreach ($fixerSignatures as $signature) {
+            if (isset($this->fixerSignatures[$signature->getName()])) {
+                throw new \UnexpectedValueException(sprintf(
+                    'Fixer signature for "%s" is already registered.',
+                    $signature->getName()
+                ));
+            }
+
+            $this->fixerSignatures[$signature->getName()] = $signature;
+        }
+
+        ksort($this->fixerSignatures);
+        $this->hash = md5(var_export($this->fixerSignatures, true));
+    }
+
+    public function equals(self $signature): bool
+    {
+        return $this->hash === $signature->getHash();
+    }
+
+    /**
+     * @return array<string, FixerSignature>
+     */
+    public function getFixerSignatures(): array
+    {
+        return $this->fixerSignatures;
+    }
+
+    public function getHash(): string
+    {
+        return $this->hash;
+    }
+}

--- a/src/Cache/Signature/RulesSignature.php
+++ b/src/Cache/Signature/RulesSignature.php
@@ -36,7 +36,13 @@ final class RulesSignature
         }
 
         ksort($this->fixerSignatures);
-        $this->hash = md5(var_export($this->fixerSignatures, true));
+        $this->hash = md5(json_encode(array_map(
+            static fn (FixerSignature $signature) => [
+                'hash' => $signature->getContentHash(),
+                'config' => $signature->getConfig(),
+            ],
+            $this->fixerSignatures
+        )));
     }
 
     public function equals(self $signature): bool

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -21,6 +21,8 @@ use PhpCsFixer\Cache\FileCacheManager;
 use PhpCsFixer\Cache\FileHandler;
 use PhpCsFixer\Cache\NullCacheManager;
 use PhpCsFixer\Cache\Signature\ConfigSignature;
+use PhpCsFixer\Cache\Signature\FixerSignature;
+use PhpCsFixer\Cache\Signature\RulesSignature;
 use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
 use PhpCsFixer\Console\Output\Progress\ProgressOutputType;
@@ -232,7 +234,7 @@ final class ConfigurationResolver
                         $this->toolInfo->getVersion(),
                         $this->getConfig()->getIndent(),
                         $this->getConfig()->getLineEnding(),
-                        $this->getRules()
+                        $this->getRulesSignature()
                     ),
                     $this->isDryRun(),
                     $this->getDirectory()
@@ -607,6 +609,16 @@ final class ConfigurationResolver
         }
 
         return $this->ruleSet;
+    }
+
+    private function getRulesSignature(): RulesSignature
+    {
+        $rules = $this->getRules();
+
+        return new RulesSignature(...array_map(
+            static fn (FixerInterface $fixer) => FixerSignature::fromInstance($fixer, $rules[$fixer->getName()]),
+            $this->getFixers()
+        ));
     }
 
     private function isStdIn(): bool

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -20,7 +20,7 @@ use PhpCsFixer\Cache\DirectoryInterface;
 use PhpCsFixer\Cache\FileCacheManager;
 use PhpCsFixer\Cache\FileHandler;
 use PhpCsFixer\Cache\NullCacheManager;
-use PhpCsFixer\Cache\Signature;
+use PhpCsFixer\Cache\Signature\ConfigSignature;
 use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
 use PhpCsFixer\Console\Output\Progress\ProgressOutputType;
@@ -227,7 +227,7 @@ final class ConfigurationResolver
             } else {
                 $this->cacheManager = new FileCacheManager(
                     new FileHandler($cacheFile),
-                    new Signature(
+                    new ConfigSignature(
                         PHP_VERSION,
                         $this->toolInfo->getVersion(),
                         $this->getConfig()->getIndent(),

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -482,8 +482,6 @@ final class ConfigurationResolver
             }
         }
 
-        $this->usingCache = $this->usingCache && ($this->toolInfo->isInstalledAsPhar() || $this->toolInfo->isInstalledByComposer());
-
         return $this->usingCache;
     }
 

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -16,8 +16,8 @@ namespace PhpCsFixer\Tests\Cache;
 
 use PhpCsFixer\Cache\Cache;
 use PhpCsFixer\Cache\CacheInterface;
-use PhpCsFixer\Cache\Signature;
-use PhpCsFixer\Cache\SignatureInterface;
+use PhpCsFixer\Cache\Signature\ConfigSignature;
+use PhpCsFixer\Cache\Signature\ConfigSignatureInterface;
 use PhpCsFixer\Config;
 use PhpCsFixer\Tests\TestCase;
 use PhpCsFixer\ToolInfo;
@@ -143,7 +143,7 @@ final class CacheTest extends TestCase
     /**
      * @dataProvider provideCanConvertToAndFromJsonCases
      */
-    public function testCanConvertToAndFromJson(SignatureInterface $signature): void
+    public function testCanConvertToAndFromJson(ConfigSignatureInterface $signature): void
     {
         $cache = new Cache($signature);
 
@@ -163,7 +163,7 @@ final class CacheTest extends TestCase
         $toolInfo = new ToolInfo();
         $config = new Config();
 
-        yield [new Signature(
+        yield [new ConfigSignature(
             PHP_VERSION,
             '2.0',
             '  ',
@@ -174,7 +174,7 @@ final class CacheTest extends TestCase
             ]
         )];
 
-        yield [new Signature(
+        yield [new ConfigSignature(
             PHP_VERSION,
             $toolInfo->getVersion(),
             $config->getIndent(),
@@ -190,7 +190,7 @@ final class CacheTest extends TestCase
     {
         $invalidUtf8Sequence = "\xB1\x31";
 
-        $signature = $this->prophesize(SignatureInterface::class);
+        $signature = $this->prophesize(ConfigSignatureInterface::class);
         $signature->getPhpVersion()->willReturn('7.1.0');
         $signature->getFixerVersion()->willReturn('2.2.0');
         $signature->getIndent()->willReturn('    ');
@@ -212,8 +212,8 @@ final class CacheTest extends TestCase
         $cache->toJson();
     }
 
-    private function getSignatureDouble(): SignatureInterface
+    private function getSignatureDouble(): ConfigSignatureInterface
     {
-        return $this->prophesize(SignatureInterface::class)->reveal();
+        return $this->prophesize(ConfigSignatureInterface::class)->reveal();
     }
 }

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -18,6 +18,8 @@ use PhpCsFixer\Cache\Cache;
 use PhpCsFixer\Cache\CacheInterface;
 use PhpCsFixer\Cache\Signature\ConfigSignature;
 use PhpCsFixer\Cache\Signature\ConfigSignatureInterface;
+use PhpCsFixer\Cache\Signature\FixerSignature;
+use PhpCsFixer\Cache\Signature\RulesSignature;
 use PhpCsFixer\Config;
 use PhpCsFixer\Tests\TestCase;
 use PhpCsFixer\ToolInfo;
@@ -168,10 +170,10 @@ final class CacheTest extends TestCase
             '2.0',
             '  ',
             "\r\n",
-            [
-                'foo' => true,
-                'bar' => true,
-            ]
+            new RulesSignature(
+                FixerSignature::fromRawValues('foo', '', true),
+                FixerSignature::fromRawValues('bar', '', true)
+            )
         )];
 
         yield [new ConfigSignature(
@@ -179,10 +181,13 @@ final class CacheTest extends TestCase
             $toolInfo->getVersion(),
             $config->getIndent(),
             $config->getLineEnding(),
-            [
-                // value encoded in ANSI, not UTF
-                'header_comment' => ['header' => 'Dariusz '.base64_decode('UnVtafFza2k=', true)],
-            ]
+            new RulesSignature(
+                FixerSignature::fromRawValues(
+                    'header_comment',
+                    '',
+                    ['header' => 'Dariusz '.base64_decode('UnVtafFza2k=', true)]
+                )
+            )
         )];
     }
 

--- a/tests/Cache/FileCacheManagerTest.php
+++ b/tests/Cache/FileCacheManagerTest.php
@@ -18,7 +18,7 @@ use PhpCsFixer\Cache\CacheInterface;
 use PhpCsFixer\Cache\CacheManagerInterface;
 use PhpCsFixer\Cache\FileCacheManager;
 use PhpCsFixer\Cache\FileHandlerInterface;
-use PhpCsFixer\Cache\SignatureInterface;
+use PhpCsFixer\Cache\Signature\ConfigSignatureInterface;
 use PhpCsFixer\Tests\TestCase;
 use Prophecy\Argument;
 
@@ -47,7 +47,7 @@ final class FileCacheManagerTest extends TestCase
 
     public function testCreatesCacheIfHandlerReturnedNoCache(): void
     {
-        $signature = $this->prophesize(SignatureInterface::class)->reveal();
+        $signature = $this->prophesize(ConfigSignatureInterface::class)->reveal();
 
         $handlerProphecy = $this->prophesize(FileHandlerInterface::class);
         $handlerProphecy->read()->shouldBeCalled()->willReturn(null);
@@ -64,9 +64,9 @@ final class FileCacheManagerTest extends TestCase
 
     public function testCreatesCacheIfCachedSignatureIsDifferent(): void
     {
-        $cachedSignature = $this->prophesize(SignatureInterface::class)->reveal();
+        $cachedSignature = $this->prophesize(ConfigSignatureInterface::class)->reveal();
 
-        $signatureProphecy = $this->prophesize(SignatureInterface::class);
+        $signatureProphecy = $this->prophesize(ConfigSignatureInterface::class);
         $signatureProphecy->equals(Argument::is($cachedSignature))->shouldBeCalled()->willReturn(false);
         $signature = $signatureProphecy->reveal();
 
@@ -89,9 +89,9 @@ final class FileCacheManagerTest extends TestCase
 
     public function testUsesCacheIfCachedSignatureIsEqualAndNoFileWasUpdated(): void
     {
-        $cachedSignature = $this->prophesize(SignatureInterface::class)->reveal();
+        $cachedSignature = $this->prophesize(ConfigSignatureInterface::class)->reveal();
 
-        $signatureProphecy = $this->prophesize(SignatureInterface::class);
+        $signatureProphecy = $this->prophesize(ConfigSignatureInterface::class);
         $signatureProphecy->equals(Argument::is($cachedSignature))->willReturn(true);
         $signature = $signatureProphecy->reveal();
 
@@ -117,9 +117,9 @@ final class FileCacheManagerTest extends TestCase
         $file = 'hello.php';
         $fileContent = '<?php echo "Hello!"';
 
-        $cachedSignature = $this->prophesize(SignatureInterface::class)->reveal();
+        $cachedSignature = $this->prophesize(ConfigSignatureInterface::class)->reveal();
 
-        $signatureProphecy = $this->prophesize(SignatureInterface::class);
+        $signatureProphecy = $this->prophesize(ConfigSignatureInterface::class);
         $signatureProphecy->equals(Argument::is($cachedSignature))->willReturn(true);
         $signature = $signatureProphecy->reveal();
 
@@ -148,9 +148,9 @@ final class FileCacheManagerTest extends TestCase
         $fileContent = '<?php echo "Hello!"';
         $previousFileContent = '<?php echo "Hello, world!"';
 
-        $cachedSignature = $this->prophesize(SignatureInterface::class)->reveal();
+        $cachedSignature = $this->prophesize(ConfigSignatureInterface::class)->reveal();
 
-        $signatureProphecy = $this->prophesize(SignatureInterface::class);
+        $signatureProphecy = $this->prophesize(ConfigSignatureInterface::class);
         $signatureProphecy->equals(Argument::is($cachedSignature))->willReturn(true);
         $signature = $signatureProphecy->reveal();
 
@@ -179,9 +179,9 @@ final class FileCacheManagerTest extends TestCase
         $file = 'hello.php';
         $fileContent = '<?php echo "Hello!"';
 
-        $cachedSignature = $this->prophesize(SignatureInterface::class)->reveal();
+        $cachedSignature = $this->prophesize(ConfigSignatureInterface::class)->reveal();
 
-        $signatureProphecy = $this->prophesize(SignatureInterface::class);
+        $signatureProphecy = $this->prophesize(ConfigSignatureInterface::class);
         $signatureProphecy->equals(Argument::is($cachedSignature))->willReturn(true);
         $signature = $signatureProphecy->reveal();
 
@@ -215,9 +215,9 @@ final class FileCacheManagerTest extends TestCase
         $directoryProphecy = $this->prophesize(\PhpCsFixer\Cache\DirectoryInterface::class);
         $directoryProphecy->getRelativePathTo(Argument::is($file))->willReturn($relativePathToFile);
 
-        $cachedSignature = $this->prophesize(SignatureInterface::class)->reveal();
+        $cachedSignature = $this->prophesize(ConfigSignatureInterface::class)->reveal();
 
-        $signatureProphecy = $this->prophesize(SignatureInterface::class);
+        $signatureProphecy = $this->prophesize(ConfigSignatureInterface::class);
         $signatureProphecy->equals(Argument::is($cachedSignature))->willReturn(true);
         $signature = $signatureProphecy->reveal();
 
@@ -249,9 +249,9 @@ final class FileCacheManagerTest extends TestCase
         $file = 'hello.php';
         $fileContent = '<?php echo "Hello!"';
 
-        $cachedSignature = $this->prophesize(SignatureInterface::class)->reveal();
+        $cachedSignature = $this->prophesize(ConfigSignatureInterface::class)->reveal();
 
-        $signatureProphecy = $this->prophesize(SignatureInterface::class);
+        $signatureProphecy = $this->prophesize(ConfigSignatureInterface::class);
         $signatureProphecy->equals(Argument::is($cachedSignature))->willReturn(true);
         $signature = $signatureProphecy->reveal();
 
@@ -281,9 +281,9 @@ final class FileCacheManagerTest extends TestCase
         $file = 'hello.php';
         $fileContent = '<?php echo "Hello!"';
 
-        $cachedSignature = $this->prophesize(SignatureInterface::class)->reveal();
+        $cachedSignature = $this->prophesize(ConfigSignatureInterface::class)->reveal();
 
-        $signatureProphecy = $this->prophesize(SignatureInterface::class);
+        $signatureProphecy = $this->prophesize(ConfigSignatureInterface::class);
         $signatureProphecy->equals(Argument::is($cachedSignature))->willReturn(true);
         $signature = $signatureProphecy->reveal();
 
@@ -316,9 +316,9 @@ final class FileCacheManagerTest extends TestCase
         $fileContent = '<?php echo "Hello!"';
         $previousFileContent = '<?php echo "Hello, world!"';
 
-        $cachedSignature = $this->prophesize(SignatureInterface::class)->reveal();
+        $cachedSignature = $this->prophesize(ConfigSignatureInterface::class)->reveal();
 
-        $signatureProphecy = $this->prophesize(SignatureInterface::class);
+        $signatureProphecy = $this->prophesize(ConfigSignatureInterface::class);
         $signatureProphecy->equals(Argument::is($cachedSignature))->willReturn(true);
         $signature = $signatureProphecy->reveal();
 
@@ -354,9 +354,9 @@ final class FileCacheManagerTest extends TestCase
         $directoryProphecy = $this->prophesize(\PhpCsFixer\Cache\DirectoryInterface::class);
         $directoryProphecy->getRelativePathTo(Argument::is($file))->willReturn($relativePathToFile);
 
-        $cachedSignature = $this->prophesize(SignatureInterface::class)->reveal();
+        $cachedSignature = $this->prophesize(ConfigSignatureInterface::class)->reveal();
 
-        $signatureProphecy = $this->prophesize(SignatureInterface::class);
+        $signatureProphecy = $this->prophesize(ConfigSignatureInterface::class);
         $signatureProphecy->equals(Argument::is($cachedSignature))->willReturn(true);
         $signature = $signatureProphecy->reveal();
 

--- a/tests/Cache/FileHandlerTest.php
+++ b/tests/Cache/FileHandlerTest.php
@@ -16,8 +16,8 @@ namespace PhpCsFixer\Tests\Cache;
 
 use PhpCsFixer\Cache\Cache;
 use PhpCsFixer\Cache\FileHandler;
-use PhpCsFixer\Cache\Signature;
-use PhpCsFixer\Cache\SignatureInterface;
+use PhpCsFixer\Cache\Signature\ConfigSignature;
+use PhpCsFixer\Cache\Signature\ConfigSignatureInterface;
 use PhpCsFixer\Tests\TestCase;
 use Symfony\Component\Filesystem\Exception\IOException;
 
@@ -212,9 +212,9 @@ final class FileHandlerTest extends TestCase
         return __DIR__.'/.php-cs-fixer.cache';
     }
 
-    private function createSignature(): SignatureInterface
+    private function createSignature(): ConfigSignatureInterface
     {
-        return new Signature(
+        return new ConfigSignature(
             PHP_VERSION,
             '2.0',
             '    ',

--- a/tests/Cache/Signature/ConfigSignatureTest.php
+++ b/tests/Cache/Signature/ConfigSignatureTest.php
@@ -12,9 +12,10 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace PhpCsFixer\Tests\Cache;
+namespace PhpCsFixer\Tests\Cache\Signature;
 
-use PhpCsFixer\Cache\Signature;
+use PhpCsFixer\Cache\Signature\ConfigSignature;
+use PhpCsFixer\Cache\Signature\ConfigSignatureInterface;
 use PhpCsFixer\Tests\TestCase;
 
 /**
@@ -22,22 +23,22 @@ use PhpCsFixer\Tests\TestCase;
  *
  * @internal
  *
- * @covers \PhpCsFixer\Cache\Signature
+ * @covers \PhpCsFixer\Cache\Signature\ConfigSignature
  */
-final class SignatureTest extends TestCase
+final class ConfigSignatureTest extends TestCase
 {
     public function testIsFinal(): void
     {
-        $reflection = new \ReflectionClass(\PhpCsFixer\Cache\Signature::class);
+        $reflection = new \ReflectionClass(ConfigSignature::class);
 
         self::assertTrue($reflection->isFinal());
     }
 
     public function testImplementsSignatureInterface(): void
     {
-        $reflection = new \ReflectionClass(\PhpCsFixer\Cache\Signature::class);
+        $reflection = new \ReflectionClass(ConfigSignature::class);
 
-        self::assertTrue($reflection->implementsInterface(\PhpCsFixer\Cache\SignatureInterface::class));
+        self::assertTrue($reflection->implementsInterface(ConfigSignatureInterface::class));
     }
 
     public function testConstructorSetsValues(): void
@@ -48,7 +49,7 @@ final class SignatureTest extends TestCase
         $lineEnding = PHP_EOL;
         $rules = ['foo' => true, 'bar' => false];
 
-        $signature = new Signature($php, $version, $indent, $lineEnding, $rules);
+        $signature = new ConfigSignature($php, $version, $indent, $lineEnding, $rules);
 
         self::assertSame($php, $signature->getPhpVersion());
         self::assertSame($version, $signature->getFixerVersion());
@@ -60,7 +61,7 @@ final class SignatureTest extends TestCase
     /**
      * @dataProvider provideEqualsReturnsFalseIfValuesAreNotIdenticalCases
      */
-    public function testEqualsReturnsFalseIfValuesAreNotIdentical(Signature $signature, Signature $anotherSignature): void
+    public function testEqualsReturnsFalseIfValuesAreNotIdentical(ConfigSignature $signature, ConfigSignature $anotherSignature): void
     {
         self::assertFalse($signature->equals($anotherSignature));
     }
@@ -73,31 +74,31 @@ final class SignatureTest extends TestCase
         $lineEnding = "\n";
         $rules = ['foo' => true, 'bar' => false];
 
-        $base = new Signature($php, $version, $indent, $lineEnding, $rules);
+        $base = new ConfigSignature($php, $version, $indent, $lineEnding, $rules);
 
         yield 'php' => [
             $base,
-            new Signature('50400', $version, $indent, $lineEnding, $rules),
+            new ConfigSignature('50400', $version, $indent, $lineEnding, $rules),
         ];
 
         yield 'version' => [
             $base,
-            new Signature($php, '2.12', $indent, $lineEnding, $rules),
+            new ConfigSignature($php, '2.12', $indent, $lineEnding, $rules),
         ];
 
         yield 'indent' => [
             $base,
-            new Signature($php, $version, "\t", $lineEnding, $rules),
+            new ConfigSignature($php, $version, "\t", $lineEnding, $rules),
         ];
 
         yield 'lineEnding' => [
             $base,
-            new Signature($php, $version, $indent, "\r\n", $rules),
+            new ConfigSignature($php, $version, $indent, "\r\n", $rules),
         ];
 
         yield 'rules' => [
             $base,
-            new Signature($php, $version, $indent, $lineEnding, ['foo' => false]),
+            new ConfigSignature($php, $version, $indent, $lineEnding, ['foo' => false]),
         ];
     }
 
@@ -109,8 +110,8 @@ final class SignatureTest extends TestCase
         $lineEnding = PHP_EOL;
         $rules = ['foo' => true, 'bar' => false];
 
-        $signature = new Signature($php, $version, $indent, $lineEnding, $rules);
-        $anotherSignature = new Signature($php, $version, $indent, $lineEnding, $rules);
+        $signature = new ConfigSignature($php, $version, $indent, $lineEnding, $rules);
+        $anotherSignature = new ConfigSignature($php, $version, $indent, $lineEnding, $rules);
 
         self::assertTrue($signature->equals($anotherSignature));
     }

--- a/tests/Cache/Signature/ConfigSignatureTest.php
+++ b/tests/Cache/Signature/ConfigSignatureTest.php
@@ -16,6 +16,8 @@ namespace PhpCsFixer\Tests\Cache\Signature;
 
 use PhpCsFixer\Cache\Signature\ConfigSignature;
 use PhpCsFixer\Cache\Signature\ConfigSignatureInterface;
+use PhpCsFixer\Cache\Signature\FixerSignature;
+use PhpCsFixer\Cache\Signature\RulesSignature;
 use PhpCsFixer\Tests\TestCase;
 
 /**
@@ -47,15 +49,20 @@ final class ConfigSignatureTest extends TestCase
         $version = '3.0';
         $indent = '    ';
         $lineEnding = PHP_EOL;
-        $rules = ['foo' => true, 'bar' => false];
 
-        $signature = new ConfigSignature($php, $version, $indent, $lineEnding, $rules);
+        $signature = new ConfigSignature($php, $version, $indent, $lineEnding, new RulesSignature(
+            FixerSignature::fromRawValues('foo', '', true),
+            FixerSignature::fromRawValues('bar', '', false)
+        ));
 
         self::assertSame($php, $signature->getPhpVersion());
         self::assertSame($version, $signature->getFixerVersion());
         self::assertSame($indent, $signature->getIndent());
         self::assertSame($lineEnding, $signature->getLineEnding());
-        self::assertSame($rules, $signature->getRules());
+        self::assertSame(
+            ['bar' => ['hash' => '', 'config' => false], 'foo' => ['hash' => '', 'config' => true]],
+            $signature->getRules()
+        );
     }
 
     /**
@@ -72,7 +79,10 @@ final class ConfigSignatureTest extends TestCase
         $version = '2.0';
         $indent = '    ';
         $lineEnding = "\n";
-        $rules = ['foo' => true, 'bar' => false];
+        $rules = new RulesSignature(
+            FixerSignature::fromRawValues('foo', '', true),
+            FixerSignature::fromRawValues('bar', '', false)
+        );
 
         $base = new ConfigSignature($php, $version, $indent, $lineEnding, $rules);
 
@@ -98,7 +108,9 @@ final class ConfigSignatureTest extends TestCase
 
         yield 'rules' => [
             $base,
-            new ConfigSignature($php, $version, $indent, $lineEnding, ['foo' => false]),
+            new ConfigSignature($php, $version, $indent, $lineEnding, new RulesSignature(
+                FixerSignature::fromRawValues('foo', '', false)
+            )),
         ];
     }
 
@@ -108,7 +120,7 @@ final class ConfigSignatureTest extends TestCase
         $version = '2.0';
         $indent = '    ';
         $lineEnding = PHP_EOL;
-        $rules = ['foo' => true, 'bar' => false];
+        $rules = new RulesSignature(FixerSignature::fromRawValues('foo', '', true));
 
         $signature = new ConfigSignature($php, $version, $indent, $lineEnding, $rules);
         $anotherSignature = new ConfigSignature($php, $version, $indent, $lineEnding, $rules);

--- a/tests/Cache/Signature/FixerSignatureTest.php
+++ b/tests/Cache/Signature/FixerSignatureTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Cache\Signature;
+
+use PhpCsFixer\Cache\Signature\FixerSignature;
+use PhpCsFixer\Tests\Fixtures\SignatureFixer;
+use PhpCsFixer\Tests\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Cache\Signature\FixerSignature
+ */
+final class FixerSignatureTest extends TestCase
+{
+    public function testIsPossibleToCreateFromFixerInstance(): void
+    {
+        $signature = FixerSignature::fromInstance(
+            new SignatureFixer(),
+            true
+        );
+
+        self::assertSame('signature_fixer', $signature->getName());
+        self::assertSame('413d3c9e640e242fe6a3c62b8d4bb9f5', $signature->getContentHash());
+        self::assertTrue($signature->getConfig());
+    }
+
+    public function testIsPossibleToCreateFromRawValues(): void
+    {
+        $signature = FixerSignature::fromRawValues(
+            $name = 'dummy_fixer',
+            $hash = 'abcdefghijklmnopqrstuvwxyz123456',
+            $config = ['foo' => 'bar']
+        );
+
+        self::assertSame($name, $signature->getName());
+        self::assertSame($hash, $signature->getContentHash());
+        self::assertSame($config, $signature->getConfig());
+    }
+}

--- a/tests/Cache/Signature/RulesSignatureTest.php
+++ b/tests/Cache/Signature/RulesSignatureTest.php
@@ -32,7 +32,7 @@ final class RulesSignatureTest extends TestCase
             FixerSignature::fromInstance(new SignatureFixer(), true)
         );
 
-        self::assertSame('c561b45d3402d7d0ef99640fea87da5e', $signature->getHash());
+        self::assertSame('5b6fc67e73d9fc77157f9c51a49ab2d3', $signature->getHash());
         self::assertCount(1, $signature->getFixerSignatures());
     }
 

--- a/tests/Cache/Signature/RulesSignatureTest.php
+++ b/tests/Cache/Signature/RulesSignatureTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Cache\Signature;
+
+use PhpCsFixer\Cache\Signature\FixerSignature;
+use PhpCsFixer\Cache\Signature\RulesSignature;
+use PhpCsFixer\Tests\Fixtures\SignatureFixer;
+use PhpCsFixer\Tests\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Cache\Signature\RulesSignature
+ */
+final class RulesSignatureTest extends TestCase
+{
+    public function testConstructorSetsValues(): void
+    {
+        $signature = new RulesSignature(
+            FixerSignature::fromInstance(new SignatureFixer(), true)
+        );
+
+        self::assertSame('c561b45d3402d7d0ef99640fea87da5e', $signature->getHash());
+        self::assertCount(1, $signature->getFixerSignatures());
+    }
+
+    public function testItThrowsExceptionOnDuplicatedFixerSignature(): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+
+        new RulesSignature(
+            FixerSignature::fromInstance(new SignatureFixer(), true),
+            FixerSignature::fromInstance(new SignatureFixer(), true)
+        );
+    }
+
+    public function testSignaturesAreEqual(): void
+    {
+        self::assertTrue(
+            (new RulesSignature(
+                FixerSignature::fromRawValues('dummy', '123abc', true),
+                FixerSignature::fromInstance(new SignatureFixer(), true)
+            ))
+                ->equals(new RulesSignature(
+                    FixerSignature::fromInstance(new SignatureFixer(), true),
+                    FixerSignature::fromRawValues('dummy', '123abc', true),
+                ))
+        );
+    }
+}

--- a/tests/Fixtures/SignatureFixer.php
+++ b/tests/Fixtures/SignatureFixer.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCsFixer\Tests\Fixtures;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class SignatureFixer implements FixerInterface
+{
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    public function fix(\SplFileInfo $file, Tokens $tokens): void
+    {
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition('Signature Fixer', []);
+    }
+
+    public function getName(): string
+    {
+        return 'signature_fixer';
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    public function supports(\SplFileInfo $file): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Fixes #6996.

This PR provides improvements for caching system: store rules' signatures and compare them before running analysis. This way when working on the Fixer's codebase developers can take advantage of the caching system but at the same time be sure rules will be applied again if any of the rules has been changed.

As you can see below, first run created cache, second run was skipped due to cache entry (image 1). Then, after changing `yoda_style` fixer's content it was run again because rule already had different signature (image 2).

<img width="1840" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/f9ffcf40-53ff-44f2-a169-fff4dd303f16">

<img width="1840" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/2288302e-cb35-4629-a8ba-91c5c28f5e96">

As I think of it, it also most probably improves caching for custom fixers - cache currently stores only Fixer's version, but custom rules may be updated to newer version independently and even if these may work differently, they wouldn't be applied because tool version and config could be exactly the same. After this change these would probably invalidate the cache (need to verify it, but if these are stored in the cache like any other rules, it would work as I said).

⚠️ Important: in order to get it to work correctly in PHPStorm it's required to configure Quality Tools correctly, so configuration files is used instead of one of pre-defined rulesets (because then PHPStorm's inspection generates new cache file with different ruleset).

<img width="1094" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/0b04c267-4894-4aab-9e2e-c038a67aacd0">
