### PR TITLE
DX: Fix warning when running test on PHP<8

### DIFF
--- a/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php
@@ -72,39 +72,41 @@ final class NameQualifiedTransformerTest extends AbstractTransformerTestCase
             ],
         ];
 
-        yield 'relative 1' => [
-            [
-                new Token([T_OPEN_TAG, "<?php\n"]),
-                new Token([T_NAMESPACE, 'namespace']),
-                new Token([T_NS_SEPARATOR, '\\']),
-                new Token([T_STRING, 'Transformer']),
-                new Token(';'),
-            ],
-            [
-                new Token([T_OPEN_TAG, "<?php\n"]),
-                new Token([T_NAME_RELATIVE, 'namespace\Transformer']),
-                new Token(';'),
-            ],
-        ];
+        if (\defined('T_NAME_RELATIVE')) { // @TODO: drop condition when PHP 8.0+ is required
+            yield 'relative 1' => [
+                [
+                    new Token([T_OPEN_TAG, "<?php\n"]),
+                    new Token([T_NAMESPACE, 'namespace']),
+                    new Token([T_NS_SEPARATOR, '\\']),
+                    new Token([T_STRING, 'Transformer']),
+                    new Token(';'),
+                ],
+                [
+                    new Token([T_OPEN_TAG, "<?php\n"]),
+                    new Token([T_NAME_RELATIVE, 'namespace\Transformer']),
+                    new Token(';'),
+                ],
+            ];
 
-        yield 'relative 2' => [
-            [
-                new Token([T_OPEN_TAG, "<?php\n"]),
-                new Token([T_NAMESPACE, 'namespace']),
-                new Token([T_NS_SEPARATOR, '\\']),
-                new Token([T_STRING, 'Transformer']),
-                new Token([T_NS_SEPARATOR, '\\']),
-                new Token([T_STRING, 'Foo']),
-                new Token([T_NS_SEPARATOR, '\\']),
-                new Token([T_STRING, 'Bar']),
-                new Token(';'),
-            ],
-            [
-                new Token([T_OPEN_TAG, "<?php\n"]),
-                new Token([T_NAME_RELATIVE, 'namespace\Transformer\Foo\Bar']),
-                new Token(';'),
-            ],
-        ];
+            yield 'relative 2' => [
+                [
+                    new Token([T_OPEN_TAG, "<?php\n"]),
+                    new Token([T_NAMESPACE, 'namespace']),
+                    new Token([T_NS_SEPARATOR, '\\']),
+                    new Token([T_STRING, 'Transformer']),
+                    new Token([T_NS_SEPARATOR, '\\']),
+                    new Token([T_STRING, 'Foo']),
+                    new Token([T_NS_SEPARATOR, '\\']),
+                    new Token([T_STRING, 'Bar']),
+                    new Token(';'),
+                ],
+                [
+                    new Token([T_OPEN_TAG, "<?php\n"]),
+                    new Token([T_NAME_RELATIVE, 'namespace\Transformer\Foo\Bar']),
+                    new Token(';'),
+                ],
+            ];
+        }
 
         yield 'name fully qualified 1' => [
             [


### PR DESCRIPTION
When running the utest on latest `main` on PHP<8 the following warning is emitted:

```
$ vendor/bin/phpunit
PHP Warning:  Use of undefined constant T_NAME_RELATIVE - assumed 'T_NAME_RELATIVE' (this will throw an Error in a future version of PHP) in /home/possum/work/PHP-CS-Fixer/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php on line 85
```

This is because PHPUnit resolves/uses the dataproviders before testing their usage against the test methods `requires` PHPDocs.

The diff look rather dramatic, but boils down to adding the `define` check and than indenting the `yields` accordingly, no other changes have been made.