### PR TITLE
minor: PHP8.3 - Typed class constants - handle nullable by transformer

### DIFF
--- a/src/Tokenizer/Transformer/NullableTypeTransformer.php
+++ b/src/Tokenizer/Transformer/NullableTypeTransformer.php
@@ -61,6 +61,7 @@ final class NullableTypeTransformer extends AbstractTransformer
                 [T_PUBLIC],
                 [T_VAR],
                 [T_STATIC],
+                [T_CONST],
             ];
 
             if (\defined('T_READONLY')) { // @TODO: drop condition when PHP 8.1+ is required

--- a/tests/Tokenizer/Transformer/NullableTypeTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NullableTypeTransformerTest.php
@@ -202,4 +202,37 @@ final class NullableTypeTransformerTest extends AbstractTransformerTestCase
             ',
         ];
     }
+
+    /**
+     * @param array<int, int> $expectedTokens
+     *
+     * @dataProvider provideProcess83Cases
+     *
+     * @requires PHP 8.3
+     */
+    public function testProcess83(array $expectedTokens, string $source): void
+    {
+        $this->doTest(
+            $source,
+            $expectedTokens,
+            [
+                CT::T_NULLABLE_TYPE,
+            ]
+        );
+    }
+
+    public static function provideProcess83Cases(): iterable
+    {
+        yield 'nullable class constant' => [
+            [
+                12 => CT::T_NULLABLE_TYPE,
+            ],
+            '<?php
+                class Foo
+                {
+                    public const ?string FOO = null;
+                }
+            ',
+        ];
+    }
 }


### PR DESCRIPTION
PHP8.3 introduces typed classy constants:
https://wiki.php.net/rfc/typed_class_constants

To support/handling these in the code I propose to change the `nullable` `?` native token into same custom token `CT::T_NULLABLE_TYPE`  as is done for the other nullable-typehints currently

part of https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6999