### PR TITLE
minor: PHP8.3 - Fix TokensAnalyzer::isAnonymousClass support for `readonly`

### DIFF
--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -286,6 +286,10 @@ final class TokensAnalyzer
 
         $index = $this->tokens->getPrevMeaningfulToken($index);
 
+        if (\defined('T_READONLY') && $this->tokens[$index]->isGivenKind(T_READONLY)) { // @TODO: drop condition when PHP 8.1+ is required
+            $index = $this->tokens->getPrevMeaningfulToken($index);
+        }
+
         while ($this->tokens[$index]->isGivenKind(CT::T_ATTRIBUTE_CLOSE)) {
             $index = $this->tokens->findBlockStart(Tokens::BLOCK_TYPE_ATTRIBUTE, $index);
             $index = $this->tokens->getPrevMeaningfulToken($index);

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -780,6 +780,23 @@ enum Foo: string
                 '<?php enum foo {}',
             ];
         }
+
+        if (\PHP_VERSION_ID >= 8_03_00) {
+            yield 'simple readonly anonymous class' => [
+                [9 => true],
+                '<?php $instance = new readonly class {};',
+            ];
+
+            yield 'readonly anonymous class with attribute' => [
+                [13 => true],
+                '<?php $instance = new #[Foo] readonly class {};',
+            ];
+
+            yield 'readonly anonymous class with multiple attributes' => [
+                [17 => true],
+                '<?php $instance = new #[Foo] #[BAR] readonly class {};',
+            ];
+        }
     }
 
     /**


### PR DESCRIPTION
Going over the PHP8.3 changes fixing each item in a single PR.

When all done I'll create new migration set if wanted.