### PR TITLE
minor: ClassDefinitionFixer - handle attributes and `readonly` in anonymous class definitions

### DIFF
--- a/src/Fixer/ClassNotation/ClassDefinitionFixer.php
+++ b/src/Fixer/ClassNotation/ClassDefinitionFixer.php
@@ -316,7 +316,7 @@ $foo = new class(){};
         }
 
         if ($def['anonymousClass']) {
-            $startIndex = $tokens->getPrevMeaningfulToken($classyIndex); // go to "new" for anonymous class
+            $startIndex = $tokens->getPrevTokenOfKind($classyIndex, [[T_NEW]]); // go to "new" for anonymous class
         } else {
             $modifiers = $tokensAnalyzer->getClassyModifiers($classyIndex);
             $startIndex = $classyIndex;

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -715,6 +715,29 @@ $a = new class implements
     }
 
     /**
+     * @dataProvider provideFix80Cases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFix80(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFix80Cases(): iterable
+    {
+        yield 'anonymous class, single attribute' => [
+            '<?php $a = new #[FOO] class(2) {};',
+            '<?php $a = new    #[FOO]   class(2){};',
+        ];
+
+        yield 'anonymous class, multiple attributes' => [
+            '<?php $a = new #[FOO] #[BAR] class {};',
+            '<?php $a = new    #[FOO]    #[BAR]  class  {};',
+        ];
+    }
+
+    /**
      * @dataProvider provideFix81Cases
      *
      * @requires PHP 8.1
@@ -773,6 +796,39 @@ $a = new class implements
 {}',
             '<?php readonly abstract class a
 {}',
+        ];
+    }
+
+    /**
+     * @dataProvider provideFix83Cases
+     *
+     * @requires PHP 8.3
+     */
+    public function testFix83(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFix83Cases(): iterable
+    {
+        yield 'anonymous class, readonly, missing spacing' => [
+            '<?php $a = new readonly class {};',
+            '<?php $a = new readonly class{};',
+        ];
+
+        yield 'anonymous class, readonly, to much spacing' => [
+            '<?php $a = new readonly class {};',
+            '<?php $a = new      readonly   class  {};',
+        ];
+
+        yield 'anonymous class, single attribute' => [
+            '<?php $a = new #[BAR] readonly class {};',
+            '<?php $a = new        #[BAR]   readonly class{};',
+        ];
+
+        yield 'anonymous class, multiple attributes' => [
+            '<?php $a = new #[FOO] #[BAR] readonly class {};',
+            '<?php $a = new    #[FOO]    #[BAR]   readonly class   {};',
         ];
     }
 


### PR DESCRIPTION
depends on https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7013 
please review:
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7014/commits/f2208e5c50de15181d4755fb244441aed1306747

also fixes more cases on PHP8.0 and up (currently bugged)