### PR TITLE
minor: ReturnAssignmentFixer - Better handling of anonymous classes

### DIFF
--- a/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+++ b/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -25,10 +25,7 @@ use PhpCsFixer\Tokenizer\TokensAnalyzer;
 
 final class ReturnAssignmentFixer extends AbstractFixer
 {
-    /**
-     * @var TokensAnalyzer
-     */
-    private $tokensAnalyzer;
+    private TokensAnalyzer $tokensAnalyzer;
 
     public function getDefinition(): FixerDefinitionInterface
     {
@@ -395,20 +392,18 @@ final class ReturnAssignmentFixer extends AbstractFixer
     {
         do {
             $index = $tokens->getPrevMeaningfulToken($index);
-        } while ($tokens[$index]->equalsAny([',', [T_STRING], [T_IMPLEMENTS], [T_EXTENDS]]));
+        } while ($tokens[$index]->equalsAny([',', [T_STRING], [T_IMPLEMENTS], [T_EXTENDS], [T_NS_SEPARATOR]]));
 
-        if ($tokens[$index]->equals(')')) {
+        if ($tokens[$index]->equals(')')) { // skip constructor braces and content within
             $index = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
             $index = $tokens->getPrevMeaningfulToken($index);
         }
 
-        if (!$tokens[$index]->isGivenKind(T_CLASS)) {
+        if (!$tokens[$index]->isGivenKind(T_CLASS) || !$this->tokensAnalyzer->isAnonymousClass($index)) {
             return null;
         }
 
-        $index = $tokens->getPrevMeaningfulToken($index);
-
-        return $tokens[$index]->isGivenKind(T_NEW) ? $index : null;
+        return $tokens->getPrevTokenOfKind($index, [[T_NEW]]);
     }
 
     /**

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -484,7 +484,7 @@ var names are case-insensitive */ return $a   ;}
 
                     function E()
                     {
-                        return new class extends Y implements O,P {};
+                        return new class extends Y implements A\O,P {};
                     }
                 ',
                 '<?php
@@ -514,7 +514,7 @@ var names are case-insensitive */ return $a   ;}
 
                     function E()
                     {
-                        $c = new class extends Y implements O,P {};
+                        $c = new class extends Y implements A\O,P {};
                         return $c;
                     }
                 ',
@@ -1061,6 +1061,67 @@ function foo(&$c) {
 
                 return $return_value;
             }
+            ',
+        ];
+
+        yield 'annotation for anonymous class' => [
+            '<?php
+                function A()
+                {
+                    return new #[Foo] class {};
+                }
+            ',
+            '<?php
+                function A()
+                {
+                    $a = new #[Foo] class {};
+                    return $a;
+                }
+            ',
+        ];
+    }
+
+    /**
+     * @requires PHP 8.3
+     *
+     * @dataProvider providePhp83Cases
+     */
+    public function testFixPhp83(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function providePhp83Cases(): iterable
+    {
+        yield 'anonymous readonly class' => [
+            '<?php
+                function A()
+                {
+                    return new readonly class {};
+                }
+            ',
+            '<?php
+                function A()
+                {
+                    $a = new readonly class {};
+                    return $a;
+                }
+            ',
+        ];
+
+        yield 'annotation for anonymous readonly class' => [
+            '<?php
+                function A()
+                {
+                    return new #[Foo] readonly class {};
+                }
+            ',
+            '<?php
+                function A()
+                {
+                    $a = new #[Foo] readonly class {};
+                    return $a;
+                }
             ',
         ];
     }

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -1064,7 +1064,7 @@ function foo(&$c) {
             ',
         ];
 
-        yield 'annotation for anonymous class' => [
+        yield 'attribute before anonymous `class`' => [
             '<?php
                 function A()
                 {
@@ -1109,7 +1109,7 @@ function foo(&$c) {
             ',
         ];
 
-        yield 'annotation for anonymous readonly class' => [
+        yield 'attribute before anonymous `readonly class`' => [
             '<?php
                 function A()
                 {


### PR DESCRIPTION
Fixes anonymous classes handling by `ReturnAssignmentFixer`:
- some cases on PHP7.4 where `\` was not considered a possible part of an anonymous classes definition
- some cases on PHP8.0 where attributes were not considered a possible part of an anonymous classes definition
- support for PHP8.3 `readonly` anonymous classes

depends on https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7013