### PR TITLE
feature: Allow case sensitive order for OrderedClassElementsFixer

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1923,7 +1923,7 @@ List of Available Rules
      | Default value: ``['use_trait', 'case', 'constant_public', 'constant_protected', 'constant_private', 'property_public', 'property_protected', 'property_private', 'construct', 'destruct', 'magic', 'phpunit', 'method_public', 'method_protected', 'method_private']``
    - | ``sort_algorithm``
      | How multiple occurrences of same type statements should be sorted.
-     | Allowed values: ``'alpha'``, ``'none'``
+     | Allowed values: ``'alpha'``, ``'alpha_case_insensitive'``, ``'alpha_case_sensitive'``, ``'none'``
      | Default value: ``'none'``
 
 

--- a/doc/rules/class_notation/ordered_class_elements.rst
+++ b/doc/rules/class_notation/ordered_class_elements.rst
@@ -46,7 +46,7 @@ Default value: ``['use_trait', 'case', 'constant_public', 'constant_protected', 
 
 How multiple occurrences of same type statements should be sorted.
 
-Allowed values: ``'alpha'``, ``'none'``
+Allowed values: ``'alpha'``, ``'alpha_case_insensitive'``, ``'alpha_case_sensitive'``, ``'none'``
 
 Default value: ``'none'``
 
@@ -122,7 +122,7 @@ With configuration: ``['order' => ['method_private', 'method_public']]``.
 Example #3
 ~~~~~~~~~~
 
-With configuration: ``['order' => ['method_public'], 'sort_algorithm' => 'alpha']``.
+With configuration: ``['order' => ['method_public'], 'sort_algorithm' => 'alpha_case_insensitive']``.
 
 .. code-block:: diff
 
@@ -137,6 +137,26 @@ With configuration: ``['order' => ['method_public'], 'sort_algorithm' => 'alpha'
    -    public function A(){}
         public function C(){}
    +    public function D(){}
+    }
+
+Example #4
+~~~~~~~~~~
+
+With configuration: ``['order' => ['method_public'], 'sort_algorithm' => 'alpha_case_sensitive']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    class Example
+    {
+   +    public function AA(){}
+   +    public function AWs(){}
+        public function Aa(){}
+   -    public function AA(){}
+        public function AwS(){}
+   -    public function AWs(){}
     }
 
 Rule sets

--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -31,8 +31,18 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 final class OrderedClassElementsFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
-    /** @internal */
+    /**
+     * @internal
+     *
+     * @deprecated use `alpha_case_insensitive` instead
+     */
     public const SORT_ALPHA = 'alpha';
+
+    /** @internal */
+    public const SORT_ALPHA_CASE_INSENSITIVE = 'alpha_case_insensitive';
+
+    /** @internal */
+    public const SORT_ALPHA_CASE_SENSITIVE = 'alpha_case_sensitive';
 
     /** @internal */
     public const SORT_NONE = 'none';
@@ -40,6 +50,8 @@ final class OrderedClassElementsFixer extends AbstractFixer implements Configura
     private const SUPPORTED_SORT_ALGORITHMS = [
         self::SORT_NONE,
         self::SORT_ALPHA,
+        self::SORT_ALPHA_CASE_INSENSITIVE,
+        self::SORT_ALPHA_CASE_SENSITIVE,
     ];
 
     /**
@@ -205,7 +217,19 @@ class Example
     public function C(){}
 }
 ',
-                    ['order' => ['method_public'], 'sort_algorithm' => self::SORT_ALPHA]
+                    ['order' => ['method_public'], 'sort_algorithm' => self::SORT_ALPHA_CASE_INSENSITIVE]
+                ),
+                new CodeSample(
+                    '<?php
+class Example
+{
+    public function Aa(){}
+    public function AA(){}
+    public function AwS(){}
+    public function AWs(){}
+}
+',
+                    ['order' => ['method_public'], 'sort_algorithm' => self::SORT_ALPHA_CASE_SENSITIVE]
                 ),
             ],
             'Accepts a subset of pre-defined element types, special element groups, and custom patterns.
@@ -569,8 +593,14 @@ Custom values:
     {
         $selectedSortAlgorithm = $this->configuration['sort_algorithm'];
 
-        if (self::SORT_ALPHA === $selectedSortAlgorithm) {
+        if (
+            self::SORT_ALPHA === $selectedSortAlgorithm || self::SORT_ALPHA_CASE_INSENSITIVE === $selectedSortAlgorithm
+        ) {
             return strcasecmp($a['name'], $b['name']);
+        }
+
+        if (self::SORT_ALPHA_CASE_SENSITIVE === $selectedSortAlgorithm) {
+            return strcmp($a['name'], $b['name']);
         }
 
         return $a['start'] <=> $b['start'];

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -1039,6 +1039,16 @@ EOT
     {
         $this->fixer->configure($configuration);
         $this->doTest($expected, $input);
+
+        if (
+            isset($configuration['sort_algorithm'])
+            && OrderedClassElementsFixer::SORT_ALPHA === $configuration['sort_algorithm']
+        ) {
+            $configuration['sort_algorithm'] = OrderedClassElementsFixer::SORT_ALPHA_CASE_INSENSITIVE;
+
+            $this->fixer->configure($configuration);
+            $this->doTest($expected, $input);
+        }
     }
 
     public static function provideSortingConfigurationCases(): array
@@ -1361,6 +1371,52 @@ class Foo
     public const C1 = 1;
     protected const C4a = 4;
     public const C3b = 3;
+}
+EOT
+            ],
+            [
+                ['sort_algorithm' => OrderedClassElementsFixer::SORT_ALPHA],
+                <<<'EOT'
+<?php
+
+class Foo
+{
+    const A_ = 1;
+    const AA = 2;
+    const Ab = 3;
+}
+EOT
+                , <<<'EOT'
+<?php
+
+class Foo
+{
+    const AA = 2;
+    const Ab = 3;
+    const A_ = 1;
+}
+EOT
+            ],
+            [
+                ['sort_algorithm' => OrderedClassElementsFixer::SORT_ALPHA_CASE_SENSITIVE],
+                <<<'EOT'
+<?php
+
+class Foo
+{
+    const AA = 2;
+    const A_ = 1;
+    const Ab = 3;
+}
+EOT
+                , <<<'EOT'
+<?php
+
+class Foo
+{
+    const AA = 2;
+    const Ab = 3;
+    const A_ = 1;
 }
 EOT
             ],


### PR DESCRIPTION
- add `alpha_case_insensitive` order option
- add `alpha_case_sensitive` order option
- deprecate `alpha` order option in favour of `alpha_case_insensitive`