### PR TITLE
minor: Utils - add naturalLanguageJoin

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -122,20 +122,20 @@ final class Utils
     }
 
     /**
-     * Join names in natural language wrapped in backticks, e.g. `a`, `b` and `c`.
+     * Join names in natural language wrapped in string $wrapper.
      *
      * @param string[] $names
      *
      * @throws \InvalidArgumentException
      */
-    public static function naturalLanguageJoinWithBackticks(array $names): string
+    public static function naturalLanguageJoin(array $names, string $wrapper = '"'): string
     {
         if (0 === \count($names)) {
             throw new \InvalidArgumentException('Array of names cannot be empty.');
         }
 
-        $names = array_map(static function (string $name): string {
-            return sprintf('`%s`', $name);
+        $names = array_map(static function (string $name) use ($wrapper): string {
+            return sprintf('%2$s%1$s%2$s', $name, $wrapper);
         }, $names);
 
         $last = array_pop($names);
@@ -145,6 +145,18 @@ final class Utils
         }
 
         return $last;
+    }
+
+    /**
+     * Join names in natural language wrapped in backticks, e.g. `a`, `b` and `c`.
+     *
+     * @param string[] $names
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function naturalLanguageJoinWithBackticks(array $names): string
+    {
+        return self::naturalLanguageJoin($names, '`');
     }
 
     public static function triggerDeprecation(\Exception $futureException): void

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -122,7 +122,7 @@ final class Utils
     }
 
     /**
-     * Join names in natural language wrapped in string $wrapper.
+     * Join names in natural language using specified wrapper (double quote by default).
      *
      * @param string[] $names
      *
@@ -132,6 +132,10 @@ final class Utils
     {
         if (0 === \count($names)) {
             throw new \InvalidArgumentException('Array of names cannot be empty.');
+        }
+
+        if (\strlen($wrapper) > 1) {
+            throw new \InvalidArgumentException('Wrapper should be a single-char string or empty.');
         }
 
         $names = array_map(static function (string $name) use ($wrapper): string {

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -216,6 +216,77 @@ final class UtilsTest extends TestCase
         );
     }
 
+    public function testNaturalLanguageJoinThrowsInvalidArgumentExceptionForEmptyArray(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Array of names cannot be empty.');
+
+        Utils::naturalLanguageJoin([]);
+    }
+
+    /**
+     * @dataProvider provideNaturalLanguageJoinCases
+     *
+     * @param list<string> $names
+     */
+    public function testNaturalLanguageJoin(string $joined, array $names, ?string $wrapper = null): void
+    {
+        $wrapper ??= '"';
+
+        self::assertSame($joined, Utils::naturalLanguageJoin($names, $wrapper));
+    }
+
+    /**
+     * @return iterable<array<null|array<string>|string>>
+     */
+    public static function provideNaturalLanguageJoinCases(): iterable
+    {
+        yield from [
+            [
+                '"a"',
+                ['a'],
+            ],
+            [
+                '"a" and "b"',
+                ['a', 'b'],
+            ],
+            [
+                '"a", "b" and "c"',
+                ['a', 'b', 'c'],
+            ],
+            [
+                '\'a\'',
+                ['a'],
+                '\'',
+            ],
+            [
+                '\'a\' and \'b\'',
+                ['a', 'b'],
+                '\'',
+            ],
+            [
+                '\'a\', \'b\' and \'c\'',
+                ['a', 'b', 'c'],
+                '\'',
+            ],
+            [
+                '?a?',
+                ['a'],
+                '?',
+            ],
+            [
+                '?a? and ?b?',
+                ['a', 'b'],
+                '?',
+            ],
+            [
+                '?a?, ?b? and ?c?',
+                ['a', 'b', 'c'],
+                '?',
+            ],
+        ];
+    }
+
     public function testNaturalLanguageJoinWithBackticksThrowsInvalidArgumentExceptionForEmptyArray(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -224,15 +224,21 @@ final class UtilsTest extends TestCase
         Utils::naturalLanguageJoin([]);
     }
 
+    public function testNaturalLanguageJoinThrowsInvalidArgumentExceptionForMoreThanOneCharWrapper(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Wrapper should be a single-char string or empty.');
+
+        Utils::naturalLanguageJoin(['a', 'b'], 'foo');
+    }
+
     /**
      * @dataProvider provideNaturalLanguageJoinCases
      *
      * @param list<string> $names
      */
-    public function testNaturalLanguageJoin(string $joined, array $names, ?string $wrapper = null): void
+    public function testNaturalLanguageJoin(string $joined, array $names, string $wrapper = '"'): void
     {
-        $wrapper ??= '"';
-
         self::assertSame($joined, Utils::naturalLanguageJoin($names, $wrapper));
     }
 
@@ -283,6 +289,21 @@ final class UtilsTest extends TestCase
                 '?a?, ?b? and ?c?',
                 ['a', 'b', 'c'],
                 '?',
+            ],
+            [
+                'a',
+                ['a'],
+                '',
+            ],
+            [
+                'a and b',
+                ['a', 'b'],
+                '',
+            ],
+            [
+                'a, b and c',
+                ['a', 'b', 'c'],
+                '',
             ],
         ];
     }


### PR DESCRIPTION
This is adapted from `Utils::naturalLanguageJoinWithBackticks` but supporting various string wrappers. Motivation for this is to normalize stringifying of lists in the project using natural language.

If this is accepted, I'll make a follow-up PR updating the implode calls to use this.