### PR TITLE
bug: `FullyQualifiedStrictTypesFixer` - fix shortening when namespace is not empty and import exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }} tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -108,6 +108,26 @@ namespace A\B\C\D
             '<?php namespace Foo; function foo(\FooBar $v): \FooBar {}',
             null,
         ];
+
+        yield 'issue #7025 - non-empty namespace, import and FQCN in argument' => [
+            '<?php namespace foo\bar\baz;
+
+use foo\baz\buzz;
+
+class A {
+    public function b(buzz $buzz): void {
+    }
+}',
+            '<?php namespace foo\bar\baz;
+
+use foo\baz\buzz;
+
+class A {
+    public function b(\foo\baz\buzz $buzz): void {
+    }
+}',
+            null,
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes #7025 