### PR TITLE
minor: `SingleSpaceAroundConstructFixer` - support space before `as`

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2960,8 +2960,8 @@ List of Available Rules
      | Default value: ``['yield_from']``
    - | ``constructs_preceded_by_a_single_space``
      | List of constructs which must be preceded by a single space.
-     | Allowed values: a subset of ``['use_lambda']``
-     | Default value: ``['use_lambda']``
+     | Allowed values: a subset of ``['as', 'use_lambda']``
+     | Default value: ``['as', 'use_lambda']``
    - | ``constructs_followed_by_a_single_space``
      | List of constructs which must be followed by a single space.
      | Allowed values: a subset of ``['abstract', 'as', 'attribute', 'break', 'case', 'catch', 'class', 'clone', 'comment', 'const', 'const_import', 'continue', 'do', 'echo', 'else', 'elseif', 'enum', 'extends', 'final', 'finally', 'for', 'foreach', 'function', 'function_import', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof', 'insteadof', 'interface', 'match', 'named_argument', 'namespace', 'new', 'open_tag_with_echo', 'php_doc', 'php_open', 'print', 'private', 'protected', 'public', 'readonly', 'require', 'require_once', 'return', 'static', 'switch', 'throw', 'trait', 'try', 'type_colon', 'use', 'use_lambda', 'use_trait', 'var', 'while', 'yield', 'yield_from']``

--- a/doc/rules/language_construct/single_space_around_construct.rst
+++ b/doc/rules/language_construct/single_space_around_construct.rst
@@ -21,9 +21,9 @@ Default value: ``['yield_from']``
 
 List of constructs which must be preceded by a single space.
 
-Allowed values: a subset of ``['use_lambda']``
+Allowed values: a subset of ``['as', 'use_lambda']``
 
-Default value: ``['use_lambda']``
+Default value: ``['as', 'use_lambda']``
 
 ``constructs_followed_by_a_single_space``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixer.php
@@ -46,7 +46,7 @@ final class SingleSpaceAroundConstructFixer extends AbstractFixer implements Con
      * @var array<string, null|int>
      */
     private static array $tokenMapPrecededByASingleSpace = [
-        // for now, only one case - but we are ready to extend it, when we learn about new cases to cover
+        'as' => T_AS,
         'use_lambda' => CT::T_USE_LAMBDA,
     ];
 

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixerTest.php
@@ -383,6 +383,134 @@ class Foo
                     'constructs_followed_by_a_single_space' => ['as'],
                 ],
             ],
+            [
+                '<?php
+namespace Foo;
+
+use Bar as Baz;
+
+final class Qux extends Baz {}
+',
+                '<?php
+namespace Foo;
+
+use Bar    as Baz;
+
+final class Qux extends Baz {}
+',
+                [
+                    'constructs_preceded_by_a_single_space' => ['as'],
+                    'constructs_followed_by_a_single_space' => [],
+                ],
+            ],
+            [
+                '<?php
+namespace Foo;
+
+use Bar as Baz;
+
+final class Qux extends Baz {}
+',
+                '<?php
+namespace Foo;
+
+use Bar
+    as Baz;
+
+final class Qux extends Baz {}
+',
+                [
+                    'constructs_preceded_by_a_single_space' => ['as'],
+                    'constructs_followed_by_a_single_space' => [],
+                ],
+            ],
+            [
+                '<?php
+namespace Foo;
+
+use Bar /** foo */ as Baz;
+
+final class Qux extends Baz {}
+',
+                '<?php
+namespace Foo;
+
+use Bar /** foo */as Baz;
+
+final class Qux extends Baz {}
+',
+                [
+                    'constructs_preceded_by_a_single_space' => ['as'],
+                    'constructs_followed_by_a_single_space' => [],
+                ],
+            ],
+            [
+                '<?php
+class Foo
+{
+    use Bar {
+        Bar::baz as bar;
+    }
+}
+',
+                '<?php
+class Foo
+{
+    use Bar {
+        Bar::baz    as bar;
+    }
+}
+',
+                [
+                    'constructs_preceded_by_a_single_space' => ['as'],
+                    'constructs_followed_by_a_single_space' => [],
+                ],
+            ],
+            [
+                '<?php
+class Foo
+{
+    use Bar {
+        Bar::baz as bar;
+    }
+}
+',
+                '<?php
+class Foo
+{
+    use Bar {
+        Bar::baz
+as bar;
+    }
+}
+',
+                [
+                    'constructs_preceded_by_a_single_space' => ['as'],
+                    'constructs_followed_by_a_single_space' => [],
+                ],
+            ],
+            [
+                '<?php
+class Foo
+{
+    use Bar {
+        Bar::baz/** foo */ as bar;
+    }
+}
+',
+                '<?php
+class Foo
+{
+    use Bar {
+        Bar::baz/** foo */as bar;
+    }
+}
+',
+                [
+                    'constructs_preceded_by_a_single_space' => ['as'],
+                    'constructs_followed_by_a_single_space' => [],
+                ],
+            ],
         ];
     }
 

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixerTest.php
@@ -204,14 +204,12 @@ abstract class Foo
 
     /**
      * @dataProvider provideFixWithAsCases
+     *
+     * @param array<string, string[]> $config
      */
-    public function testFixWithAs(string $expected, ?string $input = null): void
+    public function testFixWithAs(string $expected, ?string $input = null, array $config = []): void
     {
-        $this->fixer->configure([
-            'constructs_followed_by_a_single_space' => [
-                'as',
-            ],
-        ]);
+        $this->fixer->configure($config);
 
         $this->doTest($expected, $input);
     }
@@ -222,24 +220,77 @@ abstract class Foo
             [
                 '<?php foreach ($foo as $bar) {}',
                 '<?php foreach ($foo as$bar) {}',
+                [
+                    'constructs_preceded_by_a_single_space' => [],
+                    'constructs_followed_by_a_single_space' => ['as'],
+                ],
             ],
             [
                 '<?php foreach ($foo as $bar) {}',
                 '<?php foreach ($foo as  $bar) {}',
+                [
+                    'constructs_preceded_by_a_single_space' => [],
+                    'constructs_followed_by_a_single_space' => ['as'],
+                ],
+            ],
+            [
+                '<?php foreach ($foo as $bar) {}',
+                '<?php foreach ($foo  as $bar) {}',
+                [
+                    'constructs_preceded_by_a_single_space' => ['as'],
+                    'constructs_followed_by_a_single_space' => [],
+                ],
             ],
             [
                 '<?php foreach ($foo as $bar) {}',
                 '<?php foreach ($foo as
 
 $bar) {}',
+                [
+                    'constructs_preceded_by_a_single_space' => [],
+                    'constructs_followed_by_a_single_space' => ['as'],
+                ],
+            ],
+            [
+                '<?php foreach ($foo as $bar) {}',
+                '<?php foreach ($foo
+as $bar) {}',
+                [
+                    'constructs_preceded_by_a_single_space' => ['as'],
+                    'constructs_followed_by_a_single_space' => [],
+                ],
             ],
             [
                 '<?php foreach ($foo as /* foo */$bar) {}',
                 '<?php foreach ($foo as/* foo */$bar) {}',
+                [
+                    'constructs_preceded_by_a_single_space' => [],
+                    'constructs_followed_by_a_single_space' => ['as'],
+                ],
+            ],
+            [
+                '<?php foreach ($foo/* foo */ as $bar) {}',
+                '<?php foreach ($foo/* foo */as $bar) {}',
+                [
+                    'constructs_preceded_by_a_single_space' => ['as'],
+                    'constructs_followed_by_a_single_space' => [],
+                ],
             ],
             [
                 '<?php foreach ($foo as /* foo */$bar) {}',
                 '<?php foreach ($foo as  /* foo */$bar) {}',
+                [
+                    'constructs_preceded_by_a_single_space' => [],
+                    'constructs_followed_by_a_single_space' => ['as'],
+                ],
+            ],
+            [
+                '<?php foreach ($foo /* foo */ as $bar) {}',
+                '<?php foreach ($foo /* foo */    as $bar) {}',
+                [
+                    'constructs_preceded_by_a_single_space' => ['as'],
+                    'constructs_followed_by_a_single_space' => [],
+                ],
             ],
             [
                 '<?php
@@ -258,6 +309,10 @@ class Foo
         Bar::baz as  bar;
     }
 }',
+                [
+                    'constructs_preceded_by_a_single_space' => [],
+                    'constructs_followed_by_a_single_space' => ['as'],
+                ],
             ],
             [
                 '<?php
@@ -278,6 +333,10 @@ class Foo
 bar;
     }
 }',
+                [
+                    'constructs_preceded_by_a_single_space' => [],
+                    'constructs_followed_by_a_single_space' => ['as'],
+                ],
             ],
             [
                 '<?php
@@ -296,6 +355,11 @@ class Foo
         Bar::baz as/* foo */bar;
     }
 }',
+
+                [
+                    'constructs_preceded_by_a_single_space' => [],
+                    'constructs_followed_by_a_single_space' => ['as'],
+                ],
             ],
             [
                 '<?php
@@ -314,6 +378,10 @@ class Foo
         Bar::baz as  /* foo */bar;
     }
 }',
+                [
+                    'constructs_preceded_by_a_single_space' => [],
+                    'constructs_followed_by_a_single_space' => ['as'],
+                ],
             ],
         ];
     }

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixerTest.php
@@ -293,6 +293,39 @@ as $bar) {}',
                 ],
             ],
             [
+                '<?php foreach (range(1, 12) as $num) {}',
+                '<?php foreach (range(1, 12)as $num) {}',
+                [
+                    'constructs_preceded_by_a_single_space' => ['as'],
+                    'constructs_followed_by_a_single_space' => [],
+                ],
+            ],
+            [
+                '<?php foreach (range(1, 12) as $num) {}',
+                '<?php foreach (range(1, 12)   as $num) {}',
+                [
+                    'constructs_preceded_by_a_single_space' => ['as'],
+                    'constructs_followed_by_a_single_space' => [],
+                ],
+            ],
+            [
+                '<?php foreach ([1, 2, 3, 4] as $int) {}',
+                '<?php foreach ([1, 2, 3, 4]as $int) {}',
+                [
+                    'constructs_preceded_by_a_single_space' => ['as'],
+                    'constructs_followed_by_a_single_space' => [],
+                ],
+            ],
+            [
+                '<?php foreach ([1, 2, 3, 4] as $int) {}',
+                '<?php foreach ([1, 2, 3, 4]
+                as $int) {}',
+                [
+                    'constructs_preceded_by_a_single_space' => ['as'],
+                    'constructs_followed_by_a_single_space' => [],
+                ],
+            ],
+            [
                 '<?php
 
 class Foo


### PR DESCRIPTION
Closes #5155 