### PR TITLE
DX: Use `Utils::naturalLanguageJoin()` in implode calls

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -10,7 +10,7 @@ List of Available Rules
 
    - | ``comment_type``
      | Whether to fix PHPDoc comments only (`phpdocs_only`), any multi-line comment whose lines all start with an asterisk (`phpdocs_like`) or any multi-line comment (`all_multiline`).
-     | Allowed values: ``'all_multiline'``, ``'phpdocs_like'``, ``'phpdocs_only'``
+     | Allowed values: ``'all_multiline'``, ``'phpdocs_like'`` and ``'phpdocs_only'``
      | Default value: ``'phpdocs_only'``
 
 
@@ -41,7 +41,7 @@ List of Available Rules
 
    - | ``syntax``
      | Whether to use the `long` or `short` array syntax.
-     | Allowed values: ``'long'``, ``'short'``
+     | Allowed values: ``'long'`` and ``'short'``
      | Default value: ``'short'``
 
 
@@ -73,10 +73,10 @@ List of Available Rules
 
    - | ``default``
      | Default fix strategy.
-     | Allowed values: ``'align'``, ``'align_by_scope'``, ``'align_single_space'``, ``'align_single_space_by_scope'``, ``'align_single_space_minimal'``, ``'align_single_space_minimal_by_scope'``, ``'no_space'``, ``'single_space'``, ``null``
+     | Allowed values: ``'align'``, ``'align_by_scope'``, ``'align_single_space'``, ``'align_single_space_by_scope'``, ``'align_single_space_minimal'``, ``'align_single_space_minimal_by_scope'``, ``'no_space'``, ``'single_space'`` and ``null``
      | Default value: ``'single_space'``
    - | ``operators``
-     | Dictionary of `binary operator` => `fix strategy` values that differ from the default strategy. Supported are: `=`, `*`, `/`, `%`, `<`, `>`, `|`, `^`, `+`, `-`, `&`, `&=`, `&&`, `||`, `.=`, `/=`, `=>`, `==`, `>=`, `===`, `!=`, `<>`, `!==`, `<=`, `and`, `or`, `xor`, `-=`, `%=`, `*=`, `|=`, `+=`, `<<`, `<<=`, `>>`, `>>=`, `^=`, `**`, `**=`, `<=>`, `??`, `??=`.
+     | Dictionary of `binary operator` => `fix strategy` values that differ from the default strategy. Supported are: `=`, `*`, `/`, `%`, `<`, `>`, `|`, `^`, `+`, `-`, `&`, `&=`, `&&`, `||`, `.=`, `/=`, `=>`, `==`, `>=`, `===`, `!=`, `<>`, `!==`, `<=`, `and`, `or`, `xor`, `-=`, `%=`, `*=`, `|=`, `+=`, `<<`, `<<=`, `>>`, `>>=`, `^=`, `**`, `**=`, `<=>`, `??` and `??=`.
      | Allowed types: ``array``
      | Default value: ``[]``
 
@@ -141,15 +141,15 @@ List of Available Rules
      | Default value: ``false``
    - | ``position_after_functions_and_oop_constructs``
      | Whether the opening brace should be placed on "next" or "same" line after classy constructs (non-anonymous classes, interfaces, traits, methods and non-lambda functions).
-     | Allowed values: ``'next'``, ``'same'``
+     | Allowed values: ``'next'`` and ``'same'``
      | Default value: ``'next'``
    - | ``position_after_control_structures``
      | Whether the opening brace should be placed on "next" or "same" line after control structures.
-     | Allowed values: ``'next'``, ``'same'``
+     | Allowed values: ``'next'`` and ``'same'``
      | Default value: ``'same'``
    - | ``position_after_anonymous_constructs``
      | Whether the opening brace should be placed on "next" or "same" line after anonymous constructs (anonymous classes and lambda functions).
-     | Allowed values: ``'next'``, ``'same'``
+     | Allowed values: ``'next'`` and ``'same'``
      | Default value: ``'same'``
 
 
@@ -162,7 +162,7 @@ List of Available Rules
 
    - | ``space``
      | Spacing to apply between cast and variable.
-     | Allowed values: ``'none'``, ``'single'``
+     | Allowed values: ``'none'`` and ``'single'``
      | Default value: ``'single'``
 
 
@@ -294,7 +294,7 @@ List of Available Rules
 
    - | ``spacing``
      | Spacing to apply around concatenation operator.
-     | Allowed values: ``'none'``, ``'one'``
+     | Allowed values: ``'none'`` and ``'one'``
      | Default value: ``'none'``
 
 
@@ -309,7 +309,7 @@ List of Available Rules
 
    - | ``case``
      | Whether to use the `upper` or `lower` case syntax.
-     | Allowed values: ``'lower'``, ``'upper'``
+     | Allowed values: ``'lower'`` and ``'upper'``
      | Default value: ``'lower'``
 
 
@@ -331,7 +331,7 @@ List of Available Rules
 
    - | ``position``
      | The position of the keyword that continues the control structure.
-     | Allowed values: ``'next_line'``, ``'same_line'``
+     | Allowed values: ``'next_line'`` and ``'same_line'``
      | Default value: ``'same_line'``
 
 
@@ -346,23 +346,23 @@ List of Available Rules
 
    - | ``control_structures_opening_brace``
      | The position of the opening brace of control structures‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
      | Default value: ``'same_line'``
    - | ``functions_opening_brace``
      | The position of the opening brace of functions‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
      | Default value: ``'next_line_unless_newline_at_signature_end'``
    - | ``anonymous_functions_opening_brace``
      | The position of the opening brace of anonymous functions‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
      | Default value: ``'same_line'``
    - | ``classes_opening_brace``
      | The position of the opening brace of classes‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
      | Default value: ``'next_line_unless_newline_at_signature_end'``
    - | ``anonymous_classes_opening_brace``
      | The position of the opening brace of anonymous classes‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
      | Default value: ``'same_line'``
    - | ``allow_single_line_empty_anonymous_classes``
      | Allow anonymous classes to have opening and closing braces on the same line.
@@ -408,7 +408,7 @@ List of Available Rules
 
    - | ``space``
      | Spacing to apply around the equal sign.
-     | Allowed values: ``'none'``, ``'single'``
+     | Allowed values: ``'none'`` and ``'single'``
      | Default value: ``'none'``
 
 
@@ -452,7 +452,7 @@ List of Available Rules
      | Default value: ``['abstract', 'access', 'code', 'deprec', 'encode', 'exception', 'final', 'ingroup', 'inheritdoc', 'inheritDoc', 'magic', 'name', 'toc', 'tutorial', 'private', 'static', 'staticvar', 'staticVar', 'throw', 'api', 'author', 'category', 'copyright', 'deprecated', 'example', 'filesource', 'global', 'ignore', 'internal', 'license', 'link', 'method', 'package', 'param', 'property', 'property-read', 'property-write', 'return', 'see', 'since', 'source', 'subpackage', 'throws', 'todo', 'TODO', 'usedBy', 'uses', 'var', 'version', 'after', 'afterClass', 'backupGlobals', 'backupStaticAttributes', 'before', 'beforeClass', 'codeCoverageIgnore', 'codeCoverageIgnoreStart', 'codeCoverageIgnoreEnd', 'covers', 'coversDefaultClass', 'coversNothing', 'dataProvider', 'depends', 'expectedException', 'expectedExceptionCode', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp', 'group', 'large', 'medium', 'preserveGlobalState', 'requires', 'runTestsInSeparateProcesses', 'runInSeparateProcess', 'small', 'test', 'testdox', 'ticket', 'uses', 'SuppressWarnings', 'noinspection', 'package_version', 'enduml', 'startuml', 'psalm', 'phpstan', 'template', 'fix', 'FIXME', 'fixme', 'override']``
    - | ``operator``
      | The operator to use.
-     | Allowed values: ``':'``, ``'='``
+     | Allowed values: ``':'`` and ``'='``
      | Default value: ``'='``
 
 
@@ -471,7 +471,7 @@ List of Available Rules
      | Default value: ``['abstract', 'access', 'code', 'deprec', 'encode', 'exception', 'final', 'ingroup', 'inheritdoc', 'inheritDoc', 'magic', 'name', 'toc', 'tutorial', 'private', 'static', 'staticvar', 'staticVar', 'throw', 'api', 'author', 'category', 'copyright', 'deprecated', 'example', 'filesource', 'global', 'ignore', 'internal', 'license', 'link', 'method', 'package', 'param', 'property', 'property-read', 'property-write', 'return', 'see', 'since', 'source', 'subpackage', 'throws', 'todo', 'TODO', 'usedBy', 'uses', 'var', 'version', 'after', 'afterClass', 'backupGlobals', 'backupStaticAttributes', 'before', 'beforeClass', 'codeCoverageIgnore', 'codeCoverageIgnoreStart', 'codeCoverageIgnoreEnd', 'covers', 'coversDefaultClass', 'coversNothing', 'dataProvider', 'depends', 'expectedException', 'expectedExceptionCode', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp', 'group', 'large', 'medium', 'preserveGlobalState', 'requires', 'runTestsInSeparateProcesses', 'runInSeparateProcess', 'small', 'test', 'testdox', 'ticket', 'uses', 'SuppressWarnings', 'noinspection', 'package_version', 'enduml', 'startuml', 'psalm', 'phpstan', 'template', 'fix', 'FIXME', 'fixme', 'override']``
    - | ``syntax``
      | Whether to add or remove braces.
-     | Allowed values: ``'with_braces'``, ``'without_braces'``
+     | Allowed values: ``'with_braces'`` and ``'without_braces'``
      | Default value: ``'without_braces'``
 
 
@@ -522,27 +522,27 @@ List of Available Rules
      | Default value: ``true``
    - | ``before_argument_assignments``
      | Whether to add, remove or ignore spaces before argument assignment operator.
-     | Allowed types: ``null``, ``bool``
+     | Allowed types: ``null`` and ``bool``
      | Default value: ``false``
    - | ``after_argument_assignments``
      | Whether to add, remove or ignore spaces after argument assignment operator.
-     | Allowed types: ``null``, ``bool``
+     | Allowed types: ``null`` and ``bool``
      | Default value: ``false``
    - | ``before_array_assignments_equals``
      | Whether to add, remove or ignore spaces before array `=` assignment operator.
-     | Allowed types: ``null``, ``bool``
+     | Allowed types: ``null`` and ``bool``
      | Default value: ``true``
    - | ``after_array_assignments_equals``
      | Whether to add, remove or ignore spaces after array assignment `=` operator.
-     | Allowed types: ``null``, ``bool``
+     | Allowed types: ``null`` and ``bool``
      | Default value: ``true``
    - | ``before_array_assignments_colon``
      | Whether to add, remove or ignore spaces before array `:` assignment operator.
-     | Allowed types: ``null``, ``bool``
+     | Allowed types: ``null`` and ``bool``
      | Default value: ``true``
    - | ``after_array_assignments_colon``
      | Whether to add, remove or ignore spaces after array assignment `:` operator.
-     | Allowed types: ``null``, ``bool``
+     | Allowed types: ``null`` and ``bool``
      | Default value: ``true``
 
 
@@ -557,11 +557,11 @@ List of Available Rules
 
    - | ``format``
      | The desired language construct.
-     | Allowed values: ``'long'``, ``'short'``
+     | Allowed values: ``'long'`` and ``'short'``
      | Default value: ``'long'``
    - | ``long_function``
      | The function to be used to expand the short echo tags.
-     | Allowed values: ``'echo'``, ``'print'``
+     | Allowed values: ``'echo'`` and ``'print'``
      | Default value: ``'echo'``
    - | ``shorten_simple_statements_only``
      | Render short-echo tags only in case of simple code.
@@ -587,7 +587,7 @@ List of Available Rules
 
    - | ``style``
      | Style of empty loop-bodies.
-     | Allowed values: ``'braces'``, ``'semicolon'``
+     | Allowed values: ``'braces'`` and ``'semicolon'``
      | Default value: ``'semicolon'``
 
 
@@ -602,7 +602,7 @@ List of Available Rules
 
    - | ``style``
      | Style of empty loop-condition.
-     | Allowed values: ``'for'``, ``'while'``
+     | Allowed values: ``'for'`` and ``'while'``
      | Default value: ``'while'``
 
 
@@ -814,11 +814,11 @@ List of Available Rules
 
    - | ``closure_function_spacing``
      | Spacing to use before open parenthesis for closures.
-     | Allowed values: ``'none'``, ``'one'``
+     | Allowed values: ``'none'`` and ``'one'``
      | Default value: ``'one'``
    - | ``closure_fn_spacing``
      | Spacing to use before open parenthesis for short arrow functions.
-     | Allowed values: ``'none'``, ``'one'``
+     | Allowed values: ``'none'`` and ``'one'``
      | Default value: ``'one'``
    - | ``trailing_comma_single_line``
      | Whether trailing commas are allowed in single line signatures.
@@ -914,15 +914,15 @@ List of Available Rules
 
    - | ``import_constants``
      | Whether to import, not import or ignore global constants.
-     | Allowed values: ``false``, ``null``, ``true``
+     | Allowed values: ``false``, ``null`` and ``true``
      | Default value: ``null``
    - | ``import_functions``
      | Whether to import, not import or ignore global functions.
-     | Allowed values: ``false``, ``null``, ``true``
+     | Allowed values: ``false``, ``null`` and ``true``
      | Default value: ``null``
    - | ``import_classes``
      | Whether to import, not import or ignore global classes.
-     | Allowed values: ``false``, ``null``, ``true``
+     | Allowed values: ``false``, ``null`` and ``true``
      | Default value: ``true``
 
 
@@ -946,15 +946,15 @@ List of Available Rules
      | This option is required.
    - | ``comment_type``
      | Comment syntax type.
-     | Allowed values: ``'comment'``, ``'PHPDoc'``
+     | Allowed values: ``'comment'`` and ``'PHPDoc'``
      | Default value: ``'comment'``
    - | ``location``
      | The location of the inserted header.
-     | Allowed values: ``'after_declare_strict'``, ``'after_open'``
+     | Allowed values: ``'after_declare_strict'`` and ``'after_open'``
      | Default value: ``'after_declare_strict'``
    - | ``separate``
      | Whether the header should be separated from the file content with a new line.
-     | Allowed values: ``'both'``, ``'bottom'``, ``'none'``, ``'top'``
+     | Allowed values: ``'both'``, ``'bottom'``, ``'none'`` and ``'top'``
      | Default value: ``'both'``
 
 
@@ -967,7 +967,7 @@ List of Available Rules
 
    - | ``indentation``
      | Whether the indentation should be the same as in the start token line or one level more.
-     | Allowed values: ``'same_as_start'``, ``'start_plus_one'``
+     | Allowed values: ``'same_as_start'`` and ``'start_plus_one'``
      | Default value: ``'start_plus_one'``
 
 
@@ -1005,7 +1005,7 @@ List of Available Rules
 
    - | ``style``
      | Whether to use pre- or post-increment and decrement operators.
-     | Allowed values: ``'post'``, ``'pre'``
+     | Allowed values: ``'post'`` and ``'pre'``
      | Default value: ``'pre'``
 
 
@@ -1064,7 +1064,7 @@ List of Available Rules
 
    - | ``syntax``
      | Whether to use the `long` or `short` `list` syntax.
-     | Allowed values: ``'long'``, ``'short'``
+     | Allowed values: ``'long'`` and ``'short'``
      | Default value: ``'short'``
 
 
@@ -1136,7 +1136,7 @@ List of Available Rules
      | Default value: ``false``
    - | ``on_multiline``
      | Defines how to handle function arguments lists that contain newlines.
-     | Allowed values: ``'ensure_fully_multiline'``, ``'ensure_single_line'``, ``'ignore'``
+     | Allowed values: ``'ensure_fully_multiline'``, ``'ensure_single_line'`` and ``'ignore'``
      | Default value: ``'ensure_fully_multiline'``
    - | ``after_heredoc``
      | Whether the whitespace between heredoc end and comma should be removed.
@@ -1189,7 +1189,7 @@ List of Available Rules
 
    - | ``strategy``
      | Forbid multi-line whitespace or move the semicolon to the new line for chained calls.
-     | Allowed values: ``'new_line_for_chained_calls'``, ``'no_multi_line'``
+     | Allowed values: ``'new_line_for_chained_calls'`` and ``'no_multi_line'``
      | Default value: ``'no_multi_line'``
 
 
@@ -1218,7 +1218,7 @@ List of Available Rules
      | Default value: ``['null', 'false', 'true']``
    - | ``scope``
      | Only fix constant invocations that are made within a namespace or fix all.
-     | Allowed values: ``'all'``, ``'namespaced'``
+     | Allowed values: ``'all'`` and ``'namespaced'``
      | Default value: ``'all'``
    - | ``strict``
      | Whether leading `\` of constant invocation not meant to have it should be removed.
@@ -1254,7 +1254,7 @@ List of Available Rules
      | Default value: ``['@compiler_optimized']``
    - | ``scope``
      | Only fix function calls that are made within a namespace or fix all.
-     | Allowed values: ``'all'``, ``'namespaced'``
+     | Allowed values: ``'all'`` and ``'namespaced'``
      | Default value: ``'all'``
    - | ``strict``
      | Whether leading `\` of function call not meant to have it should be removed.
@@ -1501,7 +1501,7 @@ List of Available Rules
 
    - | ``use``
      | The desired language construct.
-     | Allowed values: ``'echo'``, ``'print'``
+     | Allowed values: ``'echo'`` and ``'print'``
      | Default value: ``'echo'``
 
 
@@ -1881,7 +1881,7 @@ List of Available Rules
      | Default value: ``false``
    - | ``position``
      | Whether to place operators at the beginning or at the end of the line.
-     | Allowed values: ``'beginning'``, ``'end'``
+     | Allowed values: ``'beginning'`` and ``'end'``
      | Default value: ``'beginning'``
 
 
@@ -1923,7 +1923,7 @@ List of Available Rules
      | Default value: ``['use_trait', 'case', 'constant_public', 'constant_protected', 'constant_private', 'property_public', 'property_protected', 'property_private', 'construct', 'destruct', 'magic', 'phpunit', 'method_public', 'method_protected', 'method_private']``
    - | ``sort_algorithm``
      | How multiple occurrences of same type statements should be sorted.
-     | Allowed values: ``'alpha'``, ``'none'``
+     | Allowed values: ``'alpha'`` and ``'none'``
      | Default value: ``'none'``
    - | ``case_sensitive``
      | Whether the sorting should be case sensitive.
@@ -1942,11 +1942,11 @@ List of Available Rules
 
    - | ``sort_algorithm``
      | Whether the statements should be sorted alphabetically or by length, or not sorted.
-     | Allowed values: ``'alpha'``, ``'length'``, ``'none'``
+     | Allowed values: ``'alpha'``, ``'length'`` and ``'none'``
      | Default value: ``'alpha'``
    - | ``imports_order``
      | Defines the order of import types.
-     | Allowed types: ``array``, ``null``
+     | Allowed types: ``array`` and ``null``
      | Default value: ``null``
 
 
@@ -1961,11 +1961,11 @@ List of Available Rules
 
    - | ``order``
      | How the interfaces should be ordered.
-     | Allowed values: ``'alpha'``, ``'length'``
+     | Allowed values: ``'alpha'`` and ``'length'``
      | Default value: ``'alpha'``
    - | ``direction``
      | Which direction the interfaces should be ordered.
-     | Allowed values: ``'ascend'``, ``'descend'``
+     | Allowed values: ``'ascend'`` and ``'descend'``
      | Default value: ``'ascend'``
 
 
@@ -1987,11 +1987,11 @@ List of Available Rules
 
    - | ``sort_algorithm``
      | Whether the types should be sorted alphabetically, or not sorted.
-     | Allowed values: ``'alpha'``, ``'none'``
+     | Allowed values: ``'alpha'`` and ``'none'``
      | Default value: ``'alpha'``
    - | ``null_adjustment``
      | Forces the position of `null` (overrides `sort_algorithm`).
-     | Allowed values: ``'always_first'``, ``'always_last'``, ``'none'``
+     | Allowed values: ``'always_first'``, ``'always_last'`` and ``'none'``
      | Default value: ``'always_first'``
 
 
@@ -2023,7 +2023,7 @@ List of Available Rules
      | Default value: ``['method', 'param', 'property', 'return', 'throws', 'type', 'var']``
    - | ``align``
      | How comments should be aligned.
-     | Allowed values: ``'left'``, ``'vertical'``
+     | Allowed values: ``'left'`` and ``'vertical'``
      | Default value: ``'vertical'``
 
 
@@ -2067,15 +2067,15 @@ List of Available Rules
 
    - | ``const``
      | Whether const blocks should be single or multi line.
-     | Allowed values: ``'multi'``, ``'single'``, ``null``
+     | Allowed values: ``'multi'``, ``'single'`` and ``null``
      | Default value: ``'multi'``
    - | ``property``
      | Whether property doc blocks should be single or multi line.
-     | Allowed values: ``'multi'``, ``'single'``, ``null``
+     | Allowed values: ``'multi'``, ``'single'`` and ``null``
      | Default value: ``'multi'``
    - | ``method``
      | Whether method doc blocks should be single or multi line.
-     | Allowed values: ``'multi'``, ``'single'``, ``null``
+     | Allowed values: ``'multi'``, ``'single'`` and ``null``
      | Default value: ``'multi'``
 
 
@@ -2358,11 +2358,11 @@ List of Available Rules
 
    - | ``sort_algorithm``
      | The sorting algorithm to apply.
-     | Allowed values: ``'alpha'``, ``'none'``
+     | Allowed values: ``'alpha'`` and ``'none'``
      | Default value: ``'alpha'``
    - | ``null_adjustment``
      | Forces the position of `null` (overrides `sort_algorithm`).
-     | Allowed values: ``'always_first'``, ``'always_last'``, ``'none'``
+     | Allowed values: ``'always_first'``, ``'always_last'`` and ``'none'``
      | Default value: ``'always_first'``
 
 
@@ -2427,7 +2427,7 @@ List of Available Rules
 
    - | ``target``
      | Target version of PHPUnit.
-     | Allowed values: ``'3.0'``, ``'3.5'``, ``'5.0'``, ``'5.6'``, ``'newest'``
+     | Allowed values: ``'3.0'``, ``'3.5'``, ``'5.0'``, ``'5.6'`` and ``'newest'``
      | Default value: ``'newest'``
 
 
@@ -2445,7 +2445,7 @@ List of Available Rules
 
    - | ``target``
      | Target version of PHPUnit.
-     | Allowed values: ``'7.5'``, ``'newest'``
+     | Allowed values: ``'7.5'`` and ``'newest'``
      | Default value: ``'newest'``
 
 
@@ -2463,7 +2463,7 @@ List of Available Rules
 
    - | ``target``
      | Target version of PHPUnit.
-     | Allowed values: ``'5.2'``, ``'5.6'``, ``'8.4'``, ``'newest'``
+     | Allowed values: ``'5.2'``, ``'5.6'``, ``'8.4'`` and ``'newest'``
      | Default value: ``'newest'``
 
 
@@ -2500,7 +2500,7 @@ List of Available Rules
 
    - | ``case``
      | Apply camel or snake case to test methods.
-     | Allowed values: ``'camel_case'``, ``'snake_case'``
+     | Allowed values: ``'camel_case'`` and ``'snake_case'``
      | Default value: ``'camel_case'``
 
 
@@ -2518,7 +2518,7 @@ List of Available Rules
 
    - | ``target``
      | Target version of PHPUnit.
-     | Allowed values: ``'5.4'``, ``'5.5'``, ``'newest'``
+     | Allowed values: ``'5.4'``, ``'5.5'`` and ``'newest'``
      | Default value: ``'newest'``
 
 
@@ -2556,7 +2556,7 @@ List of Available Rules
 
    - | ``target``
      | Target version of PHPUnit.
-     | Allowed values: ``'4.8'``, ``'5.7'``, ``'6.0'``, ``'newest'``
+     | Allowed values: ``'4.8'``, ``'5.7'``, ``'6.0'`` and ``'newest'``
      | Default value: ``'newest'``
 
 
@@ -2574,7 +2574,7 @@ List of Available Rules
 
    - | ``target``
      | Target version of PHPUnit.
-     | Allowed values: ``'3.2'``, ``'4.3'``, ``'newest'``
+     | Allowed values: ``'3.2'``, ``'4.3'`` and ``'newest'``
      | Default value: ``'newest'``
    - | ``use_class_const``
      | Use ::class notation.
@@ -2606,7 +2606,7 @@ List of Available Rules
 
    - | ``group``
      | Define a specific group to be used in case no group is already in use.
-     | Allowed values: ``'large'``, ``'medium'``, ``'small'``
+     | Allowed values: ``'large'``, ``'medium'`` and ``'small'``
      | Default value: ``'small'``
 
 
@@ -2640,7 +2640,7 @@ List of Available Rules
 
    - | ``style``
      | Whether to use the @test annotation or not.
-     | Allowed values: ``'annotation'``, ``'prefix'``
+     | Allowed values: ``'annotation'`` and ``'prefix'``
      | Default value: ``'prefix'``
 
 
@@ -2658,7 +2658,7 @@ List of Available Rules
 
    - | ``call_type``
      | The call type to use for referring to PHPUnit methods.
-     | Allowed values: ``'self'``, ``'static'``, ``'this'``
+     | Allowed values: ``'self'``, ``'static'`` and ``'this'``
      | Default value: ``'static'``
    - | ``methods``
      | Dictionary of `method` => `call_type` values that differ from the default strategy.
@@ -2703,7 +2703,7 @@ List of Available Rules
 
    - | ``dir``
      | If provided, the directory where the project code is placed.
-     | Allowed types: ``null``, ``string``
+     | Allowed types: ``null`` and ``string``
      | Default value: ``null``
 
 
@@ -2755,7 +2755,7 @@ List of Available Rules
 
    - | ``space_before``
      | Spacing to apply before colon.
-     | Allowed values: ``'none'``, ``'one'``
+     | Allowed values: ``'none'`` and ``'one'``
      | Default value: ``'none'``
 
 
@@ -3131,11 +3131,11 @@ List of Available Rules
 
    - | ``space``
      | Spacing to apply around union type and intersection type operators.
-     | Allowed values: ``'none'``, ``'single'``
+     | Allowed values: ``'none'`` and ``'single'``
      | Default value: ``'none'``
    - | ``space_multiple_catch``
      | Spacing to apply around type operator when catching exceptions of multiple types, use `null` to follow the value configured for `space`.
-     | Allowed values: ``'none'``, ``'single'``, ``null``
+     | Allowed values: ``'none'``, ``'single'`` and ``null``
      | Default value: ``null``
 
 
@@ -3206,15 +3206,15 @@ List of Available Rules
 
    - | ``equal``
      | Style for equal (`==`, `!=`) statements.
-     | Allowed types: ``bool``, ``null``
+     | Allowed types: ``bool`` and ``null``
      | Default value: ``true``
    - | ``identical``
      | Style for identical (`===`, `!==`) statements.
-     | Allowed types: ``bool``, ``null``
+     | Allowed types: ``bool`` and ``null``
      | Default value: ``true``
    - | ``less_and_greater``
      | Style for less and greater than (`<`, `<=`, `>`, `>=`) statements.
-     | Allowed types: ``bool``, ``null``
+     | Allowed types: ``bool`` and ``null``
      | Default value: ``null``
    - | ``always_move_variable``
      | Whether variables should always be on non assignable side when applying Yoda style.

--- a/doc/rules/alias/no_mixed_echo_print.rst
+++ b/doc/rules/alias/no_mixed_echo_print.rst
@@ -12,7 +12,7 @@ Configuration
 
 The desired language construct.
 
-Allowed values: ``'echo'``, ``'print'``
+Allowed values: ``'echo'`` and ``'print'``
 
 Default value: ``'echo'``
 

--- a/doc/rules/array_notation/array_syntax.rst
+++ b/doc/rules/array_notation/array_syntax.rst
@@ -12,7 +12,7 @@ Configuration
 
 Whether to use the ``long`` or ``short`` array syntax.
 
-Allowed values: ``'long'``, ``'short'``
+Allowed values: ``'long'`` and ``'short'``
 
 Default value: ``'short'``
 

--- a/doc/rules/basic/braces.rst
+++ b/doc/rules/basic/braces.rst
@@ -44,7 +44,7 @@ Whether the opening brace should be placed on "next" or "same" line after classy
 constructs (non-anonymous classes, interfaces, traits, methods and non-lambda
 functions).
 
-Allowed values: ``'next'``, ``'same'``
+Allowed values: ``'next'`` and ``'same'``
 
 Default value: ``'next'``
 
@@ -54,7 +54,7 @@ Default value: ``'next'``
 Whether the opening brace should be placed on "next" or "same" line after
 control structures.
 
-Allowed values: ``'next'``, ``'same'``
+Allowed values: ``'next'`` and ``'same'``
 
 Default value: ``'same'``
 
@@ -64,7 +64,7 @@ Default value: ``'same'``
 Whether the opening brace should be placed on "next" or "same" line after
 anonymous constructs (anonymous classes and lambda functions).
 
-Allowed values: ``'next'``, ``'same'``
+Allowed values: ``'next'`` and ``'same'``
 
 Default value: ``'same'``
 

--- a/doc/rules/basic/curly_braces_position.rst
+++ b/doc/rules/basic/curly_braces_position.rst
@@ -12,7 +12,7 @@ Configuration
 
 The position of the opening brace of control structures‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'``
+Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
 
 Default value: ``'same_line'``
 
@@ -21,7 +21,7 @@ Default value: ``'same_line'``
 
 The position of the opening brace of functions‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'``
+Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
 
 Default value: ``'next_line_unless_newline_at_signature_end'``
 
@@ -30,7 +30,7 @@ Default value: ``'next_line_unless_newline_at_signature_end'``
 
 The position of the opening brace of anonymous functions‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'``
+Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
 
 Default value: ``'same_line'``
 
@@ -39,7 +39,7 @@ Default value: ``'same_line'``
 
 The position of the opening brace of classes‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'``
+Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
 
 Default value: ``'next_line_unless_newline_at_signature_end'``
 
@@ -48,7 +48,7 @@ Default value: ``'next_line_unless_newline_at_signature_end'``
 
 The position of the opening brace of anonymous classes‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'``
+Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
 
 Default value: ``'same_line'``
 

--- a/doc/rules/basic/psr_autoloading.rst
+++ b/doc/rules/basic/psr_autoloading.rst
@@ -22,7 +22,7 @@ Configuration
 
 If provided, the directory where the project code is placed.
 
-Allowed types: ``null``, ``string``
+Allowed types: ``null`` and ``string``
 
 Default value: ``null``
 

--- a/doc/rules/casing/constant_case.rst
+++ b/doc/rules/casing/constant_case.rst
@@ -13,7 +13,7 @@ Configuration
 
 Whether to use the ``upper`` or ``lower`` case syntax.
 
-Allowed values: ``'lower'``, ``'upper'``
+Allowed values: ``'lower'`` and ``'upper'``
 
 Default value: ``'lower'``
 

--- a/doc/rules/cast_notation/cast_spaces.rst
+++ b/doc/rules/cast_notation/cast_spaces.rst
@@ -12,7 +12,7 @@ Configuration
 
 Spacing to apply between cast and variable.
 
-Allowed values: ``'none'``, ``'single'``
+Allowed values: ``'none'`` and ``'single'``
 
 Default value: ``'single'``
 

--- a/doc/rules/class_notation/ordered_class_elements.rst
+++ b/doc/rules/class_notation/ordered_class_elements.rst
@@ -46,7 +46,7 @@ Default value: ``['use_trait', 'case', 'constant_public', 'constant_protected', 
 
 How multiple occurrences of same type statements should be sorted.
 
-Allowed values: ``'alpha'``, ``'none'``
+Allowed values: ``'alpha'`` and ``'none'``
 
 Default value: ``'none'``
 

--- a/doc/rules/class_notation/ordered_interfaces.rst
+++ b/doc/rules/class_notation/ordered_interfaces.rst
@@ -12,7 +12,7 @@ Configuration
 
 How the interfaces should be ordered.
 
-Allowed values: ``'alpha'``, ``'length'``
+Allowed values: ``'alpha'`` and ``'length'``
 
 Default value: ``'alpha'``
 
@@ -21,7 +21,7 @@ Default value: ``'alpha'``
 
 Which direction the interfaces should be ordered.
 
-Allowed values: ``'ascend'``, ``'descend'``
+Allowed values: ``'ascend'`` and ``'descend'``
 
 Default value: ``'ascend'``
 

--- a/doc/rules/class_notation/ordered_types.rst
+++ b/doc/rules/class_notation/ordered_types.rst
@@ -12,7 +12,7 @@ Configuration
 
 Whether the types should be sorted alphabetically, or not sorted.
 
-Allowed values: ``'alpha'``, ``'none'``
+Allowed values: ``'alpha'`` and ``'none'``
 
 Default value: ``'alpha'``
 
@@ -21,7 +21,7 @@ Default value: ``'alpha'``
 
 Forces the position of ``null`` (overrides ``sort_algorithm``).
 
-Allowed values: ``'always_first'``, ``'always_last'``, ``'none'``
+Allowed values: ``'always_first'``, ``'always_last'`` and ``'none'``
 
 Default value: ``'always_first'``
 

--- a/doc/rules/comment/header_comment.rst
+++ b/doc/rules/comment/header_comment.rst
@@ -21,7 +21,7 @@ This option is required.
 
 Comment syntax type.
 
-Allowed values: ``'comment'``, ``'PHPDoc'``
+Allowed values: ``'comment'`` and ``'PHPDoc'``
 
 Default value: ``'comment'``
 
@@ -30,7 +30,7 @@ Default value: ``'comment'``
 
 The location of the inserted header.
 
-Allowed values: ``'after_declare_strict'``, ``'after_open'``
+Allowed values: ``'after_declare_strict'`` and ``'after_open'``
 
 Default value: ``'after_declare_strict'``
 
@@ -39,7 +39,7 @@ Default value: ``'after_declare_strict'``
 
 Whether the header should be separated from the file content with a new line.
 
-Allowed values: ``'both'``, ``'bottom'``, ``'none'``, ``'top'``
+Allowed values: ``'both'``, ``'bottom'``, ``'none'`` and ``'top'``
 
 Default value: ``'both'``
 

--- a/doc/rules/constant_notation/native_constant_invocation.rst
+++ b/doc/rules/constant_notation/native_constant_invocation.rst
@@ -50,7 +50,7 @@ Default value: ``['null', 'false', 'true']``
 
 Only fix constant invocations that are made within a namespace or fix all.
 
-Allowed values: ``'all'``, ``'namespaced'``
+Allowed values: ``'all'`` and ``'namespaced'``
 
 Default value: ``'all'``
 

--- a/doc/rules/control_structure/control_structure_continuation_position.rst
+++ b/doc/rules/control_structure/control_structure_continuation_position.rst
@@ -12,7 +12,7 @@ Configuration
 
 The position of the keyword that continues the control structure.
 
-Allowed values: ``'next_line'``, ``'same_line'``
+Allowed values: ``'next_line'`` and ``'same_line'``
 
 Default value: ``'same_line'``
 

--- a/doc/rules/control_structure/empty_loop_body.rst
+++ b/doc/rules/control_structure/empty_loop_body.rst
@@ -12,7 +12,7 @@ Configuration
 
 Style of empty loop-bodies.
 
-Allowed values: ``'braces'``, ``'semicolon'``
+Allowed values: ``'braces'`` and ``'semicolon'``
 
 Default value: ``'semicolon'``
 

--- a/doc/rules/control_structure/empty_loop_condition.rst
+++ b/doc/rules/control_structure/empty_loop_condition.rst
@@ -12,7 +12,7 @@ Configuration
 
 Style of empty loop-condition.
 
-Allowed values: ``'for'``, ``'while'``
+Allowed values: ``'for'`` and ``'while'``
 
 Default value: ``'while'``
 

--- a/doc/rules/control_structure/yoda_style.rst
+++ b/doc/rules/control_structure/yoda_style.rst
@@ -14,7 +14,7 @@ Configuration
 
 Style for equal (``==``, ``!=``) statements.
 
-Allowed types: ``bool``, ``null``
+Allowed types: ``bool`` and ``null``
 
 Default value: ``true``
 
@@ -23,7 +23,7 @@ Default value: ``true``
 
 Style for identical (``===``, ``!==``) statements.
 
-Allowed types: ``bool``, ``null``
+Allowed types: ``bool`` and ``null``
 
 Default value: ``true``
 
@@ -32,7 +32,7 @@ Default value: ``true``
 
 Style for less and greater than (``<``, ``<=``, ``>``, ``>=``) statements.
 
-Allowed types: ``bool``, ``null``
+Allowed types: ``bool`` and ``null``
 
 Default value: ``null``
 

--- a/doc/rules/doctrine_annotation/doctrine_annotation_array_assignment.rst
+++ b/doc/rules/doctrine_annotation/doctrine_annotation_array_assignment.rst
@@ -21,7 +21,7 @@ Default value: ``['abstract', 'access', 'code', 'deprec', 'encode', 'exception',
 
 The operator to use.
 
-Allowed values: ``':'``, ``'='``
+Allowed values: ``':'`` and ``'='``
 
 Default value: ``'='``
 

--- a/doc/rules/doctrine_annotation/doctrine_annotation_braces.rst
+++ b/doc/rules/doctrine_annotation/doctrine_annotation_braces.rst
@@ -21,7 +21,7 @@ Default value: ``['abstract', 'access', 'code', 'deprec', 'encode', 'exception',
 
 Whether to add or remove braces.
 
-Allowed values: ``'with_braces'``, ``'without_braces'``
+Allowed values: ``'with_braces'`` and ``'without_braces'``
 
 Default value: ``'without_braces'``
 

--- a/doc/rules/doctrine_annotation/doctrine_annotation_spaces.rst
+++ b/doc/rules/doctrine_annotation/doctrine_annotation_spaces.rst
@@ -46,7 +46,7 @@ Default value: ``true``
 
 Whether to add, remove or ignore spaces before argument assignment operator.
 
-Allowed types: ``null``, ``bool``
+Allowed types: ``null`` and ``bool``
 
 Default value: ``false``
 
@@ -55,7 +55,7 @@ Default value: ``false``
 
 Whether to add, remove or ignore spaces after argument assignment operator.
 
-Allowed types: ``null``, ``bool``
+Allowed types: ``null`` and ``bool``
 
 Default value: ``false``
 
@@ -64,7 +64,7 @@ Default value: ``false``
 
 Whether to add, remove or ignore spaces before array ``=`` assignment operator.
 
-Allowed types: ``null``, ``bool``
+Allowed types: ``null`` and ``bool``
 
 Default value: ``true``
 
@@ -73,7 +73,7 @@ Default value: ``true``
 
 Whether to add, remove or ignore spaces after array assignment ``=`` operator.
 
-Allowed types: ``null``, ``bool``
+Allowed types: ``null`` and ``bool``
 
 Default value: ``true``
 
@@ -82,7 +82,7 @@ Default value: ``true``
 
 Whether to add, remove or ignore spaces before array ``:`` assignment operator.
 
-Allowed types: ``null``, ``bool``
+Allowed types: ``null`` and ``bool``
 
 Default value: ``true``
 
@@ -91,7 +91,7 @@ Default value: ``true``
 
 Whether to add, remove or ignore spaces after array assignment ``:`` operator.
 
-Allowed types: ``null``, ``bool``
+Allowed types: ``null`` and ``bool``
 
 Default value: ``true``
 

--- a/doc/rules/function_notation/function_declaration.rst
+++ b/doc/rules/function_notation/function_declaration.rst
@@ -12,7 +12,7 @@ Configuration
 
 Spacing to use before open parenthesis for closures.
 
-Allowed values: ``'none'``, ``'one'``
+Allowed values: ``'none'`` and ``'one'``
 
 Default value: ``'one'``
 
@@ -21,7 +21,7 @@ Default value: ``'one'``
 
 Spacing to use before open parenthesis for short arrow functions.
 
-Allowed values: ``'none'``, ``'one'``
+Allowed values: ``'none'`` and ``'one'``
 
 Default value: ``'one'``
 

--- a/doc/rules/function_notation/method_argument_space.rst
+++ b/doc/rules/function_notation/method_argument_space.rst
@@ -25,7 +25,7 @@ Default value: ``false``
 
 Defines how to handle function arguments lists that contain newlines.
 
-Allowed values: ``'ensure_fully_multiline'``, ``'ensure_single_line'``, ``'ignore'``
+Allowed values: ``'ensure_fully_multiline'``, ``'ensure_single_line'`` and ``'ignore'``
 
 Default value: ``'ensure_fully_multiline'``
 

--- a/doc/rules/function_notation/native_function_invocation.rst
+++ b/doc/rules/function_notation/native_function_invocation.rst
@@ -40,7 +40,7 @@ Default value: ``['@compiler_optimized']``
 
 Only fix function calls that are made within a namespace or fix all.
 
-Allowed values: ``'all'``, ``'namespaced'``
+Allowed values: ``'all'`` and ``'namespaced'``
 
 Default value: ``'all'``
 

--- a/doc/rules/function_notation/return_type_declaration.rst
+++ b/doc/rules/function_notation/return_type_declaration.rst
@@ -17,7 +17,7 @@ Configuration
 
 Spacing to apply before colon.
 
-Allowed values: ``'none'``, ``'one'``
+Allowed values: ``'none'`` and ``'one'``
 
 Default value: ``'none'``
 

--- a/doc/rules/import/global_namespace_import.rst
+++ b/doc/rules/import/global_namespace_import.rst
@@ -12,7 +12,7 @@ Configuration
 
 Whether to import, not import or ignore global constants.
 
-Allowed values: ``false``, ``null``, ``true``
+Allowed values: ``false``, ``null`` and ``true``
 
 Default value: ``null``
 
@@ -21,7 +21,7 @@ Default value: ``null``
 
 Whether to import, not import or ignore global functions.
 
-Allowed values: ``false``, ``null``, ``true``
+Allowed values: ``false``, ``null`` and ``true``
 
 Default value: ``null``
 
@@ -30,7 +30,7 @@ Default value: ``null``
 
 Whether to import, not import or ignore global classes.
 
-Allowed values: ``false``, ``null``, ``true``
+Allowed values: ``false``, ``null`` and ``true``
 
 Default value: ``true``
 

--- a/doc/rules/import/ordered_imports.rst
+++ b/doc/rules/import/ordered_imports.rst
@@ -13,7 +13,7 @@ Configuration
 Whether the statements should be sorted alphabetically or by length, or not
 sorted.
 
-Allowed values: ``'alpha'``, ``'length'``, ``'none'``
+Allowed values: ``'alpha'``, ``'length'`` and ``'none'``
 
 Default value: ``'alpha'``
 
@@ -22,7 +22,7 @@ Default value: ``'alpha'``
 
 Defines the order of import types.
 
-Allowed types: ``array``, ``null``
+Allowed types: ``array`` and ``null``
 
 Default value: ``null``
 

--- a/doc/rules/language_construct/declare_equal_normalize.rst
+++ b/doc/rules/language_construct/declare_equal_normalize.rst
@@ -13,7 +13,7 @@ Configuration
 
 Spacing to apply around the equal sign.
 
-Allowed values: ``'none'``, ``'single'``
+Allowed values: ``'none'`` and ``'single'``
 
 Default value: ``'none'``
 

--- a/doc/rules/list_notation/list_syntax.rst
+++ b/doc/rules/list_notation/list_syntax.rst
@@ -13,7 +13,7 @@ Configuration
 
 Whether to use the ``long`` or ``short`` ``list`` syntax.
 
-Allowed values: ``'long'``, ``'short'``
+Allowed values: ``'long'`` and ``'short'``
 
 Default value: ``'short'``
 

--- a/doc/rules/operator/binary_operator_spaces.rst
+++ b/doc/rules/operator/binary_operator_spaces.rst
@@ -12,7 +12,7 @@ Configuration
 
 Default fix strategy.
 
-Allowed values: ``'align'``, ``'align_by_scope'``, ``'align_single_space'``, ``'align_single_space_by_scope'``, ``'align_single_space_minimal'``, ``'align_single_space_minimal_by_scope'``, ``'no_space'``, ``'single_space'``, ``null``
+Allowed values: ``'align'``, ``'align_by_scope'``, ``'align_single_space'``, ``'align_single_space_by_scope'``, ``'align_single_space_minimal'``, ``'align_single_space_minimal_by_scope'``, ``'no_space'``, ``'single_space'`` and ``null``
 
 Default value: ``'single_space'``
 
@@ -24,7 +24,7 @@ the default strategy. Supported are: ``=``, ``*``, ``/``, ``%``, ``<``, ``>``,
 ``|``, ``^``, ``+``, ``-``, ``&``, ``&=``, ``&&``, ``||``, ``.=``, ``/=``,
 ``=>``, ``==``, ``>=``, ``===``, ``!=``, ``<>``, ``!==``, ``<=``, ``and``,
 ``or``, ``xor``, ``-=``, ``%=``, ``*=``, ``|=``, ``+=``, ``<<``, ``<<=``,
-``>>``, ``>>=``, ``^=``, ``**``, ``**=``, ``<=>``, ``??``, ``??=``.
+``>>``, ``>>=``, ``^=``, ``**``, ``**=``, ``<=>``, ``??`` and ``??=``.
 
 Allowed types: ``array``
 

--- a/doc/rules/operator/concat_space.rst
+++ b/doc/rules/operator/concat_space.rst
@@ -12,7 +12,7 @@ Configuration
 
 Spacing to apply around concatenation operator.
 
-Allowed values: ``'none'``, ``'one'``
+Allowed values: ``'none'`` and ``'one'``
 
 Default value: ``'none'``
 

--- a/doc/rules/operator/increment_style.rst
+++ b/doc/rules/operator/increment_style.rst
@@ -12,7 +12,7 @@ Configuration
 
 Whether to use pre- or post-increment and decrement operators.
 
-Allowed values: ``'post'``, ``'pre'``
+Allowed values: ``'post'`` and ``'pre'``
 
 Default value: ``'pre'``
 

--- a/doc/rules/operator/operator_linebreak.rst
+++ b/doc/rules/operator/operator_linebreak.rst
@@ -22,7 +22,7 @@ Default value: ``false``
 
 Whether to place operators at the beginning or at the end of the line.
 
-Allowed values: ``'beginning'``, ``'end'``
+Allowed values: ``'beginning'`` and ``'end'``
 
 Default value: ``'beginning'``
 

--- a/doc/rules/php_tag/echo_tag_syntax.rst
+++ b/doc/rules/php_tag/echo_tag_syntax.rst
@@ -13,7 +13,7 @@ Configuration
 
 The desired language construct.
 
-Allowed values: ``'long'``, ``'short'``
+Allowed values: ``'long'`` and ``'short'``
 
 Default value: ``'long'``
 
@@ -22,7 +22,7 @@ Default value: ``'long'``
 
 The function to be used to expand the short echo tags.
 
-Allowed values: ``'echo'``, ``'print'``
+Allowed values: ``'echo'`` and ``'print'``
 
 Default value: ``'echo'``
 

--- a/doc/rules/php_unit/php_unit_dedicate_assert.rst
+++ b/doc/rules/php_unit/php_unit_dedicate_assert.rst
@@ -21,7 +21,7 @@ Configuration
 
 Target version of PHPUnit.
 
-Allowed values: ``'3.0'``, ``'3.5'``, ``'5.0'``, ``'5.6'``, ``'newest'``
+Allowed values: ``'3.0'``, ``'3.5'``, ``'5.0'``, ``'5.6'`` and ``'newest'``
 
 Default value: ``'newest'``
 

--- a/doc/rules/php_unit/php_unit_dedicate_assert_internal_type.rst
+++ b/doc/rules/php_unit/php_unit_dedicate_assert_internal_type.rst
@@ -22,7 +22,7 @@ Configuration
 
 Target version of PHPUnit.
 
-Allowed values: ``'7.5'``, ``'newest'``
+Allowed values: ``'7.5'`` and ``'newest'``
 
 Default value: ``'newest'``
 

--- a/doc/rules/php_unit/php_unit_expectation.rst
+++ b/doc/rules/php_unit/php_unit_expectation.rst
@@ -22,7 +22,7 @@ Configuration
 
 Target version of PHPUnit.
 
-Allowed values: ``'5.2'``, ``'5.6'``, ``'8.4'``, ``'newest'``
+Allowed values: ``'5.2'``, ``'5.6'``, ``'8.4'`` and ``'newest'``
 
 Default value: ``'newest'``
 

--- a/doc/rules/php_unit/php_unit_method_casing.rst
+++ b/doc/rules/php_unit/php_unit_method_casing.rst
@@ -12,7 +12,7 @@ Configuration
 
 Apply camel or snake case to test methods.
 
-Allowed values: ``'camel_case'``, ``'snake_case'``
+Allowed values: ``'camel_case'`` and ``'snake_case'``
 
 Default value: ``'camel_case'``
 

--- a/doc/rules/php_unit/php_unit_mock.rst
+++ b/doc/rules/php_unit/php_unit_mock.rst
@@ -22,7 +22,7 @@ Configuration
 
 Target version of PHPUnit.
 
-Allowed values: ``'5.4'``, ``'5.5'``, ``'newest'``
+Allowed values: ``'5.4'``, ``'5.5'`` and ``'newest'``
 
 Default value: ``'newest'``
 

--- a/doc/rules/php_unit/php_unit_namespaced.rst
+++ b/doc/rules/php_unit/php_unit_namespaced.rst
@@ -35,7 +35,7 @@ Configuration
 
 Target version of PHPUnit.
 
-Allowed values: ``'4.8'``, ``'5.7'``, ``'6.0'``, ``'newest'``
+Allowed values: ``'4.8'``, ``'5.7'``, ``'6.0'`` and ``'newest'``
 
 Default value: ``'newest'``
 

--- a/doc/rules/php_unit/php_unit_no_expectation_annotation.rst
+++ b/doc/rules/php_unit/php_unit_no_expectation_annotation.rst
@@ -22,7 +22,7 @@ Configuration
 
 Target version of PHPUnit.
 
-Allowed values: ``'3.2'``, ``'4.3'``, ``'newest'``
+Allowed values: ``'3.2'``, ``'4.3'`` and ``'newest'``
 
 Default value: ``'newest'``
 

--- a/doc/rules/php_unit/php_unit_size_class.rst
+++ b/doc/rules/php_unit/php_unit_size_class.rst
@@ -19,7 +19,7 @@ Configuration
 
 Define a specific group to be used in case no group is already in use.
 
-Allowed values: ``'large'``, ``'medium'``, ``'small'``
+Allowed values: ``'large'``, ``'medium'`` and ``'small'``
 
 Default value: ``'small'``
 

--- a/doc/rules/php_unit/php_unit_test_annotation.rst
+++ b/doc/rules/php_unit/php_unit_test_annotation.rst
@@ -21,7 +21,7 @@ Configuration
 
 Whether to use the @test annotation or not.
 
-Allowed values: ``'annotation'``, ``'prefix'``
+Allowed values: ``'annotation'`` and ``'prefix'``
 
 Default value: ``'prefix'``
 

--- a/doc/rules/php_unit/php_unit_test_case_static_method_calls.rst
+++ b/doc/rules/php_unit/php_unit_test_case_static_method_calls.rst
@@ -22,7 +22,7 @@ Configuration
 
 The call type to use for referring to PHPUnit methods.
 
-Allowed values: ``'self'``, ``'static'``, ``'this'``
+Allowed values: ``'self'``, ``'static'`` and ``'this'``
 
 Default value: ``'static'``
 

--- a/doc/rules/phpdoc/align_multiline_comment.rst
+++ b/doc/rules/phpdoc/align_multiline_comment.rst
@@ -15,7 +15,7 @@ Whether to fix PHPDoc comments only (``phpdocs_only``), any multi-line comment
 whose lines all start with an asterisk (``phpdocs_like``) or any multi-line
 comment (``all_multiline``).
 
-Allowed values: ``'all_multiline'``, ``'phpdocs_like'``, ``'phpdocs_only'``
+Allowed values: ``'all_multiline'``, ``'phpdocs_like'`` and ``'phpdocs_only'``
 
 Default value: ``'phpdocs_only'``
 

--- a/doc/rules/phpdoc/phpdoc_align.rst
+++ b/doc/rules/phpdoc/phpdoc_align.rst
@@ -22,7 +22,7 @@ Default value: ``['method', 'param', 'property', 'return', 'throws', 'type', 'va
 
 How comments should be aligned.
 
-Allowed values: ``'left'``, ``'vertical'``
+Allowed values: ``'left'`` and ``'vertical'``
 
 Default value: ``'vertical'``
 

--- a/doc/rules/phpdoc/phpdoc_line_span.rst
+++ b/doc/rules/phpdoc/phpdoc_line_span.rst
@@ -13,7 +13,7 @@ Configuration
 
 Whether const blocks should be single or multi line.
 
-Allowed values: ``'multi'``, ``'single'``, ``null``
+Allowed values: ``'multi'``, ``'single'`` and ``null``
 
 Default value: ``'multi'``
 
@@ -22,7 +22,7 @@ Default value: ``'multi'``
 
 Whether property doc blocks should be single or multi line.
 
-Allowed values: ``'multi'``, ``'single'``, ``null``
+Allowed values: ``'multi'``, ``'single'`` and ``null``
 
 Default value: ``'multi'``
 
@@ -31,7 +31,7 @@ Default value: ``'multi'``
 
 Whether method doc blocks should be single or multi line.
 
-Allowed values: ``'multi'``, ``'single'``, ``null``
+Allowed values: ``'multi'``, ``'single'`` and ``null``
 
 Default value: ``'multi'``
 

--- a/doc/rules/phpdoc/phpdoc_types_order.rst
+++ b/doc/rules/phpdoc/phpdoc_types_order.rst
@@ -12,7 +12,7 @@ Configuration
 
 The sorting algorithm to apply.
 
-Allowed values: ``'alpha'``, ``'none'``
+Allowed values: ``'alpha'`` and ``'none'``
 
 Default value: ``'alpha'``
 
@@ -21,7 +21,7 @@ Default value: ``'alpha'``
 
 Forces the position of ``null`` (overrides ``sort_algorithm``).
 
-Allowed values: ``'always_first'``, ``'always_last'``, ``'none'``
+Allowed values: ``'always_first'``, ``'always_last'`` and ``'none'``
 
 Default value: ``'always_first'``
 

--- a/doc/rules/semicolon/multiline_whitespace_before_semicolons.rst
+++ b/doc/rules/semicolon/multiline_whitespace_before_semicolons.rst
@@ -14,7 +14,7 @@ Configuration
 Forbid multi-line whitespace or move the semicolon to the new line for chained
 calls.
 
-Allowed values: ``'new_line_for_chained_calls'``, ``'no_multi_line'``
+Allowed values: ``'new_line_for_chained_calls'`` and ``'no_multi_line'``
 
 Default value: ``'no_multi_line'``
 

--- a/doc/rules/whitespace/heredoc_indentation.rst
+++ b/doc/rules/whitespace/heredoc_indentation.rst
@@ -13,7 +13,7 @@ Configuration
 Whether the indentation should be the same as in the start token line or one
 level more.
 
-Allowed values: ``'same_as_start'``, ``'start_plus_one'``
+Allowed values: ``'same_as_start'`` and ``'start_plus_one'``
 
 Default value: ``'start_plus_one'``
 

--- a/doc/rules/whitespace/types_spaces.rst
+++ b/doc/rules/whitespace/types_spaces.rst
@@ -13,7 +13,7 @@ Configuration
 
 Spacing to apply around union type and intersection type operators.
 
-Allowed values: ``'none'``, ``'single'``
+Allowed values: ``'none'`` and ``'single'``
 
 Default value: ``'none'``
 
@@ -23,7 +23,7 @@ Default value: ``'none'``
 Spacing to apply around type operator when catching exceptions of multiple
 types, use ``null`` to follow the value configured for ``space``.
 
-Allowed values: ``'none'``, ``'single'``, ``null``
+Allowed values: ``'none'``, ``'single'`` and ``null``
 
 Default value: ``null``
 

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Cache;
 
+use PhpCsFixer\Utils;
+
 /**
  * @author Andreas Möller <am@localheinz.com>
  *
@@ -111,8 +113,8 @@ final class Cache implements CacheInterface
 
         if (\count($missingKeys) > 0) {
             throw new \InvalidArgumentException(sprintf(
-                'JSON data is missing keys "%s"',
-                implode('", "', $missingKeys)
+                'JSON data is missing keys %s',
+                Utils::naturalLanguageJoin(array_keys($missingKeys))
             ));
         }
 

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -215,7 +215,7 @@ final class DescribeCommand extends Command
                     }, $allowed);
                 }
 
-                $line .= ' ('.implode(', ', $allowed).')';
+                $line .= ' ('.Utils::naturalLanguageJoin($allowed, '').')';
 
                 $description = Preg::replace('/(`.+?`)/', '<info>$1</info>', OutputFormatter::escape($option->getDescription()));
                 $line .= ': '.lcfirst(Preg::replace('/\.$/', '', $description)).'; ';

--- a/src/Console/Command/ListSetsCommand.php
+++ b/src/Console/Command/ListSetsCommand.php
@@ -20,6 +20,7 @@ use PhpCsFixer\Console\Report\ListSetsReport\ReporterInterface;
 use PhpCsFixer\Console\Report\ListSetsReport\ReportSummary;
 use PhpCsFixer\Console\Report\ListSetsReport\TextReporter;
 use PhpCsFixer\RuleSet\RuleSets;
+use PhpCsFixer\Utils;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatter;
@@ -81,7 +82,7 @@ final class ListSetsCommand extends Command
             $formats = $factory->getFormats();
             sort($formats);
 
-            throw new InvalidConfigurationException(sprintf('The format "%s" is not defined, supported are "%s".', $format, implode('", "', $formats)));
+            throw new InvalidConfigurationException(sprintf('The format "%s" is not defined, supported are %s.', $format, Utils::naturalLanguageJoin($formats)));
         }
 
         return $reporter;

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -343,7 +343,7 @@ final class ConfigurationResolver
                 );
 
                 if (\count($riskyFixers) > 0) {
-                    throw new InvalidConfigurationException(sprintf('The rules contain risky fixers ("%s"), but they are not allowed to run. Perhaps you forget to use --allow-risky=yes option?', implode('", "', $riskyFixers)));
+                    throw new InvalidConfigurationException(sprintf('The rules contain risky fixers (%s), but they are not allowed to run. Perhaps you forget to use --allow-risky=yes option?', Utils::naturalLanguageJoin($riskyFixers)));
                 }
             }
         }
@@ -417,9 +417,9 @@ final class ConfigurationResolver
                     $progressType = $this->getConfig()->getHideProgress() ? 'none' : 'dots';
                 } elseif (!\in_array($progressType, $progressTypes, true)) {
                     throw new InvalidConfigurationException(sprintf(
-                        'The progress type "%s" is not defined, supported are "%s".',
+                        'The progress type "%s" is not defined, supported are %s.',
                         $progressType,
-                        implode('", "', $progressTypes)
+                        Utils::naturalLanguageJoin($progressTypes)
                     ));
                 }
 
@@ -446,7 +446,7 @@ final class ConfigurationResolver
                 $formats = $reporterFactory->getFormats();
                 sort($formats);
 
-                throw new InvalidConfigurationException(sprintf('The format "%s" is not defined, supported are "%s".', $format, implode('", "', $formats)));
+                throw new InvalidConfigurationException(sprintf('The format "%s" is not defined, supported are %s.', $format, Utils::naturalLanguageJoin($formats)));
             }
         }
 
@@ -831,9 +831,9 @@ final class ConfigurationResolver
             true
         )) {
             throw new InvalidConfigurationException(sprintf(
-                'The path-mode "%s" is not defined, supported are "%s".',
+                'The path-mode "%s" is not defined, supported are %s.',
                 $this->options['path-mode'],
-                implode('", "', $modes)
+                Utils::naturalLanguageJoin($modes)
             ));
         }
 

--- a/src/Documentation/FixerDocumentGenerator.php
+++ b/src/Documentation/FixerDocumentGenerator.php
@@ -161,7 +161,7 @@ RST;
                     }, $allowed);
                 }
 
-                $allowed = implode(', ', $allowed);
+                $allowed = Utils::naturalLanguageJoin($allowed, '');
                 $optionInfo .= "\n\n{$allowedKind}: {$allowed}";
 
                 if ($option->hasDefault()) {

--- a/src/Documentation/ListDocumentGenerator.php
+++ b/src/Documentation/ListDocumentGenerator.php
@@ -121,7 +121,7 @@ RST;
                         }, $allowed);
                     }
 
-                    $allowed = implode(', ', $allowed);
+                    $allowed = Utils::naturalLanguageJoin($allowed, '');
                     $documentation .= "\n     | {$allowedKind}: {$allowed}";
 
                     if ($option->hasDefault()) {

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -30,6 +30,7 @@ use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use PhpCsFixer\Utils;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 /**
@@ -198,8 +199,8 @@ class Sample
                         if (!\in_array($type, $supportedTypes, true)) {
                             throw new InvalidOptionsException(
                                 sprintf(
-                                    'Unexpected element type, expected any of "%s", got "%s".',
-                                    implode('", "', $supportedTypes),
+                                    'Unexpected element type, expected any of %s, got "%s".',
+                                    Utils::naturalLanguageJoin($supportedTypes),
                                     \gettype($type).'#'.$type
                                 )
                             );
@@ -210,9 +211,9 @@ class Sample
                         if (!\in_array($spacing, $supportedSpacings, true)) {
                             throw new InvalidOptionsException(
                                 sprintf(
-                                    'Unexpected spacing for element type "%s", expected any of "%s", got "%s".',
+                                    'Unexpected spacing for element type "%s", expected any of %s, got "%s".',
                                     $spacing,
-                                    implode('", "', $supportedSpacings),
+                                    Utils::naturalLanguageJoin($supportedSpacings),
                                     \is_object($spacing) ? \get_class($spacing) : (null === $spacing ? 'null' : \gettype($spacing).'#'.$spacing)
                                 )
                             );

--- a/src/Fixer/ClassNotation/FinalInternalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalInternalClassFixer.php
@@ -28,6 +28,7 @@ use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use PhpCsFixer\Utils;
 use Symfony\Component\OptionsResolver\Options;
 
 /**
@@ -45,7 +46,7 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurabl
         );
 
         if (\count($intersect) > 0) {
-            throw new InvalidFixerConfigurationException($this->getName(), sprintf('Annotation cannot be used in both the include and exclude list, got duplicates: "%s".', implode('", "', array_keys($intersect))));
+            throw new InvalidFixerConfigurationException($this->getName(), sprintf('Annotation cannot be used in both the include and exclude list, got duplicates: %s.', Utils::naturalLanguageJoin(array_keys($intersect))));
         }
     }
 

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -26,6 +26,7 @@ use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceAnalysis;
 use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Utils;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 /**
@@ -234,7 +235,7 @@ $c = get_class($d);
                         ];
 
                         if (str_starts_with($functionName, '@') && !\in_array($functionName, $sets, true)) {
-                            throw new InvalidOptionsException(sprintf('Unknown set "%s", known sets are "%s".', $functionName, implode('", "', $sets)));
+                            throw new InvalidOptionsException(sprintf('Unknown set "%s", known sets are %s.', $functionName, Utils::naturalLanguageJoin($sets)));
                         }
                     }
 

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -28,6 +28,7 @@ use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use PhpCsFixer\Utils;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 /**
@@ -250,18 +251,18 @@ use Bar;
                         $missing = array_diff($supportedSortTypes, $value);
                         if (\count($missing) > 0) {
                             throw new InvalidOptionsException(sprintf(
-                                'Missing sort %s "%s".',
+                                'Missing sort %s %s.',
                                 1 === \count($missing) ? 'type' : 'types',
-                                implode('", "', $missing)
+                                Utils::naturalLanguageJoin($missing)
                             ));
                         }
 
                         $unknown = array_diff($value, $supportedSortTypes);
                         if (\count($unknown) > 0) {
                             throw new InvalidOptionsException(sprintf(
-                                'Unknown sort %s "%s".',
+                                'Unknown sort %s %s.',
                                 1 === \count($unknown) ? 'type' : 'types',
-                                implode('", "', $unknown)
+                                Utils::naturalLanguageJoin($unknown)
                             ));
                         }
                     }

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -27,6 +27,7 @@ use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use PhpCsFixer\Utils;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 /**
@@ -350,15 +351,15 @@ $array = [
                 ->setDefault(self::SINGLE_SPACE)
                 ->setAllowedValues(self::$allowedValues)
                 ->getOption(),
-            (new FixerOptionBuilder('operators', 'Dictionary of `binary operator` => `fix strategy` values that differ from the default strategy. Supported are: `'.implode('`, `', self::SUPPORTED_OPERATORS).'`.'))
+            (new FixerOptionBuilder('operators', 'Dictionary of `binary operator` => `fix strategy` values that differ from the default strategy. Supported are: '.Utils::naturalLanguageJoinWithBackticks(self::SUPPORTED_OPERATORS).'.'))
                 ->setAllowedTypes(['array'])
                 ->setAllowedValues([static function (array $option): bool {
                     foreach ($option as $operator => $value) {
                         if (!\in_array($operator, self::SUPPORTED_OPERATORS, true)) {
                             throw new InvalidOptionsException(
                                 sprintf(
-                                    'Unexpected "operators" key, expected any of "%s", got "%s".',
-                                    implode('", "', self::SUPPORTED_OPERATORS),
+                                    'Unexpected "operators" key, expected any of %s, got "%s".',
+                                    Utils::naturalLanguageJoin(self::SUPPORTED_OPERATORS),
                                     \gettype($operator).'#'.$operator
                                 )
                             );
@@ -367,9 +368,12 @@ $array = [
                         if (!\in_array($value, self::$allowedValues, true)) {
                             throw new InvalidOptionsException(
                                 sprintf(
-                                    'Unexpected value for operator "%s", expected any of "%s", got "%s".',
+                                    'Unexpected value for operator "%s", expected any of %s, got "%s".',
                                     $operator,
-                                    implode('", "', self::$allowedValues),
+                                    Utils::naturalLanguageJoin(array_map(
+                                        static fn ($value): string => Utils::toString($value),
+                                        self::$allowedValues
+                                    )),
                                     \is_object($value) ? \get_class($value) : (null === $value ? 'null' : \gettype($value).'#'.$value)
                                 )
                             );

--- a/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
@@ -27,6 +27,7 @@ use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use PhpCsFixer\Utils;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 /**
@@ -366,8 +367,8 @@ final class MyTest extends \PHPUnit_Framework_TestCase
                         if (!isset($thisFixer->staticMethods[$method])) {
                             throw new InvalidOptionsException(
                                 sprintf(
-                                    'Unexpected "methods" key, expected any of "%s", got "%s".',
-                                    implode('", "', array_keys($thisFixer->staticMethods)),
+                                    'Unexpected "methods" key, expected any of %s, got "%s".',
+                                    Utils::naturalLanguageJoin(array_keys($thisFixer->staticMethods)),
                                     \gettype($method).'#'.$method
                                 )
                             );
@@ -376,9 +377,9 @@ final class MyTest extends \PHPUnit_Framework_TestCase
                         if (!isset($thisFixer->allowedValues[$value])) {
                             throw new InvalidOptionsException(
                                 sprintf(
-                                    'Unexpected value for method "%s", expected any of "%s", got "%s".',
+                                    'Unexpected value for method "%s", expected any of %s, got "%s".',
                                     $method,
-                                    implode('", "', array_keys($thisFixer->allowedValues)),
+                                    Utils::naturalLanguageJoin(array_keys($thisFixer->allowedValues)),
                                     \is_object($value) ? \get_class($value) : (null === $value ? 'null' : \gettype($value).'#'.$value)
                                 )
                             );

--- a/src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
@@ -26,6 +26,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use PhpCsFixer\Utils;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Options;
 
@@ -145,17 +146,17 @@ class Sample
 
                         if (!isset($default[$from])) {
                             throw new InvalidOptionsException(sprintf(
-                                'Unknown key "%s", expected any of "%s".',
+                                'Unknown key "%s", expected any of %s.',
                                 \gettype($from).'#'.$from,
-                                implode('", "', array_keys($default))
+                                Utils::naturalLanguageJoin(array_keys($default))
                             ));
                         }
 
                         if (!\in_array($to, self::$toTypes, true)) {
                             throw new InvalidOptionsException(sprintf(
-                                'Unknown value "%s", expected any of "%s".',
+                                'Unknown value "%s", expected any of %s.',
                                 \is_object($to) ? \get_class($to) : \gettype($to).(\is_resource($to) ? '' : '#'.$to),
-                                implode('", "', self::$toTypes)
+                                Utils::naturalLanguageJoin(self::$toTypes)
                             ));
                         }
 

--- a/src/FixerFactory.php
+++ b/src/FixerFactory.php
@@ -227,7 +227,7 @@ final class FixerFactory
             );
 
             if (\count($report[$fixer]) > 0) {
-                $message .= sprintf("\n- \"%s\" with \"%s\"", $fixer, implode('", "', $report[$fixer]));
+                $message .= sprintf("\n- \"%s\" with %s", $fixer, Utils::naturalLanguageJoin($report[$fixer]));
             }
         }
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -147,7 +147,7 @@ final class ConfigurationResolverTest extends TestCase
         ]);
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The progress type "foo" is not defined, supported are "none", "dots".');
+        $this->expectExceptionMessage('The progress type "foo" is not defined, supported are "none" and "dots".');
 
         $resolver->getProgress();
     }
@@ -247,7 +247,7 @@ final class ConfigurationResolverTest extends TestCase
     public function testResolveConfigFileChooseFileWithInvalidFormat(): void
     {
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessageMatches('/^The format "xls" is not defined, supported are "checkstyle", "gitlab", "json", "junit", "txt", "xml"\.$/');
+        $this->expectExceptionMessageMatches('/^The format "xls" is not defined, supported are "checkstyle", "gitlab", "json", "junit", "txt" and "xml"\.$/');
 
         $dirBase = self::getFixtureDir();
 

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -108,7 +108,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
             [
                 ['@xxx'],
                 InvalidFixerConfigurationException::class,
-                '[native_function_invocation] Invalid configuration: Unknown set "@xxx", known sets are "@all", "@internal", "@compiler_optimized".',
+                '[native_function_invocation] Invalid configuration: Unknown set "@xxx", known sets are "@all", "@internal" and "@compiler_optimized".',
             ],
             [
                 [' x '],

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -1077,7 +1077,7 @@ use function some\a\{fn_a, fn_b, fn_c,};
     public function testUnknownOrderTypes(): void
     {
         $this->expectException(InvalidFixerConfigurationException::class);
-        $this->expectExceptionMessage('[ordered_imports] Invalid configuration: Unknown sort types "foo", "bar".');
+        $this->expectExceptionMessage('[ordered_imports] Invalid configuration: Unknown sort types "foo" and "bar".');
 
         $this->fixer->configure([
             'sort_algorithm' => OrderedImportsFixer::SORT_ALPHA,

--- a/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
@@ -176,13 +176,13 @@ class F
         return [
             [
                 ['replacements' => [1 => 'a']],
-                'Invalid configuration: Unknown key "integer#1", expected any of "this", "@this", "$self", "@self", "$static", "@static".',
+                'Invalid configuration: Unknown key "integer#1", expected any of "this", "@this", "$self", "@self", "$static" and "@static".',
             ],
             [
                 ['replacements' => [
                     'this' => 'foo',
                 ]],
-                'Invalid configuration: Unknown value "string#foo", expected any of "$this", "static", "self".',
+                'Invalid configuration: Unknown value "string#foo", expected any of "$this", "static" and "self".',
             ],
         ];
     }

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -289,8 +289,8 @@ final class FixerFactoryTest extends TestCase
         self::assertSame(
             'Rule contains conflicting fixers:
 - "a" with "b"
-- "c" with "d", "e", "f"
-- "d" with "g", "h"
+- "c" with "d", "e" and "f"
+- "d" with "g" and "h"
 - "e" with "a"',
             $method->invoke(
                 $factory,


### PR DESCRIPTION
Follow up to #7022 

Changes mainly done on documentation generation and exception messages.