### PR TITLE
minor: Transfer `HelpCommand::toString()` to `Utils`

### DIFF
--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -210,8 +210,8 @@ final class DescribeCommand extends Command
                 } else {
                     $allowed = array_map(static function ($value): string {
                         return $value instanceof AllowedValueSubset
-                            ? 'a subset of <comment>'.HelpCommand::toString($value->getAllowedValues()).'</comment>'
-                            : '<comment>'.HelpCommand::toString($value).'</comment>';
+                            ? 'a subset of <comment>'.Utils::toString($value->getAllowedValues()).'</comment>'
+                            : '<comment>'.Utils::toString($value).'</comment>';
                     }, $allowed);
                 }
 
@@ -223,7 +223,7 @@ final class DescribeCommand extends Command
                 if ($option->hasDefault()) {
                     $line .= sprintf(
                         'defaults to <comment>%s</comment>',
-                        HelpCommand::toString($option->getDefault())
+                        Utils::toString($option->getDefault())
                     );
                 } else {
                     $line .= '<comment>required</comment>';
@@ -296,7 +296,7 @@ final class DescribeCommand extends Command
                     if (null === $configuration) {
                         $output->writeln(sprintf(' * Example #%d. Fixing with the <comment>default</comment> configuration.', $index + 1));
                     } else {
-                        $output->writeln(sprintf(' * Example #%d. Fixing with configuration: <comment>%s</comment>.', $index + 1, HelpCommand::toString($codeSample->getConfiguration())));
+                        $output->writeln(sprintf(' * Example #%d. Fixing with configuration: <comment>%s</comment>.', $index + 1, Utils::toString($codeSample->getConfiguration())));
                     }
                 } else {
                     $output->writeln(sprintf(' * Example #%d.', $index + 1));
@@ -349,7 +349,7 @@ final class DescribeCommand extends Command
                 $rule,
                 $fixer->isRisky() ? ' <error>risky</error>' : '',
                 $definition->getSummary(),
-                true !== $config ? sprintf("   <comment>| Configuration: %s</comment>\n", HelpCommand::toString($config)) : ''
+                true !== $config ? sprintf("   <comment>| Configuration: %s</comment>\n", Utils::toString($config)) : ''
             );
         }
 

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -16,7 +16,7 @@ namespace PhpCsFixer\Console\Command;
 
 use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
 use PhpCsFixer\FixerConfiguration\FixerOptionInterface;
-use PhpCsFixer\Preg;
+use PhpCsFixer\Utils;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\HelpCommand as BaseHelpCommand;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
@@ -36,16 +36,6 @@ final class HelpCommand extends BaseHelpCommand
      * @var string
      */
     protected static $defaultName = 'help';
-
-    /**
-     * @param mixed $value
-     */
-    public static function toString($value): string
-    {
-        return \is_array($value)
-            ? self::arrayToString($value)
-            : self::scalarToString($value);
-    }
 
     /**
      * Returns the allowed values of the given option that can be converted to a string.
@@ -71,8 +61,8 @@ final class HelpCommand extends BaseHelpCommand
                 }
 
                 return strcasecmp(
-                    self::toString($valueA),
-                    self::toString($valueB)
+                    Utils::toString($valueA),
+                    Utils::toString($valueB)
                 );
             });
 
@@ -87,40 +77,5 @@ final class HelpCommand extends BaseHelpCommand
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $output->getFormatter()->setStyle('url', new OutputFormatterStyle('blue'));
-    }
-
-    /**
-     * @param mixed $value
-     */
-    private static function scalarToString($value): string
-    {
-        $str = var_export($value, true);
-
-        return Preg::replace('/\bNULL\b/', 'null', $str);
-    }
-
-    /**
-     * @param array<mixed> $value
-     */
-    private static function arrayToString(array $value): string
-    {
-        if (0 === \count($value)) {
-            return '[]';
-        }
-
-        $isHash = !array_is_list($value);
-        $str = '[';
-
-        foreach ($value as $k => $v) {
-            if ($isHash) {
-                $str .= self::scalarToString($k).' => ';
-            }
-
-            $str .= \is_array($v)
-                ? self::arrayToString($v).', '
-                : self::scalarToString($v).', ';
-        }
-
-        return substr($str, 0, -2).']';
     }
 }

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -23,7 +23,6 @@ use PhpCsFixer\Cache\NullCacheManager;
 use PhpCsFixer\Cache\Signature;
 use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
-use PhpCsFixer\Console\Command\HelpCommand;
 use PhpCsFixer\Console\Report\FixReport\ReporterFactory;
 use PhpCsFixer\Console\Report\FixReport\ReporterInterface;
 use PhpCsFixer\Differ\DifferInterface;
@@ -776,7 +775,7 @@ final class ConfigurationResolver
                         '"%s" is renamed (did you mean "%s"?%s), ',
                         $unknownFixer,
                         $renamedRules[$unknownFixer]['new_name'],
-                        isset($renamedRules[$unknownFixer]['config']) ? ' (note: use configuration "'.HelpCommand::toString($renamedRules[$unknownFixer]['config']).'")' : ''
+                        isset($renamedRules[$unknownFixer]['config']) ? ' (note: use configuration "'.Utils::toString($renamedRules[$unknownFixer]['config']).'")' : ''
                     );
                 } else { // Go to normal matcher if it is not a renamed rule
                     $matcher = new WordMatcher($availableFixers);

--- a/src/Documentation/FixerDocumentGenerator.php
+++ b/src/Documentation/FixerDocumentGenerator.php
@@ -156,8 +156,8 @@ RST;
                     $allowedKind = 'Allowed values';
                     $allowed = array_map(static function ($value): string {
                         return $value instanceof AllowedValueSubset
-                            ? 'a subset of ``'.HelpCommand::toString($value->getAllowedValues()).'``'
-                            : '``'.HelpCommand::toString($value).'``';
+                            ? 'a subset of ``'.Utils::toString($value->getAllowedValues()).'``'
+                            : '``'.Utils::toString($value).'``';
                     }, $allowed);
                 }
 
@@ -165,7 +165,7 @@ RST;
                 $optionInfo .= "\n\n{$allowedKind}: {$allowed}";
 
                 if ($option->hasDefault()) {
-                    $default = HelpCommand::toString($option->getDefault());
+                    $default = Utils::toString($option->getDefault());
                     $optionInfo .= "\n\nDefault value: ``{$default}``";
                 } else {
                     $optionInfo .= "\n\nThis option is required.";
@@ -196,7 +196,7 @@ RST;
                     } else {
                         $doc .= sprintf(
                             "\n\nWith configuration: ``%s``.",
-                            HelpCommand::toString($sample->getConfiguration())
+                            Utils::toString($sample->getConfiguration())
                         );
                     }
                 }
@@ -238,7 +238,7 @@ RST;
 RST;
 
                 if (null !== $config) {
-                    $doc .= " with the config below:\n\n  ``".HelpCommand::toString($config).'``';
+                    $doc .= " with the config below:\n\n  ``".Utils::toString($config).'``';
                 } elseif ($fixer instanceof ConfigurableFixerInterface) {
                     $doc .= ' with the default config.';
                 } else {

--- a/src/Documentation/ListDocumentGenerator.php
+++ b/src/Documentation/ListDocumentGenerator.php
@@ -116,8 +116,8 @@ RST;
                         $allowedKind = 'Allowed values';
                         $allowed = array_map(static function ($value): string {
                             return $value instanceof AllowedValueSubset
-                                ? 'a subset of ``'.HelpCommand::toString($value->getAllowedValues()).'``'
-                                : '``'.HelpCommand::toString($value).'``';
+                                ? 'a subset of ``'.Utils::toString($value->getAllowedValues()).'``'
+                                : '``'.Utils::toString($value).'``';
                         }, $allowed);
                     }
 
@@ -125,7 +125,7 @@ RST;
                     $documentation .= "\n     | {$allowedKind}: {$allowed}";
 
                     if ($option->hasDefault()) {
-                        $default = HelpCommand::toString($option->getDefault());
+                        $default = Utils::toString($option->getDefault());
                         $documentation .= "\n     | Default value: ``{$default}``";
                     } else {
                         $documentation .= "\n     | This option is required.";

--- a/src/Documentation/RuleSetDocumentationGenerator.php
+++ b/src/Documentation/RuleSetDocumentationGenerator.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Documentation;
 
-use PhpCsFixer\Console\Command\HelpCommand;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\Preg;
 use PhpCsFixer\RuleSet\RuleSetDescriptionInterface;
+use PhpCsFixer\Utils;
 
 /**
  * @internal
@@ -76,7 +76,7 @@ final class RuleSetDocumentationGenerator
                     }
 
                     if (!\is_bool($config)) {
-                        $doc .= "\n  config:\n  ``".HelpCommand::toString($config).'``';
+                        $doc .= "\n  config:\n  ``".Utils::toString($config).'``';
                     }
                 }
             };

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -189,4 +189,49 @@ final class Utils
 
         return $triggeredDeprecations;
     }
+
+    /**
+     * @param mixed $value
+     */
+    public static function toString($value): string
+    {
+        return \is_array($value)
+            ? self::arrayToString($value)
+            : self::scalarToString($value);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function scalarToString($value): string
+    {
+        $str = var_export($value, true);
+
+        return Preg::replace('/\bNULL\b/', 'null', $str);
+    }
+
+    /**
+     * @param array<mixed> $value
+     */
+    private static function arrayToString(array $value): string
+    {
+        if (0 === \count($value)) {
+            return '[]';
+        }
+
+        $isHash = !array_is_list($value);
+        $str = '[';
+
+        foreach ($value as $k => $v) {
+            if ($isHash) {
+                $str .= self::scalarToString($k).' => ';
+            }
+
+            $str .= \is_array($v)
+                ? self::arrayToString($v).', '
+                : self::scalarToString($v).', ';
+        }
+
+        return substr($str, 0, -2).']';
+    }
 }

--- a/tests/Console/Command/HelpCommandTest.php
+++ b/tests/Console/Command/HelpCommandTest.php
@@ -27,41 +27,6 @@ use PhpCsFixer\Tests\TestCase;
 final class HelpCommandTest extends TestCase
 {
     /**
-     * @param mixed $input
-     *
-     * @dataProvider provideToStringCases
-     */
-    public function testToString(string $expected, $input): void
-    {
-        self::assertSame($expected, HelpCommand::toString($input));
-    }
-
-    public static function provideToStringCases(): iterable
-    {
-        yield ["['a' => 3, 'b' => 'c']", ['a' => 3, 'b' => 'c']];
-
-        yield ['[[1], [2]]', [[1], [2]]];
-
-        yield ['[0 => [1], \'a\' => [2]]', [[1], 'a' => [2]]];
-
-        yield ['[1, 2, \'foo\', null]', [1, 2, 'foo', null]];
-
-        yield ['[1, 2]', [1, 2]];
-
-        yield ['[]', []];
-
-        yield ['1.5', 1.5];
-
-        yield ['false', false];
-
-        yield ['true', true];
-
-        yield ['1', 1];
-
-        yield ["'foo'", 'foo'];
-    }
-
-    /**
      * @param null|mixed $expected
      *
      * @dataProvider provideGetDisplayableAllowedValuesCases

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -379,6 +379,41 @@ final class UtilsTest extends TestCase
         self::assertNotContains($message, $triggered);
     }
 
+    /**
+     * @param mixed $input
+     *
+     * @dataProvider provideToStringCases
+     */
+    public function testToString(string $expected, $input): void
+    {
+        self::assertSame($expected, Utils::toString($input));
+    }
+
+    public static function provideToStringCases(): iterable
+    {
+        yield ["['a' => 3, 'b' => 'c']", ['a' => 3, 'b' => 'c']];
+
+        yield ['[[1], [2]]', [[1], [2]]];
+
+        yield ['[0 => [1], \'a\' => [2]]', [[1], 'a' => [2]]];
+
+        yield ['[1, 2, \'foo\', null]', [1, 2, 'foo', null]];
+
+        yield ['[1, 2]', [1, 2]];
+
+        yield ['[]', []];
+
+        yield ['1.5', 1.5];
+
+        yield ['false', false];
+
+        yield ['true', true];
+
+        yield ['1', 1];
+
+        yield ["'foo'", 'foo'];
+    }
+
     private function createFixerDouble(string $name, int $priority): FixerInterface
     {
         $fixer = $this->prophesize(FixerInterface::class);


### PR DESCRIPTION
Since `HelpCommand` is internal, I did not mind deprecating the previous.