### PR TITLE
CI: Conventional Commits support in PRLint config

### DIFF
--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -1,8 +1,8 @@
 {
   "title": [
     {
-      "pattern": "^(feat|bug|chore|CI|docs|DX|refactor|test)(\\([a-zA-Z0-9]+\\))?!?:\\s{1}\\S.+\\S$",
-      "message": "PR title does not meet requirement, use Conventional Commits format using one of these categories: feat, bug, chore, ci, docs, DX, refactor, test"
+      "pattern": "^(feat|fix|chore|CI|docs|DX|refactor|test)(\\([a-zA-Z0-9]+\\))?!?:\\s{1}\\S.+\\S$",
+      "message": "PR title does not meet requirement, use Conventional Commits format using one of these categories: feat, fix, chore, CI, docs, DX, refactor, test"
     },
     {
       "pattern": "((?<=`)@\\S*`)|(^[^@]*$)",

--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -1,8 +1,8 @@
 {
   "title": [
     {
-      "pattern": "^(feat(ure)?|bug|chore|CI|docs|DX|refactor|test)(\\([a-zA-Z0-9]+\\))?:\\s{1}.+\\S$",
-      "message": "PR title does not meet requirement, use Conventional Commits format using one of these categories: feature, bug, chore, ci, docs, DX, refactor, test"
+      "pattern": "^(feat|bug|chore|CI|docs|DX|refactor|test)(\\([a-zA-Z0-9]+\\))?!?:\\s{1}\\S.+\\S$",
+      "message": "PR title does not meet requirement, use Conventional Commits format using one of these categories: feat, bug, chore, ci, docs, DX, refactor, test"
     },
     {
       "pattern": "((?<=`)@\\S*`)|(^[^@]*$)",

--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -1,8 +1,8 @@
 {
   "title": [
     {
-      "pattern": "^(feature|bug|minor|docs|DX|chore):\\s.+\\S$",
-      "message": "Your title needs to match the convention: use '(feature|bug|minor|docs|DX|chore):' prefix."
+      "pattern": "^(feat(ure)?|bug|chore|CI|docs|DX|refactor|test)(\\([a-zA-Z0-9]+\\))?:\\s{1}.+\\S$",
+      "message": "PR title does not meet requirement, use Conventional Commits format using one of these categories: feature, bug, chore, ci, docs, DX, refactor, test"
     },
     {
       "pattern": "((?<=`)@\\S*`)|(^[^@]*$)",

--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -1,8 +1,8 @@
 {
   "title": [
     {
-      "pattern": "^(feature|bug|minor|docs|DX):\\s.+\\S$",
-      "message": "Your title needs to match the convention: use '(feature|bug|minor|docs|DX):' prefix."
+      "pattern": "^(feature|bug|minor|docs|DX|chore):\\s.+\\S$",
+      "message": "Your title needs to match the convention: use '(feature|bug|minor|docs|DX|chore):' prefix."
     },
     {
       "pattern": "((?<=`)@\\S*`)|(^[^@]*$)",


### PR DESCRIPTION
Sometimes it's really hard to choose proper category of PR to satisfy PRLint. For example cleaning up the code isn't neither DX, feature or any other currently allowed PR type.

ℹ️  [Here's how it works in practice](https://regex101.com/r/XwOSjW/4).

Distinction between `DX` and `chore`:
- `DX` for things that bring actual value when it comes to working with the project (like [this](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6839))
- `chore` for minor changes that have to be done, but don't fit any other category