### PR TITLE
DX: Cleanup duplicate files in finder

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -27,10 +27,6 @@ $finder = PhpCsFixer\Finder::create()
     ->ignoreVCSIgnored(true)
     ->exclude(['dev-tools/phpstan', 'tests/Fixtures'])
     ->in(__DIR__)
-    ->append([
-        __DIR__.'/dev-tools/doc.php',
-        // __DIR__.'/php-cs-fixer', disabled, as we want to be able to run bootstrap file even on lower PHP version, to show nice message
-    ])
 ;
 
 $config = new PhpCsFixer\Config();


### PR DESCRIPTION
While looking at the output of `php php-cs-fixer list-files`, it seems `dev-tools/doc.php` is already included but appended again.