### PR TITLE
feature: Introduce ``same_line_without_extra_space`` for ``CurlyBracesPositionFixer``

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -346,23 +346,23 @@ List of Available Rules
 
    - | ``control_structures_opening_brace``
      | The position of the opening brace of control structures‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``'same_line_without_extra_space'``
      | Default value: ``'same_line'``
    - | ``functions_opening_brace``
      | The position of the opening brace of functions‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``'same_line_without_extra_space'``
      | Default value: ``'next_line_unless_newline_at_signature_end'``
    - | ``anonymous_functions_opening_brace``
      | The position of the opening brace of anonymous functions‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``'same_line_without_extra_space'``
      | Default value: ``'same_line'``
    - | ``classes_opening_brace``
      | The position of the opening brace of classes‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``'same_line_without_extra_space'``
      | Default value: ``'next_line_unless_newline_at_signature_end'``
    - | ``anonymous_classes_opening_brace``
      | The position of the opening brace of anonymous classes‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``'same_line_without_extra_space'``
      | Default value: ``'same_line'``
    - | ``allow_single_line_empty_anonymous_classes``
      | Allow anonymous classes to have opening and closing braces on the same line.

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -346,23 +346,23 @@ List of Available Rules
 
    - | ``control_structures_opening_brace``
      | The position of the opening brace of control structures‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
      | Default value: ``'same_line'``
    - | ``functions_opening_brace``
      | The position of the opening brace of functions‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
      | Default value: ``'next_line_unless_newline_at_signature_end'``
    - | ``anonymous_functions_opening_brace``
      | The position of the opening brace of anonymous functions‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
      | Default value: ``'same_line'``
    - | ``classes_opening_brace``
      | The position of the opening brace of classes‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
      | Default value: ``'next_line_unless_newline_at_signature_end'``
    - | ``anonymous_classes_opening_brace``
      | The position of the opening brace of anonymous classes‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
      | Default value: ``'same_line'``
    - | ``allow_single_line_empty_anonymous_classes``
      | Allow anonymous classes to have opening and closing braces on the same line.

--- a/doc/rules/basic/curly_braces_position.rst
+++ b/doc/rules/basic/curly_braces_position.rst
@@ -12,7 +12,7 @@ Configuration
 
 The position of the opening brace of control structures‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
+Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
 
 Default value: ``'same_line'``
 
@@ -21,7 +21,7 @@ Default value: ``'same_line'``
 
 The position of the opening brace of functions‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
+Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
 
 Default value: ``'next_line_unless_newline_at_signature_end'``
 
@@ -30,7 +30,7 @@ Default value: ``'next_line_unless_newline_at_signature_end'``
 
 The position of the opening brace of anonymous functions‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
+Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
 
 Default value: ``'same_line'``
 
@@ -39,7 +39,7 @@ Default value: ``'same_line'``
 
 The position of the opening brace of classes‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
+Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
 
 Default value: ``'next_line_unless_newline_at_signature_end'``
 
@@ -48,7 +48,7 @@ Default value: ``'next_line_unless_newline_at_signature_end'``
 
 The position of the opening brace of anonymous classes‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
+Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
 
 Default value: ``'same_line'``
 
@@ -228,6 +228,36 @@ With configuration: ``['allow_single_line_anonymous_functions' => true]``.
    +$result = true;
    +    return $result;
    +};
+
+Example #10
+~~~~~~~~~~
+
+With configuration: ``['control_structures_opening_brace' => 'same_line_without_extra_space']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -if (foo()) {
+   +if (foo()){
+        bar();
+    }
+
+Example #11
+~~~~~~~~~~
+
+With configuration: ``['classes_opening_brace' => 'same_line_without_extra_space']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -class Foo
+   -{
+   +class Foo{
+    }
 
 Rule sets
 ---------

--- a/doc/rules/basic/curly_braces_position.rst
+++ b/doc/rules/basic/curly_braces_position.rst
@@ -12,7 +12,7 @@ Configuration
 
 The position of the opening brace of control structures‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
+Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``'same_line_without_extra_space'``
 
 Default value: ``'same_line'``
 
@@ -21,7 +21,7 @@ Default value: ``'same_line'``
 
 The position of the opening brace of functions‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
+Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``'same_line_without_extra_space'``
 
 Default value: ``'next_line_unless_newline_at_signature_end'``
 
@@ -30,7 +30,7 @@ Default value: ``'next_line_unless_newline_at_signature_end'``
 
 The position of the opening brace of anonymous functions‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
+Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``'same_line_without_extra_space'``
 
 Default value: ``'same_line'``
 
@@ -39,7 +39,7 @@ Default value: ``'same_line'``
 
 The position of the opening brace of classes‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
+Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``'same_line_without_extra_space'``
 
 Default value: ``'next_line_unless_newline_at_signature_end'``
 
@@ -48,7 +48,7 @@ Default value: ``'next_line_unless_newline_at_signature_end'``
 
 The position of the opening brace of anonymous classes‘ body.
 
-Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``same_line_without_extra_space``
+Allowed values: ``'next_line_unless_newline_at_signature_end'``, ``'same_line'`` and ``'same_line_without_extra_space'``
 
 Default value: ``'same_line'``
 
@@ -230,22 +230,7 @@ With configuration: ``['allow_single_line_anonymous_functions' => true]``.
    +};
 
 Example #10
-~~~~~~~~~~
-
-With configuration: ``['control_structures_opening_brace' => 'same_line_without_extra_space']``.
-
-.. code-block:: diff
-
-   --- Original
-   +++ New
-    <?php
-   -if (foo()) {
-   +if (foo()){
-        bar();
-    }
-
-Example #11
-~~~~~~~~~~
+~~~~~~~~~~~
 
 With configuration: ``['classes_opening_brace' => 'same_line_without_extra_space']``.
 

--- a/src/Fixer/Basic/CurlyBracesPositionFixer.php
+++ b/src/Fixer/Basic/CurlyBracesPositionFixer.php
@@ -137,6 +137,14 @@ $bar = function () { $result = true;
 ',
                     ['allow_single_line_anonymous_functions' => true]
                 ),
+                new CodeSample(
+                    '<?php
+class Foo
+{
+}
+',
+                    ['classes_opening_brace' => self::SAME_LINE_WITHOUT_EXTRA_SPACE]
+                ),
             ]
         );
     }

--- a/src/Fixer/Basic/CurlyBracesPositionFixer.php
+++ b/src/Fixer/Basic/CurlyBracesPositionFixer.php
@@ -46,6 +46,11 @@ final class CurlyBracesPositionFixer extends AbstractFixer implements Configurab
      */
     public const SAME_LINE = 'same_line';
 
+    /**
+     * @internal
+     */
+    public const SAME_LINE_WITHOUT_EXTRA_SPACE = 'same_line_without_extra_space';
+
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
@@ -320,7 +325,9 @@ $bar = function () { $result = true;
                 $openBraceIndex = $moveBraceToIndex;
             }
 
-            if ($tokens->ensureWhitespaceAtIndex($openBraceIndex - 1, 1, $whitespace)) {
+            if (self::SAME_LINE_WITHOUT_EXTRA_SPACE === $this->configuration[$positionOption]) {
+                $tokens->removeLeadingWhitespace($openBraceIndex);
+            } elseif ($tokens->ensureWhitespaceAtIndex($openBraceIndex - 1, 1, $whitespace)) {
                 ++$closeBraceIndex;
                 if (null !== $allowSingleLineUntil) {
                     ++$allowSingleLineUntil;
@@ -350,23 +357,23 @@ $bar = function () { $result = true;
     {
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('control_structures_opening_brace', 'The position of the opening brace of control structures‘ body.'))
-                ->setAllowedValues([self::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END, self::SAME_LINE])
+                ->setAllowedValues([self::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END, self::SAME_LINE, self::SAME_LINE_WITHOUT_EXTRA_SPACE])
                 ->setDefault(self::SAME_LINE)
                 ->getOption(),
             (new FixerOptionBuilder('functions_opening_brace', 'The position of the opening brace of functions‘ body.'))
-                ->setAllowedValues([self::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END, self::SAME_LINE])
+                ->setAllowedValues([self::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END, self::SAME_LINE, self::SAME_LINE_WITHOUT_EXTRA_SPACE])
                 ->setDefault(self::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END)
                 ->getOption(),
             (new FixerOptionBuilder('anonymous_functions_opening_brace', 'The position of the opening brace of anonymous functions‘ body.'))
-                ->setAllowedValues([self::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END, self::SAME_LINE])
+                ->setAllowedValues([self::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END, self::SAME_LINE, self::SAME_LINE_WITHOUT_EXTRA_SPACE])
                 ->setDefault(self::SAME_LINE)
                 ->getOption(),
             (new FixerOptionBuilder('classes_opening_brace', 'The position of the opening brace of classes‘ body.'))
-                ->setAllowedValues([self::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END, self::SAME_LINE])
+                ->setAllowedValues([self::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END, self::SAME_LINE, self::SAME_LINE_WITHOUT_EXTRA_SPACE])
                 ->setDefault(self::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END)
                 ->getOption(),
             (new FixerOptionBuilder('anonymous_classes_opening_brace', 'The position of the opening brace of anonymous classes‘ body.'))
-                ->setAllowedValues([self::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END, self::SAME_LINE])
+                ->setAllowedValues([self::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END, self::SAME_LINE, self::SAME_LINE_WITHOUT_EXTRA_SPACE])
                 ->setDefault(self::SAME_LINE)
                 ->getOption(),
             (new FixerOptionBuilder('allow_single_line_empty_anonymous_classes', 'Allow anonymous classes to have opening and closing braces on the same line.'))

--- a/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
+++ b/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
@@ -62,6 +62,18 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
         ];
 
+        yield 'if (same line without extra space)' => [
+            '<?php
+                if ($foo){
+                    foo();
+                }',
+            '<?php
+                if ($foo) {
+                    foo();
+                }',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'else (default)' => [
             '<?php
                 if ($foo) {
@@ -99,6 +111,24 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                     bar();
                 }',
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
+        ];
+
+        yield 'else (same line without extra space)' => [
+            '<?php
+                if ($foo){
+                    foo();
+                }
+                else{
+                    bar();
+                }',
+            '<?php
+                if ($foo) {
+                    foo();
+                }
+                else {
+                    bar();
+                }',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
         ];
 
         yield 'elseif (default)' => [
@@ -140,6 +170,24 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
         ];
 
+        yield 'elseif (same line without extra space)' => [
+            '<?php
+                if ($foo){
+                    foo();
+                }
+                elseif ($bar){
+                    bar();
+                }',
+            '<?php
+                if ($foo) {
+                    foo();
+                }
+                elseif ($bar) {
+                    bar();
+                }',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'else if (default)' => [
             '<?php
                 if ($foo) {
@@ -179,6 +227,24 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
         ];
 
+        yield 'else if (same line without extra space)' => [
+            '<?php
+                if ($foo){
+                    foo();
+                }
+                else if ($bar){
+                    bar();
+                }',
+            '<?php
+                if ($foo) {
+                    foo();
+                }
+                else if ($bar) {
+                    bar();
+                }',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'for (default)' => [
             '<?php
                 for (;;) {
@@ -202,6 +268,18 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                     foo();
                 }',
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
+        ];
+
+        yield 'for (same line without extra space)' => [
+            '<?php
+                for (;;){
+                    foo();
+                }',
+            '<?php
+                for (;;) {
+                    foo();
+                }',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
         ];
 
         yield 'foreach (default)' => [
@@ -229,6 +307,18 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
         ];
 
+        yield 'foreach (same line without extra space)' => [
+            '<?php
+                foreach ($foo as $bar){
+                    foo();
+                }',
+            '<?php
+                foreach ($foo as $bar) {
+                    foo();
+                }',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'while (default)' => [
             '<?php
                 while ($foo) {
@@ -254,6 +344,18 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
         ];
 
+        yield 'while (same line without extra space)' => [
+            '<?php
+                while ($foo){
+                    foo();
+                }',
+            '<?php
+                while ($foo) {
+                    foo();
+                }',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'do while (default)' => [
             '<?php
                 do {
@@ -277,6 +379,18 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                     foo();
                 } while ($foo);',
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
+        ];
+
+        yield 'do while (same line without extra space)' => [
+            '<?php
+                do{
+                    foo();
+                } while ($foo);',
+            '<?php
+                do {
+                    foo();
+                } while ($foo);',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
         ];
 
         yield 'switch (default)' => [
@@ -308,6 +422,20 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
         ];
 
+        yield 'switch (same line without extra space)' => [
+            '<?php
+                switch ($foo){
+                    case 1:
+                        foo();
+                }',
+            '<?php
+                switch ($foo) {
+                    case 1:
+                        foo();
+                }',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'try catch finally (default)' => [
             '<?php
                 switch ($foo) {
@@ -337,6 +465,20 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
         ];
 
+        yield 'try catch finally (same line without extra space)' => [
+            '<?php
+                switch ($foo){
+                    case 1:
+                        foo();
+                }',
+            '<?php
+                switch ($foo) {
+                    case 1:
+                        foo();
+                }',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'class (default)' => [
             '<?php
                 class Foo
@@ -356,6 +498,17 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                 {
                 }',
             ['classes_opening_brace' => 'same_line'],
+        ];
+
+        yield 'class (same line without extra space)' => [
+            '<?php
+                class Foo{
+                }',
+            '<?php
+                class Foo
+                {
+                }',
+            ['classes_opening_brace' => 'same_line_without_extra_space'],
         ];
 
         yield 'function (default)' => [
@@ -379,6 +532,17 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['functions_opening_brace' => 'same_line'],
         ];
 
+        yield 'function (same line without extra space)' => [
+            '<?php
+                function foo(){
+                }',
+            '<?php
+                function foo()
+                {
+                }',
+            ['functions_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'anonymous function (default)' => [
             '<?php
                 $foo = function () {
@@ -398,6 +562,16 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                 $foo = function () {
                 };',
             ['anonymous_functions_opening_brace' => 'next_line_unless_newline_at_signature_end'],
+        ];
+
+        yield 'anonymous function (same line without extra space)' => [
+            '<?php
+                $foo = function (){
+                };',
+            '<?php
+                $foo = function () {
+                };',
+            ['anonymous_functions_opening_brace' => 'same_line_without_extra_space'],
         ];
 
         yield 'with blank lines inside braces' => [
@@ -456,6 +630,18 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['functions_opening_brace' => 'same_line'],
         ];
 
+        yield 'with comment after opening brace (same line without extra space)' => [
+            '<?php
+                function foo(){ // foo
+                /* foo */
+                }',
+            '<?php
+                function foo() // foo
+                { /* foo */
+                }',
+            ['functions_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'next line with multiline signature' => [
             '<?php
                 if (
@@ -488,6 +674,21 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
         ];
 
+        yield 'same line without extra space with newline before closing parenthesis' => [
+            '<?php
+                if ($foo
+                ){
+                    foo();
+                }',
+            '<?php
+                if ($foo
+                )
+                {
+                    foo();
+                }',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'next line with newline in signature but not before closing parenthesis' => [
             '<?php
                 if (
@@ -501,6 +702,20 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                     foo();
                 }',
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
+        ];
+
+        yield 'same line without extra space with newline in signature but not before closing parenthesis' => [
+            '<?php
+                if (
+                    $foo){
+                    foo();
+                }',
+            '<?php
+                if (
+                    $foo) {
+                    foo();
+                }',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
         ];
 
         yield 'anonymous class (same line)' => [
@@ -524,6 +739,16 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['anonymous_classes_opening_brace' => 'next_line_unless_newline_at_signature_end'],
         ];
 
+        yield 'anonymous class (same line without extra space)' => [
+            '<?php
+                $foo = new class(){
+                };',
+            '<?php
+                $foo = new class() {
+                };',
+            ['anonymous_classes_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'next line with multiline signature and return type' => [
             '<?php
                 function foo(
@@ -539,6 +764,23 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                     foo();
                 }',
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
+        ];
+
+        yield 'same line without extra space with multiline signature and return type' => [
+            '<?php
+                function foo(
+                    $foo
+                ): int{
+                    foo();
+                }',
+            '<?php
+                function foo(
+                    $foo
+                ): int
+                {
+                    foo();
+                }',
+            ['functions_opening_brace' => 'same_line_without_extra_space'],
         ];
 
         yield 'next line with multiline signature and return type (nullable)' => [
@@ -558,6 +800,23 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
         ];
 
+        yield 'same line without extra space with multiline signature and return type (nullable)' => [
+            '<?php
+                function foo(
+                    $foo
+                ): ?int{
+                    foo();
+                }',
+            '<?php
+                function foo(
+                    $foo
+                ): ?int
+                {
+                    foo();
+                }',
+            ['functions_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'next line with multiline signature and return type (array)' => [
             '<?php
                 function foo(
@@ -573,6 +832,23 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                     foo();
                 }',
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
+        ];
+
+        yield 'same line without extra space with multiline signature and return type (array)' => [
+            '<?php
+                function foo(
+                    $foo
+                ): array{
+                    foo();
+                }',
+            '<?php
+                function foo(
+                    $foo
+                ): array
+                {
+                    foo();
+                }',
+            ['functions_opening_brace' => 'same_line_without_extra_space'],
         ];
 
         yield 'next line with multiline signature and return type (class name)' => [
@@ -592,6 +868,23 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
         ];
 
+        yield 'same line without extra space with with multiline signature and return type (class name)' => [
+            '<?php
+                function foo(
+                    $foo
+                ): \Foo\Bar{
+                    foo();
+                }',
+            '<?php
+                function foo(
+                    $foo
+                ): \Foo\Bar
+                {
+                    foo();
+                }',
+            ['functions_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'next line with newline before closing parenthesis and return type' => [
             '<?php
                 function foo($foo
@@ -605,6 +898,21 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                     foo();
                 }',
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
+        ];
+
+        yield 'same line without extra space with newline before closing parenthesis and return type' => [
+            '<?php
+                function foo($foo
+                ): int{
+                    foo();
+                }',
+            '<?php
+                function foo($foo
+                ): int
+                {
+                    foo();
+                }',
+            ['functions_opening_brace' => 'same_line_without_extra_space'],
         ];
 
         yield 'next line with newline before closing parenthesis and callable type' => [
@@ -622,6 +930,21 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
         ];
 
+        yield 'same line without extra space with newline before closing parenthesis and callable type' => [
+            '<?php
+                function foo($foo
+                ): callable{
+                    return function (): void {};
+                }',
+            '<?php
+                function foo($foo
+                ): callable
+                {
+                    return function (): void {};
+                }',
+            ['functions_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'next line with newline in signature but not before closing parenthesis and return type' => [
             '<?php
                 function foo(
@@ -635,6 +958,20 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                     foo();
                 }',
             ['control_structures_opening_brace' => 'next_line_unless_newline_at_signature_end'],
+        ];
+
+        yield 'same line without extra space with newline in signature but not before closing parenthesis and return type' => [
+            '<?php
+                function foo(
+                    $foo): int{
+                    foo();
+                }',
+            '<?php
+                function foo(
+                    $foo): int {
+                    foo();
+                }',
+            ['functions_opening_brace' => 'same_line_without_extra_space'],
         ];
 
         yield 'multiple elseifs' => [
@@ -660,6 +997,30 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                 }',
         ];
 
+        yield 'multiple elseifs (same line without extra space)' => [
+            '<?php if ($foo){
+                } elseif ($foo){
+                } elseif ($foo){
+                } elseif ($foo){
+                } elseif ($foo){
+                } elseif ($foo){
+                } elseif ($foo){
+                } elseif ($foo){
+                } elseif ($foo){
+                }',
+            '<?php if ($foo) {
+                } elseif ($foo) {
+                } elseif ($foo) {
+                } elseif ($foo) {
+                } elseif ($foo) {
+                } elseif ($foo) {
+                } elseif ($foo) {
+                } elseif ($foo) {
+                } elseif ($foo) {
+                }',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'open brace preceded by comment and whitespace' => [
             '<?php
                 if (true) { /* foo */
@@ -671,6 +1032,18 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                 }',
         ];
 
+        yield 'open brace preceded by comment and whitespace (without extra space)' => [
+            '<?php
+                if (true){ /* foo */
+                    foo();
+                }',
+            '<?php
+                if (true) /* foo */ {
+                    foo();
+                }',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
+        ];
+
         yield 'open brace surrounded by comment and whitespace' => [
             '<?php
                 if (true) { /* foo */ /* bar */
@@ -680,6 +1053,18 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
                 if (true) /* foo */ { /* bar */
                     foo();
                 }',
+        ];
+
+        yield 'open brace surrounded by comment and whitespace (without extra space)' => [
+            '<?php
+                if (true){ /* foo */ /* bar */
+                    foo();
+                }',
+            '<?php
+                if (true) /* foo */ { /* bar */
+                    foo();
+                }',
+            ['control_structures_opening_brace' => 'same_line_without_extra_space'],
         ];
 
         yield 'open brace not preceded by space and followed by a comment' => [


### PR DESCRIPTION
Allows the desire for no space before the opening braces.  
I understand that this doesn't fit into the PHP-CS-Fixer standard, but I think it's important to provide this option, which isn't so complicated to set up.  

I looked into the question of this PR to limit the cost of developing team members and allow the addition of this option, which on closer inspection doesn't require much more. 

I tried to cover as many cases as possible to see if my solution was sufficient. 