### PR TITLE
bug: Exclude `$this` from `TernaryToNullCoalescingFixer`

### DIFF
--- a/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+++ b/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
@@ -89,6 +89,10 @@ final class TernaryToNullCoalescingFixer extends AbstractFixer
             return; // some weird stuff inside the isset
         }
 
+        if ($issetTokens->generateCode() === '$this') {
+            return; // null coalescing operator does not with $this
+        }
+
         // search what is inside the middle argument of ternary operator
         $ternaryColonIndex = $tokens->getNextTokenOfKind($ternaryQuestionMarkIndex, [':']);
         $ternaryFirstOperandTokens = $this->getMeaningfulSequence($tokens, $ternaryQuestionMarkIndex, $ternaryColonIndex);

--- a/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+++ b/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
@@ -89,7 +89,7 @@ final class TernaryToNullCoalescingFixer extends AbstractFixer
             return; // some weird stuff inside the isset
         }
 
-        if ($issetTokens->generateCode() === '$this') {
+        if ('$this' === $issetTokens->generateCode()) {
             return; // null coalescing operator does not with $this
         }
 

--- a/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+++ b/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
@@ -91,7 +91,7 @@ final class TernaryToNullCoalescingFixer extends AbstractFixer
 
         $issetCode = $issetTokens->generateCode();
 
-        if ('$this' === strtolower($issetCode)) {
+        if ('$this' === $issetCode) {
             return; // null coalescing operator does not with $this
         }
 

--- a/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+++ b/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
@@ -91,7 +91,7 @@ final class TernaryToNullCoalescingFixer extends AbstractFixer
 
         $issetCode = $issetTokens->generateCode();
 
-        if ('$this' !== strtolower($issetCode)) {
+        if ('$this' === strtolower($issetCode)) {
             return; // null coalescing operator does not with $this
         }
 

--- a/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+++ b/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
@@ -89,7 +89,9 @@ final class TernaryToNullCoalescingFixer extends AbstractFixer
             return; // some weird stuff inside the isset
         }
 
-        if ('$this' === $issetTokens->generateCode()) {
+        $issetCode = $issetTokens->generateCode();
+
+        if ('$this' !== strtolower($issetCode)) {
             return; // null coalescing operator does not with $this
         }
 
@@ -97,7 +99,7 @@ final class TernaryToNullCoalescingFixer extends AbstractFixer
         $ternaryColonIndex = $tokens->getNextTokenOfKind($ternaryQuestionMarkIndex, [':']);
         $ternaryFirstOperandTokens = $this->getMeaningfulSequence($tokens, $ternaryQuestionMarkIndex, $ternaryColonIndex);
 
-        if ($issetTokens->generateCode() !== $ternaryFirstOperandTokens->generateCode()) {
+        if ($issetCode !== $ternaryFirstOperandTokens->generateCode()) {
             return; // regardless of non-meaningful tokens, the operands are different
         }
 

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -41,6 +41,7 @@ final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
             ['<?php $x = isset($a) and $a ? $a : "";'],
             ['<?php $x = "isset($a) ? $a : null";'],
             ['<?php $x = isset($a) ? $$a : null;'],
+            ['<?php $x = isset($this) ? $this : null;'],
             ['<?php $x = isset($a) ? "$a" : null;'],
             ['<?php $x = isset($a) ?: false;'],
             ['<?php $x = $y ?? isset($a) ? $a : null;'],

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -180,14 +180,6 @@ null
                 '<?php $x = $THIS ?? null;',
                 '<?php $x = isset($THIS) ? $THIS : null;',
             ],
-            [
-                '<?php $x = $this->foo ?? null;',
-                '<?php $x = isset($this->foo) ? $this->foo : null;',
-            ],
-            [
-                '<?php $x = $this["foo"] ?? null;',
-                '<?php $x = isset($this["foo"]) ? $this["foo"] : null;',
-            ],
         ];
     }
 

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -42,7 +42,6 @@ final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
             ['<?php $x = "isset($a) ? $a : null";'],
             ['<?php $x = isset($a) ? $$a : null;'],
             ['<?php $x = isset($this) ? $this : null;'],
-            ['<?php $x = isset($THIS) ? $THIS : null;'],
             ['<?php $x = isset($A) ? $a : null;'], // different case
             ['<?php $x = isset($a) ? "$a" : null;'],
             ['<?php $x = isset($a) ?: false;'],
@@ -176,6 +175,18 @@ null
 )
 # c7
 ;',
+            ],
+            [
+                '<?php $x = $THIS ?? null;',
+                '<?php $x = isset($THIS) ? $THIS : null;',
+            ],
+            [
+                '<?php $x = $this->foo ?? null;',
+                '<?php $x = isset($this->foo) ? $this->foo : null;',
+            ],
+            [
+                '<?php $x = $this["foo"] ?? null;',
+                '<?php $x = isset($this["foo"]) ? $this["foo"] : null;',
             ],
         ];
     }

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -42,6 +42,8 @@ final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
             ['<?php $x = "isset($a) ? $a : null";'],
             ['<?php $x = isset($a) ? $$a : null;'],
             ['<?php $x = isset($this) ? $this : null;'],
+            ['<?php $x = isset($THIS) ? $THIS : null;'],
+            ['<?php $x = isset($A) ? $a : null;'], // different case
             ['<?php $x = isset($a) ? "$a" : null;'],
             ['<?php $x = isset($a) ?: false;'],
             ['<?php $x = $y ?? isset($a) ? $a : null;'],


### PR DESCRIPTION
Fix #7051