### PR TITLE
DX: rename data providers

### DIFF
--- a/tests/AbstractDoctrineAnnotationFixerTestCase.php
+++ b/tests/AbstractDoctrineAnnotationFixerTestCase.php
@@ -25,7 +25,7 @@ abstract class AbstractDoctrineAnnotationFixerTestCase extends AbstractFixerTest
     /**
      * @param array<mixed> $configuration
      *
-     * @dataProvider provideInvalidConfigurationCases
+     * @dataProvider provideConfigureWithInvalidConfigurationCases
      */
     public function testConfigureWithInvalidConfiguration(array $configuration): void
     {
@@ -34,7 +34,7 @@ abstract class AbstractDoctrineAnnotationFixerTestCase extends AbstractFixerTest
         $this->fixer->configure($configuration);
     }
 
-    public static function provideInvalidConfigurationCases(): array
+    public static function provideConfigureWithInvalidConfigurationCases(): array
     {
         return [
             [['foo' => 'bar']],

--- a/tests/AutoReview/DocumentationTest.php
+++ b/tests/AutoReview/DocumentationTest.php
@@ -38,7 +38,7 @@ use Symfony\Component\Finder\Finder;
 final class DocumentationTest extends TestCase
 {
     /**
-     * @dataProvider provideFixerCases
+     * @dataProvider provideFixerDocumentationFileIsUpToDateCases
      */
     public function testFixerDocumentationFileIsUpToDate(FixerInterface $fixer): void
     {
@@ -92,7 +92,7 @@ final class DocumentationTest extends TestCase
         self::assertSame($expected, $actual);
     }
 
-    public static function provideFixerCases(): iterable
+    public static function provideFixerDocumentationFileIsUpToDateCases(): iterable
     {
         foreach (self::getFixers() as $fixer) {
             yield $fixer->getName() => [$fixer];

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -72,7 +72,7 @@ final class FixerFactoryTest extends TestCase
     /**
      * @param string[] $edges
      *
-     * @dataProvider provideFixersPriorityCasesHaveIntegrationCases
+     * @dataProvider provideFixersPriorityCasesHaveIntegrationTestCases
      */
     public function testFixersPriorityCasesHaveIntegrationTest(string $fixerName, array $edges): void
     {
@@ -137,7 +137,7 @@ final class FixerFactoryTest extends TestCase
         self::assertCount(0, $missingIntegrationsTests, sprintf("There shall be an integration test. How do you know that priority set up is good, if there is no integration test to check it?\nMissing:\n- %s", implode("\n- ", $missingIntegrationsTests)));
     }
 
-    public static function provideFixersPriorityCasesHaveIntegrationCases(): iterable
+    public static function provideFixersPriorityCasesHaveIntegrationTestCases(): iterable
     {
         foreach (self::getFixersPriorityGraph() as $fixerName => $edges) {
             yield $fixerName => [$fixerName, $edges];
@@ -145,7 +145,7 @@ final class FixerFactoryTest extends TestCase
     }
 
     /**
-     * @dataProvider provideIntegrationTestFilesCases
+     * @dataProvider providePriorityIntegrationTestFilesAreListedAsPriorityCasesCases
      */
     public function testPriorityIntegrationTestFilesAreListedAsPriorityCases(\SplFileInfo $file): void
     {
@@ -168,7 +168,7 @@ final class FixerFactoryTest extends TestCase
         );
     }
 
-    public static function provideIntegrationTestFilesCases(): iterable
+    public static function providePriorityIntegrationTestFilesAreListedAsPriorityCasesCases(): iterable
     {
         foreach (new \DirectoryIterator(self::getIntegrationPriorityDirectory()) as $candidate) {
             if (!$candidate->isDot()) {

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -80,7 +80,7 @@ final class ProjectCodeTest extends TestCase
     }
 
     /**
-     * @dataProvider provideSrcConcreteClassCases
+     * @dataProvider provideThatSrcClassHaveTestClassCases
      */
     public function testThatSrcClassHaveTestClass(string $className): void
     {
@@ -96,7 +96,7 @@ final class ProjectCodeTest extends TestCase
     }
 
     /**
-     * @dataProvider provideSrcClassesNotAbuseInterfacesCases
+     * @dataProvider provideThatSrcClassesNotAbuseInterfacesCases
      */
     public function testThatSrcClassesNotAbuseInterfaces(string $className): void
     {
@@ -374,7 +374,7 @@ final class ProjectCodeTest extends TestCase
     }
 
     /**
-     * @dataProvider provideClassesWherePregFunctionsAreForbiddenCases
+     * @dataProvider provideThereIsNoPregFunctionUsedDirectlyCases
      */
     public function testThereIsNoPregFunctionUsedDirectly(string $className): void
     {
@@ -591,7 +591,7 @@ final class ProjectCodeTest extends TestCase
         );
     }
 
-    public static function provideSrcClassesNotAbuseInterfacesCases(): array
+    public static function provideThatSrcClassesNotAbuseInterfacesCases(): array
     {
         return array_map(
             static function (string $item): array {
@@ -637,7 +637,7 @@ final class ProjectCodeTest extends TestCase
         );
     }
 
-    public static function provideSrcConcreteClassCases(): array
+    public static function provideThatSrcClassHaveTestClassCases(): array
     {
         return array_map(
             static fn (string $item): array => [$item],
@@ -667,7 +667,7 @@ final class ProjectCodeTest extends TestCase
         yield from self::$testClassCases;
     }
 
-    public static function provideClassesWherePregFunctionsAreForbiddenCases(): array
+    public static function provideThereIsNoPregFunctionUsedDirectlyCases(): array
     {
         return array_map(
             static fn (string $item): array => [$item],

--- a/tests/AutoReview/TransformerTest.php
+++ b/tests/AutoReview/TransformerTest.php
@@ -43,7 +43,7 @@ final class TransformerTest extends TestCase
     }
 
     /**
-     * @dataProvider provideTransformerCases
+     * @dataProvider provideTransformerPriorityIsListedCases
      */
     public function testTransformerPriorityIsListed(TransformerInterface $transformer): void
     {
@@ -74,7 +74,7 @@ final class TransformerTest extends TestCase
     {
         $transformers = [];
 
-        foreach (self::provideTransformerCases() as [$transformer]) {
+        foreach (self::provideTransformerPriorityIsListedCases() as [$transformer]) {
             $transformers[$transformer->getName()] = $transformer;
         }
 
@@ -102,7 +102,7 @@ final class TransformerTest extends TestCase
     /**
      * @return TransformerInterface[]
      */
-    public static function provideTransformerCases(): array
+    public static function provideTransformerPriorityIsListedCases(): array
     {
         static $transformersArray = null;
 

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -108,7 +108,7 @@ final class CacheTest extends TestCase
     /**
      * @param array<string, mixed> $data
      *
-     * @dataProvider provideMissingDataCases
+     * @dataProvider provideFromJsonThrowsInvalidArgumentExceptionIfJsonIsMissingKeyCases
      */
     public function testFromJsonThrowsInvalidArgumentExceptionIfJsonIsMissingKey(array $data): void
     {
@@ -119,7 +119,7 @@ final class CacheTest extends TestCase
         Cache::fromJson($json);
     }
 
-    public static function provideMissingDataCases(): array
+    public static function provideFromJsonThrowsInvalidArgumentExceptionIfJsonIsMissingKeyCases(): array
     {
         $data = [
             'php' => '7.1.2',

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -181,7 +181,7 @@ final class ConfigurationResolverTest extends TestCase
     }
 
     /**
-     * @dataProvider provideResolveConfigFileDefaultCases
+     * @dataProvider provideResolveConfigFileChooseFileCases
      */
     public function testResolveConfigFileChooseFile(string $expectedFile, string $expectedClass, string $path, ?string $cwdPath = null): void
     {
@@ -195,7 +195,7 @@ final class ConfigurationResolverTest extends TestCase
         self::assertInstanceOf($expectedClass, $resolver->getConfig());
     }
 
-    public static function provideResolveConfigFileDefaultCases(): array
+    public static function provideResolveConfigFileChooseFileCases(): array
     {
         $dirBase = self::getFixtureDir();
 
@@ -285,7 +285,7 @@ final class ConfigurationResolverTest extends TestCase
      * @param array<int, string> $paths
      * @param array<int, string> $expectedPaths
      *
-     * @dataProvider providePathCases
+     * @dataProvider provideResolvePathCases
      */
     public function testResolvePath(array $paths, string $cwd, array $expectedPaths): void
     {
@@ -298,7 +298,7 @@ final class ConfigurationResolverTest extends TestCase
         self::assertSame($expectedPaths, $resolver->getPath());
     }
 
-    public static function providePathCases(): iterable
+    public static function provideResolvePathCases(): iterable
     {
         yield [
             ['Command'],
@@ -328,7 +328,7 @@ final class ConfigurationResolverTest extends TestCase
     /**
      * @param array<string> $paths
      *
-     * @dataProvider provideEmptyPathCases
+     * @dataProvider provideRejectInvalidPathCases
      */
     public function testRejectInvalidPath(array $paths, string $expectedMessage): void
     {
@@ -344,7 +344,7 @@ final class ConfigurationResolverTest extends TestCase
         $resolver->getPath();
     }
 
-    public static function provideEmptyPathCases(): iterable
+    public static function provideRejectInvalidPathCases(): iterable
     {
         yield [
             [''],
@@ -961,7 +961,7 @@ final class ConfigurationResolverTest extends TestCase
     /**
      * @param string[] $rules
      *
-     * @dataProvider provideRenamedRulesCases
+     * @dataProvider provideResolveRenamedRulesWithUnknownRulesCases
      */
     public function testResolveRenamedRulesWithUnknownRules(string $expectedMessage, array $rules): void
     {
@@ -972,7 +972,7 @@ final class ConfigurationResolverTest extends TestCase
         $resolver->getRules();
     }
 
-    public static function provideRenamedRulesCases(): iterable
+    public static function provideResolveRenamedRulesWithUnknownRulesCases(): iterable
     {
         yield 'with config' => [
             'The rules contain unknown fixers: "blank_line_before_return" is renamed (did you mean "blank_line_before_statement"? (note: use configuration "[\'statements\' => [\'return\']]")).
@@ -1069,7 +1069,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
     /**
      * @param null|bool|string $diffConfig
      *
-     * @dataProvider provideDifferCases
+     * @dataProvider provideResolveDifferCases
      */
     public function testResolveDiffer(string $expected, $diffConfig): void
     {
@@ -1080,7 +1080,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         self::assertInstanceOf($expected, $resolver->getDiffer());
     }
 
-    public static function provideDifferCases(): array
+    public static function provideResolveDifferCases(): array
     {
         return [
             [

--- a/tests/Console/Output/ErrorOutputTest.php
+++ b/tests/Console/Output/ErrorOutputTest.php
@@ -29,7 +29,7 @@ use Symfony\Component\Console\Output\StreamOutput;
 final class ErrorOutputTest extends TestCase
 {
     /**
-     * @dataProvider provideTestCases
+     * @dataProvider provideErrorOutputCases
      */
     public function testErrorOutput(Error $error, int $verbosityLevel, int $lineNumber, int $exceptionLineNumber, string $process): void
     {
@@ -70,7 +70,7 @@ Files that were not fixed due to errors reported during %s:
                 '
       PhpCsFixer\Tests\Console\Output\ErrorOutputTest::getErrorAndLineNumber()
         in %s at line %d
-      PhpCsFixer\Tests\Console\Output\ErrorOutputTest::provideTestCases()
+      PhpCsFixer\Tests\Console\Output\ErrorOutputTest::provideErrorOutputCases()
       ReflectionMethod->invoke()
 ',
                 __FILE__,
@@ -81,7 +81,7 @@ Files that were not fixed due to errors reported during %s:
         self::assertStringStartsWith($startWith, $displayed);
     }
 
-    public static function provideTestCases(): array
+    public static function provideErrorOutputCases(): array
     {
         $lineNumber = __LINE__;
         [$exceptionLineNumber, $error] = self::getErrorAndLineNumber(); // note: keep call and __LINE__ separated with one line break

--- a/tests/Console/SelfUpdate/NewVersionCheckerTest.php
+++ b/tests/Console/SelfUpdate/NewVersionCheckerTest.php
@@ -33,7 +33,7 @@ final class NewVersionCheckerTest extends TestCase
     }
 
     /**
-     * @dataProvider provideLatestVersionOfMajorCases
+     * @dataProvider provideGetLatestVersionOfMajorCases
      */
     public function testGetLatestVersionOfMajor(int $majorVersion, ?string $expectedVersion): void
     {
@@ -42,7 +42,7 @@ final class NewVersionCheckerTest extends TestCase
         self::assertSame($expectedVersion, $checker->getLatestVersionOfMajor($majorVersion));
     }
 
-    public static function provideLatestVersionOfMajorCases(): array
+    public static function provideGetLatestVersionOfMajorCases(): array
     {
         return [
             [1, 'v1.13.2'],

--- a/tests/Differ/DiffConsoleFormatterTest.php
+++ b/tests/Differ/DiffConsoleFormatterTest.php
@@ -26,7 +26,7 @@ use Symfony\Component\Console\Formatter\OutputFormatter;
 final class DiffConsoleFormatterTest extends TestCase
 {
     /**
-     * @dataProvider provideTestCases
+     * @dataProvider provideDiffConsoleFormatterCases
      */
     public function testDiffConsoleFormatter(string $expected, bool $isDecoratedOutput, string $template, string $diff, string $lineTemplate): void
     {
@@ -38,7 +38,7 @@ final class DiffConsoleFormatterTest extends TestCase
         );
     }
 
-    public static function provideTestCases(): array
+    public static function provideDiffConsoleFormatterCases(): array
     {
         return [
             [

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -544,7 +544,7 @@ final class AnnotationTest extends TestCase
     /**
      * @param NamespaceUseAnalysis[] $namespaceUses
      *
-     * @dataProvider provideTypeExpressionCases
+     * @dataProvider provideGetTypeExpressionCases
      */
     public function testGetTypeExpression(string $line, ?NamespaceAnalysis $namespace, array $namespaceUses, ?string $expectedCommonType): void
     {
@@ -554,7 +554,7 @@ final class AnnotationTest extends TestCase
         self::assertSame($expectedCommonType, $result->getCommonType());
     }
 
-    public static function provideTypeExpressionCases(): iterable
+    public static function provideGetTypeExpressionCases(): iterable
     {
         $appNamespace = new NamespaceAnalysis('App', 'App', 0, 999, 0, 999);
         $useTraversable = new NamespaceUseAnalysis('Traversable', 'Traversable', false, 0, 999, NamespaceUseAnalysis::TYPE_CLASS);
@@ -567,7 +567,7 @@ final class AnnotationTest extends TestCase
     }
 
     /**
-     * @dataProvider provideGetVariableCases
+     * @dataProvider provideGetVariableNameCases
      */
     public function testGetVariableName(string $line, ?string $expectedVariableName): void
     {
@@ -575,7 +575,7 @@ final class AnnotationTest extends TestCase
         self::assertSame($expectedVariableName, $annotation->getVariableName());
     }
 
-    public static function provideGetVariableCases(): iterable
+    public static function provideGetVariableNameCases(): iterable
     {
         yield ['* @param int $foo', '$foo'];
 

--- a/tests/DocBlock/DocBlockTest.php
+++ b/tests/DocBlock/DocBlockTest.php
@@ -156,7 +156,7 @@ final class DocBlockTest extends TestCase
     }
 
     /**
-     * @dataProvider provideDocBlocksToConvertToMultiLineCases
+     * @dataProvider provideMakeMultiLIneCases
      */
     public function testMakeMultiLIne(string $inputDocBlock, string $outputDocBlock = null, string $indent = '', string $newLine = "\n"): void
     {
@@ -170,7 +170,7 @@ final class DocBlockTest extends TestCase
         self::assertSame($outputDocBlock, $doc->getContent());
     }
 
-    public static function provideDocBlocksToConvertToMultiLineCases(): array
+    public static function provideMakeMultiLIneCases(): array
     {
         return [
             'It keeps a multi line doc block as is' => [
@@ -201,7 +201,7 @@ final class DocBlockTest extends TestCase
     }
 
     /**
-     * @dataProvider provideDocBlocksToConvertToSingleLineCases
+     * @dataProvider provideMakeSingleLineCases
      */
     public function testMakeSingleLine(string $inputDocBlock, string $outputDocBlock = null): void
     {
@@ -215,7 +215,7 @@ final class DocBlockTest extends TestCase
         self::assertSame($outputDocBlock, $doc->getContent());
     }
 
-    public static function provideDocBlocksToConvertToSingleLineCases(): array
+    public static function provideMakeSingleLineCases(): array
     {
         return [
             'It keeps a single line doc block as is' => [

--- a/tests/DocBlock/LineTest.php
+++ b/tests/DocBlock/LineTest.php
@@ -149,7 +149,7 @@ final class LineTest extends TestCase
     }
 
     /**
-     * @dataProvider provideLinesWithUsefulCases
+     * @dataProvider provideUsefulCases
      */
     public function testUseful(int $pos, bool $useful): void
     {
@@ -159,7 +159,7 @@ final class LineTest extends TestCase
         self::assertSame($useful, $line->containsUsefulContent());
     }
 
-    public static function provideLinesWithUsefulCases(): iterable
+    public static function provideUsefulCases(): iterable
     {
         foreach (self::$useful as $index => $useful) {
             yield [$index, $useful];
@@ -167,7 +167,7 @@ final class LineTest extends TestCase
     }
 
     /**
-     * @dataProvider provideLinesWithTagCases
+     * @dataProvider provideTagCases
      */
     public function testTag(int $pos, bool $tag): void
     {
@@ -177,7 +177,7 @@ final class LineTest extends TestCase
         self::assertSame($tag, $line->containsATag());
     }
 
-    public static function provideLinesWithTagCases(): iterable
+    public static function provideTagCases(): iterable
     {
         foreach (self::$tag as $index => $tag) {
             yield [$index, $tag];

--- a/tests/DocBlock/TagComparatorTest.php
+++ b/tests/DocBlock/TagComparatorTest.php
@@ -30,7 +30,7 @@ use PhpCsFixer\Tests\TestCase;
 final class TagComparatorTest extends TestCase
 {
     /**
-     * @dataProvider provideComparatorCases
+     * @dataProvider provideComparatorTogetherCases
      *
      * @group legacy
      */
@@ -44,7 +44,7 @@ final class TagComparatorTest extends TestCase
         self::assertSame($expected, TagComparator::shouldBeTogether($tag1, $tag2));
     }
 
-    public static function provideComparatorCases(): array
+    public static function provideComparatorTogetherCases(): array
     {
         return [
             ['return', 'return', true],
@@ -60,7 +60,7 @@ final class TagComparatorTest extends TestCase
     }
 
     /**
-     * @dataProvider provideComparatorWithDefinedGroupsCases
+     * @dataProvider provideComparatorTogetherWithDefinedGroupsCases
      *
      * @param string[][] $groups
      *
@@ -79,7 +79,7 @@ final class TagComparatorTest extends TestCase
         );
     }
 
-    public static function provideComparatorWithDefinedGroupsCases(): array
+    public static function provideComparatorTogetherWithDefinedGroupsCases(): array
     {
         return [
             [[['param', 'return']], 'return', 'return', true],

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -308,7 +308,7 @@ final class TypeExpressionTest extends TestCase
     /**
      * @param NamespaceUseAnalysis[] $namespaceUses
      *
-     * @dataProvider provideCommonTypeCases
+     * @dataProvider provideGetCommonTypeCases
      */
     public function testGetCommonType(string $typesExpression, ?string $expectedCommonType, NamespaceAnalysis $namespace = null, array $namespaceUses = []): void
     {
@@ -316,7 +316,7 @@ final class TypeExpressionTest extends TestCase
         self::assertSame($expectedCommonType, $expression->getCommonType());
     }
 
-    public static function provideCommonTypeCases(): iterable
+    public static function provideGetCommonTypeCases(): iterable
     {
         $globalNamespace = new NamespaceAnalysis('', '', 0, 999, 0, 999);
         $appNamespace = new NamespaceAnalysis('App', 'App', 0, 999, 0, 999);

--- a/tests/Doctrine/Annotation/TokenTest.php
+++ b/tests/Doctrine/Annotation/TokenTest.php
@@ -61,7 +61,7 @@ final class TokenTest extends TestCase
     }
 
     /**
-     * @dataProvider provideIsTypeCases
+     * @dataProvider provideIsTypeReturnsTrueCases
      *
      * @param int|int[] $types
      */
@@ -74,7 +74,7 @@ final class TokenTest extends TestCase
         self::assertTrue($token->isType($types));
     }
 
-    public static function provideIsTypeCases(): array
+    public static function provideIsTypeReturnsTrueCases(): array
     {
         return [
             'same-value' => [
@@ -92,7 +92,7 @@ final class TokenTest extends TestCase
     }
 
     /**
-     * @dataProvider provideIsNotTypeCases
+     * @dataProvider provideIsTypeReturnsFalseCases
      *
      * @param int|int[] $types
      */
@@ -105,7 +105,7 @@ final class TokenTest extends TestCase
         self::assertFalse($token->isType($types));
     }
 
-    public static function provideIsNotTypeCases(): array
+    public static function provideIsTypeReturnsFalseCases(): array
     {
         return [
             'different-value' => [

--- a/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
+++ b/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
@@ -28,7 +28,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideEchoToPrintFixCases
+     * @dataProvider provideFixEchoToPrintCases
      * @dataProvider provideEchoToPrintFixNewCases
      */
     public function testFixEchoToPrint(string $expected, ?string $input = null): void
@@ -37,7 +37,7 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideEchoToPrintFixCases(): array
+    public static function provideFixEchoToPrintCases(): array
     {
         return [
             [
@@ -145,7 +145,7 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider providePrintToEchoFixCases
+     * @dataProvider provideFixPrintToEchoCases
      * @dataProvider providePrintToEchoFixNewCases
      */
     public function testFixPrintToEcho(string $expected, ?string $input = null): void
@@ -154,7 +154,7 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function providePrintToEchoFixCases(): array
+    public static function provideFixPrintToEchoCases(): array
     {
         return [
             [

--- a/tests/Fixer/ArrayNotation/ArraySyntaxFixerTest.php
+++ b/tests/Fixer/ArrayNotation/ArraySyntaxFixerTest.php
@@ -45,7 +45,7 @@ final class ArraySyntaxFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideLongSyntaxCases
+     * @dataProvider provideFixLongSyntaxCases
      */
     public function testFixLongSyntax(string $expected, ?string $input = null): void
     {
@@ -53,7 +53,7 @@ final class ArraySyntaxFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideLongSyntaxCases(): array
+    public static function provideFixLongSyntaxCases(): array
     {
         return [
             ['<?php $x = array();', '<?php $x = [];'],
@@ -83,7 +83,7 @@ final class ArraySyntaxFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideShortSyntaxCases
+     * @dataProvider provideFixShortSyntaxCases
      */
     public function testFixShortSyntax(string $expected, ?string $input = null): void
     {
@@ -91,7 +91,7 @@ final class ArraySyntaxFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideShortSyntaxCases(): array
+    public static function provideFixShortSyntaxCases(): array
     {
         return [
             ['<?php $x = [];', '<?php $x = array();'],

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -4976,7 +4976,7 @@ if (true) {
     }
 
     /**
-     * @dataProvider provideFixWithAllowOnelineLambdaCases
+     * @dataProvider provideFixWithAllowSingleLineClosureCases
      */
     public function testFixWithAllowSingleLineClosure(string $expected, ?string $input = null): void
     {
@@ -4987,7 +4987,7 @@ if (true) {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixWithAllowOnelineLambdaCases(): iterable
+    public static function provideFixWithAllowSingleLineClosureCases(): iterable
     {
         return [
             [

--- a/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
+++ b/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
@@ -450,14 +450,14 @@ class ClassTwo {};
     /**
      * @requires PHP 8.0
      *
-     * @dataProvider providePhp80Cases
+     * @dataProvider provideFix80Cases
      */
     public function testFix80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function providePhp80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield 'anonymous + annotation' => [
             '<?php
@@ -472,14 +472,14 @@ class extends stdClass {};
     /**
      * @requires PHP 8.1
      *
-     * @dataProvider providePhp81Cases
+     * @dataProvider provideFix81Cases
      */
     public function testFix81(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input, self::getTestFile(__FILE__));
     }
 
-    public static function providePhp81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'enum with wrong casing' => [
             '<?php enum PsrAutoloadingFixerTest {}',

--- a/tests/Fixer/Casing/ConstantCaseFixerTest.php
+++ b/tests/Fixer/Casing/ConstantCaseFixerTest.php
@@ -99,7 +99,7 @@ final class ConstantCaseFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideLowerGeneratedCases
+     * @dataProvider provideFixLowerGeneratedCasesCases
      */
     public function testFixLowerGeneratedCases(string $expected, ?string $input = null): void
     {
@@ -107,7 +107,7 @@ final class ConstantCaseFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideLowerGeneratedCases(): iterable
+    public static function provideFixLowerGeneratedCasesCases(): iterable
     {
         foreach (['true', 'false', 'null'] as $case) {
             yield [
@@ -131,7 +131,7 @@ final class ConstantCaseFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideUpperGeneratedCases
+     * @dataProvider provideFixUpperGeneratedCasesCases
      */
     public function testFixUpperGeneratedCases(string $expected, ?string $input = null): void
     {
@@ -139,7 +139,7 @@ final class ConstantCaseFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideUpperGeneratedCases(): iterable
+    public static function provideFixUpperGeneratedCasesCases(): iterable
     {
         foreach (['true', 'false', 'null'] as $case) {
             yield [

--- a/tests/Fixer/Casing/IntegerLiteralCaseFixerTest.php
+++ b/tests/Fixer/Casing/IntegerLiteralCaseFixerTest.php
@@ -54,7 +54,7 @@ final class IntegerLiteralCaseFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideFix80Cases
+     * @dataProvider provideFix81Cases
      *
      * @requires PHP 8.1
      */
@@ -63,7 +63,7 @@ final class IntegerLiteralCaseFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideFix80Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php $foo = 0o123;',

--- a/tests/Fixer/CastNotation/CastSpacesFixerTest.php
+++ b/tests/Fixer/CastNotation/CastSpacesFixerTest.php
@@ -113,7 +113,7 @@ final class CastSpacesFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideNoneSpaceFixCases
+     * @dataProvider provideFixCastsNoneSpaceCases
      */
     public function testFixCastsNoneSpace(string $expected, ?string $input = null): void
     {
@@ -121,7 +121,7 @@ final class CastSpacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideNoneSpaceFixCases(): array
+    public static function provideFixCastsNoneSpaceCases(): array
     {
         return [
             [

--- a/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
+++ b/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
@@ -32,7 +32,7 @@ final class LowercaseCastFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideFixDeprecatedCases
+     * @dataProvider provideFix74DeprecatedCases
      *
      * @group legacy
      *
@@ -60,7 +60,7 @@ final class LowercaseCastFixerTest extends AbstractFixerTestCase
         }
     }
 
-    public static function provideFixDeprecatedCases(): iterable
+    public static function provideFix74DeprecatedCases(): iterable
     {
         return self::createCasesFor('real');
     }

--- a/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
+++ b/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
@@ -32,7 +32,7 @@ final class ShortScalarCastFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideFixDeprecatedCases
+     * @dataProvider provideFix74DeprecatedCases
      *
      * @group legacy
      *
@@ -54,7 +54,7 @@ final class ShortScalarCastFixerTest extends AbstractFixerTestCase
         }
     }
 
-    public static function provideFixDeprecatedCases(): iterable
+    public static function provideFix74DeprecatedCases(): iterable
     {
         return self::createCasesFor('real', 'float');
     }

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -1165,7 +1165,7 @@ class ezcReflectionMethod extends ReflectionMethod {
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideConfigCases
+     * @dataProvider provideWithConfigCases
      */
     public function testWithConfig(string $expected, ?string $input, array $config): void
     {
@@ -1173,7 +1173,7 @@ class ezcReflectionMethod extends ReflectionMethod {
         $this->doTest($expected, $input);
     }
 
-    public static function provideConfigCases(): array
+    public static function provideWithConfigCases(): array
     {
         return [
             'multi line property' => [

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -50,7 +50,7 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
      * @param string              $input    PHP source code
      * @param array<string, bool> $config
      *
-     * @dataProvider provideAnonymousClassesCases
+     * @dataProvider provideFixingAnonymousClassesCases
      */
     public function testFixingAnonymousClasses(string $expected, string $input, array $config = []): void
     {
@@ -59,7 +59,7 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideClassesCases
+     * @dataProvider provideFixingClassesCases
      */
     public function testFixingClasses(string $expected, string $input): void
     {
@@ -70,7 +70,7 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideClassesWithConfigCases
+     * @dataProvider provideFixingClassesWithConfigCases
      */
     public function testFixingClassesWithConfig(string $expected, string $input, array $config): void
     {
@@ -79,7 +79,7 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideInterfacesCases
+     * @dataProvider provideFixingInterfacesCases
      */
     public function testFixingInterfaces(string $expected, string $input): void
     {
@@ -88,7 +88,7 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideTraitsCases
+     * @dataProvider provideFixingTraitsCases
      */
     public function testFixingTraits(string $expected, string $input): void
     {
@@ -118,7 +118,7 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
         $fixer->configure(['single_line' => 'z']);
     }
 
-    public static function provideAnonymousClassesCases(): array
+    public static function provideFixingAnonymousClassesCases(): array
     {
         return [
             [
@@ -315,7 +315,7 @@ A#
         ];
     }
 
-    public static function provideClassesCases(): array
+    public static function provideFixingClassesCases(): array
     {
         return array_merge(
             self::provideClassyCases('class'),
@@ -324,7 +324,7 @@ A#
         );
     }
 
-    public static function provideClassesWithConfigCases(): array
+    public static function provideFixingClassesWithConfigCases(): array
     {
         return [
             [
@@ -374,7 +374,7 @@ A#
         ];
     }
 
-    public static function provideInterfacesCases(): array
+    public static function provideFixingInterfacesCases(): array
     {
         $cases = array_merge(
             self::provideClassyCases('interface'),
@@ -411,7 +411,7 @@ TestInterface3, /**/     TestInterface4   ,
         return $cases;
     }
 
-    public static function provideTraitsCases(): array
+    public static function provideFixingTraitsCases(): array
     {
         return self::provideClassyCases('trait');
     }
@@ -524,14 +524,14 @@ TestInterface3, /**/     TestInterface4   ,
     /**
      * @param array<string, mixed> $expected
      *
-     * @dataProvider provideClassyImplementsInfoCases
+     * @dataProvider provideClassyInheritanceInfoCases
      */
     public function testClassyInheritanceInfo(string $source, string $label, array $expected): void
     {
         $this->doTestClassyInheritanceInfo($source, $label, $expected);
     }
 
-    public static function provideClassyImplementsInfoCases(): iterable
+    public static function provideClassyInheritanceInfoCases(): iterable
     {
         yield from [
             '1' => [

--- a/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
@@ -337,7 +337,7 @@ class Foo {}
      * @param string      $expected PHP source code
      * @param null|string $input    PHP source code
      *
-     * @dataProvider provideAnonymousClassesCases
+     * @dataProvider provideAnonymousClassesCasesCases
      */
     public function testAnonymousClassesCases(string $expected, ?string $input = null): void
     {
@@ -347,7 +347,7 @@ class Foo {}
     /**
      * @return iterable<int|string, array{0: string, 1?: string}>
      */
-    public static function provideAnonymousClassesCases(): iterable
+    public static function provideAnonymousClassesCasesCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixerTest.php
@@ -35,7 +35,7 @@ final class NoBlankLinesAfterClassOpeningFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideTraitsCases
+     * @dataProvider provideFixTraitsCases
      */
     public function testFixTraits(string $expected, ?string $input = null): void
     {
@@ -164,7 +164,7 @@ function bar() {}
         return $cases;
     }
 
-    public static function provideTraitsCases(): array
+    public static function provideFixTraitsCases(): array
     {
         $cases = [];
 

--- a/tests/Fixer/ClassNotation/NoPhp4ConstructorFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoPhp4ConstructorFixerTest.php
@@ -64,14 +64,14 @@ final class NoPhp4ConstructorFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideSimpleCases
+     * @dataProvider provideSimpleClassCases
      */
     public function testSimpleClass(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideSimpleCases(): array
+    public static function provideSimpleClassCases(): array
     {
         return [
             [

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -388,7 +388,7 @@ EOT
     /**
      * @param array<string, mixed> $configuration
      *
-     * @dataProvider provideConfigurationCases
+     * @dataProvider provideFixWithConfigurationCases
      */
     public function testFixWithConfiguration(array $configuration, string $expected, string $input): void
     {
@@ -396,7 +396,7 @@ EOT
         $this->doTest($expected, $input);
     }
 
-    public static function provideConfigurationCases(): array
+    public static function provideFixWithConfigurationCases(): array
     {
         return [
             [
@@ -1033,7 +1033,7 @@ EOT
     /**
      * @param array<string, mixed> $configuration
      *
-     * @dataProvider provideSortingConfigurationCases
+     * @dataProvider provideFixWithSortingAlgorithmCases
      */
     public function testFixWithSortingAlgorithm(array $configuration, string $expected, string $input): void
     {
@@ -1041,7 +1041,7 @@ EOT
         $this->doTest($expected, $input);
     }
 
-    public static function provideSortingConfigurationCases(): array
+    public static function provideFixWithSortingAlgorithmCases(): array
     {
         return [
             [

--- a/tests/Fixer/ClassNotation/OrderedTypesFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedTypesFixerTest.php
@@ -26,7 +26,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class OrderedTypesFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideFixCases
+     * @dataProvider provideFixCasesCases
      *
      * @param null|array<string, string> $config
      */
@@ -42,7 +42,7 @@ final class OrderedTypesFixerTest extends AbstractFixerTestCase
     /**
      * @return iterable<string, (null|array<string, string>|string)[]|string[]>
      */
-    public static function provideFixCases(): iterable
+    public static function provideFixCasesCases(): iterable
     {
         yield 'catch with default, no spaces, with both leading slash' => [
             '<?php
@@ -146,7 +146,7 @@ try {
     }
 
     /**
-     * @dataProvider providePhp80Cases
+     * @dataProvider provideFixPhp80Cases
      *
      * @param null|array<string, string> $config
      *
@@ -164,7 +164,7 @@ try {
     /**
      * @return iterable<(null|array<string, string>|string)[]>
      */
-    public static function providePhp80Cases(): iterable
+    public static function provideFixPhp80Cases(): iterable
     {
         yield 'sort alpha, null none' => [
             "<?php\nclass Foo\n{\n    public A|null|Z \$bar;\n}\n",
@@ -204,7 +204,7 @@ try {
     }
 
     /**
-     * @dataProvider provideDefaultCases
+     * @dataProvider provideFixDefaultCasesCases
      *
      * @requires PHP 8.0
      */
@@ -216,7 +216,7 @@ try {
     /**
      * @return iterable<(null|array<string, string>|string)[]|string[]>
      */
-    public static function provideDefaultCases(): iterable
+    public static function provideFixDefaultCasesCases(): iterable
     {
         yield [
             "<?php\nclass Foo\n{\n    public null|int|string \$bar = null;\n}\n",
@@ -315,7 +315,7 @@ try {
     }
 
     /**
-     * @dataProvider provideAlphaAlgorithmAndNullAlwaysLastCases
+     * @dataProvider provideFixWithAlphaAlgorithmAndNullAlwaysLastCases
      *
      * @requires PHP 8.0
      */
@@ -332,7 +332,7 @@ try {
     /**
      * @return iterable<(null|string|string[])[]|string[]>
      */
-    public static function provideAlphaAlgorithmAndNullAlwaysLastCases(): iterable
+    public static function provideFixWithAlphaAlgorithmAndNullAlwaysLastCases(): iterable
     {
         yield [
             "<?php\nclass Foo\n{\n    public int|string|null \$bar = null;\n}\n",
@@ -431,7 +431,7 @@ try {
     }
 
     /**
-     * @dataProvider provideAlphaAlgorithmOnlyCases
+     * @dataProvider provideFixWithAlphaAlgorithmOnlyCases
      *
      * @requires PHP 8.0
      */
@@ -448,7 +448,7 @@ try {
     /**
      * @return iterable<(null|array<string, string>|string)[]|string[]>
      */
-    public static function provideAlphaAlgorithmOnlyCases(): iterable
+    public static function provideFixWithAlphaAlgorithmOnlyCases(): iterable
     {
         yield [
             "<?php\nclass Foo\n{\n    public int|null|string \$bar = null;\n}\n",
@@ -547,7 +547,7 @@ try {
     }
 
     /**
-     * @dataProvider provideSandwichedWhitespaceOrCommentInTypeCases
+     * @dataProvider provideFixWithSandwichedWhitespaceOrCommentInTypeCases
      *
      * @requires PHP 8.0
      */
@@ -563,7 +563,7 @@ try {
     /**
      * @return iterable<(null|array<string, string>|string)[]|string[]>
      */
-    public static function provideSandwichedWhitespaceOrCommentInTypeCases(): iterable
+    public static function provideFixWithSandwichedWhitespaceOrCommentInTypeCases(): iterable
     {
         yield [
             "<?php\nclass Foo\n{\n    public null|int|string \$bar = null;\n}\n",
@@ -587,7 +587,7 @@ try {
     }
 
     /**
-     * @dataProvider providePhp81Cases
+     * @dataProvider provideFixPhp81Cases
      *
      * @param null|array<string, string> $config
      *
@@ -605,7 +605,7 @@ try {
     /**
      * @return iterable<(null|array<string, string>|string)[]|string[]>
      */
-    public static function providePhp81Cases(): iterable
+    public static function provideFixPhp81Cases(): iterable
     {
         yield [
             "<?php\nclass Foo\n{\n    public A&B \$bar;\n}\n",
@@ -644,7 +644,7 @@ try {
     /**
      * Provisional support for PHP 8.2's Disjunctive Normal Form (DNF) Types.
      *
-     * @dataProvider providePhp82Cases
+     * @dataProvider provideFixPhp82Cases
      *
      * @param null|array<string, string> $config
      *
@@ -662,7 +662,7 @@ try {
     /**
      * @return iterable<(null|array<string, string>|string)[]|string[]>
      */
-    public static function providePhp82Cases(): iterable
+    public static function provideFixPhp82Cases(): iterable
     {
         yield [
             "<?php\nclass Foo\n{\n    public null|array|(At&Bz)|string \$bar = null;\n}\n",

--- a/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
+++ b/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
@@ -689,7 +689,7 @@ echo Foo::A, Foo::B;
     /**
      * @param array<string, mixed> $configuration
      *
-     * @dataProvider provideConfigurationCases
+     * @dataProvider provideFixWithConfigurationCases
      */
     public function testFixWithConfiguration(array $configuration, string $expected): void
     {
@@ -707,7 +707,7 @@ EOT;
         $this->doTest($expected, $input);
     }
 
-    public static function provideConfigurationCases(): array
+    public static function provideFixWithConfigurationCases(): array
     {
         return [
             [

--- a/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
+++ b/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
@@ -28,7 +28,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideTestCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
@@ -36,7 +36,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
+++ b/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
@@ -254,7 +254,7 @@ echo 1;
      * @param int    $endIndex   expected index of the last token of the block
      * @param bool   $isEmpty    expected value of empty flag returned
      *
-     * @dataProvider provideCommentBlockCases
+     * @dataProvider provideGetCommentBlockCases
      */
     public function testGetCommentBlock(string $source, int $startIndex, int $endIndex, bool $isEmpty): void
     {
@@ -272,7 +272,7 @@ echo 1;
         self::assertSame($isEmpty, $foundIsEmpty, 'Is empty comment block detection failed.');
     }
 
-    public static function provideCommentBlockCases(): array
+    public static function provideGetCommentBlockCases(): array
     {
         $cases = [
             [

--- a/tests/Fixer/Comment/SingleLineCommentSpacingFixerTest.php
+++ b/tests/Fixer/Comment/SingleLineCommentSpacingFixerTest.php
@@ -24,14 +24,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class SingleLineCommentSpacingFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideTestCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'comment list' => [
             '<?php

--- a/tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
+++ b/tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
@@ -218,7 +218,7 @@ second line*/',
     }
 
     /**
-     * @dataProvider provideHashCases
+     * @dataProvider provideHashCasesCases
      */
     public function testHashCases(string $expected, ?string $input = null): void
     {
@@ -226,7 +226,7 @@ second line*/',
         $this->doTest($expected, $input);
     }
 
-    public static function provideHashCases(): array
+    public static function provideHashCasesCases(): array
     {
         return [
             [
@@ -288,14 +288,14 @@ second line*/',
     }
 
     /**
-     * @dataProvider provideAllCases
+     * @dataProvider provideAllCasesCases
      */
     public function testAllCases(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideAllCases(): array
+    public static function provideAllCasesCases(): array
     {
         return [
             [

--- a/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+++ b/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
@@ -488,7 +488,7 @@ echo M_PI;
     }
 
     /**
-     * @dataProvider provideFix80Cases
+     * @dataProvider provideFixPhp80Cases
      *
      * @requires PHP 8.0
      */
@@ -498,7 +498,7 @@ echo M_PI;
         $this->doTest($expected);
     }
 
-    public static function provideFix80Cases(): iterable
+    public static function provideFixPhp80Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/ControlStructure/ElseifFixerTest.php
+++ b/tests/Fixer/ControlStructure/ElseifFixerTest.php
@@ -26,14 +26,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class ElseifFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             ['<?php if ($some) { $test = true; } else { $test = false; }'],

--- a/tests/Fixer/ControlStructure/EmptyLoopBodyFixerTest.php
+++ b/tests/Fixer/ControlStructure/EmptyLoopBodyFixerTest.php
@@ -26,7 +26,7 @@ final class EmptyLoopBodyFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideFixCases
+     * @dataProvider provideFixConfigCases
      */
     public function testFixConfig(string $expected, ?string $input = null, array $config = []): void
     {
@@ -46,7 +46,7 @@ final class EmptyLoopBodyFixerTest extends AbstractFixerTestCase
         }
     }
 
-    public static function provideFixCases(): iterable
+    public static function provideFixConfigCases(): iterable
     {
         yield 'simple "while"' => [
             '<?php while(foo());',

--- a/tests/Fixer/ControlStructure/EmptyLoopConditionFixerTest.php
+++ b/tests/Fixer/ControlStructure/EmptyLoopConditionFixerTest.php
@@ -26,7 +26,7 @@ final class EmptyLoopConditionFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideFixCases
+     * @dataProvider provideFixConfigCases
      */
     public function testFixConfig(string $expected, ?string $input = null, array $config = []): void
     {
@@ -35,7 +35,7 @@ final class EmptyLoopConditionFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixCases(): iterable
+    public static function provideFixConfigCases(): iterable
     {
         yield 'from `for` to `while`' => [
             '<?php

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -1052,7 +1052,7 @@ switch ($foo) {
     }
 
     /**
-     * @dataProvider provideTestFixWithDifferentCommentTextCases
+     * @dataProvider provideFixWithDifferentCommentTextCases
      */
     public function testFixWithDifferentCommentText(string $expected, ?string $input = null): void
     {
@@ -1062,7 +1062,7 @@ switch ($foo) {
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixWithDifferentCommentTextCases(): array
+    public static function provideFixWithDifferentCommentTextCases(): array
     {
         $cases = self::provideFixCases();
 
@@ -1112,7 +1112,7 @@ switch ($foo) {
     }
 
     /**
-     * @dataProvider provideTestFixWithDifferentLineEndingCases
+     * @dataProvider provideFixWithDifferentLineEndingCases
      */
     public function testFixWithDifferentLineEnding(string $expected, ?string $input = null): void
     {
@@ -1120,7 +1120,7 @@ switch ($foo) {
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixWithDifferentLineEndingCases(): iterable
+    public static function provideFixWithDifferentLineEndingCases(): iterable
     {
         foreach (self::provideFixCases() as $case) {
             $case[0] = str_replace("\n", "\r\n", $case[0]);

--- a/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
@@ -1470,7 +1470,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideFixWithConfigCases
+     * @dataProvider provideWithConfigCases
      */
     public function testWithConfig(array $config, string $expected, string $input): void
     {
@@ -1481,7 +1481,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
         $this->doTest($input);
     }
 
-    public static function provideFixWithConfigCases(): iterable
+    public static function provideWithConfigCases(): iterable
     {
         yield 'config: break' => [
             ['statements' => ['break']],

--- a/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
@@ -26,14 +26,14 @@ use PhpCsFixer\Tokenizer\Tokens;
 final class NoUselessElseFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider providePHPCloseTagCases
+     * @dataProvider provideCloseTagCasesCases
      */
     public function testCloseTagCases(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function providePHPCloseTagCases(): array
+    public static function provideCloseTagCasesCases(): array
     {
         return [
             [
@@ -438,14 +438,14 @@ else?><?php echo 5;',
     }
 
     /**
-     * @dataProvider provideNegativeCases
+     * @dataProvider provideNegativeCasesCases
      */
     public function testNegativeCases(string $expected): void
     {
         $this->doTest($expected);
     }
 
-    public static function provideNegativeCases(): iterable
+    public static function provideNegativeCasesCases(): iterable
     {
         yield from [
             [
@@ -608,7 +608,7 @@ else?><?php echo 5;',
     }
 
     /**
-     * @dataProvider provideNegativePhp80Cases
+     * @dataProvider provideNegativePhp80CasesCases
      *
      * @requires PHP 8.0
      */
@@ -617,7 +617,7 @@ else?><?php echo 5;',
         $this->doTest($expected);
     }
 
-    public static function provideNegativePhp80Cases(): iterable
+    public static function provideNegativePhp80CasesCases(): iterable
     {
         $cases = [
             '$bar = $foo1 ?? throw new \Exception($e);',

--- a/tests/Fixer/ControlStructure/SwitchContinueToBreakFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchContinueToBreakFixerTest.php
@@ -24,14 +24,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class SwitchContinueToBreakFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             'alternative syntax |' => [

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -791,7 +791,7 @@ switch ($a) {
     /**
      * @param array<mixed> $config
      *
-     * @dataProvider provideInvalidConfigurationCases
+     * @dataProvider provideInvalidConfigCases
      */
     public function testInvalidConfig(array $config, string $expectedMessage): void
     {
@@ -801,7 +801,7 @@ switch ($a) {
         $this->fixer->configure($config);
     }
 
-    public static function provideInvalidConfigurationCases(): array
+    public static function provideInvalidConfigCases(): array
     {
         return [
             [['equal' => 2], 'Invalid configuration: The option "equal" with value 2 is expected to be of type "bool" or "null", but is of type "(int|integer)"\.'],
@@ -886,7 +886,7 @@ switch ($a) {
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideFixWithConfigCases
+     * @dataProvider provideWithConfigCases
      */
     public function testWithConfig(array $config, string $expected): void
     {
@@ -894,7 +894,7 @@ switch ($a) {
         $this->doTest($expected);
     }
 
-    public static function provideFixWithConfigCases(): iterable
+    public static function provideWithConfigCases(): iterable
     {
         yield [
             [
@@ -945,7 +945,7 @@ while (2 !== $b = array_pop($c));
      *
      * @param array<string, mixed> $configuration
      *
-     * @dataProvider providePHP74Cases
+     * @dataProvider providePHP74CasesInverseCases
      */
     public function testPHP74CasesInverse(string $expected, ?string $input = null, array $configuration = []): void
     {
@@ -954,7 +954,7 @@ while (2 !== $b = array_pop($c));
         $this->doTest($expected, $input);
     }
 
-    public static function providePHP74Cases(): iterable
+    public static function providePHP74CasesInverseCases(): iterable
     {
         yield [
             '<?php fn() => $c === array(1) ? $b : $d;',

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -44,7 +44,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideInvalidConfigurationElementCases
+     * @dataProvider provideConfigureRejectsInvalidConfigurationElementCases
      *
      * @param mixed $element
      */
@@ -63,7 +63,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
         ]);
     }
 
-    public static function provideInvalidConfigurationElementCases(): array
+    public static function provideConfigureRejectsInvalidConfigurationElementCases(): array
     {
         return [
             'null' => [null],

--- a/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
@@ -141,7 +141,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
     }
 
     /**
-     * @dataProvider provideInvertedFixCases
+     * @dataProvider provideFixInverseCases
      * @dataProvider provideInverseOnlyFixCases
      */
     public function testFixInverse(string $expected, string $input): void
@@ -327,7 +327,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         ];
     }
 
-    public static function provideInvertedFixCases(): iterable
+    public static function provideFixInverseCases(): iterable
     {
         return TestCaseUtils::swapExpectedInputTestCases(self::provideFixCases());
     }
@@ -377,7 +377,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
     }
 
     /**
-     * @dataProvider provideInvertedFixPhp74Cases
+     * @dataProvider provideFixInversePhp74Cases
      */
     public function testFixInversePhp74(string $expected, string $input): void
     {
@@ -422,7 +422,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         ];
     }
 
-    public static function provideInvertedFixPhp74Cases(): iterable
+    public static function provideFixInversePhp74Cases(): iterable
     {
         return TestCaseUtils::swapExpectedInputTestCases(self::provideFixPhp74Cases());
     }
@@ -438,7 +438,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
     }
 
     /**
-     * @dataProvider provideInvertedFix80Cases
+     * @dataProvider provideFixInverse80Cases
      *
      * @requires PHP 8.0
      */
@@ -503,7 +503,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         ];
     }
 
-    public static function provideInvertedFix80Cases(): iterable
+    public static function provideFixInverse80Cases(): iterable
     {
         return TestCaseUtils::swapExpectedInputTestCases(self::provideFix80Cases());
     }

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -1358,14 +1358,14 @@ use /**/A\B/**/;
     /**
      * @requires PHP 8.0
      *
-     * @dataProvider providePhp80Cases
+     * @dataProvider provideFix80Cases
      */
     public function testFix80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function providePhp80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php
@@ -1430,14 +1430,14 @@ function f( #[Target(\'xxx\')] LoggerInterface|null $logger) {}
     /**
      * @requires PHP 8.1
      *
-     * @dataProvider providePhp81Cases
+     * @dataProvider provideFix81Cases
      */
     public function testFix81(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function providePhp81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'final const' => [
             '<?php

--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -26,14 +26,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class ExplicitIndirectVariableFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -73,7 +73,7 @@ $foo
      * @param mixed $expected
      * @param mixed $input
      *
-     * @dataProvider provideTestFix80Cases
+     * @dataProvider provideFix80Cases
      *
      * @requires PHP 8.0
      */
@@ -82,7 +82,7 @@ $foo
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFix80Cases(): array
+    public static function provideFix80Cases(): array
     {
         return [
             [

--- a/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
@@ -27,7 +27,7 @@ final class FunctionToConstantFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideTestCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
@@ -35,7 +35,7 @@ final class FunctionToConstantFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'Minimal case, alternative casing, alternative statement end.' => [

--- a/tests/Fixer/LanguageConstruct/GetClassToClassKeywordFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/GetClassToClassKeywordFixerTest.php
@@ -28,14 +28,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class GetClassToClassKeywordFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideFixCases
+     * @dataProvider provideFixCasesCases
      */
     public function testFixCases(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixCases(): iterable
+    public static function provideFixCasesCases(): iterable
     {
         yield [
             '

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
@@ -27,7 +27,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class SingleSpaceAfterConstructFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideInvalidConstructCases
+     * @dataProvider provideConfigureRejectsInvalidControlStatementCases
      *
      * @param mixed $construct
      */
@@ -42,7 +42,7 @@ final class SingleSpaceAfterConstructFixerTest extends AbstractFixerTestCase
         ]);
     }
 
-    public static function provideInvalidConstructCases(): array
+    public static function provideConfigureRejectsInvalidControlStatementCases(): array
     {
         return [
             'null' => [null],

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixerTest.php
@@ -28,7 +28,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class SingleSpaceAroundConstructFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideInvalidConstructCases
+     * @dataProvider provideConfigureRejectsInvalidControlStatementCases
      *
      * @param mixed $construct
      */
@@ -43,7 +43,7 @@ final class SingleSpaceAroundConstructFixerTest extends AbstractFixerTestCase
         ]);
     }
 
-    public static function provideInvalidConstructCases(): array
+    public static function provideConfigureRejectsInvalidControlStatementCases(): array
     {
         return [
             'null' => [null],

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -518,14 +518,14 @@ $a = $ae?? $b;
     }
 
     /**
-     * @dataProvider provideFixCases
+     * @dataProvider provideFixDefaultsCases
      */
     public function testFixDefaults(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixCases(): array
+    public static function provideFixDefaultsCases(): array
     {
         return [
             [
@@ -1287,7 +1287,7 @@ $b;
     }
 
     /**
-     * @dataProvider provideAlignEqualsCases
+     * @dataProvider provideFixAlignEqualsCases
      */
     public function testFixAlignEquals(string $expected, ?string $input = null): void
     {
@@ -1295,7 +1295,7 @@ $b;
         $this->doTest($expected, $input);
     }
 
-    public static function provideAlignEqualsCases(): array
+    public static function provideFixAlignEqualsCases(): array
     {
         return [
             [
@@ -1634,7 +1634,7 @@ $start = (
     }
 
     /**
-     * @dataProvider provideAlignDoubleArrowCases
+     * @dataProvider provideFixAlignDoubleArrowCases
      */
     public function testFixAlignDoubleArrow(string $expected, ?string $input = null): void
     {
@@ -1642,7 +1642,7 @@ $start = (
         $this->doTest($expected, $input);
     }
 
-    public static function provideAlignDoubleArrowCases(): array
+    public static function provideFixAlignDoubleArrowCases(): array
     {
         return [
             [
@@ -2331,7 +2331,7 @@ function test()
     }
 
     /**
-     * @dataProvider provideAlignScopedDoubleArrowCases
+     * @dataProvider provideFixAlignScopedDoubleArrowCases
      */
     public function testFixAlignScopedDoubleArrow(string $expected, ?string $input = null): void
     {
@@ -2339,7 +2339,7 @@ function test()
         $this->doTest($expected, $input);
     }
 
-    public static function provideAlignScopedDoubleArrowCases(): array
+    public static function provideFixAlignScopedDoubleArrowCases(): array
     {
         return [
             [

--- a/tests/Fixer/Operator/ConcatSpaceFixerTest.php
+++ b/tests/Fixer/Operator/ConcatSpaceFixerTest.php
@@ -43,7 +43,7 @@ final class ConcatSpaceFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideWithoutSpaceCases
+     * @dataProvider provideFixWithoutSpaceCases
      */
     public function testFixWithoutSpace(string $expected, ?string $input = null): void
     {
@@ -51,7 +51,7 @@ final class ConcatSpaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideWithoutSpaceCases(): array
+    public static function provideFixWithoutSpaceCases(): array
     {
         return [
             [
@@ -142,7 +142,7 @@ final class ConcatSpaceFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideWithSpaceCases
+     * @dataProvider provideFixWithSpaceCases
      */
     public function testFixWithSpace(string $expected, ?string $input = null): void
     {
@@ -150,7 +150,7 @@ final class ConcatSpaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideWithSpaceCases(): array
+    public static function provideFixWithSpaceCases(): array
     {
         return [
             [

--- a/tests/Fixer/Operator/NewWithBracesFixerTest.php
+++ b/tests/Fixer/Operator/NewWithBracesFixerTest.php
@@ -26,14 +26,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class NewWithBracesFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideNamedWithDefaultConfigurationCases
+     * @dataProvider provideFixNamedWithDefaultConfigurationCases
      */
     public function testFixNamedWithDefaultConfiguration(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideNamedWithDefaultConfigurationCases(): iterable
+    public static function provideFixNamedWithDefaultConfigurationCases(): iterable
     {
         yield from [
             ['<?php $x = new X(foo(/**/));'],
@@ -277,7 +277,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideNamedWithoutBracesCases
+     * @dataProvider provideFixNamedWithoutBracesCases
      */
     public function testFixNamedWithoutBraces(string $expected, ?string $input = null): void
     {
@@ -285,7 +285,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideNamedWithoutBracesCases(): iterable
+    public static function provideFixNamedWithoutBracesCases(): iterable
     {
         yield from [
             ['<?php $x = new X(foo(/**/));'],
@@ -531,14 +531,14 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideAnonymousWithDefaultConfigurationCases
+     * @dataProvider provideFixAnonymousWithDefaultConfigurationCases
      */
     public function testFixAnonymousWithDefaultConfiguration(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideAnonymousWithDefaultConfigurationCases(): iterable
+    public static function provideFixAnonymousWithDefaultConfigurationCases(): iterable
     {
         yield from [
             ['<?php $a = new class($a) {use SomeTrait;};'],
@@ -593,7 +593,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideAnonymousWithoutBracesCases
+     * @dataProvider provideFixAnonymousWithoutBracesCases
      */
     public function testFixAnonymousWithoutBraces(string $expected, ?string $input = null): void
     {
@@ -601,7 +601,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideAnonymousWithoutBracesCases(): iterable
+    public static function provideFixAnonymousWithoutBracesCases(): iterable
     {
         yield from [
             ['<?php $a = new class($a) {use SomeTrait;};'],

--- a/tests/Fixer/Operator/TernaryToElvisOperatorFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToElvisOperatorFixerTest.php
@@ -497,7 +497,7 @@ EOT
      *
      * @requires PHP 8.0
      */
-    public function test80DoNotFix(string $input): void
+    public function testDoNotFix80(string $input): void
     {
         $this->doTest($input);
     }

--- a/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
@@ -27,7 +27,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null): void
     {
@@ -48,7 +48,7 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
         }
     }
 
-    public static function provideTestFixCases(): array
+    public static function provideFixCases(): array
     {
         $cases = [
             ['$sth->assertSame(true, $foo);'],

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
@@ -28,7 +28,7 @@ final class PhpUnitDedicateAssertFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
@@ -36,7 +36,7 @@ final class PhpUnitDedicateAssertFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield from [
             [

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixerTest.php
@@ -26,14 +26,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class PhpUnitDedicateAssertInternalTypeFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideTestFixInternalTypeCases
+     * @dataProvider provideFixInternalTypeCases
      */
     public function testFixInternalType(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixInternalTypeCases(): iterable
+    public static function provideFixInternalTypeCases(): iterable
     {
         yield 'skip cases' => [
             '<?php

--- a/tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
@@ -30,7 +30,7 @@ final class PhpUnitExpectationFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
@@ -39,7 +39,7 @@ final class PhpUnitExpectationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/PhpUnit/PhpUnitMockFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMockFixerTest.php
@@ -29,7 +29,7 @@ final class PhpUnitMockFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
@@ -38,7 +38,7 @@ final class PhpUnitMockFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
@@ -30,7 +30,7 @@ final class PhpUnitNamespacedFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
@@ -38,7 +38,7 @@ final class PhpUnitNamespacedFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'class_mapping' => [

--- a/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
@@ -30,7 +30,7 @@ final class PhpUnitNoExpectationAnnotationFixerTest extends AbstractFixerTestCas
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
@@ -38,7 +38,7 @@ final class PhpUnitNoExpectationAnnotationFixerTest extends AbstractFixerTestCas
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             'empty exception message' => [

--- a/tests/Fixer/PhpUnit/PhpUnitStrictFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitStrictFixerTest.php
@@ -27,7 +27,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class PhpUnitStrictFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null): void
     {
@@ -37,7 +37,7 @@ final class PhpUnitStrictFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php $self->foo();'];
 
@@ -107,7 +107,7 @@ final class PhpUnitStrictFixerTest extends AbstractFixerTestCase
     /**
      * Only method calls with 2 or 3 arguments should be fixed.
      *
-     * @dataProvider provideTestNoFixWithWrongNumberOfArgumentsCases
+     * @dataProvider provideNoFixWithWrongNumberOfArgumentsCases
      */
     public function testNoFixWithWrongNumberOfArguments(string $expected): void
     {
@@ -115,7 +115,7 @@ final class PhpUnitStrictFixerTest extends AbstractFixerTestCase
         $this->doTest($expected);
     }
 
-    public static function provideTestNoFixWithWrongNumberOfArgumentsCases(): array
+    public static function provideNoFixWithWrongNumberOfArgumentsCases(): array
     {
         $cases = [];
 

--- a/tests/Fixer/PhpUnit/PhpUnitTargetVersionTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTargetVersionTest.php
@@ -27,7 +27,7 @@ use PhpCsFixer\Tests\TestCase;
 final class PhpUnitTargetVersionTest extends TestCase
 {
     /**
-     * @dataProvider provideTestFulfillsCases
+     * @dataProvider provideFulfillsCases
      */
     public function testFulfills(bool $expected, string $candidate, string $target, ?string $exception = null): void
     {
@@ -41,7 +41,7 @@ final class PhpUnitTargetVersionTest extends TestCase
         );
     }
 
-    public static function provideTestFulfillsCases(): array
+    public static function provideFulfillsCases(): array
     {
         return [
             [true, PhpUnitTargetVersion::VERSION_NEWEST, PhpUnitTargetVersion::VERSION_5_6],

--- a/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
@@ -66,7 +66,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
@@ -74,7 +74,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
@@ -87,7 +87,7 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider providePropertyCases
+     * @dataProvider providePropertyFixCases
      */
     public function testPropertyFix(string $expected, ?string $input = null): void
     {
@@ -99,7 +99,7 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function providePropertyCases(): array
+    public static function providePropertyFixCases(): array
     {
         return [
             [
@@ -126,7 +126,7 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideTypeToVarCases
+     * @dataProvider provideTypeToVarFixCases
      */
     public function testTypeToVarFix(string $expected, ?string $input = null): void
     {
@@ -137,7 +137,7 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideTypeToVarCases(): array
+    public static function provideTypeToVarFixCases(): array
     {
         return [
             [
@@ -184,7 +184,7 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideVarToTypeCases
+     * @dataProvider provideVarToTypeFixCases
      */
     public function testVarToTypeFix(string $expected, ?string $input = null): void
     {
@@ -195,7 +195,7 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideVarToTypeCases(): array
+    public static function provideVarToTypeFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocOrderByValueFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocOrderByValueFixerTest.php
@@ -28,7 +28,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideInvalidAnnotationCases
+     * @dataProvider provideConfigureRejectsInvalidControlStatementCases
      *
      * @param mixed $annotation
      */
@@ -43,7 +43,7 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
         ]);
     }
 
-    public static function provideInvalidAnnotationCases(): array
+    public static function provideConfigureRejectsInvalidControlStatementCases(): array
     {
         return [
             'null' => [null],

--- a/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
@@ -396,7 +396,7 @@ EOF;
     }
 
     /**
-     * @dataProvider provideBasicCodeWithDifferentOrdersCases
+     * @dataProvider provideFixBasicCaseWithDifferentOrdersCases
      *
      * @param array<string, mixed> $config
      */
@@ -410,7 +410,7 @@ EOF;
     /**
      * @return array<array<null|array<string, mixed>|string>>
      */
-    public static function provideBasicCodeWithDifferentOrdersCases(): array
+    public static function provideFixBasicCaseWithDifferentOrdersCases(): array
     {
         $input = <<<'EOF'
 <?php
@@ -519,7 +519,7 @@ EOF;
     }
 
     /**
-     * @dataProvider provideCompleteCasesWithCustomOrdersCases
+     * @dataProvider provideFixCompleteCasesWithCustomOrdersCases
      *
      * @param array<string, mixed> $config
      */
@@ -533,7 +533,7 @@ EOF;
     /**
      * @return array<string, array<int, string|string[][]>>
      */
-    public static function provideCompleteCasesWithCustomOrdersCases(): array
+    public static function provideFixCompleteCasesWithCustomOrdersCases(): array
     {
         return [
             'intepacuthre' => [

--- a/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
@@ -25,7 +25,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class PhpdocReturnSelfReferenceFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideDefaultConfigurationTestCases
+     * @dataProvider provideFixWithDefaultConfigurationCases
      */
     public function testFixWithDefaultConfiguration(string $expected, ?string $input = null): void
     {
@@ -33,7 +33,7 @@ final class PhpdocReturnSelfReferenceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideDefaultConfigurationTestCases(): array
+    public static function provideFixWithDefaultConfigurationCases(): array
     {
         return [
             [
@@ -80,7 +80,7 @@ trait SomeTrait
     /**
      * @param array<string, string> $configuration
      *
-     * @dataProvider provideTestCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null, array $configuration = []): void
     {
@@ -88,7 +88,7 @@ trait SomeTrait
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocSummaryFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSummaryFixerTest.php
@@ -360,14 +360,14 @@ EOF;
     }
 
     /**
-     * @dataProvider provideInheritDocCases
+     * @dataProvider provideWithInheritDocCases
      */
     public function testWithInheritDoc(string $expected): void
     {
         $this->doTest($expected);
     }
 
-    public static function provideInheritDocCases(): array
+    public static function provideWithInheritDocCases(): array
     {
         return [
             [

--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -32,7 +32,7 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideFixCases
+     * @dataProvider provideFixWithNullFirstCases
      */
     public function testFixWithNullFirst(string $expected, ?string $input = null): void
     {
@@ -44,7 +44,7 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixCases(): array
+    public static function provideFixWithNullFirstCases(): array
     {
         return [
             [

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -1290,14 +1290,14 @@ function foo(&$c) {
     /**
      * @requires PHP 8.0
      *
-     * @dataProvider providePhp80Cases
+     * @dataProvider provideFix80Cases
      */
     public function testFix80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function providePhp80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield 'match' => [
             '<?php
@@ -1340,14 +1340,14 @@ function foo(&$c) {
     /**
      * @requires PHP 8.3
      *
-     * @dataProvider providePhp83Cases
+     * @dataProvider provideFixPhp83Cases
      */
     public function testFixPhp83(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function providePhp83Cases(): iterable
+    public static function provideFixPhp83Cases(): iterable
     {
         yield 'anonymous readonly class' => [
             '<?php

--- a/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
+++ b/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
@@ -31,7 +31,7 @@ use PhpCsFixer\WhitespacesFixerConfig;
 final class MultilineWhitespaceBeforeSemicolonsFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideMultiLineWhitespaceFixCases
+     * @dataProvider provideFixMultiLineWhitespaceCases
      */
     public function testFixMultiLineWhitespace(string $expected, ?string $input = null): void
     {
@@ -39,7 +39,7 @@ final class MultilineWhitespaceBeforeSemicolonsFixerTest extends AbstractFixerTe
         $this->doTest($expected, $input);
     }
 
-    public static function provideMultiLineWhitespaceFixCases(): array
+    public static function provideFixMultiLineWhitespaceCases(): array
     {
         return [
             [
@@ -254,7 +254,7 @@ $seconds = $minutes
     }
 
     /**
-     * @dataProvider provideMessyWhitespacesMultiLineWhitespaceFixCases
+     * @dataProvider provideMessyWhitespacesMultiLineWhitespaceCases
      */
     public function testMessyWhitespacesMultiLineWhitespace(string $expected, ?string $input = null): void
     {
@@ -263,7 +263,7 @@ $seconds = $minutes
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesMultiLineWhitespaceFixCases(): array
+    public static function provideMessyWhitespacesMultiLineWhitespaceCases(): array
     {
         return [
             [
@@ -1076,7 +1076,7 @@ switch ($foo) {
     }
 
     /**
-     * @dataProvider provideMessyWhitespacesSemicolonForChainedCallsFixCases
+     * @dataProvider provideMessyWhitespacesSemicolonForChainedCallsCases
      */
     public function testMessyWhitespacesSemicolonForChainedCalls(string $expected, ?string $input = null): void
     {
@@ -1085,7 +1085,7 @@ switch ($foo) {
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesSemicolonForChainedCallsFixCases(): array
+    public static function provideMessyWhitespacesSemicolonForChainedCallsCases(): array
     {
         return [
             [

--- a/tests/Fixer/Strict/StrictComparisonFixerTest.php
+++ b/tests/Fixer/Strict/StrictComparisonFixerTest.php
@@ -26,14 +26,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class StrictComparisonFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             ['<?php $a === $b;', '<?php $a == $b;'],

--- a/tests/Fixer/StringNotation/EscapeImplicitBackslashesFixerTest.php
+++ b/tests/Fixer/StringNotation/EscapeImplicitBackslashesFixerTest.php
@@ -28,7 +28,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, mixed> $configuration
      *
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null, array $configuration = []): void
     {
@@ -36,7 +36,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
@@ -26,14 +26,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class ExplicitStringVariableFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): array
+    public static function provideFixCases(): array
     {
         $input = $expected = '<?php';
 

--- a/tests/Fixer/StringNotation/HeredocToNowdocFixerTest.php
+++ b/tests/Fixer/StringNotation/HeredocToNowdocFixerTest.php
@@ -26,14 +26,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [<<<'EOF'

--- a/tests/Fixer/StringNotation/NoBinaryStringFixerTest.php
+++ b/tests/Fixer/StringNotation/NoBinaryStringFixerTest.php
@@ -26,14 +26,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class NoBinaryStringFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/StringNotation/SingleQuoteFixerTest.php
+++ b/tests/Fixer/StringNotation/SingleQuoteFixerTest.php
@@ -26,14 +26,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class SingleQuoteFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): array
+    public static function provideFixCases(): array
     {
         return [
             [
@@ -122,7 +122,7 @@ EOF
     }
 
     /**
-     * @dataProvider provideTestSingleQuoteFixCases
+     * @dataProvider provideSingleQuoteFixCases
      */
     public function testSingleQuoteFix(string $expected, ?string $input = null): void
     {
@@ -133,7 +133,7 @@ EOF
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestSingleQuoteFixCases(): array
+    public static function provideSingleQuoteFixCases(): array
     {
         return [
             [

--- a/tests/Fixer/StringNotation/StringLengthToEmptyFixerTest.php
+++ b/tests/Fixer/StringNotation/StringLengthToEmptyFixerTest.php
@@ -24,14 +24,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class StringLengthToEmptyFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideTestFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideTestFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php $a = \'\' === $b;',

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -29,7 +29,7 @@ use PhpCsFixer\WhitespacesFixerConfig;
 final class BlankLineBeforeStatementFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideInvalidControlStatementCases
+     * @dataProvider provideConfigureRejectsInvalidControlStatementCases
      *
      * @param mixed $controlStatement
      */
@@ -42,7 +42,7 @@ final class BlankLineBeforeStatementFixerTest extends AbstractFixerTestCase
         ]);
     }
 
-    public static function provideInvalidControlStatementCases(): array
+    public static function provideConfigureRejectsInvalidControlStatementCases(): array
     {
         return [
             'null' => [null],
@@ -1497,7 +1497,7 @@ enum UserStatus: string {
     }
 
     /**
-     * @dataProvider provideFixWithDocCommentCases
+     * @dataProvider provideFixWithDocCommentCasesCases
      */
     public function testFixWithDocCommentCases(string $expected, string $input = null): void
     {
@@ -1508,7 +1508,7 @@ enum UserStatus: string {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixWithDocCommentCases(): iterable
+    public static function provideFixWithDocCommentCasesCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Whitespace/BlankLineBetweenImportGroupsFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBetweenImportGroupsFixerTest.php
@@ -24,14 +24,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class BlankLineBetweenImportGroupsFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideFixTypesOrderAndWhitespaceCases
+     * @dataProvider provideFixTypesOrderAndNewlinesCases
      */
     public function testFixTypesOrderAndNewlines(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixTypesOrderAndWhitespaceCases(): iterable
+    public static function provideFixTypesOrderAndNewlinesCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -359,14 +359,14 @@ EOF;
     }
 
     /**
-     * @dataProvider provideCommentCases
+     * @dataProvider provideFixWithCommentsCases
      */
     public function testFixWithComments(string $expected, string $input): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideCommentCases(): array
+    public static function provideFixWithCommentsCases(): array
     {
         return [
             [
@@ -413,14 +413,14 @@ EOF
     }
 
     /**
-     * @dataProvider provideLineBreakCases
+     * @dataProvider provideFixWithLineBreaksCases
      */
     public function testFixWithLineBreaks(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideLineBreakCases(): iterable
+    public static function provideFixWithLineBreaksCases(): iterable
     {
         $input = '<?php //
 
@@ -775,7 +775,7 @@ class Foo
     }
 
     /**
-     * @dataProvider provideOneAndInLineCases
+     * @dataProvider provideOneOrInLineCasesCases
      */
     public function testOneOrInLineCases(string $expected, ?string $input = null): void
     {
@@ -792,7 +792,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public static function provideOneAndInLineCases(): iterable
+    public static function provideOneOrInLineCasesCases(): iterable
     {
         yield [
             "<?php\n\n\$a = function() use (\$b) { while(3<1)break; \$c = \$b[1]; while(\$b<1)continue; if (true) throw \$e; return 1; };\n\n",
@@ -825,7 +825,7 @@ class Foo
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideBraceCases
+     * @dataProvider provideBracesCases
      */
     public function testBraces(array $config, string $expected, ?string $input = null): void
     {
@@ -834,7 +834,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public static function provideBraceCases(): array
+    public static function provideBracesCases(): array
     {
         return [
             [
@@ -965,7 +965,7 @@ class Foo
     /**
      * @param list<string> $config
      *
-     * @dataProvider provideSwitchCases
+     * @dataProvider provideInSwitchStatementCases
      */
     public function testInSwitchStatement(array $config, string $expected, ?string $input = null): void
     {
@@ -974,7 +974,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public static function provideSwitchCases(): array
+    public static function provideInSwitchStatementCases(): array
     {
         return [
             [

--- a/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
@@ -27,7 +27,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class NoSpacesAroundOffsetFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideInsideCases
+     * @dataProvider provideFixSpaceInsideOffsetCases
      */
     public function testFixSpaceInsideOffset(string $expected, ?string $input = null): void
     {
@@ -35,7 +35,7 @@ final class NoSpacesAroundOffsetFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideOutsideCases
+     * @dataProvider provideFixSpaceOutsideOffsetCases
      */
     public function testFixSpaceOutsideOffset(string $expected, ?string $input = null): void
     {
@@ -65,14 +65,14 @@ EOF;
     }
 
     /**
-     * @dataProvider provideCommentCases
+     * @dataProvider provideCommentsCasesCases
      */
     public function testCommentsCases(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideCommentCases(): array
+    public static function provideCommentsCasesCases(): array
     {
         return [
             [
@@ -115,7 +115,7 @@ EOF;
         $this->doTest($expected);
     }
 
-    public static function provideOutsideCases(): iterable
+    public static function provideFixSpaceOutsideOffsetCases(): iterable
     {
         yield from [
             [
@@ -206,7 +206,7 @@ $var = $arr[0]{     0
         }
     }
 
-    public static function provideInsideCases(): array
+    public static function provideFixSpaceInsideOffsetCases(): array
     {
         return [
             [
@@ -295,7 +295,7 @@ $var = $arr[0][     0
     /**
      * @param list<string> $configuration
      *
-     * @dataProvider provideConfigurationCases
+     * @dataProvider provideFixWithConfigurationCases
      */
     public function testFixWithConfiguration(array $configuration, string $expected, string $input): void
     {
@@ -303,7 +303,7 @@ $var = $arr[0][     0
         $this->doTest($expected, $input);
     }
 
-    public static function provideConfigurationCases(): iterable
+    public static function provideFixWithConfigurationCases(): iterable
     {
         $tests = [
             [

--- a/tests/FixerDefinition/VersionSpecificCodeSampleTest.php
+++ b/tests/FixerDefinition/VersionSpecificCodeSampleTest.php
@@ -56,7 +56,7 @@ final class VersionSpecificCodeSampleTest extends TestCase
     }
 
     /**
-     * @dataProvider provideIsSuitableForVersionUsesVersionSpecificationCases
+     * @dataProvider provideIsSuitableForUsesVersionSpecificationCases
      */
     public function testIsSuitableForUsesVersionSpecification(int $version, bool $isSatisfied): void
     {
@@ -75,7 +75,7 @@ final class VersionSpecificCodeSampleTest extends TestCase
         self::assertSame($isSatisfied, $codeSample->isSuitableFor($version));
     }
 
-    public static function provideIsSuitableForVersionUsesVersionSpecificationCases(): array
+    public static function provideIsSuitableForUsesVersionSpecificationCases(): array
     {
         return [
             'is-satisfied' => [\PHP_VERSION_ID, true],

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -278,7 +278,7 @@ final class RuleSetTest extends TestCase
     /**
      * @param array<string, array<string, mixed>|bool> $set
      *
-     * @dataProvider provideSafeSetCases
+     * @dataProvider provideRiskyRulesInSetCases
      */
     public function testRiskyRulesInSet(array $set, bool $safe): void
     {
@@ -310,7 +310,7 @@ final class RuleSetTest extends TestCase
         );
     }
 
-    public static function provideSafeSetCases(): iterable
+    public static function provideRiskyRulesInSetCases(): iterable
     {
         foreach (RuleSets::getSetDefinitionNames() as $name) {
             yield $name => [
@@ -349,7 +349,7 @@ final class RuleSetTest extends TestCase
     }
 
     /**
-     * @dataProvider provideAllSetCases
+     * @dataProvider provideDuplicateRuleConfigurationInSetDefinitionsCases
      */
     public function testDuplicateRuleConfigurationInSetDefinitions(RuleSetDescriptionInterface $set): void
     {
@@ -391,7 +391,7 @@ final class RuleSetTest extends TestCase
         ));
     }
 
-    public static function provideAllSetCases(): iterable
+    public static function provideDuplicateRuleConfigurationInSetDefinitionsCases(): iterable
     {
         foreach (RuleSets::getSetDefinitions() as $name => $set) {
             yield $name => [$set];

--- a/tests/RuleSet/RuleSetsTest.php
+++ b/tests/RuleSet/RuleSetsTest.php
@@ -150,7 +150,7 @@ Integration of %s.
     }
 
     /**
-     * @dataProvider providePHPUnitMigrationSetDefinitionNameCases
+     * @dataProvider providePHPUnitMigrationTargetVersionsCases
      */
     public function testPHPUnitMigrationTargetVersions(string $setName): void
     {
@@ -166,7 +166,7 @@ Integration of %s.
     /**
      * @return string[][]
      */
-    public static function providePHPUnitMigrationSetDefinitionNameCases(): array
+    public static function providePHPUnitMigrationTargetVersionsCases(): array
     {
         $setDefinitionNames = RuleSets::getSetDefinitionNames();
 

--- a/tests/TextDiffTest.php
+++ b/tests/TextDiffTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 final class TextDiffTest extends TestCase
 {
     /**
-     * @dataProvider provideDiffReportingCases
+     * @dataProvider provideDiffReportingDecoratedCases
      */
     public function testDiffReportingDecorated(string $expected, string $format, bool $isDecorated): void
     {
@@ -62,7 +62,7 @@ final class TextDiffTest extends TestCase
         self::assertStringMatchesFormat($expected, $commandTester->getDisplay(false));
     }
 
-    public static function provideDiffReportingCases(): iterable
+    public static function provideDiffReportingDecoratedCases(): iterable
     {
         $expected = <<<'TEST'
 %A$output->writeln('<error>'.(int)$output.'</error>');%A

--- a/tests/Tokenizer/Analyzer/AlternativeSyntaxAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/AlternativeSyntaxAnalyzerTest.php
@@ -87,7 +87,7 @@ final class AlternativeSyntaxAnalyzerTest extends TestCase
     }
 
     /**
-     * @dataProvider provideFindBlockEndCases
+     * @dataProvider provideItFindsTheEndOfAnAlternativeSyntaxBlockCases
      */
     public function testItFindsTheEndOfAnAlternativeSyntaxBlock(string $code, int $startIndex, int $expectedResult): void
     {
@@ -102,7 +102,7 @@ final class AlternativeSyntaxAnalyzerTest extends TestCase
         );
     }
 
-    public static function provideFindBlockEndCases(): iterable
+    public static function provideItFindsTheEndOfAnAlternativeSyntaxBlockCases(): iterable
     {
         yield ['<?php if ($foo): foo(); endif;', 1, 13];
 
@@ -181,7 +181,7 @@ final class AlternativeSyntaxAnalyzerTest extends TestCase
     }
 
     /**
-     * @dataProvider provideFindInvalidBlockEndCases
+     * @dataProvider provideItThrowsOnInvalidAlternativeSyntaxBlockStartIndexCases
      */
     public function testItThrowsOnInvalidAlternativeSyntaxBlockStartIndex(string $code, int $startIndex, string $expectedMessage): void
     {
@@ -195,7 +195,7 @@ final class AlternativeSyntaxAnalyzerTest extends TestCase
         $analyzer->findAlternativeSyntaxBlockEnd($tokens, $startIndex);
     }
 
-    public static function provideFindInvalidBlockEndCases(): iterable
+    public static function provideItThrowsOnInvalidAlternativeSyntaxBlockStartIndexCases(): iterable
     {
         yield ['<?php if ($foo): foo(); endif;', 0, 'Token at index 0 is not the start of an alternative syntax block.'];
 

--- a/tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
@@ -138,7 +138,7 @@ final class ArgumentsAnalyzerTest extends TestCase
     }
 
     /**
-     * @dataProvider provideArgumentsInfoCases
+     * @dataProvider provideArgumentInfoCases
      */
     public function testArgumentInfo(string $code, int $openIndex, int $closeIndex, ArgumentAnalysis $expected): void
     {
@@ -148,7 +148,7 @@ final class ArgumentsAnalyzerTest extends TestCase
         self::assertArgumentAnalysis($expected, $analyzer->getArgumentInfo($tokens, $openIndex, $closeIndex));
     }
 
-    public static function provideArgumentsInfoCases(): iterable
+    public static function provideArgumentInfoCases(): iterable
     {
         yield ['<?php function($a){};', 3, 3, new ArgumentAnalysis(
             '$a',
@@ -281,7 +281,7 @@ final class ArgumentsAnalyzerTest extends TestCase
     /**
      * @requires PHP 8.0
      *
-     * @dataProvider provideArgumentsInfo80Cases
+     * @dataProvider provideArgumentInfo80Cases
      */
     public function testArgumentInfo80(string $code, int $openIndex, int $closeIndex, ArgumentAnalysis $expected): void
     {
@@ -291,7 +291,7 @@ final class ArgumentsAnalyzerTest extends TestCase
         self::assertArgumentAnalysis($expected, $analyzer->getArgumentInfo($tokens, $openIndex, $closeIndex));
     }
 
-    public static function provideArgumentsInfo80Cases(): iterable
+    public static function provideArgumentInfo80Cases(): iterable
     {
         yield [
             '<?php function foo(#[AnAttribute] ?string $param = null) {}',
@@ -331,7 +331,7 @@ final class ArgumentsAnalyzerTest extends TestCase
     /**
      * @requires PHP 8.1
      *
-     * @dataProvider provideArgumentsInfo81Cases
+     * @dataProvider provideArgumentInfo81Cases
      */
     public function testArgumentInfo81(string $code, int $openIndex, int $closeIndex, ArgumentAnalysis $expected): void
     {
@@ -341,7 +341,7 @@ final class ArgumentsAnalyzerTest extends TestCase
         self::assertArgumentAnalysis($expected, $analyzer->getArgumentInfo($tokens, $openIndex, $closeIndex));
     }
 
-    public static function provideArgumentsInfo81Cases(): iterable
+    public static function provideArgumentInfo81Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
@@ -370,7 +370,7 @@ class(){};
     /**
      * @param array<string, ArgumentAnalysis> $expected
      *
-     * @dataProvider provideFunctionsWithArgumentsCases
+     * @dataProvider provideFunctionArgumentInfoCases
      */
     public function testFunctionArgumentInfo(string $code, int $methodIndex, array $expected): void
     {
@@ -392,7 +392,7 @@ class(){};
         self::assertSame(serialize($expected), serialize($actual));
     }
 
-    public static function provideFunctionsWithArgumentsCases(): iterable
+    public static function provideFunctionArgumentInfoCases(): iterable
     {
         yield from [
             ['<?php function(){};', 1, []],
@@ -701,7 +701,7 @@ class(){};
     /**
      * @param array<string, ArgumentAnalysis> $expected
      *
-     * @dataProvider provideFunctionsWithArgumentsPhp80Cases
+     * @dataProvider provideFunctionArgumentInfoPhp80Cases
      *
      * @requires PHP 8.0
      */
@@ -713,7 +713,7 @@ class(){};
         self::assertSame(serialize($expected), serialize($analyzer->getFunctionArguments($tokens, $methodIndex)));
     }
 
-    public static function provideFunctionsWithArgumentsPhp80Cases(): iterable
+    public static function provideFunctionArgumentInfoPhp80Cases(): iterable
     {
         yield ['<?php function($aa,){};', 1, [
             '$aa' => new ArgumentAnalysis(

--- a/tests/Tokenizer/Analyzer/GotoLabelAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/GotoLabelAnalyzerTest.php
@@ -28,7 +28,7 @@ final class GotoLabelAnalyzerTest extends TestCase
     /**
      * @param int[] $expectedTrue
      *
-     * @dataProvider provideIsClassyInvocationCases
+     * @dataProvider provideGotoLabelAnalyzerTestCases
      */
     public function testGotoLabelAnalyzerTest(string $source, array $expectedTrue): void
     {
@@ -43,7 +43,7 @@ final class GotoLabelAnalyzerTest extends TestCase
         }
     }
 
-    public static function provideIsClassyInvocationCases(): iterable
+    public static function provideGotoLabelAnalyzerTestCases(): iterable
     {
         yield from [
             'no candidates' => [

--- a/tests/Tokenizer/Analyzer/NamespaceUsesAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/NamespaceUsesAnalyzerTest.php
@@ -32,7 +32,7 @@ final class NamespaceUsesAnalyzerTest extends TestCase
     /**
      * @param list<NamespaceUseAnalysis> $expected
      *
-     * @dataProvider provideNamespaceUsesCases
+     * @dataProvider provideUsesFromTokensCases
      */
     public function testUsesFromTokens(string $code, array $expected): void
     {
@@ -45,7 +45,7 @@ final class NamespaceUsesAnalyzerTest extends TestCase
         );
     }
 
-    public static function provideNamespaceUsesCases(): array
+    public static function provideUsesFromTokensCases(): array
     {
         return [
             ['<?php // no uses', [], []],

--- a/tests/Tokenizer/TokenTest.php
+++ b/tests/Tokenizer/TokenTest.php
@@ -192,7 +192,7 @@ final class TokenTest extends TestCase
     /**
      * @param ?int $tokenId
      *
-     * @dataProvider provideMagicConstantCases
+     * @dataProvider provideIsMagicConstantCases
      */
     public function testIsMagicConstant(?int $tokenId, string $content, bool $isConstant = true): void
     {
@@ -203,7 +203,7 @@ final class TokenTest extends TestCase
         self::assertSame($isConstant, $token->isMagicConstant());
     }
 
-    public static function provideMagicConstantCases(): iterable
+    public static function provideIsMagicConstantCases(): iterable
     {
         $cases = [
             [T_CLASS_C, '__CLASS__'],
@@ -471,14 +471,14 @@ final class TokenTest extends TestCase
     }
 
     /**
-     * @dataProvider provideTokenGetNameCases
+     * @dataProvider provideTokenGetNameForIdCases
      */
     public function testTokenGetNameForId(?string $expected, int $id): void
     {
         self::assertSame($expected, Token::getNameForId($id));
     }
 
-    public static function provideTokenGetNameCases(): array
+    public static function provideTokenGetNameForIdCases(): array
     {
         return [
             [

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -524,7 +524,7 @@ PHP;
      * @param int[]   $indexes  to clear
      * @param Token[] $expected tokens
      *
-     * @dataProvider provideGetClearTokenAndMergeSurroundingWhitespaceCases
+     * @dataProvider provideClearTokenAndMergeSurroundingWhitespaceCases
      */
     public function testClearTokenAndMergeSurroundingWhitespace(string $source, array $indexes, array $expected): void
     {
@@ -534,7 +534,7 @@ PHP;
         }
     }
 
-    public static function provideGetClearTokenAndMergeSurroundingWhitespaceCases(): array
+    public static function provideClearTokenAndMergeSurroundingWhitespaceCases(): array
     {
         $clearToken = new Token('');
 

--- a/tests/WhitespacesFixerConfigTest.php
+++ b/tests/WhitespacesFixerConfigTest.php
@@ -26,7 +26,7 @@ use PhpCsFixer\WhitespacesFixerConfig;
 final class WhitespacesFixerConfigTest extends TestCase
 {
     /**
-     * @dataProvider provideTestCases
+     * @dataProvider provideCasesCases
      */
     public function testCases(string $indent, string $lineEnding, ?string $exceptionRegExp = null): void
     {
@@ -41,7 +41,7 @@ final class WhitespacesFixerConfigTest extends TestCase
         self::assertSame($lineEnding, $config->getLineEnding());
     }
 
-    public static function provideTestCases(): array
+    public static function provideCasesCases(): array
     {
         return [
             ['    ', "\n"],


### PR DESCRIPTION
Renames made automatically by [`PhpUnitDataProviderNameFixer`](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7057), except for:

- test function `test80DoNotFix` renamed to `testDoNotFix80` as if the data provider would become `provide80DoNotFixCases` it would not match the [regular expression](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.17.0/tests/AutoReview/ProjectCodeTest.php#L312)
-  in `tests/Console/Output/ErrorOutputTest.php` output is updated as it contains the data provider name