### PR TITLE
feat: Allow FQCN as fixer name and configuration key for rules

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -127,6 +127,40 @@ The following example shows how to use all ``PhpCsFixer`` rules but without the 
 
 If you need to set up exception for rules, eg ignore or reconfigure a rule for specific files, check the `Rules exceptions <./rules_exceptions.rst>`_.
 
+Using class names as rule keys
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of string rule names, you can use the fully-qualified class name (FQCN) of a fixer as the key.
+The recommended way is to use the ``::class`` constant, which gives you IDE autocompletion, go-to-definition, and rename-refactoring support out of the box:
+
+.. code-block:: php
+
+    <?php
+
+    use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
+    use PhpCsFixer\Fixer\Phpdoc\AlignMultilineCommentFixer;
+    use PhpCsFixer\Fixer\Strict\StrictParamFixer;
+
+    $finder = (new PhpCsFixer\Finder())
+        ->in(__DIR__)
+    ;
+
+    return (new PhpCsFixer\Config())
+        ->setRules([
+            '@PSR12' => true,
+            StrictParamFixer::class => true,
+            ArraySyntaxFixer::class => ['syntax' => 'short'],
+            AlignMultilineCommentFixer::class => false,
+        ])
+        ->setFinder($finder)
+    ;
+
+String names and ``::class`` constants are interchangeable and can be mixed freely.
+This is especially useful when overriding rules from a ruleset that was defined using class names, or vice versa.
+
+A raw FQCN string (e.g. ``'PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer'``) is also accepted,
+but the ``::class`` constant form is preferred as it is refactoring-safe and verified by static analysis tools.
+
 
 Configuring whitespaces
 -----------------------

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -795,9 +795,7 @@ final class ConfigurationResolver
 
         $configuredFixers = array_keys($ruleSet->getRules());
 
-        $fixers = $this->createFixerFactory()->getFixers();
-
-        $availableFixers = array_map(static fn (FixerInterface $fixer): string => $fixer->getName(), $fixers);
+        $availableFixers = $this->createFixerFactory()->getRegisteredFixerNames();
 
         $unknownFixers = array_diff($configuredFixers, $availableFixers);
 
@@ -885,13 +883,13 @@ final class ConfigurationResolver
             $message = substr($message, 0, -2).'.';
 
             if ($hasOldRule) {
-                $message .= "\nFor more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md#renamed-ruless.";
+                $message .= "\nFor more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md#renamed-rules";
             }
 
             throw new InvalidConfigurationException($message);
         }
 
-        foreach ($fixers as $fixer) {
+        foreach ($this->createFixerFactory()->getFixers() as $fixer) {
             $fixerName = $fixer->getName();
             if (isset($rules[$fixerName]) && $fixer instanceof DeprecatedFixerInterface) {
                 $successors = $fixer->getSuccessorsNames();

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -891,7 +891,7 @@ final class ConfigurationResolver
 
         foreach ($this->createFixerFactory()->getFixers() as $fixer) {
             $fixerName = $fixer->getName();
-            if (isset($rules[$fixerName]) && $fixer instanceof DeprecatedFixerInterface) {
+            if ((isset($rules[$fixerName]) || isset($rules[\get_class($fixer)])) && $fixer instanceof DeprecatedFixerInterface) {
                 $successors = $fixer->getSuccessorsNames();
                 $messageEnd = [] === $successors
                     ? \sprintf(' and will be removed in version %d.0.', Application::getMajorVersion() + 1)

--- a/src/Documentation/RuleSetDocumentationGenerator.php
+++ b/src/Documentation/RuleSetDocumentationGenerator.php
@@ -18,6 +18,7 @@ use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\Preg;
 use PhpCsFixer\RuleSet\AutomaticRuleSetDefinitionInterface;
 use PhpCsFixer\RuleSet\DeprecatedRuleSetDefinitionInterface;
+use PhpCsFixer\RuleSet\RuleSet;
 use PhpCsFixer\RuleSet\RuleSetDefinitionInterface;
 use PhpCsFixer\Utils;
 
@@ -79,9 +80,10 @@ final class RuleSetDocumentationGenerator
             $doc .= "\n\n".$header($warningsHeader).implode("\n", $warnings);
         }
 
-        $rules = $definition instanceof AutomaticRuleSetDefinitionInterface
-                ? $definition->getRulesCandidates()
-                : $definition->getRules();
+        $rules = RuleSet::normaliseConfig($definition instanceof AutomaticRuleSetDefinitionInterface
+            ? $definition->getRulesCandidates()
+            : $definition->getRules()
+        );
 
         if ([] === $rules) {
             $doc .= "\n\nThis is an empty set.";
@@ -105,7 +107,7 @@ final class RuleSetDocumentationGenerator
                             $this->locator->getFixerDocumentationFilePath($fixerNames[$rule]),
                         );
 
-                        $doc .= "\n- `{$rule} <{$path}>`_";
+                        $doc .= "\n- `{$fixerNames[$rule]->getName()} <{$path}>`_";
                     }
 
                     if (!\is_bool($config)) {

--- a/src/Documentation/RuleSetDocumentationGenerator.php
+++ b/src/Documentation/RuleSetDocumentationGenerator.php
@@ -80,9 +80,10 @@ final class RuleSetDocumentationGenerator
             $doc .= "\n\n".$header($warningsHeader).implode("\n", $warnings);
         }
 
-        $rules = RuleSet::normaliseConfig($definition instanceof AutomaticRuleSetDefinitionInterface
+        $rules = RuleSet::normaliseConfig(
+            $definition instanceof AutomaticRuleSetDefinitionInterface
             ? $definition->getRulesCandidates()
-            : $definition->getRules()
+            : $definition->getRules(),
         );
 
         if ([] === $rules) {

--- a/src/Documentation/RuleSetDocumentationGenerator.php
+++ b/src/Documentation/RuleSetDocumentationGenerator.php
@@ -108,7 +108,7 @@ final class RuleSetDocumentationGenerator
                             $this->locator->getFixerDocumentationFilePath($fixerNames[$rule]),
                         );
 
-                        $doc .= "\n- `{$fixerNames[$rule]->getName()} <{$path}>`_";
+                        $doc .= "\n- `{$rule} <{$path}>`_";
                     }
 
                     if (!\is_bool($config)) {

--- a/src/FixerFactory.php
+++ b/src/FixerFactory.php
@@ -79,14 +79,14 @@ final class FixerFactory
     }
 
     /**
-     * @return array<string>
+     * @return list<string>
      */
     public function getRegisteredFixerNames(): array
     {
         $ruleNames = array_keys($this->fixersByName);
         ksort($ruleNames);
 
-        return $ruleNames;
+        return array_values($ruleNames);
     }
 
     /**

--- a/src/FixerFactory.php
+++ b/src/FixerFactory.php
@@ -18,6 +18,7 @@ use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
+use PhpCsFixer\RuleSet\RuleSet;
 use PhpCsFixer\RuleSet\RuleSetInterface;
 use Symfony\Component\Finder\Finder as SymfonyFinder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -75,6 +76,17 @@ final class FixerFactory
         $this->fixers = Utils::sortFixers($this->fixers);
 
         return $this->fixers;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getRegisteredFixerNames(): array
+    {
+        $ruleNames = array_keys($this->fixersByName);
+        ksort($ruleNames);
+
+        return $ruleNames;
     }
 
     /**
@@ -160,6 +172,8 @@ final class FixerFactory
 
         $fixerNames = array_keys($ruleSet->getRules());
         foreach ($fixerNames as $name) {
+            $name = RuleSet::normaliseRuleName($name);
+
             if (!\array_key_exists($name, $this->fixersByName)) {
                 throw new \UnexpectedValueException(\sprintf('Rule "%s" does not exist.', $name));
             }
@@ -192,6 +206,7 @@ final class FixerFactory
             throw new \UnexpectedValueException($this->generateConflictMessage($fixerConflicts));
         }
 
+        ksort($fixersByName);
         $this->fixers = $fixers;
         $this->fixersByName = $fixersByName;
 
@@ -203,7 +218,18 @@ final class FixerFactory
      */
     public function hasRule(string $name): bool
     {
-        return isset($this->fixersByName[$name]);
+        return isset($this->fixersByName[RuleSet::normaliseRuleName($name)]);
+    }
+
+    public function getRule(string $name): FixerInterface
+    {
+        $fixer = $this->fixersByName[RuleSet::normaliseRuleName($name)] ?? null;
+
+        if (null === $fixer) {
+            throw new \UnexpectedValueException(\sprintf('Rule "%s" does not exist.', $name));
+        }
+
+        return $fixer;
     }
 
     /**

--- a/src/FixerFactory.php
+++ b/src/FixerFactory.php
@@ -84,9 +84,9 @@ final class FixerFactory
     public function getRegisteredFixerNames(): array
     {
         $ruleNames = array_keys($this->fixersByName);
-        ksort($ruleNames);
+        sort($ruleNames);
 
-        return array_values($ruleNames);
+        return $ruleNames;
     }
 
     /**

--- a/src/FixerNameValidator.php
+++ b/src/FixerNameValidator.php
@@ -29,7 +29,7 @@ final class FixerNameValidator
             return Preg::match('/^[a-z][a-z0-9_]*$/', $name);
         }
 
-        // See: https://regex101.com/r/UngJUn/4
-        return Preg::match('/^[a-zA-Z][a-zA-Z0-9]*(?!$)((\/[a-z][a-z0-9_]*)?|((?i)(?<!PhpCsFixer)(?-i)\\\[a-zA-Z][a-zA-Z0-9_]*)*){1}$/', $name);
+        // See: https://regex101.com/r/UngJUn/6
+        return Preg::match('/^[a-z][a-z0-9]*(?!$)((?:\/(?!\d)[a-z0-9_]*)?|(?:(?<!PhpCsFixer)\\\(?!\d)[a-z0-9_]*)*)$/i', $name);
     }
 }

--- a/src/FixerNameValidator.php
+++ b/src/FixerNameValidator.php
@@ -29,6 +29,7 @@ final class FixerNameValidator
             return Preg::match('/^[a-z][a-z0-9_]*$/', $name);
         }
 
-        return Preg::match('/^[A-Z][a-zA-Z0-9]*\/[a-z][a-z0-9_]*$/', $name);
+        // See: https://regex101.com/r/UngJUn/3
+        return Preg::match('/^[a-zA-Z][a-zA-Z0-9]*(?!$)((\/[a-z][a-z0-9_]*)?|(\\\[a-zA-Z][a-zA-Z0-9_]*)*){1}$/', $name);
     }
 }

--- a/src/FixerNameValidator.php
+++ b/src/FixerNameValidator.php
@@ -29,7 +29,7 @@ final class FixerNameValidator
             return Preg::match('/^[a-z][a-z0-9_]*$/', $name);
         }
 
-        // See: https://regex101.com/r/UngJUn/3
-        return Preg::match('/^[a-zA-Z][a-zA-Z0-9]*(?!$)((\/[a-z][a-z0-9_]*)?|(\\\[a-zA-Z][a-zA-Z0-9_]*)*){1}$/', $name);
+        // See: https://regex101.com/r/UngJUn/4
+        return Preg::match('/^[a-zA-Z][a-zA-Z0-9]*(?!$)((\/[a-z][a-z0-9_]*)?|((?i)(?<!PhpCsFixer)(?-i)\\\[a-zA-Z][a-zA-Z0-9_]*)*){1}$/', $name);
     }
 }

--- a/src/FixerNameValidator.php
+++ b/src/FixerNameValidator.php
@@ -30,6 +30,6 @@ final class FixerNameValidator
         }
 
         // See: https://regex101.com/r/UngJUn/6
-        return Preg::match('/^[a-z][a-z0-9]*(?!$)((?:\/(?!\d)[a-z0-9_]*)?|(?:(?<!PhpCsFixer)\\\(?!\d)[a-z0-9_]*)*)$/i', $name);
+        return Preg::match('/^[a-z][a-z0-9]*(?!$)((?:\/(?!\d)[a-z0-9_]*)?|(?:(?<!^PhpCsFixer)\\\(?!\d)[a-z0-9_]*)*)$/i', $name);
     }
 }

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -44,8 +44,6 @@ final class RuleSet implements RuleSetInterface
 
     public function __construct(array $set = [])
     {
-        $set = self::normaliseConfig($set);
-
         foreach ($set as $name => $value) {
             if ('' === $name) {
                 throw new \InvalidArgumentException('Rule/set name must not be empty.');
@@ -66,6 +64,8 @@ final class RuleSet implements RuleSetInterface
             }
         }
 
+        $set = self::normaliseConfig($set);
+
         $this->rules = $this->resolveSet($set);
     }
 
@@ -79,7 +79,7 @@ final class RuleSet implements RuleSetInterface
         $normalisedConfig = [];
 
         foreach ($rulesConfig as $name => $config) {
-            $normalisedConfig[\is_int($name) ? $name : self::normaliseRuleName($name)] = $config;
+            $normalisedConfig[self::normaliseRuleName($name)] = $config;
         }
 
         return $normalisedConfig;

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -96,6 +96,7 @@ final class RuleSet implements RuleSetInterface
         if (class_exists($name)
             && \in_array(FixerInterface::class, class_implements($name), true)
         ) {
+            // @phpstan-ignore method.notFound (we're sure it's a `FixerInterface` instance)
             return (new $name())->getName();
         }
 

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -93,9 +93,7 @@ final class RuleSet implements RuleSetInterface
      */
     public static function normaliseRuleName(string $name): string
     {
-        if (class_exists($name)
-            && \in_array(FixerInterface::class, class_implements($name), true)
-        ) {
+        if (is_a($name, FixerInterface::class, true)) {
             // @phpstan-ignore method.notFound (we're sure it's a `FixerInterface` instance)
             return (new $name())->getName();
         }

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -15,8 +15,8 @@ declare(strict_types=1);
 namespace PhpCsFixer\RuleSet;
 
 use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
-use PhpCsFixer\Future;
 use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\Future;
 use PhpCsFixer\Utils;
 
 /**
@@ -141,7 +141,7 @@ final class RuleSet implements RuleSetInterface
 
                 $resolvedRules = array_merge(
                     $resolvedRules,
-                    $this->resolveSubset($name, $value)
+                    $this->resolveSubset($name, $value),
                 );
             } else {
                 $resolvedRules[$name] = $value;

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -93,12 +93,9 @@ final class RuleSet implements RuleSetInterface
      */
     public static function normaliseRuleName(string $name): string
     {
-        if (is_a($name, FixerInterface::class, true)) {
-            // @phpstan-ignore method.notFound (we're sure it's a `FixerInterface` instance)
-            return (new $name())->getName();
-        }
-
-        return $name;
+        return is_a($name, FixerInterface::class, true)
+            ? (new $name())->getName()
+            : $name;
     }
 
     public function hasRule(string $rule): bool

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\RuleSet\Sets;
 
+use PhpCsFixer\Fixer;
 use PhpCsFixer\RuleSet\AbstractRuleSetDefinition;
+use PhpCsFixer\RuleSet\RuleSet;
 
 /**
  * @internal
@@ -25,10 +27,10 @@ final class PhpCsFixerSet extends AbstractRuleSetDefinition
 {
     public function getRules(): array
     {
-        return [
+        return RuleSet::normaliseConfig([
             '@PER-CS' => true,
             '@Symfony' => true,
-            'blank_line_before_statement' => [
+            Fixer\Whitespace\BlankLineBeforeStatementFixer::class => [
                 'statements' => [
                     'break',
                     'case',
@@ -50,25 +52,25 @@ final class PhpCsFixerSet extends AbstractRuleSetDefinition
                     'yield_from',
                 ],
             ],
-            'combine_consecutive_issets' => true,
-            'combine_consecutive_unsets' => true,
-            'empty_loop_body' => true,
-            'explicit_indirect_variable' => true,
-            'explicit_string_variable' => true,
-            'fully_qualified_strict_types' => [
+            Fixer\LanguageConstruct\CombineConsecutiveIssetsFixer::class => true,
+            Fixer\LanguageConstruct\CombineConsecutiveUnsetsFixer::class => true,
+            Fixer\ControlStructure\EmptyLoopBodyFixer::class => true,
+            Fixer\LanguageConstruct\ExplicitIndirectVariableFixer::class => true,
+            Fixer\StringNotation\ExplicitStringVariableFixer::class => true,
+            Fixer\Import\FullyQualifiedStrictTypesFixer::class => [
                 'import_symbols' => true,
             ],
-            'heredoc_to_nowdoc' => true,
-            'method_argument_space' => [
+            Fixer\StringNotation\HeredocToNowdocFixer::class => true,
+            Fixer\FunctionNotation\MethodArgumentSpaceFixer::class => [
                 'after_heredoc' => true,
                 'on_multiline' => 'ensure_fully_multiline',
             ],
-            'method_chaining_indentation' => true,
-            'multiline_comment_opening_closing' => true,
-            'multiline_whitespace_before_semicolons' => [
+            Fixer\Whitespace\MethodChainingIndentationFixer::class => true,
+            Fixer\Comment\MultilineCommentOpeningClosingFixer::class => true,
+            Fixer\Semicolon\MultilineWhitespaceBeforeSemicolonsFixer::class => [
                 'strategy' => 'new_line_for_chained_calls',
             ],
-            'no_extra_blank_lines' => [
+            Fixer\Whitespace\NoExtraBlankLinesFixer::class => [
                 'tokens' => [
                     'attribute',
                     'break',
@@ -85,35 +87,35 @@ final class PhpCsFixerSet extends AbstractRuleSetDefinition
                     'use',
                 ],
             ],
-            'no_superfluous_elseif' => true,
-            'no_superfluous_phpdoc_tags' => [
+            Fixer\ControlStructure\NoSuperfluousElseifFixer::class => true,
+            Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer::class => [
                 'allow_hidden_params' => true,
                 'allow_mixed' => true, // @TODO revalidate to keep `true` or unify into `false`
                 'remove_inheritdoc' => true,
             ],
-            'no_whitespace_in_empty_array' => true,
-            'operator_linebreak' => true,
-            'ordered_class_elements' => true,
-            'ordered_types' => [
+            Fixer\ArrayNotation\NoWhitespaceInEmptyArrayFixer::class => true,
+            Fixer\Operator\OperatorLinebreakFixer::class => true,
+            Fixer\ClassNotation\OrderedClassElementsFixer::class => true,
+            Fixer\ClassNotation\OrderedTypesFixer::class => [
                 'null_adjustment' => 'always_last',
             ],
-            'php_unit_data_provider_method_order' => true,
-            'php_unit_internal_class' => true,
-            'php_unit_test_class_requires_covers' => true,
-            'phpdoc_add_missing_param_annotation' => true,
-            'phpdoc_no_duplicate_types' => true,
-            'phpdoc_no_empty_return' => true,
-            'phpdoc_order_by_value' => true,
-            'phpdoc_types_order' => true,
-            'return_assignment' => true,
-            'self_static_accessor' => true,
-            'single_line_comment_style' => true,
-            'single_line_empty_body' => true,
-            'single_line_throw' => false,
-            'string_implicit_backslashes' => true,
-            'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays']],
-            'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
-        ];
+            Fixer\PhpUnit\PhpUnitDataProviderMethodOrderFixer::class => true,
+            Fixer\PhpUnit\PhpUnitInternalClassFixer::class => true,
+            Fixer\PhpUnit\PhpUnitTestClassRequiresCoversFixer::class => true,
+            Fixer\Phpdoc\PhpdocAddMissingParamAnnotationFixer::class => true,
+            Fixer\Phpdoc\PhpdocNoDuplicateTypesFixer::class => true,
+            Fixer\Phpdoc\PhpdocNoEmptyReturnFixer::class => true,
+            Fixer\Phpdoc\PhpdocOrderByValueFixer::class => true,
+            Fixer\Phpdoc\PhpdocTypesOrderFixer::class => true,
+            Fixer\ReturnNotation\ReturnAssignmentFixer::class => true,
+            Fixer\ClassNotation\SelfStaticAccessorFixer::class => true,
+            Fixer\Comment\SingleLineCommentStyleFixer::class => true,
+            Fixer\Basic\SingleLineEmptyBodyFixer::class => true,
+            Fixer\FunctionNotation\SingleLineThrowFixer::class => false,
+            Fixer\StringNotation\StringImplicitBackslashesFixer::class => true,
+            Fixer\ControlStructure\TrailingCommaInMultilineFixer::class => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays']],
+            Fixer\ArrayNotation\WhitespaceAfterCommaInArrayFixer::class => ['ensure_single_space' => true],
+        ]);
     }
 
     public function getDescription(): string

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -145,6 +145,34 @@ final class ConfigTest extends TestCase
         );
     }
 
+    public function testConfigWithFullyQualifiedClassNamesAsFixersNames(): void
+    {
+        $customConfigFile = __DIR__.'/Fixtures/.php-cs-fixer.fqcn.php';
+
+        $application = new Application();
+        $application->add(new FixCommand(new ToolInfo()));
+
+        $commandTester = new CommandTester($application->find('fix'));
+
+        $commandTester->execute(
+            [
+                '--config' => $customConfigFile,
+                '--diff' => true,
+                '--dry-run' => true,
+                'path' => [$customConfigFile],
+            ],
+            [
+                'decorated' => false,
+                'verbosity' => OutputInterface::VERBOSITY_VERY_VERBOSE,
+            ]
+        );
+
+        self::assertStringContainsString(
+            '.php-cs-fixer.fqcn.php (declare_strict_types, blank_line_after_opening_tag, multiline_whitespace_before_semicolons)',
+            $commandTester->getDisplay(true)
+        );
+    }
+
     public function testThatFinderWorksWithDirSetOnConfig(): void
     {
         $config = new Config();

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -164,12 +164,12 @@ final class ConfigTest extends TestCase
             [
                 'decorated' => false,
                 'verbosity' => OutputInterface::VERBOSITY_VERY_VERBOSE,
-            ]
+            ],
         );
 
         self::assertStringContainsString(
             '.php-cs-fixer.fqcn.php (declare_strict_types, blank_line_after_opening_tag, multiline_whitespace_before_semicolons)',
-            $commandTester->getDisplay(true)
+            $commandTester->getDisplay(true),
         );
     }
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1368,20 +1368,20 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
      */
     #[DataProvider('provideDeprecatedFixerConfiguredCases')]
     #[Group('legacy')]
-    public function testDeprecatedFixerConfigured($ruleConfig): void
+    public function testDeprecatedFixerConfigured($ruleConfig, bool $useFqcnAsRuleName = false): void
     {
         $this->expectDeprecation('Rule "Vendor4/foo" is deprecated. Use "testA" and "testB" instead.');
         $fixer = $this->createDeprecatedFixerDouble();
         $config = new Config();
         $config->registerCustomFixers([$fixer]);
-        $config->setRules([$fixer->getName() => $ruleConfig]);
+        $config->setRules([($useFqcnAsRuleName ? \get_class($fixer) : $fixer->getName()) => $ruleConfig]);
 
         $resolver = $this->createConfigurationResolver([], $config);
         $resolver->getFixers();
     }
 
     /**
-     * @return iterable<int, array{array<string, mixed>|bool}>
+     * @return iterable<array{0: array<string, mixed>|bool, 1?: bool}>
      */
     public static function provideDeprecatedFixerConfiguredCases(): iterable
     {
@@ -1390,6 +1390,8 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         yield [['foo' => true]];
 
         yield [false];
+
+        yield 'by FQCN as rule name' => [true, true];
     }
 
     public function testItCanRegisterCustomRuleSets(): void

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1197,25 +1197,25 @@ final class ConfigurationResolverTest extends TestCase
     {
         yield 'with config' => [
             'The rules contain unknown fixers: "blank_line_before_return" is renamed (did you mean "blank_line_before_statement"? (note: use configuration "[\'statements\' => [\'return\']]")).
-For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md#renamed-ruless.',
+For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md#renamed-rules',
             ['blank_line_before_return'],
         ];
 
         yield 'without config' => [
             'The rules contain unknown fixers: "final_static_access" is renamed (did you mean "self_static_accessor"?).
-For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md#renamed-ruless.',
+For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md#renamed-rules',
             ['final_static_access'],
         ];
 
         yield [
             'The rules contain unknown fixers: "hash_to_slash_comment" is renamed (did you mean "single_line_comment_style"? (note: use configuration "[\'comment_types\' => [\'hash\']]")).
-For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md#renamed-ruless.',
+For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md#renamed-rules',
             ['hash_to_slash_comment'],
         ];
 
         yield 'both renamed and unknown' => [
             'The rules contain unknown fixers: "final_static_access" is renamed (did you mean "self_static_accessor"?), "binary_operator_space" (did you mean "binary_operator_spaces"?).
-For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md#renamed-ruless.',
+For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md#renamed-rules',
             ['final_static_access', 'binary_operator_space'],
         ];
     }

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace PhpCsFixer\Tests;
 
 use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
+use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\Fixer\InternalFixerInterface;
@@ -306,6 +307,40 @@ final class FixerFactoryTest extends TestCase
         $factory->useRuleSet(new RuleSet(['f2' => true]));
         self::assertFalse($factory->hasRule('f1'), 'Should not have f1 fixer');
         self::assertTrue($factory->hasRule('f2'), 'Should have f2 fixer');
+    }
+
+    public function testGetRegisteredFixerNames(): void
+    {
+        $factory = new FixerFactory();
+        $factory->registerFixer($this->createFixerDouble('f3'), false);
+        $factory->registerFixer($this->createFixerDouble('f1'), false);
+        $factory->registerFixer($this->createFixerDouble('f2'), false);
+
+        self::assertSame(['f1', 'f2', 'f3'], $factory->getRegisteredFixerNames());
+    }
+
+    public function testGetRule(): void
+    {
+        $factory = new FixerFactory();
+        $f1 = $this->createFixerDouble('f1');
+        $factory->registerFixer($f1, false);
+
+        self::assertSame($f1, $factory->getRule('f1'));
+    }
+
+    public function testGetRuleWithFqcn(): void
+    {
+        $factory = (new FixerFactory())->registerBuiltInFixers();
+
+        self::assertInstanceOf(ArraySyntaxFixer::class, $factory->getRule(ArraySyntaxFixer::class));
+    }
+
+    public function testGetRuleThrowsForNonExistentRule(): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Rule "non_existing_rule" does not exist.');
+
+        (new FixerFactory())->getRule('non_existing_rule');
     }
 
     /**

--- a/tests/FixerNameValidatorTest.php
+++ b/tests/FixerNameValidatorTest.php
@@ -96,6 +96,12 @@ final class FixerNameValidatorTest extends TestCase
 
         yield ['OneFoo\2Bar', true, false];
 
+        yield ['PhpCsFixer\Restricted', true, false];
+
+        yield ['phpcsfixer\Restricted', true, false];
+
+        yield ['PHPCSFIXER\Restricted', true, false];
+
         yield ['_Foo\bar', true, false];
 
         yield ['Foo\Bar-Bara', true, false];

--- a/tests/FixerNameValidatorTest.php
+++ b/tests/FixerNameValidatorTest.php
@@ -102,6 +102,8 @@ final class FixerNameValidatorTest extends TestCase
 
         yield ['PHPCSFIXER\Restricted', true, false];
 
+        yield ['CustomFixersForPhpCsFixer\Allowed', true, true];
+
         yield ['_Foo\bar', true, false];
 
         yield ['Foo\Bar-Bara', true, false];

--- a/tests/FixerNameValidatorTest.php
+++ b/tests/FixerNameValidatorTest.php
@@ -70,7 +70,7 @@ final class FixerNameValidatorTest extends TestCase
 
         yield ['vendor/foo', false, false];
 
-        yield ['bendor/foo', true, false];
+        yield ['vendor/foo', true, true];
 
         yield ['Vendor/foo', true, true];
 
@@ -80,11 +80,25 @@ final class FixerNameValidatorTest extends TestCase
 
         yield ['FooBar/foo', true, true];
 
+        yield ['foo\bar', true, true];
+
+        yield ['Foo\Bar', true, true];
+
+        yield ['Foo\Bar\Baz', true, true];
+
+        yield ['FooBar\B4z\MyFixer123', true, true];
+
         yield ['Foo-Bar/foo', true, false];
 
         yield ['Foo_Bar/foo', true, false];
 
         yield ['Foo/foo/bar', true, false];
+
+        yield ['OneFoo\2Bar', true, false];
+
+        yield ['_Foo\bar', true, false];
+
+        yield ['Foo\Bar-Bara', true, false];
 
         yield ['/foo', true, false];
 

--- a/tests/Fixtures/.php-cs-fixer.fqcn.php
+++ b/tests/Fixtures/.php-cs-fixer.fqcn.php
@@ -1,0 +1,31 @@
+<?php
+
+return (new PhpCsFixer\Config())
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->files()
+            ->in(__DIR__)
+            ->name(__FILE__)
+    )
+    ->setUsingCache(false)
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PhpCsFixer' => true,
+        // Overrides @PhpCsFixer's ruleset config (FQCN) using legacy fixer name.
+        // This basically checks if fixers' names are normalized and legacy names can be used interchangeably with FQCNs.
+        // Without this Fixer would have wanted to import `PhpCsFixer\Config` and `PhpCsFixer\Finder` used in config.
+        'fully_qualified_strict_types' => [
+            'import_symbols' => false,
+        ],
+        // Overrides @PhpCsFixer's ruleset config (FQCN) using FQCN.
+        PhpCsFixer\Fixer\Semicolon\MultilineWhitespaceBeforeSemicolonsFixer::class => [
+            'strategy' => 'no_multi_line',
+        ],
+        // Overrides @Symfony's ruleset config (legacy name) with FQCN.
+        // We're disabling it here so the missing comma after last fixer is not reported.
+        PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer::class => false,
+        // This adds new fixer not defined in the @PhpCsFixer (and nested rulesets)
+        // This verifies that FQCNs used as raw strings also work as a rule name.
+        'PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer' => true
+    ])
+;

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -279,14 +279,14 @@ final class RuleSetTest extends TestCase
             ],
         ];
 
-        yield 'same rule configure three times with different approaches for names, but with leading backslash in raw string\'s FQCN' => [
+        yield 'same rule configure three times with different approaches for names, with leading backslash in raw string\'s FQCN' => [
             [
                 '\PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer' => true,
-                'array_syntax' => false,
-                ArraySyntaxFixer::class => true,
+                'array_syntax' => ['syntax' => 'long'],
+                ArraySyntaxFixer::class => ['syntax' => 'short'],
             ],
             [
-                'array_syntax' => true,
+                'array_syntax' => ['syntax' => 'short'],
             ],
         ];
 

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -67,20 +67,13 @@ final class RuleSetTest extends TestCase
         $factory = new FixerFactory();
         $factory->registerBuiltInFixers();
 
-        $fixers = [];
-
-        foreach ($factory->getFixers() as $fixer) {
-            $fixers[$fixer->getName()] = $fixer;
-        }
-
-        self::assertArrayHasKey($ruleName, $fixers, \sprintf('RuleSet "%s" contains unknown rule.', $setName));
+        self::assertTrue($factory->hasRule($ruleName), \sprintf('RuleSet "%s" contains unknown rule.', $setName));
 
         if (true === $ruleConfig) {
             return; // rule doesn't need configuration.
         }
 
-        \assert(\array_key_exists($ruleName, $fixers));
-        $fixer = $fixers[$ruleName];
+        $fixer = $factory->getRule($ruleName);
         self::assertInstanceOf(ConfigurableFixerInterface::class, $fixer, \sprintf('RuleSet "%s" contains configuration for rule "%s" which cannot be configured.', $setName, $ruleName));
 
         try {

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -188,6 +188,7 @@ final class RuleSetTest extends TestCase
      *
      * @dataProvider provideResolveRulesWithSetCases
      */
+    #[DataProvider('provideResolveRulesWithSetCases')]
     public function testResolveRulesWithSet(array $input, array $output): void
     {
         $ruleSet = new RuleSet($input);

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace PhpCsFixer\Tests\RuleSet;
 
 use PhpCsFixer\ConfigurationException\InvalidForEnvFixerConfigurationException;
+use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Fixer\DeprecatedFixerInterface;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTargetVersion;
@@ -181,59 +182,125 @@ final class RuleSetTest extends TestCase
         new RuleSet(['braces']);
     }
 
-    public function testResolveRulesWithSet(): void
+    /**
+     * @param array<string, array<string, mixed>|bool> $input
+     * @param array<string, array<string, mixed>|bool> $output
+     *
+     * @dataProvider provideResolveRulesWithSetCases
+     */
+    public function testResolveRulesWithSet(array $input, array $output): void
     {
-        $ruleSet = new RuleSet([
-            '@PSR1' => true,
-            'braces' => true,
-            'encoding' => false,
-            'line_ending' => true,
-            'strict_comparison' => true,
-        ]);
+        $ruleSet = new RuleSet($input);
 
-        self::assertSameRules(
+        self::assertSameRules($output, $ruleSet->getRules());
+    }
+
+    /**
+     * @return iterable<string, array{array<string, array<string, mixed>|bool>, array<string, array<string, mixed>|bool>}>
+     */
+    public static function provideResolveRulesWithSetCases(): iterable
+    {
+        yield 'overriding ruleset' => [
+            [
+                '@PSR1' => true,
+                'braces' => true,
+                'encoding' => false,
+                'line_ending' => true,
+                'strict_comparison' => true,
+            ],
             [
                 'braces' => true,
                 'full_opening_tag' => true,
                 'line_ending' => true,
                 'strict_comparison' => true,
             ],
-            $ruleSet->getRules(),
-        );
-    }
+        ];
 
-    public function testResolveRulesWithNestedSet(): void
-    {
-        $ruleSet = new RuleSet([
-            '@PHP70Migration' => true,
-            'strict_comparison' => true,
-        ]);
-
-        self::assertSameRules(
+        yield 'overriding ruleset with nested set' => [
+            [
+                '@PHP70Migration' => true,
+                'strict_comparison' => true,
+            ],
             [
                 'array_syntax' => true,
                 'strict_comparison' => true,
                 'ternary_to_null_coalescing' => true,
             ],
-            $ruleSet->getRules(),
-        );
-    }
+        ];
 
-    public function testResolveRulesWithDisabledSet(): void
-    {
-        $ruleSet = new RuleSet([
-            '@PHP70Migration' => true,
-            '@PHP54Migration' => false,
-            'strict_comparison' => true,
-        ]);
-
-        self::assertSameRules(
+        yield 'overriding ruleset with disabled set' => [
+            [
+                '@PHP70Migration' => true,
+                '@PHP54Migration' => false,
+                'strict_comparison' => true,
+            ],
             [
                 'strict_comparison' => true,
                 'ternary_to_null_coalescing' => true,
             ],
-            $ruleSet->getRules(),
-        );
+        ];
+
+        yield 'FQCN as rule name' => [
+            [
+                ArraySyntaxFixer::class => true,
+            ],
+            [
+                'array_syntax' => true,
+            ],
+        ];
+
+        yield 'FQCN as rule name overridden by next entry that uses rule name' => [
+            [
+                ArraySyntaxFixer::class => false,
+                'array_syntax' => true,
+            ],
+            [
+                'array_syntax' => true,
+            ],
+        ];
+
+        yield 'native rule name overridden by next entry with FQCN as rule name (class resolution)' => [
+            [
+                'array_syntax' => false,
+                ArraySyntaxFixer::class => true,
+            ],
+            [
+                'array_syntax' => true,
+            ],
+        ];
+
+        yield 'native rule name overridden by next entry with FQCN as rule name (raw string)' => [
+            [
+                'array_syntax' => false,
+                'PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer' => true,
+            ],
+            [
+                'array_syntax' => true,
+            ],
+        ];
+
+        yield 'same rule configure three times with different approaches for names, but with leading backslash in raw string\'s FQCN' => [
+            [
+                '\PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer' => true,
+                'array_syntax' => false,
+                ArraySyntaxFixer::class => true,
+            ],
+            [
+                'array_syntax' => true,
+            ],
+        ];
+
+        // This one is weird, because you would expect that `array_syntax` is enabled,
+        // but seems like PHP reduces the array and keeps only first (not last!) entry with FQCN as a key.
+        yield 'same rule configure three times with different approaches for names, with weird behaviour for array canonicalising' => [
+            [
+                // @phpstan-ignore array.duplicateKey (we explicitly test this particular behaviour with same key defined twice)
+                'PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer' => true,
+                'array_syntax' => false,
+                ArraySyntaxFixer::class => true,
+            ],
+            [],
+        ];
     }
 
     /**

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -280,7 +280,7 @@ final class RuleSetTest extends TestCase
             ],
         ];
 
-        yield 'same rule configure three times with different approaches for names, with leading backslash in raw string\'s FQCN' => [
+        yield 'same rule configured three times with different approaches for names, with leading backslash in raw string\'s FQCN' => [
             [
                 '\PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer' => true,
                 'array_syntax' => ['syntax' => 'long'],
@@ -293,7 +293,7 @@ final class RuleSetTest extends TestCase
 
         // This one is weird, because you would expect that `array_syntax` is enabled,
         // but seems like PHP reduces the array and keeps only first (not last!) entry with FQCN as a key.
-        yield 'same rule configure three times with different approaches for names, with weird behaviour for array canonicalising' => [
+        yield 'same rule configured three times with different approaches for names, with weird behaviour for array canonicalising' => [
             [
                 // @phpstan-ignore array.duplicateKey (we explicitly test this particular behaviour with same key defined twice)
                 'PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer' => true,

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -270,13 +270,17 @@ final class RuleSetTest extends TestCase
             ],
         ];
 
+        // `strict_comparison` added here only to make this test case unique,
+        // otherwise ProjectCodeTest::testDataFromDataProviders() reports it as duplicate of the one above.
         yield 'native rule name overridden by next entry with FQCN as rule name (raw string)' => [
             [
                 'array_syntax' => false,
                 'PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer' => true,
+                'strict_comparison' => true,
             ],
             [
                 'array_syntax' => true,
+                'strict_comparison' => true,
             ],
         ];
 


### PR DESCRIPTION
Fixes #7062

- Allow FQCN as fixer name
- Allow lowercased vendor in custom fixers (foo/bar)
- Allow using FQCN in rulesets configuration (as a array key, for including/configuring/excluding rule in the set)