### PR TITLE
bug: Improve definition of conflicting fixers

### DIFF
--- a/src/FixerFactory.php
+++ b/src/FixerFactory.php
@@ -200,6 +200,10 @@ final class FixerFactory
     private function getFixersConflicts(FixerInterface $fixer): array
     {
         static $conflictMap = [
+            'blank_lines_before_namespace' => [
+                'no_blank_lines_before_namespace',
+                'single_blank_line_before_namespace',
+            ],
             'no_blank_lines_before_namespace' => ['single_blank_line_before_namespace'],
             'single_import_per_statement' => ['group_import'],
         ];


### PR DESCRIPTION
Missing in #7053, new fixer should NOT be used along with deprecated ones.