### PR TITLE
DX: add `php_unit_data_provider_name` to `@PhpCsFixer:risky` set

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2449,6 +2449,8 @@ List of Available Rules
      | Default value: ``'Cases'``
 
 
+   Part of rule set `@PhpCsFixer:risky <./ruleSets/PhpCsFixerRisky.rst>`_
+
    `Source PhpCsFixer\\Fixer\\PhpUnit\\PhpUnitDataProviderNameFixer <./../src/Fixer/PhpUnit/PhpUnitDataProviderNameFixer.php>`_
 -  `php_unit_data_provider_static <./rules/php_unit/php_unit_data_provider_static.rst>`_
 

--- a/doc/ruleSets/PhpCsFixerRisky.rst
+++ b/doc/ruleSets/PhpCsFixerRisky.rst
@@ -19,6 +19,7 @@ Rules
   ``['sets' => ['@all']]``
 - `no_unreachable_default_argument_value <./../rules/function_notation/no_unreachable_default_argument_value.rst>`_
 - `no_unset_on_property <./../rules/language_construct/no_unset_on_property.rst>`_
+- `php_unit_data_provider_name <./../rules/php_unit/php_unit_data_provider_name.rst>`_
 - `php_unit_strict <./../rules/php_unit/php_unit_strict.rst>`_
 - `php_unit_test_case_static_method_calls <./../rules/php_unit/php_unit_test_case_static_method_calls.rst>`_
   config:

--- a/doc/rules/php_unit/php_unit_data_provider_name.rst
+++ b/doc/rules/php_unit/php_unit_data_provider_name.rst
@@ -112,3 +112,11 @@ With configuration: ``['prefix' => 'provides', 'suffix' => 'Data']``.
         public function dataProviderUsedAsFirstInTest() {}
         public function dataProviderUsedAsSecondInTest() {}
     }
+
+Rule sets
+---------
+
+The rule is part of the following rule set:
+
+@PhpCsFixer:risky
+  Using the `@PhpCsFixer:risky <./../../ruleSets/PhpCsFixerRisky.rst>`_ rule set will enable the ``php_unit_data_provider_name`` rule with the default config.

--- a/src/RuleSet/Sets/PhpCsFixerRiskySet.php
+++ b/src/RuleSet/Sets/PhpCsFixerRiskySet.php
@@ -49,6 +49,7 @@ final class PhpCsFixerRiskySet extends AbstractRuleSetDescription
             ],
             'no_unreachable_default_argument_value' => true,
             'no_unset_on_property' => true,
+            'php_unit_data_provider_name' => true,
             'php_unit_strict' => true,
             'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
             'strict_comparison' => true,

--- a/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
@@ -382,7 +382,7 @@ enum Foo: int {
     }
 
     /**
-     * @dataProvider provideNotPhpdocCandidatePhp811Cases
+     * @dataProvider provideNotPhpdocCandidatePhp81Cases
      *
      * @requires PHP 8.1
      */
@@ -395,7 +395,7 @@ enum Foo: int {
         self::assertFalse($analyzer->isBeforeStructuralElement($tokens, $index));
     }
 
-    public static function provideNotPhpdocCandidatePhp811Cases(): iterable
+    public static function provideNotPhpdocCandidatePhp81Cases(): iterable
     {
         yield 'enum and switch' => [
             '<?php


### PR DESCRIPTION
Follow up to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7058 and https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7057 motivated by [this comment](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7058#discussion_r1231945744).