### PR TITLE
DX: rename tests and data providers

### DIFF
--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -145,9 +145,9 @@ final class FixerFactoryTest extends TestCase
     }
 
     /**
-     * @dataProvider providePriorityIntegrationTestFilesAreListedAsPriorityCasesCases
+     * @dataProvider providePriorityIntegrationTestFilesAreListedInPriorityGraphCases
      */
-    public function testPriorityIntegrationTestFilesAreListedAsPriorityCases(\SplFileInfo $file): void
+    public function testPriorityIntegrationTestFilesAreListedInPriorityGraph(\SplFileInfo $file): void
     {
         $fileName = $file->getFilename();
 
@@ -168,7 +168,7 @@ final class FixerFactoryTest extends TestCase
         );
     }
 
-    public static function providePriorityIntegrationTestFilesAreListedAsPriorityCasesCases(): iterable
+    public static function providePriorityIntegrationTestFilesAreListedInPriorityGraphCases(): iterable
     {
         foreach (new \DirectoryIterator(self::getIntegrationPriorityDirectory()) as $candidate) {
             if (!$candidate->isDot()) {

--- a/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
+++ b/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
@@ -29,7 +29,6 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideFixEchoToPrintCases
-     * @dataProvider provideEchoToPrintFixNewCases
      */
     public function testFixEchoToPrint(string $expected, ?string $input = null): void
     {
@@ -37,9 +36,9 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixEchoToPrintCases(): array
+    public static function provideFixEchoToPrintCases(): iterable
     {
-        return [
+        yield from [
             [
                 '<?php
                 print "test";
@@ -132,10 +131,7 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
                 '<?=$foo?>',
             ],
         ];
-    }
 
-    public static function provideEchoToPrintFixNewCases(): iterable
-    {
         foreach (self::getCodeSnippetsToConvertBothWays() as $codeSnippet) {
             yield [
                 sprintf($codeSnippet, 'print'),
@@ -146,7 +142,6 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPrintToEchoCases
-     * @dataProvider providePrintToEchoFixNewCases
      */
     public function testFixPrintToEcho(string $expected, ?string $input = null): void
     {
@@ -154,9 +149,9 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixPrintToEchoCases(): array
+    public static function provideFixPrintToEchoCases(): iterable
     {
-        return [
+        yield from [
             [
                 '<?php
                 echo "test";
@@ -270,10 +265,7 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
-    }
 
-    public static function providePrintToEchoFixNewCases(): iterable
-    {
         foreach (self::getCodeSnippetsToConvertBothWays() as $codeSnippet) {
             yield [
                 sprintf($codeSnippet, 'echo'),

--- a/tests/Fixer/Casing/ConstantCaseFixerTest.php
+++ b/tests/Fixer/Casing/ConstantCaseFixerTest.php
@@ -99,15 +99,15 @@ final class ConstantCaseFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideFixLowerGeneratedCasesCases
+     * @dataProvider provideFixToLowerCases
      */
-    public function testFixLowerGeneratedCases(string $expected, ?string $input = null): void
+    public function testFixToLower(string $expected, ?string $input = null): void
     {
         $this->fixer->configure(['case' => 'lower']);
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixLowerGeneratedCasesCases(): iterable
+    public static function provideFixToLowerCases(): iterable
     {
         foreach (['true', 'false', 'null'] as $case) {
             yield [
@@ -131,15 +131,15 @@ final class ConstantCaseFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideFixUpperGeneratedCasesCases
+     * @dataProvider provideFixToUpperCases
      */
-    public function testFixUpperGeneratedCases(string $expected, ?string $input = null): void
+    public function testFixToUpper(string $expected, ?string $input = null): void
     {
         $this->fixer->configure(['case' => 'upper']);
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixUpperGeneratedCasesCases(): iterable
+    public static function provideFixToUpperCases(): iterable
     {
         foreach (['true', 'false', 'null'] as $case) {
             yield [

--- a/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
@@ -337,9 +337,9 @@ class Foo {}
      * @param string      $expected PHP source code
      * @param null|string $input    PHP source code
      *
-     * @dataProvider provideAnonymousClassesCasesCases
+     * @dataProvider provideAnonymousClassesCases
      */
-    public function testAnonymousClassesCases(string $expected, ?string $input = null): void
+    public function testAnonymousClasses(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -347,7 +347,7 @@ class Foo {}
     /**
      * @return iterable<int|string, array{0: string, 1?: string}>
      */
-    public static function provideAnonymousClassesCasesCases(): iterable
+    public static function provideAnonymousClassesCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/ClassNotation/OrderedTypesFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedTypesFixerTest.php
@@ -26,11 +26,11 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class OrderedTypesFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideFixCasesCases
+     * @dataProvider provideFixCases
      *
      * @param null|array<string, string> $config
      */
-    public function testFixCases(string $expected, ?string $input = null, ?array $config = null): void
+    public function testFix(string $expected, ?string $input = null, ?array $config = null): void
     {
         if (null !== $config) {
             $this->fixer->configure($config);
@@ -42,7 +42,7 @@ final class OrderedTypesFixerTest extends AbstractFixerTestCase
     /**
      * @return iterable<string, (null|array<string, string>|string)[]|string[]>
      */
-    public static function provideFixCasesCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'catch with default, no spaces, with both leading slash' => [
             '<?php
@@ -204,11 +204,11 @@ try {
     }
 
     /**
-     * @dataProvider provideFixDefaultCasesCases
+     * @dataProvider provideFixDefaultCases
      *
      * @requires PHP 8.0
      */
-    public function testFixDefaultCases(string $expected, ?string $input = null): void
+    public function testFixDefault(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -216,7 +216,7 @@ try {
     /**
      * @return iterable<(null|array<string, string>|string)[]|string[]>
      */
-    public static function provideFixDefaultCasesCases(): iterable
+    public static function provideFixDefaultCases(): iterable
     {
         yield [
             "<?php\nclass Foo\n{\n    public null|int|string \$bar = null;\n}\n",

--- a/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+++ b/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
@@ -568,7 +568,7 @@ const F=1; }',
         ];
     }
 
-    public function testCommentCases(): void
+    public function testComment(): void
     {
         $expected = '<?php
 class A

--- a/tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
+++ b/tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
@@ -218,15 +218,15 @@ second line*/',
     }
 
     /**
-     * @dataProvider provideHashCasesCases
+     * @dataProvider provideHashCases
      */
-    public function testHashCases(string $expected, ?string $input = null): void
+    public function testHash(string $expected, ?string $input = null): void
     {
         $this->fixer->configure(['comment_types' => ['hash']]);
         $this->doTest($expected, $input);
     }
 
-    public static function provideHashCasesCases(): array
+    public static function provideHashCases(): array
     {
         return [
             [
@@ -288,14 +288,14 @@ second line*/',
     }
 
     /**
-     * @dataProvider provideAllCasesCases
+     * @dataProvider provideAllCases
      */
-    public function testAllCases(string $expected, ?string $input = null): void
+    public function testAll(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideAllCasesCases(): array
+    public static function provideAllCases(): array
     {
         return [
             [

--- a/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
@@ -26,14 +26,14 @@ use PhpCsFixer\Tokenizer\Tokens;
 final class NoUselessElseFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideCloseTagCasesCases
+     * @dataProvider provideCloseTagCases
      */
-    public function testCloseTagCases(string $expected, ?string $input = null): void
+    public function testCloseTag(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideCloseTagCasesCases(): array
+    public static function provideCloseTagCases(): array
     {
         return [
             [
@@ -438,14 +438,14 @@ else?><?php echo 5;',
     }
 
     /**
-     * @dataProvider provideNegativeCasesCases
+     * @dataProvider provideNegativeCases
      */
-    public function testNegativeCases(string $expected): void
+    public function testNegative(string $expected): void
     {
         $this->doTest($expected);
     }
 
-    public static function provideNegativeCasesCases(): iterable
+    public static function provideNegativeCases(): iterable
     {
         yield from [
             [
@@ -608,16 +608,16 @@ else?><?php echo 5;',
     }
 
     /**
-     * @dataProvider provideNegativePhp80CasesCases
+     * @dataProvider provideNegativePhp80Cases
      *
      * @requires PHP 8.0
      */
-    public function testNegativePhp80Cases(string $expected): void
+    public function testNegativePhp80(string $expected): void
     {
         $this->doTest($expected);
     }
 
-    public static function provideNegativePhp80CasesCases(): iterable
+    public static function provideNegativePhp80Cases(): iterable
     {
         $cases = [
             '$bar = $foo1 ?? throw new \Exception($e);',

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -817,7 +817,7 @@ switch ($a) {
     /**
      * @dataProvider providePHP71Cases
      */
-    public function testPHP71Cases(string $expected, ?string $input = null): void
+    public function testPHP71(string $expected, ?string $input = null): void
     {
         $this->fixer->configure(['equal' => true, 'identical' => true]);
         $this->doTest($expected, $input);
@@ -828,7 +828,7 @@ switch ($a) {
      *
      * @dataProvider providePHP71Cases
      */
-    public function testPHP71CasesInverse(string $expected, ?string $input = null): void
+    public function testPHP71Inverse(string $expected, ?string $input = null): void
     {
         $this->fixer->configure(['equal' => false, 'identical' => false]);
 

--- a/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
@@ -141,7 +141,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
     }
 
     /**
-     * @dataProvider provideFixInverseCases
+     * @dataProvider provideInvertedFixCases
      * @dataProvider provideInverseOnlyFixCases
      */
     public function testFixInverse(string $expected, string $input): void
@@ -327,7 +327,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
         ];
     }
 
-    public static function provideFixInverseCases(): iterable
+    public static function provideInvertedFixCases(): iterable
     {
         return TestCaseUtils::swapExpectedInputTestCases(self::provideFixCases());
     }

--- a/tests/Fixer/LanguageConstruct/GetClassToClassKeywordFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/GetClassToClassKeywordFixerTest.php
@@ -28,14 +28,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class GetClassToClassKeywordFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideFixCasesCases
+     * @dataProvider provideFixCases
      */
-    public function testFixCases(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixCasesCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -1497,9 +1497,9 @@ enum UserStatus: string {
     }
 
     /**
-     * @dataProvider provideFixWithDocCommentCasesCases
+     * @dataProvider provideFixWithDocCommentCases
      */
-    public function testFixWithDocCommentCases(string $expected, string $input = null): void
+    public function testFixWithDocComment(string $expected, string $input = null): void
     {
         $this->fixer->configure([
             'statements' => ['phpdoc'],
@@ -1508,7 +1508,7 @@ enum UserStatus: string {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixWithDocCommentCasesCases(): iterable
+    public static function provideFixWithDocCommentCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -775,9 +775,9 @@ class Foo
     }
 
     /**
-     * @dataProvider provideOneOrInLineCasesCases
+     * @dataProvider provideOneOrInLineCases
      */
-    public function testOneOrInLineCases(string $expected, ?string $input = null): void
+    public function testOneOrInLine(string $expected, ?string $input = null): void
     {
         $this->fixer->configure(['tokens' => [
             'break',
@@ -792,7 +792,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public static function provideOneOrInLineCasesCases(): iterable
+    public static function provideOneOrInLineCases(): iterable
     {
         yield [
             "<?php\n\n\$a = function() use (\$b) { while(3<1)break; \$c = \$b[1]; while(\$b<1)continue; if (true) throw \$e; return 1; };\n\n",

--- a/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
@@ -65,14 +65,14 @@ EOF;
     }
 
     /**
-     * @dataProvider provideCommentsCasesCases
+     * @dataProvider provideCommentsCases
      */
-    public function testCommentsCases(string $expected, ?string $input = null): void
+    public function testComments(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideCommentsCasesCases(): array
+    public static function provideCommentsCases(): array
     {
         return [
             [

--- a/tests/WhitespacesFixerConfigTest.php
+++ b/tests/WhitespacesFixerConfigTest.php
@@ -26,9 +26,9 @@ use PhpCsFixer\WhitespacesFixerConfig;
 final class WhitespacesFixerConfigTest extends TestCase
 {
     /**
-     * @dataProvider provideCasesCases
+     * @dataProvider provideFixCases
      */
-    public function testCases(string $indent, string $lineEnding, ?string $exceptionRegExp = null): void
+    public function testFix(string $indent, string $lineEnding, ?string $exceptionRegExp = null): void
     {
         if (null !== $exceptionRegExp) {
             $this->expectException(\InvalidArgumentException::class);
@@ -41,7 +41,7 @@ final class WhitespacesFixerConfigTest extends TestCase
         self::assertSame($lineEnding, $config->getLineEnding());
     }
 
-    public static function provideCasesCases(): array
+    public static function provideFixCases(): array
     {
         return [
             ['    ', "\n"],


### PR DESCRIPTION
Final PR related to the introduction of `PhpUnitDataProviderNameFixer`.

Manual changes method names, so data providers do not have silly names and other cleanups.