### PR TITLE
feat: Add literal separator support for `integer_literal_case`

### DIFF
--- a/src/Fixer/Basic/OctalNotationFixer.php
+++ b/src/Fixer/Basic/OctalNotationFixer.php
@@ -52,13 +52,13 @@ final class OctalNotationFixer extends AbstractFixer
 
             $content = $token->getContent();
 
-            if (!Preg::match('#^0[\d_]+$#', $content)) {
+            $newContent = Preg::replace('#^(0)_*+([0-7_]+)$#', '$1o$2', $content);
+
+            if ($content === $newContent) {
                 continue;
             }
 
-            $tokens[$index] = Preg::match('#^0+$#', $content)
-                ? new Token([T_LNUMBER, '0'])
-                : new Token([T_LNUMBER, '0o'.('_' === $content[1] ? '0' : '').substr($content, 1)]);
+            $tokens[$index] = new Token([T_LNUMBER, $newContent]);
         }
     }
 }

--- a/src/Fixer/Basic/OctalNotationFixer.php
+++ b/src/Fixer/Basic/OctalNotationFixer.php
@@ -52,7 +52,7 @@ final class OctalNotationFixer extends AbstractFixer
 
             $content = $token->getContent();
 
-            $newContent = Preg::replace('#^(0)_*+([0-7_]+)$#', '$1o$2', $content);
+            $newContent = Preg::replace('#^0_*+([0-7_]+)$#', '0o$1', $content);
 
             if ($content === $newContent) {
                 continue;

--- a/src/Fixer/Casing/IntegerLiteralCaseFixer.php
+++ b/src/Fixer/Casing/IntegerLiteralCaseFixer.php
@@ -50,11 +50,9 @@ final class IntegerLiteralCaseFixer extends AbstractFixer
 
             $content = $token->getContent();
 
-            if (!Preg::match('#^0[bxoBXO][0-9a-fA-F]+$#', $content)) {
-                continue;
-            }
-
-            $newContent = '0'.strtolower($content[1]).strtoupper(substr($content, 2));
+            $newContent = Preg::replaceCallback('#^(0)([boxBOX])([0-9a-fA-F_]+)$#', function ($matches) {
+                return $matches[1].strtolower($matches[2]).strtoupper($matches[3]);
+            }, $content);
 
             if ($content === $newContent) {
                 continue;

--- a/src/Fixer/Casing/IntegerLiteralCaseFixer.php
+++ b/src/Fixer/Casing/IntegerLiteralCaseFixer.php
@@ -50,8 +50,8 @@ final class IntegerLiteralCaseFixer extends AbstractFixer
 
             $content = $token->getContent();
 
-            $newContent = Preg::replaceCallback('#^(0)([boxBOX])([0-9a-fA-F_]+)$#', function ($matches) {
-                return $matches[1].strtolower($matches[2]).strtoupper($matches[3]);
+            $newContent = Preg::replaceCallback('#^0([boxBOX])([0-9a-fA-F_]+)$#', function ($matches) {
+                return '0'.strtolower($matches[1]).strtoupper($matches[2]);
             }, $content);
 
             if ($content === $newContent) {

--- a/src/Fixer/Casing/IntegerLiteralCaseFixer.php
+++ b/src/Fixer/Casing/IntegerLiteralCaseFixer.php
@@ -50,9 +50,7 @@ final class IntegerLiteralCaseFixer extends AbstractFixer
 
             $content = $token->getContent();
 
-            $newContent = Preg::replaceCallback('#^0([boxBOX])([0-9a-fA-F_]+)$#', function ($matches) {
-                return '0'.strtolower($matches[1]).strtoupper($matches[2]);
-            }, $content);
+            $newContent = Preg::replaceCallback('#^0([boxBOX])([0-9a-fA-F_]+)$#', static fn ($matches) => '0'.strtolower($matches[1]).strtoupper($matches[2]), $content);
 
             if ($content === $newContent) {
                 continue;

--- a/tests/Fixer/Basic/OctalNotationFixerTest.php
+++ b/tests/Fixer/Basic/OctalNotationFixerTest.php
@@ -55,7 +55,7 @@ final class OctalNotationFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
-            '<?php $foo = 0;',
+            '<?php $foo = 0o0000;',
             '<?php $foo = 00000;',
         ];
 
@@ -76,8 +76,13 @@ final class OctalNotationFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
-            '<?php $foo = 0o0_123_456;',
-            '<?php $foo = 0_123_456;',
+            '<?php $foo = +0o1_234;',
+            '<?php $foo = +01_234;',
+        ];
+
+        yield [
+            '<?php $foo = -0o123_456;',
+            '<?php $foo = -0_123_456;',
         ];
     }
 }

--- a/tests/Fixer/Casing/IntegerLiteralCaseFixerTest.php
+++ b/tests/Fixer/Casing/IntegerLiteralCaseFixerTest.php
@@ -44,12 +44,42 @@ final class IntegerLiteralCaseFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
+            '<?php $foo = -0xA1FB20;',
+            '<?php $foo = -0xa1fb20;',
+        ];
+
+        yield [
             '<?php $foo = 0b1101;',
             '<?php $foo = 0B1101;',
         ];
 
         yield [
             '<?php $A = 1_234_567;',
+        ];
+
+        yield [
+            '<?php $A = +0xAA_FF_00;',
+            '<?php $A = +0Xaa_ff_00;',
+        ];
+
+        yield [
+            '<?php $A = -0x00_AA_FF_00;',
+            '<?php $A = -0X00_aa_ff_00;',
+        ];
+
+        yield 'bin_PHP_INT_MAX' => [
+            '<?php $foo = 0b111111111111111111111111111111111111111111111111111111111111111;',
+            '<?php $foo = 0B111111111111111111111111111111111111111111111111111111111111111;',
+        ];
+
+        yield 'hex_plus_PHP_INT_MAX' => [
+            '<?php $foo = +0x7FFFFFFFFFFFFFFF;',
+            '<?php $foo = +0X7fffffffffffffff;',
+        ];
+
+        yield 'hex_minus_PHP_INT_MAX' => [
+            '<?php $foo = -0x7FFFFFFFFFFFFFFF;',
+            '<?php $foo = -0X7fffffffffffffff;',
         ];
     }
 
@@ -68,6 +98,11 @@ final class IntegerLiteralCaseFixerTest extends AbstractFixerTestCase
         yield [
             '<?php $foo = 0o123;',
             '<?php $foo = 0O123;',
+        ];
+
+        yield [
+            '<?php $foo = -0o123;',
+            '<?php $foo = -0O123;',
         ];
     }
 }


### PR DESCRIPTION
and simplify the fixers

and add tests with +/- sign, although sign is parsed as a separate token