### PR TITLE
feature: Add "number_literal_case" rule

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -795,6 +795,13 @@ List of Available Rules
    *warning risky* Risky when overriding ``public`` methods of ``abstract`` classes.
 
    `Source PhpCsFixer\\Fixer\\ClassNotation\\FinalPublicMethodForAbstractClassFixer <./../src/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixer.php>`_
+-  `float_literal_case <./rules/casing/float_literal_case.rst>`_
+
+   Float literals must be in correct case.
+
+   Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+
+   `Source PhpCsFixer\\Fixer\\Casing\\FloatLiteralCaseFixer <./../src/Fixer/Casing/FloatLiteralCaseFixer.php>`_
 -  `fopen_flags <./rules/function_notation/fopen_flags.rst>`_
 
    The flags in ``fopen`` calls must omit ``t``, and ``b`` must be omitted or included consistently.

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -34,6 +34,7 @@ Rules
   config:
   ``['style' => 'braces']``
 - `empty_loop_condition <./../rules/control_structure/empty_loop_condition.rst>`_
+- `float_literal_case <./../rules/casing/float_literal_case.rst>`_
 - `fully_qualified_strict_types <./../rules/import/fully_qualified_strict_types.rst>`_
 - `function_typehint_space <./../rules/function_notation/function_typehint_space.rst>`_
 - `general_phpdoc_tag_rename <./../rules/phpdoc/general_phpdoc_tag_rename.rst>`_

--- a/doc/rules/casing/float_literal_case.rst
+++ b/doc/rules/casing/float_literal_case.rst
@@ -1,0 +1,32 @@
+===========================
+Rule ``float_literal_case``
+===========================
+
+Float literals must be in correct case.
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -$foo = 1e80;
+   -$bar = 2.5e-3;
+   +$foo = 1E80;
+   +$bar = 2.5E-3;
+
+Rule sets
+---------
+
+The rule is part of the following rule sets:
+
+@PhpCsFixer
+  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``float_literal_case`` rule.
+
+@Symfony
+  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``float_literal_case`` rule.

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -104,6 +104,9 @@ Casing
 - `constant_case <./casing/constant_case.rst>`_
 
   The PHP constants ``true``, ``false``, and ``null`` MUST be written using the correct casing.
+- `float_literal_case <./casing/float_literal_case.rst>`_
+
+  Float literals must be in correct case.
 - `integer_literal_case <./casing/integer_literal_case.rst>`_
 
   Integer literals must be in correct case.

--- a/src/Fixer/Casing/FloatLiteralCaseFixer.php
+++ b/src/Fixer/Casing/FloatLiteralCaseFixer.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Casing;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class FloatLiteralCaseFixer extends AbstractFixer
+{
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Float literals must be in correct case.',
+            [
+                new CodeSample(
+                    "<?php\n\$foo = 1e80;\n\$bar = 2.5e-3;\n"
+                ),
+            ]
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_DNUMBER);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_DNUMBER)) {
+                continue;
+            }
+
+            $content = $token->getContent();
+
+            $newContent = str_replace('e', 'E', $content);
+
+            if ($content === $newContent) {
+                continue;
+            }
+
+            $tokens[$index] = new Token([T_DNUMBER, $newContent]);
+        }
+    }
+}

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -54,6 +54,7 @@ final class SymfonySet extends AbstractRuleSetDescription
             'echo_tag_syntax' => true,
             'empty_loop_body' => ['style' => 'braces'],
             'empty_loop_condition' => true,
+            'float_literal_case' => true,
             'fully_qualified_strict_types' => true,
             'function_typehint_space' => true,
             'general_phpdoc_tag_rename' => [

--- a/tests/Fixer/Casing/FloatLiteralCaseFixerTest.php
+++ b/tests/Fixer/Casing/FloatLiteralCaseFixerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Casing;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Casing\FloatLiteralCaseFixer
+ */
+final class FloatLiteralCaseFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix(string $expected, string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixCases(): iterable
+    {
+        yield [
+            '<?php $foo1 = 1.0; $foo2 = 1E+10; $foo3 = -1E-10;',
+            '<?php $foo1 = 1.0; $foo2 = 1e+10; $foo3 = -1e-10;',
+        ];
+
+        yield [
+            '<?php $foo = 1E0;',
+            '<?php $foo = 1e0;',
+        ];
+
+        yield [
+            '<?php $foo = .1E-0;',
+            '<?php $foo = .1e-0;',
+        ];
+
+        yield [
+            '<?php $foo = 8.2023437675747321E320;',
+            '<?php $foo = 8.2023437675747321e320;',
+        ];
+
+        yield [
+            '<?php $foo = 123_456_789E+0_2_0;',
+            '<?php $foo = 123_456_789e+0_2_0;',
+        ];
+    }
+}


### PR DESCRIPTION
like `integer_literal_case` rule, but for floats, `integer_literal_case` is deprecated in favor of the new fixer (per discussion below)