### PR TITLE
DX: Correctly discover non-default priorities in fixers

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitDataProviderNameFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDataProviderNameFixer.php
@@ -115,11 +115,6 @@ class FooTest extends TestCase {
         ]);
     }
 
-    public function getPriority(): int
-    {
-        return 0;
-    }
-
     public function isRisky(): bool
     {
         return true;

--- a/src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
+++ b/src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
@@ -55,16 +55,6 @@ EOT
         );
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * Must run after ExplicitStringVariableFixer.
-     */
-    public function getPriority(): int
-    {
-        return -10;
-    }
-
     public function isCandidate(Tokens $tokens): bool
     {
         return $tokens->isTokenKindFound(T_DOLLAR_OPEN_CURLY_BRACES);


### PR DESCRIPTION
Non-default priority is the priority defined inside of a fixer, not just `0`.