### PR TITLE
bug: CurlyBracesPositionFixer - fix for someting that is wrong

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }} tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
+++ b/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
@@ -713,6 +713,24 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
 }
 ',
         ];
+
+        yield 'function as argument to function call' => [
+            '<?php
+f(function () { if (true) {} });
+',
+        ];
+
+        yield 'function as argument to function calls' => [
+            '<?php
+f1(function () { if (true) {} });
+f2(function () { if (true) {
+} });
+',
+            '<?php
+f1(function () { if (true) {} });
+f2(function () { if (true) {} });
+',
+        ];
     }
 
     /**

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -431,12 +431,12 @@ abstract class AbstractFixerTestCase extends TestCase
             $this->fixer->fix($file, $tokens);
         }
 
-        self::assertThat(
-            $tokens->generateCode(),
-            new IsIdenticalString($expected),
-            'Code build on expected code must not change.'
-        );
-        self::assertFalse($tokens->isChanged(), 'Tokens collection built on expected code must not be marked as changed after fixing.');
+        // self::assertThat(
+        //     $tokens->generateCode(),
+        //     new IsIdenticalString($expected),
+        //     'Code build on expected code must not change.'
+        // );
+        // self::assertFalse($tokens->isChanged(), 'Tokens collection built on expected code must not be marked as changed after fixing.');
     }
 
     protected function lintSource(string $source): ?string


### PR DESCRIPTION
Help would be welcomed here, `CurlyBracesPositionFixer` is scary.

Changes in `tests/Test/AbstractFixerTestCase.php` are to show that the test cases are changed that way, but the 2nd one is changed once again after fixing.