### PR TITLE
bug: PhpdocAddMissingParamAnnotationFixer - fix for promoted properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }} tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }} tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -27,6 +27,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -128,7 +129,6 @@ function f9(string $foo, $bar, $baz) {}
                 T_PROTECTED,
                 T_PUBLIC,
                 T_STATIC,
-                T_VAR,
             ])) {
                 $index = $tokens->getNextMeaningfulToken($index);
             }
@@ -232,7 +232,16 @@ function f9(string $foo, $bar, $baz) {}
         for ($index = $start; $index <= $end; ++$index) {
             $token = $tokens[$index];
 
-            if ($token->isComment() || $token->isWhitespace()) {
+            if (
+                $token->isComment()
+                || $token->isWhitespace()
+                || $token->isGivenKind([
+                    CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE,
+                    CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED,
+                    CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC,
+                ])
+                || \defined('T_READONLY') && $token->isGivenKind(T_READONLY)
+            ) {
                 continue;
             }
 

--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -240,7 +240,7 @@ function f9(string $foo, $bar, $baz) {}
                     CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED,
                     CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC,
                 ])
-                || \defined('T_READONLY') && $token->isGivenKind(T_READONLY)
+                || (\defined('T_READONLY') && $token->isGivenKind(T_READONLY))
             ) {
                 continue;
             }

--- a/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
@@ -493,4 +493,77 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
             ],
         ];
     }
+
+    /**
+     * @dataProvider provideFix80Cases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFix80(string $expected, ?string $input = null): void
+    {
+        $this->fixer->configure(['only_untyped' => false]);
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFix80Cases(): iterable
+    {
+        yield [
+            '<?php class Foo {
+                /**
+                 * @param Bar $x
+                 * @param ?Bar $y
+                 * @param null|Bar $z
+                 */
+                public function __construct(
+                    Bar $x,
+                    ?Bar $y,
+                    null|Bar $z,
+                ) {}
+            }',
+            '<?php class Foo {
+                /**
+                 */
+                public function __construct(
+                    Bar $x,
+                    ?Bar $y,
+                    null|Bar $z,
+                ) {}
+            }',
+        ];
+    }
+
+    /**
+     * @dataProvider provideFix81Cases
+     *
+     * @requires PHP 8.1
+     */
+    public function testFix81(string $expected, ?string $input = null): void
+    {
+        $this->fixer->configure(['only_untyped' => false]);
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFix81Cases(): iterable
+    {
+        yield [
+            '<?php class Foo {
+                /**
+                 * @param Bar $bar
+                 * @param Baz $baz
+                 */
+                public function __construct(
+                    Bar $bar,
+                    Baz $baz,
+                ) {}
+            }',
+            '<?php class Foo {
+                /**
+                 */
+                public function __construct(
+                    Bar $bar,
+                    Baz $baz,
+                ) {}
+            }',
+        ];
+    }
 }

--- a/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
@@ -515,18 +515,18 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
                  * @param null|Bar $z
                  */
                 public function __construct(
-                    Bar $x,
-                    ?Bar $y,
-                    null|Bar $z,
+                    public Bar $x,
+                    protected ?Bar $y,
+                    private null|Bar $z,
                 ) {}
             }',
             '<?php class Foo {
                 /**
                  */
                 public function __construct(
-                    Bar $x,
-                    ?Bar $y,
-                    null|Bar $z,
+                    public Bar $x,
+                    protected ?Bar $y,
+                    private null|Bar $z,
                 ) {}
             }',
         ];
@@ -552,16 +552,16 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
                  * @param Baz $baz
                  */
                 public function __construct(
-                    Bar $bar,
-                    Baz $baz,
+                    public readonly Bar $bar,
+                    readonly public Baz $baz,
                 ) {}
             }',
             '<?php class Foo {
                 /**
                  */
                 public function __construct(
-                    Bar $bar,
-                    Baz $baz,
+                    public readonly Bar $bar,
+                    readonly public Baz $baz,
                 ) {}
             }',
         ];


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7075