### PR TITLE
DX: use FAST_LINT_TEST_CASES=1 for CI run on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           - operating-system: 'macos-latest'
             php-version: '8.2'
             job-description: 'on macOS'
+            FAST_LINT_TEST_CASES: 1
 
     name: PHP ${{ matrix.php-version }} ${{ matrix.job-description }}
 


### PR DESCRIPTION
As of writing this, there is a failed action on master, once again related to macOS run: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/actions/runs/5370809936/jobs/9743153345
![image](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/9282069/86e59995-f944-4cf2-af9a-162e5674fddc)

Sometimes it is another error, writing "30 seconds timeout exceeded".

Windows job is already using it and there is a Linux job on PHP 8.2, so this change won't make PHP 8.2 not being tested with `FAST_LINT_TEST_CASES` disabled. 