### PR TITLE
bug: Use with different case must not be removed by non-risky fixer

### DIFF
--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -175,7 +175,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
 
             if ($token->isComment()
                 && Preg::match(
-                    '/(?<![[:alnum:]\$])(?<!\\\\)'.$import->getShortName().'(?![[:alnum:]])/',
+                    '/(?<![[:alnum:]\$])(?<!\\\\)'.$import->getShortName().'(?![[:alnum:]])/i',
                     $token->getContent()
                 )
             ) {

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -696,6 +696,19 @@ EOF
                 '<?php ?>',
                 '<?php use A\B?>',
             ],
+            'case_mismatch_typo' => [
+                '<?php
+use Foo\exception; // must be kept by non-risky fixer
+
+try {
+    x();
+} catch (Exception $e) {
+    echo \'Foo\Exception caught\';
+} catch (\Exception $e) {
+    echo \'Exception caught\';
+}
+',
+            ],
             'with_matches_in_comments' => [
                 '<?php
 use Foo;

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -708,11 +708,6 @@ use Baz;
             ],
             'with_case_insensitive_matches_in_comments' => [
                 '<?php
-
-//foo
-#bar
-/*baz*/',
-                '<?php
 use Foo;
 use Bar;
 use Baz;
@@ -801,8 +796,6 @@ EOF
 class Foo extends \PHPUnit_Framework_TestCase
 {
     /**
-     * The exception is thrown when foo = bar
-     *
      * @expectedException \Exception
      */
     public function testBar()
@@ -817,8 +810,6 @@ use Some\Exception;
 class Foo extends \PHPUnit_Framework_TestCase
 {
     /**
-     * The exception is thrown when foo = bar
-     *
      * @expectedException \Exception
      */
     public function testBar()


### PR DESCRIPTION
revert #6909

and better test is added to prevent simillar problem in the future

realworld repro: https://3v4l.org/CsTYN (`eval` is used in the repro to represent a class under a different NS in a single file)