### PR TITLE
feature: SingleLineEmptyBodyFixer - support interfaces, traits and enums

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2950,7 +2950,7 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\Comment\\SingleLineCommentStyleFixer <./../src/Fixer/Comment/SingleLineCommentStyleFixer.php>`_
 -  `single_line_empty_body <./rules/basic/single_line_empty_body.rst>`_
 
-   Empty body of class or function must be abbreviated as ``{}`` and placed on the same line as the previous symbol, separated by a space.
+   Empty body of class, interface, trait, enum or function must be abbreviated as ``{}`` and placed on the same line as the previous symbol, separated by a single space.
 
    `Source PhpCsFixer\\Fixer\\Basic\\SingleLineEmptyBodyFixer <./../src/Fixer/Basic/SingleLineEmptyBodyFixer.php>`_
 -  `single_line_throw <./rules/function_notation/single_line_throw.rst>`_

--- a/doc/rules/basic/single_line_empty_body.rst
+++ b/doc/rules/basic/single_line_empty_body.rst
@@ -2,8 +2,9 @@
 Rule ``single_line_empty_body``
 ===============================
 
-Empty body of class or function must be abbreviated as ``{}`` and placed on the
-same line as the previous symbol, separated by a space.
+Empty body of class, interface, trait, enum or function must be abbreviated as
+``{}`` and placed on the same line as the previous symbol, separated by a single
+space.
 
 Examples
 --------

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -93,7 +93,7 @@ Basic
   Classes must be in a path that matches their namespace, be at least one namespace deep and the class name should match the file name.
 - `single_line_empty_body <./basic/single_line_empty_body.rst>`_
 
-  Empty body of class or function must be abbreviated as ``{}`` and placed on the same line as the previous symbol, separated by a space.
+  Empty body of class, interface, trait, enum or function must be abbreviated as ``{}`` and placed on the same line as the previous symbol, separated by a single space.
 
 Casing
 ------

--- a/tests/Fixer/Basic/SingleLineEmptyBodyFixerTest.php
+++ b/tests/Fixer/Basic/SingleLineEmptyBodyFixerTest.php
@@ -242,6 +242,24 @@ final class SingleLineEmptyBodyFixerTest extends AbstractFixerTestCase
                 };
             ',
         ];
+
+        yield 'interface' => [
+            '<?php interface Foo {}
+            ',
+            '<?php interface Foo
+                {
+                }
+            ',
+        ];
+
+        yield 'trait' => [
+            '<?php trait Foo {}
+            ',
+            '<?php trait Foo
+                {
+                }
+            ',
+        ];
     }
 
     /**
@@ -290,6 +308,31 @@ final class SingleLineEmptyBodyFixerTest extends AbstractFixerTestCase
                         private int $y,
                     ) {
                     }
+                }
+            ',
+        ];
+    }
+
+    /**
+     * @dataProvider provideFix81Cases
+     *
+     * @requires PHP 8.1
+     */
+    public function testFix81(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<array{0: string, 1?: string}>
+     */
+    public static function provideFix81Cases(): iterable
+    {
+        yield 'enum' => [
+            '<?php enum Foo {}
+            ',
+            '<?php enum Foo
+                {
                 }
             ',
         ];


### PR DESCRIPTION
Ref. https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6932#issuecomment-1606866479