### PR TITLE
DX: Rename abstract test classes to `*TestCase` convention

### DIFF
--- a/tests/RuleSet/Sets/AbstractSetTestCase.php
+++ b/tests/RuleSet/Sets/AbstractSetTestCase.php
@@ -24,7 +24,7 @@ use PhpCsFixer\Tests\TestCase;
 /**
  * @internal
  */
-abstract class AbstractSetTest extends TestCase
+abstract class AbstractSetTestCase extends TestCase
 {
     public function testSet(): void
     {

--- a/tests/RuleSet/Sets/DoctrineAnnotationSetTest.php
+++ b/tests/RuleSet/Sets/DoctrineAnnotationSetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\DoctrineAnnotationSet
  */
-final class DoctrineAnnotationSetTest extends AbstractSetTest
+final class DoctrineAnnotationSetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PERCS1x0RiskySetTest.php
+++ b/tests/RuleSet/Sets/PERCS1x0RiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PERCS1x0RiskySet
  */
-final class PERCS1x0RiskySetTest extends AbstractSetTest
+final class PERCS1x0RiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PERCS1x0SetTest.php
+++ b/tests/RuleSet/Sets/PERCS1x0SetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PERCS1x0Set
  */
-final class PERCS1x0SetTest extends AbstractSetTest
+final class PERCS1x0SetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PERRiskySetTest.php
+++ b/tests/RuleSet/Sets/PERRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PERRiskySet
  */
-final class PERRiskySetTest extends AbstractSetTest
+final class PERRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PERSetTest.php
+++ b/tests/RuleSet/Sets/PERSetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PERSet
  */
-final class PERSetTest extends AbstractSetTest
+final class PERSetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHP54MigrationSetTest.php
+++ b/tests/RuleSet/Sets/PHP54MigrationSetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHP54MigrationSet
  */
-final class PHP54MigrationSetTest extends AbstractSetTest
+final class PHP54MigrationSetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHP56MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHP56MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHP56MigrationRiskySet
  */
-final class PHP56MigrationRiskySetTest extends AbstractSetTest
+final class PHP56MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHP70MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHP70MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHP70MigrationRiskySet
  */
-final class PHP70MigrationRiskySetTest extends AbstractSetTest
+final class PHP70MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHP70MigrationSetTest.php
+++ b/tests/RuleSet/Sets/PHP70MigrationSetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHP70MigrationSet
  */
-final class PHP70MigrationSetTest extends AbstractSetTest
+final class PHP70MigrationSetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHP71MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHP71MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHP71MigrationRiskySet
  */
-final class PHP71MigrationRiskySetTest extends AbstractSetTest
+final class PHP71MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHP71MigrationSetTest.php
+++ b/tests/RuleSet/Sets/PHP71MigrationSetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHP71MigrationSet
  */
-final class PHP71MigrationSetTest extends AbstractSetTest
+final class PHP71MigrationSetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHP73MigrationSetTest.php
+++ b/tests/RuleSet/Sets/PHP73MigrationSetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHP73MigrationSet
  */
-final class PHP73MigrationSetTest extends AbstractSetTest
+final class PHP73MigrationSetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHP74MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHP74MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHP74MigrationRiskySet
  */
-final class PHP74MigrationRiskySetTest extends AbstractSetTest
+final class PHP74MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHP74MigrationSetTest.php
+++ b/tests/RuleSet/Sets/PHP74MigrationSetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHP74MigrationSet
  */
-final class PHP74MigrationSetTest extends AbstractSetTest
+final class PHP74MigrationSetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHP80MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHP80MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHP80MigrationRiskySet
  */
-final class PHP80MigrationRiskySetTest extends AbstractSetTest
+final class PHP80MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHP80MigrationSetTest.php
+++ b/tests/RuleSet/Sets/PHP80MigrationSetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHP80MigrationSet
  */
-final class PHP80MigrationSetTest extends AbstractSetTest
+final class PHP80MigrationSetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHP81MigrationSetTest.php
+++ b/tests/RuleSet/Sets/PHP81MigrationSetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHP81MigrationSet
  */
-final class PHP81MigrationSetTest extends AbstractSetTest
+final class PHP81MigrationSetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHP82MigrationSetTest.php
+++ b/tests/RuleSet/Sets/PHP82MigrationSetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHP82MigrationSet
  */
-final class PHP82MigrationSetTest extends AbstractSetTest
+final class PHP82MigrationSetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit100MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit100MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit100MigrationRiskySet
  */
-final class PHPUnit100MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit100MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit30MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit30MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit30MigrationRiskySet
  */
-final class PHPUnit30MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit30MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit32MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit32MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit32MigrationRiskySet
  */
-final class PHPUnit32MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit32MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit35MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit35MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit35MigrationRiskySet
  */
-final class PHPUnit35MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit35MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit43MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit43MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit43MigrationRiskySet
  */
-final class PHPUnit43MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit43MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit48MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit48MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit48MigrationRiskySet
  */
-final class PHPUnit48MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit48MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit50MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit50MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit50MigrationRiskySet
  */
-final class PHPUnit50MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit50MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit52MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit52MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit52MigrationRiskySet
  */
-final class PHPUnit52MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit52MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit54MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit54MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit54MigrationRiskySet
  */
-final class PHPUnit54MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit54MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit55MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit55MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit55MigrationRiskySet
  */
-final class PHPUnit55MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit55MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit56MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit56MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit56MigrationRiskySet
  */
-final class PHPUnit56MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit56MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit57MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit57MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit57MigrationRiskySet
  */
-final class PHPUnit57MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit57MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit60MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit60MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit60MigrationRiskySet
  */
-final class PHPUnit60MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit60MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit75MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit75MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit75MigrationRiskySet
  */
-final class PHPUnit75MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit75MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PHPUnit84MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHPUnit84MigrationRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PHPUnit84MigrationRiskySet
  */
-final class PHPUnit84MigrationRiskySetTest extends AbstractSetTest
+final class PHPUnit84MigrationRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PSR12RiskySetTest.php
+++ b/tests/RuleSet/Sets/PSR12RiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PSR12RiskySet
  */
-final class PSR12RiskySetTest extends AbstractSetTest
+final class PSR12RiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PSR12SetTest.php
+++ b/tests/RuleSet/Sets/PSR12SetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PSR12Set
  */
-final class PSR12SetTest extends AbstractSetTest
+final class PSR12SetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PSR1SetTest.php
+++ b/tests/RuleSet/Sets/PSR1SetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PSR1Set
  */
-final class PSR1SetTest extends AbstractSetTest
+final class PSR1SetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PSR2SetTest.php
+++ b/tests/RuleSet/Sets/PSR2SetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PSR2Set
  */
-final class PSR2SetTest extends AbstractSetTest
+final class PSR2SetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PhpCsFixerRiskySetTest.php
+++ b/tests/RuleSet/Sets/PhpCsFixerRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PhpCsFixerRiskySet
  */
-final class PhpCsFixerRiskySetTest extends AbstractSetTest
+final class PhpCsFixerRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/PhpCsFixerSetTest.php
+++ b/tests/RuleSet/Sets/PhpCsFixerSetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\PhpCsFixerSet
  */
-final class PhpCsFixerSetTest extends AbstractSetTest
+final class PhpCsFixerSetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/SymfonyRiskySetTest.php
+++ b/tests/RuleSet/Sets/SymfonyRiskySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\SymfonyRiskySet
  */
-final class SymfonyRiskySetTest extends AbstractSetTest
+final class SymfonyRiskySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/RuleSet/Sets/SymfonySetTest.php
+++ b/tests/RuleSet/Sets/SymfonySetTest.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
  *
  * @covers \PhpCsFixer\RuleSet\Sets\SymfonySet
  */
-final class SymfonySetTest extends AbstractSetTest
+final class SymfonySetTest extends AbstractSetTestCase
 {
 }

--- a/tests/Smoke/AbstractSmokeTestCase.php
+++ b/tests/Smoke/AbstractSmokeTestCase.php
@@ -27,7 +27,7 @@ use PhpCsFixer\Tests\TestCase;
  *
  * @group covers-nothing
  */
-abstract class AbstractSmokeTest extends TestCase
+abstract class AbstractSmokeTestCase extends TestCase
 {
     protected static function markTestSkippedOrFail(string $message): void
     {

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -32,7 +32,7 @@ use PhpCsFixer\Console\Application;
  *
  * @large
  */
-final class CiIntegrationTest extends AbstractSmokeTest
+final class CiIntegrationTest extends AbstractSmokeTestCase
 {
     /**
      * @var string

--- a/tests/Smoke/InstallViaComposerTest.php
+++ b/tests/Smoke/InstallViaComposerTest.php
@@ -29,7 +29,7 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * @large
  */
-final class InstallViaComposerTest extends AbstractSmokeTest
+final class InstallViaComposerTest extends AbstractSmokeTestCase
 {
     /**
      * @var string[]

--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @large
  */
-final class PharTest extends AbstractSmokeTest
+final class PharTest extends AbstractSmokeTestCase
 {
     /**
      * @var string

--- a/tests/Smoke/StdinTest.php
+++ b/tests/Smoke/StdinTest.php
@@ -30,7 +30,7 @@ use PhpCsFixer\Preg;
  *
  * @large
  */
-final class StdinTest extends AbstractSmokeTest
+final class StdinTest extends AbstractSmokeTestCase
 {
     public function testFixingStdin(): void
     {


### PR DESCRIPTION
Deprecated in PHPUnit 10, abstract test's name should not end with `Test`, also it's more consistent with other "test case" classes (internal and upstream).