### PR TITLE
bug: `phpdoc_types` do not lowercase literals e.g. 'NULL'

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocTypesFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesFixer.php
@@ -132,7 +132,7 @@ final class PhpdocTypesFixer extends AbstractPhpdocTypesFixer implements Configu
     protected function normalize(string $type): string
     {
         return Preg::replaceCallback(
-            '/(\b|(?=\$|\\\\))(\$|\\\\)?'.TypeExpression::REGEX_IDENTIFIER.'(?!\\\\|\h*:)/',
+            '/(\b|(?=\$|\\\\))(\$|\\\\)?'.TypeExpression::REGEX_IDENTIFIER.'(?!\\\\|\'|\h*:)/',
             function (array $matches): string {
                 $valueLower = strtolower($matches[0]);
                 if (isset($this->typesSetToFix[$valueLower])) {

--- a/tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
@@ -263,6 +263,12 @@ final class PhpdocTypesFixerTest extends AbstractFixerTestCase
                     */',
         ];
 
+        yield 'null and \'NULL\' as string' => [
+            '<?php /**
+                    * @return \'NULL\'|null|false|int|(\'FOO\'|\'LaL\')
+                    */',
+        ];
+
         yield 'no space between type and variable' => [
             '<?php /** @param null|string$foo */',
             '<?php /** @param NULL|STRING$foo */',


### PR DESCRIPTION
fix issue #7101