### PR TITLE
DX: Fix `FileRemovalTest` (do not fail when running it standalone)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }} tests/FileRemovalTest.php
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }} tests/FileRemovalTest.php
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/tests/FileRemovalTest.php
+++ b/tests/FileRemovalTest.php
@@ -46,35 +46,6 @@ final class FileRemovalTest extends TestCase
         }
     }
 
-    /**
-     * @runInSeparateProcess
-     *
-     * @doesNotPerformAssertions
-     */
-    public function testShutdownRemovesObservedFilesSetup(): void
-    {
-        self::$removeFilesOnTearDown = false;
-
-        $fileToBeDeleted = sys_get_temp_dir().'/cs_fixer_foo.php';
-        $fileNotToBeDeleted = sys_get_temp_dir().'/cs_fixer_bar.php';
-
-        file_put_contents($fileToBeDeleted, '');
-        file_put_contents($fileNotToBeDeleted, '');
-
-        $fileRemoval = new FileRemoval();
-
-        $fileRemoval->observe($fileToBeDeleted);
-    }
-
-    /**
-     * @depends testShutdownRemovesObservedFilesSetup
-     */
-    public function testShutdownRemovesObservedFiles(): void
-    {
-        self::assertFileDoesNotExist(sys_get_temp_dir().'/cs_fixer_foo.php');
-        self::assertFileExists(sys_get_temp_dir().'/cs_fixer_bar.php');
-    }
-
     public function testCleanRemovesObservedFiles(): void
     {
         $fs = $this->getMockFileSystem();
@@ -149,6 +120,37 @@ final class FileRemovalTest extends TestCase
 
         $fileRemoval = new FileRemoval();
         $fileRemoval->__wakeup();
+    }
+
+    /**
+     * Must NOT be run as first test, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7104.
+     *
+     * @runInSeparateProcess
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testShutdownRemovesObservedFilesSetup(): void
+    {
+        self::$removeFilesOnTearDown = false;
+
+        $fileToBeDeleted = sys_get_temp_dir().'/cs_fixer_foo.php';
+        $fileNotToBeDeleted = sys_get_temp_dir().'/cs_fixer_bar.php';
+
+        file_put_contents($fileToBeDeleted, '');
+        file_put_contents($fileNotToBeDeleted, '');
+
+        $fileRemoval = new FileRemoval();
+
+        $fileRemoval->observe($fileToBeDeleted);
+    }
+
+    /**
+     * @depends testShutdownRemovesObservedFilesSetup
+     */
+    public function testShutdownRemovesObservedFiles(): void
+    {
+        self::assertFileDoesNotExist(sys_get_temp_dir().'/cs_fixer_foo.php');
+        self::assertFileExists(sys_get_temp_dir().'/cs_fixer_bar.php');
     }
 
     private function getMockFileSystem(): vfsStreamDirectory


### PR DESCRIPTION
Related to #6883 - when I run tests locally using PHPUnit and `beStrictAboutTestsThatDoNotTestAnything="true"` (which is default value), `FileRemovalTest::testShutdownRemovesObservedFilesSetup()` fails with "This test did not perform any assertions" even if there's `@doesNotPerformAssertions`. 

<img width="924" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/23dfac0f-f791-4823-9d1a-dd5ac5bee882">

The same test causes ParaUnit's suite fail. I want to explicitly call this test here and check if it passes (maybe it's not executed in our suite somehow?).