### PR TITLE
DX: test all PHPUnit migration sets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }} tests/RuleSet/RuleSetsTest.php
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }} tests/RuleSet/RuleSetsTest.php
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/tests/RuleSet/RuleSetsTest.php
+++ b/tests/RuleSet/RuleSetsTest.php
@@ -171,7 +171,7 @@ Integration of %s.
         $setDefinitionNames = RuleSets::getSetDefinitionNames();
 
         $setDefinitionPHPUnitMigrationNames = array_filter($setDefinitionNames, static function (string $setDefinitionName): bool {
-            return 1 === preg_match('/^@PHPUnit\d{2}Migration:risky$/', $setDefinitionName);
+            return 1 === preg_match('/^@PHPUnit\d+Migration:risky$/', $setDefinitionName);
         });
 
         return array_map(static function (string $setDefinitionName): array {
@@ -181,7 +181,7 @@ Integration of %s.
 
     private static function assertPHPUnitVersionIsLargestAllowed(string $setName, string $ruleName, string $actualTargetVersion): void
     {
-        $maximumVersionForRuleset = preg_replace('/^@PHPUnit(\d)(\d)Migration:risky$/', '$1.$2', $setName);
+        $maximumVersionForRuleset = preg_replace('/^@PHPUnit(\d+)(\d)Migration:risky$/', '$1.$2', $setName);
 
         $fixer = self::getFixerByName($ruleName);
 

--- a/tests/RuleSet/RuleSetsTest.php
+++ b/tests/RuleSet/RuleSetsTest.php
@@ -208,7 +208,7 @@ Integration of %s.
         $allowedVersionsForRuleset = array_filter(
             $allowedVersionsForFixer,
             static function (string $version) use ($maximumVersionForRuleset): bool {
-                return (int) str_replace('.', '', $maximumVersionForRuleset) >= (int) str_replace('.', '', $version);
+                return version_compare($maximumVersionForRuleset, $version) >= 0;
             }
         );
 


### PR DESCRIPTION
@keradus @Wirone what should be the fix here?

- removing `php_unit_data_provider_static` from `@PHPUnit100Migration:risky`?
- removing the requirement of having `target` option for every fixer in PHPUnit migration sets
- adding `target` option with only a single choice to `php_unit_data_provider_static`? (We don't have such situation yet in other fixers)