### PR TITLE
DX: do not nest ".editorconfig" files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,14 @@
 root = true
+
 [*]
 end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
+
+[tests/Fixtures/**]
+trim_trailing_whitespace = false
 
 [{*.yml, *.yaml}]
 indent_size = 2

--- a/tests/Fixtures/.editorconfig
+++ b/tests/Fixtures/.editorconfig
@@ -1,1 +1,0 @@
-root = true


### PR DESCRIPTION
We are not nesting `.gitignore` files, why should we `.editorconfig`?

P.S. Is it not working only for me? I'm looking for a volunteer to check it:
1.  Add lines:
    ```
    [tests/Fixtures/**]
    trim_trailing_whitespace = false
    ```
    to `.editorconfig` (in project's root)
2. Open file `tests/Fixtures/Integration/priority/no_superfluous_elseif,simplified_if_return.test` - see that line 10 has already trailing whitespace
3. Add some trailing whitespaces in line 12
4. Save the file
5. First question: were the trailing whitespaces from lines 10 and 12 removed?
6. Remove file `tests/Fixtures/.editorconfig`
3. Add some trailing whitespaces in line 16
4. Save the file
5. Second question: were the trailing whitespaces from line 16 removed?