### PR TITLE
DX: Make `AbstractFixerTestCase::getTestFile()` final

### DIFF
--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -354,15 +354,11 @@ abstract class AbstractFixerTestCase extends TestCase
         return new $fixerClassName();
     }
 
-    protected static function getTestFile(string $filename = __FILE__): \SplFileInfo
+    final protected static function getTestFile(string $filename = __FILE__): \SplFileInfo
     {
         static $files = [];
 
-        if (!isset($files[$filename])) {
-            $files[$filename] = new \SplFileInfo($filename);
-        }
-
-        return $files[$filename];
+        return $files[$filename] ?? $files[$filename] = new \SplFileInfo($filename);
     }
 
     /**


### PR DESCRIPTION
#6860  This PR mark the `getTestFile()` method to static, but it still be use `self::` called in this class. 
This will result in the overridden `getTestFile()` method by the user not being called correctly.
