### PR TITLE
docs: Add allowed values of tags in the `phpdoc_align`

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2064,7 +2064,7 @@ List of Available Rules
    Configuration options:
 
    - | ``tags``
-     | The tags that should be aligned.
+     | The tags that should be aligned. Allowed values are tags with name (`'param', 'property', 'property-read', 'property-write', 'phpstan-param', 'phpstan-property', 'phpstan-property-read', 'phpstan-property-write', 'phpstan-assert', 'phpstan-assert-if-true', 'phpstan-assert-if-false', 'psalm-param', 'psalm-param-out', 'psalm-property', 'psalm-property-read', 'psalm-property-write', 'psalm-assert', 'psalm-assert-if-true', 'psalm-assert-if-false'`), tags with method signature (`'method', 'phpstan-method', 'psalm-method'`) and any custom tag with description (e.g. `@tag <desc>`).
      | Allowed types: ``array``
      | Default value: ``['method', 'param', 'property', 'return', 'throws', 'type', 'var']``
    - | ``align``

--- a/doc/rules/phpdoc/phpdoc_align.rst
+++ b/doc/rules/phpdoc/phpdoc_align.rst
@@ -11,7 +11,15 @@ Configuration
 ``tags``
 ~~~~~~~~
 
-The tags that should be aligned.
+The tags that should be aligned. Allowed values are tags with name (``'param',
+'property', 'property-read', 'property-write', 'phpstan-param',
+'phpstan-property', 'phpstan-property-read', 'phpstan-property-write',
+'phpstan-assert', 'phpstan-assert-if-true', 'phpstan-assert-if-false',
+'psalm-param', 'psalm-param-out', 'psalm-property', 'psalm-property-read',
+'psalm-property-write', 'psalm-assert', 'psalm-assert-if-true',
+'psalm-assert-if-false'``), tags with method signature (``'method',
+'phpstan-method', 'psalm-method'``) and any custom tag with description (e.g.
+``@tag <desc>``).
 
 Allowed types: ``array``
 

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -150,7 +150,7 @@ EOF;
                 new CodeSample($code),
                 new CodeSample($code, ['align' => self::ALIGN_VERTICAL]),
                 new CodeSample($code, ['align' => self::ALIGN_LEFT]),
-            ]
+            ],
         );
     }
 
@@ -195,7 +195,10 @@ EOF;
 
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
-        $tags = new FixerOptionBuilder('tags', 'The tags that should be aligned.');
+        $tags = new FixerOptionBuilder(
+            'tags',
+            'The tags that should be aligned. Allowed values are tags with name (`\''.implode('\', \'', self::TAGS_WITH_NAME).'\'`), tags with method signature (`\''.implode('\', \'', self::TAGS_WITH_METHOD_SIGNATURE).'\'`) and any custom tag with description (e.g. `@tag <desc>`).'
+        );
         $tags
             ->setAllowedTypes(['array'])
             ->setDefault(self::DEFAULT_TAGS)


### PR DESCRIPTION
The current document lacks configurable values, which makes it inconvenient for users to configure.