### PR TITLE
feature: `BlankLineBetweenImportGroupsFixer` - keep indent

### DIFF
--- a/src/Fixer/Whitespace/BlankLineBetweenImportGroupsFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBetweenImportGroupsFixer.php
@@ -19,6 +19,7 @@ use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Analyzer\WhitespacesAnalyzer;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -154,11 +155,12 @@ use Bar;
         }
 
         $index = $this->getInsertIndex($tokens, $index);
+        $indent = WhitespacesAnalyzer::detectIndent($tokens, $index);
 
         if ($tokens[$index]->isWhitespace()) {
-            $tokens[$index] = new Token([T_WHITESPACE, $lineEnding]);
+            $tokens[$index] = new Token([T_WHITESPACE, $lineEnding.$indent]);
         } else {
-            $tokens->insertSlices([$index + 1 => [new Token([T_WHITESPACE, $lineEnding])]]);
+            $tokens->insertSlices([$index + 1 => [new Token([T_WHITESPACE, $lineEnding.$indent])]]);
         }
     }
 

--- a/src/Fixer/Whitespace/BlankLineBetweenImportGroupsFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBetweenImportGroupsFixer.php
@@ -21,7 +21,6 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Analyzer\WhitespacesAnalyzer;
 use PhpCsFixer\Tokenizer\CT;
-use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
 
@@ -157,11 +156,7 @@ use Bar;
         $index = $this->getInsertIndex($tokens, $index);
         $indent = WhitespacesAnalyzer::detectIndent($tokens, $index);
 
-        if ($tokens[$index]->isWhitespace()) {
-            $tokens[$index] = new Token([T_WHITESPACE, $lineEnding.$indent]);
-        } else {
-            $tokens->insertSlices([$index + 1 => [new Token([T_WHITESPACE, $lineEnding.$indent])]]);
-        }
+        $tokens->ensureWhitespaceAtIndex($index, 1, $lineEnding.$indent);
     }
 
     private function getInsertIndex(Tokens $tokens, int $index): int

--- a/tests/Fixer/Whitespace/BlankLineBetweenImportGroupsFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBetweenImportGroupsFixerTest.php
@@ -428,23 +428,23 @@ use /* x */ function /* x */ Psl\Str\ /* x */ {
 namespace A\B6 {
     use C1\B1;
 
-use const C6\Z1;
+    use const C6\Z1;
 
-use C2\B2;
+    use C2\B2;
 
-use const C7\Z2;
+    use const C7\Z2;
 
-use C3\B3;
+    use C3\B3;
 
-use const C8\Z3;
+    use const C8\Z3;
 
-use C4\B4;
+    use C4\B4;
 
-use const C9\Z4;
+    use const C9\Z4;
 
-use C5\B5;
+    use C5\B5;
 
-use const C0\Z5;
+    use const C0\Z5;
 }
             ',
             '<?php
@@ -463,27 +463,27 @@ namespace A\B6 {
 namespace A\B1 {
     use C\B;
 
-use const C\Z;
+    use const C\Z;
 }
 namespace A\B2 {
     use C\B;
 
-use const C\Z;
+    use const C\Z;
 }
 namespace A\B3 {
     use C\B;
 
-use const C\Z;
+    use const C\Z;
 }
 namespace A\B4 {
     use C\B;
 
-use const C\Z;
+    use const C\Z;
 }
 namespace A\B5 {
     use C\B;
 
-use const C\Z;
+    use const C\Z;
 }
             ',
             '<?php


### PR DESCRIPTION
Closes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6989