### PR TITLE
docs: Add information about installing Fixer as dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ in a dedicated `composer.json` file in your project, for example in the
 
 ```console
 mkdir -p tools/php-cs-fixer
-composer require --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer
+composer require --working-dir=tools/php-cs-fixer --dev friendsofphp/php-cs-fixer
 ```
 
 For more details and other installation methods, see

--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ in a dedicated `composer.json` file in your project, for example in the
 
 ```console
 mkdir -p tools/php-cs-fixer
-composer require --working-dir=tools/php-cs-fixer --dev friendsofphp/php-cs-fixer
+composer require --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer
+```
+
+Or using the main `composer.json`:
+```console
+composer require --dev friendsofphp/php-cs-fixer
 ```
 
 For more details and other installation methods, see


### PR DESCRIPTION
The tool is meant to modify the source files, so it should be considered a part of the dev section of the composer.