### PR TITLE
feature: NativeConstTypeDeclarationCasingFixer - Introduction

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1258,6 +1258,11 @@ List of Available Rules
    Part of rule sets `@PhpCsFixer:risky <./ruleSets/PhpCsFixerRisky.rst>`_ `@Symfony:risky <./ruleSets/SymfonyRisky.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ConstantNotation\\NativeConstantInvocationFixer <./../src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php>`_
+-  `native_const_type_declaration_casing <./rules/casing/native_const_type_declaration_casing.rst>`_
+
+   Native type hints for constants should use the correct case.
+
+   `Source PhpCsFixer\\Fixer\\Casing\\NativeConstTypeDeclarationCasingFixer <./../src/Fixer/Casing/NativeConstTypeDeclarationCasingFixer.php>`_
 -  `native_function_casing <./rules/casing/native_function_casing.rst>`_
 
    Function defined by PHP should be called using the correct casing.

--- a/doc/rules/casing/native_const_type_declaration_casing.rst
+++ b/doc/rules/casing/native_const_type_declaration_casing.rst
@@ -1,0 +1,22 @@
+=============================================
+Rule ``native_const_type_declaration_casing``
+=============================================
+
+Native type hints for constants should use the correct case.
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    class Foo
+    {
+   -    const INT BAR = 1;
+   +    const int BAR = 1;
+    }

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -119,6 +119,9 @@ Casing
 - `magic_method_casing <./casing/magic_method_casing.rst>`_
 
   Magic method definitions and calls must be using the correct casing.
+- `native_const_type_declaration_casing <./casing/native_const_type_declaration_casing.rst>`_
+
+  Native type hints for constants should use the correct case.
 - `native_function_casing <./casing/native_function_casing.rst>`_
 
   Function defined by PHP should be called using the correct casing.

--- a/src/Fixer/Casing/NativeConstTypeDeclarationCasingFixer.php
+++ b/src/Fixer/Casing/NativeConstTypeDeclarationCasingFixer.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Casing;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class NativeConstTypeDeclarationCasingFixer extends AbstractFixer
+{
+    /*
+     * https://wiki.php.net/rfc/typed_class_constants
+     * Supported types
+     * Class constant type declarations support all type declarations supported by PHP,
+     * except `void`, `callable`, `never`.
+     *
+     * array
+     * bool
+     * callable
+     * float
+     * int
+     * iterable
+     * object
+     * mixed
+     * parent
+     * self
+     * string
+     * any class or interface name -> not native, so not applicable for this Fixer
+     * ?type -> not native, `?` has no casing, so not applicable for this Fixer
+     *
+     * Not in the list referenced but supported:
+     * null
+     */
+    private const SUPPORTED_HINTS = [
+        'array' => true,
+        'bool' => true,
+        'float' => true,
+        'int' => true,
+        'iterable' => true,
+        'mixed' => true,
+        'null' => true,
+        'object' => true,
+        'parent' => true,
+        'self' => true,
+        'string' => true,
+    ];
+
+    private const TYPE_SEPARATION_TYPES = [
+        CT::T_TYPE_ALTERNATION,
+        CT::T_TYPE_INTERSECTION,
+        CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_OPEN,
+        CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_CLOSE,
+    ];
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Native type hints for constants should use the correct case.',
+            [
+                new VersionSpecificCodeSample(
+                    "<?php\nclass Foo\n{\n    const INT BAR = 1;\n}\n",
+                    new VersionSpecification(8_03_00),
+                ),
+            ]
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return \PHP_VERSION_ID >= 8_03_00
+            && $tokens->isTokenKindFound(T_CONST)
+            && $tokens->isAnyTokenKindsFound(Token::getClassyTokenKinds());
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_CONST) || $this->isConstWithoutType($tokens, $index)) {
+                continue;
+            }
+
+            foreach ($this->getNativeTypeHintCandidates($tokens, $index) as $nativeTypeHintIndex) {
+                $this->fixCasing($tokens, $nativeTypeHintIndex);
+            }
+        }
+    }
+
+    /** @return iterable<int> */
+    private function getNativeTypeHintCandidates(Tokens $tokens, int $index): iterable
+    {
+        $constNameIndex = $this->getConstNameIndex($tokens, $index);
+        $index = $this->getConstTypeFirstIndex($tokens, $index);
+
+        do {
+            $typeEnd = $this->getTypeEnd($tokens, $index, $constNameIndex);
+
+            if ($typeEnd === $index) {
+                yield $index;
+            }
+
+            do {
+                $index = $tokens->getNextMeaningfulToken($index);
+            } while ($tokens[$index]->isGivenKind(self::TYPE_SEPARATION_TYPES));
+        } while ($index < $constNameIndex);
+    }
+
+    private function getTypeEnd(Tokens $tokens, int $index, int $upperLimit): int
+    {
+        if (!$tokens[$index]->isGivenKind([T_STRING, T_NS_SEPARATOR])) {
+            return $index; // callable, array, etc.
+        }
+
+        $endIndex = $index;
+        while ($tokens[$index]->isGivenKind([T_STRING, T_NS_SEPARATOR]) && $index < $upperLimit) {
+            $endIndex = $index;
+            $index = $tokens->getNextMeaningfulToken($index);
+        }
+
+        return $endIndex;
+    }
+
+    private function isConstWithoutType(Tokens $tokens, int $index): bool
+    {
+        $index = $tokens->getNextMeaningfulToken($index);
+
+        return $tokens[$index]->isGivenKind(T_STRING) && $tokens[$tokens->getNextMeaningfulToken($index)]->equals('=');
+    }
+
+    private function getConstNameIndex(Tokens $tokens, int $index): int
+    {
+        return $tokens->getPrevMeaningfulToken(
+            $tokens->getNextTokenOfKind($index, ['=']),
+        );
+    }
+
+    private function getConstTypeFirstIndex(Tokens $tokens, int $index): int
+    {
+        $index = $tokens->getNextMeaningfulToken($index);
+
+        if ($tokens[$index]->isGivenKind(CT::T_NULLABLE_TYPE)) {
+            $index = $tokens->getNextMeaningfulToken($index);
+        }
+
+        if ($tokens[$index]->isGivenKind(CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_OPEN)) {
+            $index = $tokens->getNextMeaningfulToken($index);
+        }
+
+        return $index;
+    }
+
+    private function fixCasing(Tokens $tokens, int $index): void
+    {
+        $typeContent = $tokens[$index]->getContent();
+        $typeContentLower = strtolower($typeContent);
+
+        if (isset($this::SUPPORTED_HINTS[$typeContentLower]) && $typeContent !== $typeContentLower) {
+            $tokens[$index] = new Token([$tokens[$index]->getId(), $typeContentLower]);
+        }
+    }
+}

--- a/tests/Fixer/Casing/NativeConstTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeConstTypeDeclarationCasingFixerTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Casing;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Casing\NativeConstTypeDeclarationCasingFixer
+ */
+final class NativeConstTypeDeclarationCasingFixerTest extends AbstractFixerTestCase
+{
+    public function testDoNotFixCases(): void
+    {
+        $this->doTest(
+            '<?php
+                class Foo
+                {
+                    const A = 1;
+                    const B = [];
+                    const INT = "A"; // INT is the name of the const, not the type
+                    const FLOAT=1.2;
+                }
+
+                const INT = "A"; // INT is the name of the const, not the type
+                function foo_1(INT $a) {}
+            ',
+        );
+    }
+
+    /**
+     * @dataProvider provideFixCases
+     *
+     * @requires PHP 8.3
+     */
+    public function testFix(string $expected, string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixCases(): iterable
+    {
+        yield 'single types' => [
+            '<?php
+                class Foo
+                {
+                    const int SOME_INT = 3;
+                    const array SOME_ARRAY = [7];
+                    const float SOME_FLOAT = 1.23;
+                    const iterable SOME_ITERABLE = [1, 2];
+                    const mixed SOME_MIXED = 1;
+                    const null SOME_NULL = NULL;
+                    const string SOME_STRING = "X";
+                }
+            ',
+            '<?php
+                class Foo
+                {
+                    const INT SOME_INT = 3;
+                    const ARRAY SOME_ARRAY = [7];
+                    const Float SOME_FLOAT = 1.23;
+                    const ITERABLE SOME_ITERABLE = [1, 2];
+                    const MIXED SOME_MIXED = 1;
+                    const NULL SOME_NULL = NULL;
+                    const STRING SOME_STRING = "X";
+                }
+            ',
+        ];
+
+        yield 'nullables `self`, `parent` and `object`' => [
+            '<?php
+                class Foo extends FooParent
+                {
+                    const ?object SOME_OBJECT = NULL;
+                    const ?parent SOME_PARENT = NULL;
+                    const ?self SOME_SELF = NULL;
+                    const ?int/* x */A/* y */= 3;
+
+                    const ?BAR B = null;
+                    const ?BAR C = null;
+                    const ?\BAR D = null;
+                    const ?\INT\B E = null;
+                    public const ?INT\A/* x */X=C;
+                }
+            ',
+            '<?php
+                class Foo extends FooParent
+                {
+                    const ?OBJECT SOME_OBJECT = NULL;
+                    const ?PARENT SOME_PARENT = NULL;
+                    const ?Self SOME_SELF = NULL;
+                    const ?INT/* x */A/* y */= 3;
+
+                    const ?BAR B = null;
+                    const ?BAR C = null;
+                    const ?\BAR D = null;
+                    const ?\INT\B E = null;
+                    public const ?INT\A/* x */X=C;
+                }
+            ',
+        ];
+
+        yield 'simple `|`' => [
+            '<?php class Foo1 {
+                const D|float BAR = 1.0;
+            }',
+            '<?php class Foo1 {
+                const D|Float BAR = 1.0;
+            }',
+        ];
+
+        yield 'multiple `|`' => [
+            '<?php class Foo2 {
+                const int|array|null|A\B|\C\D|float BAR_1 = NULL;
+            }',
+            '<?php class Foo2 {
+                const INT|ARRAY|NULL|A\B|\C\D|FLOAT BAR_1 = NULL;
+            }',
+        ];
+
+        yield 'handle mix of `|` and `(X&Y)`' => [
+            '<?php
+                class Foo extends FooParent
+                {
+                    private const Z|A\S\T\R|int|float|iterable SOMETHING = 123;
+                    protected const \A\B|(Foo & Stringable )|null|\X D = null;
+
+                    public const Foo&Stringable G = V::A;
+                }
+            ',
+            '<?php
+                class Foo extends FooParent
+                {
+                    private const Z|A\S\T\R|INT|FLOAT|ITERABLE SOMETHING = 123;
+                    protected const \A\B|(Foo & Stringable )|NULL|\X D = null;
+
+                    public const Foo&Stringable G = V::A;
+                }
+            ',
+        ];
+
+        yield 'interface, nullable int' => [
+            '<?php interface SomeInterface {
+                const ?int FOO = 1;
+            }',
+            '<?php interface SomeInterface {
+                const ?INT FOO = 1;
+            }',
+        ];
+
+        yield 'trait, string' => [
+            '<?php trait T {
+                const string TEST = E::TEST;
+            }',
+            '<?php trait T {
+                const STRING TEST = E::TEST;
+            }',
+        ];
+
+        yield 'enum, int' => [
+            '<?php enum E {
+                const int TEST = 789;
+            }',
+            '<?php enum E {
+                const INT TEST = 789;
+            }',
+        ];
+
+        yield 'do not fix' => [
+            '<?php class Foo {
+                PUBLIC FUNCTION FOO_1(INT|FLOAT|NULL|ITERABLE $A): VOID {}
+
+                PUBLIC CONST FOO&STRINGABLE G = A::B;
+            }
+
+            enum E {
+                PUBLIC CONST STATIC A = E::FOO;
+                CASE FOO;
+            }
+
+            CONST A = 1;',
+        ];
+    }
+}


### PR DESCRIPTION
PHP8.3

Rule changes native type hints for `const` to lowercase.

```diff
--- Original
+++ New
 <?php
 class Foo
 {
-    const INT BAR = 1;
+    const int BAR = 1;
 }
```

Types supported based on: https://wiki.php.net/rfc/typed_class_constants "Supported types"
- array
- bool
- float 
- int
- iterable
- mixed
- null
- object
- parent
- self
- string
