### PR TITLE
DX: improve `Tokens` checking for found tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
+        run: vendor/bin/paraunit run ${{ matrix.phpunit-flags || '--exclude-group auto-review' }} tests/Tokenizer/TokensTest.php
 
       - name: Collect code coverage
         if: matrix.calculate-code-coverage == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run ${{ matrix.phpunit-flags || '--exclude-group auto-review' }} tests/Tokenizer/TokensTest.php
+        run: vendor/bin/paraunit run ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
 
       - name: Collect code coverage
         if: matrix.calculate-code-coverage == 'yes'

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -319,10 +319,7 @@ class Tokens extends \SplFixedArray
             $this->changed = true;
             $this->namespaceDeclarations = null;
 
-            if (isset($this[$index])) {
-                $this->unregisterFoundToken($this[$index]);
-            }
-
+            $this->unregisterFoundToken($this[$index]);
             $this->registerFoundToken($newval);
         }
 
@@ -1079,7 +1076,7 @@ class Tokens extends \SplFixedArray
      */
     public function isTokenKindFound($tokenKind): bool
     {
-        return !empty($this->foundTokenKinds[$tokenKind]);
+        return isset($this->foundTokenKinds[$tokenKind]);
     }
 
     /**
@@ -1387,12 +1384,20 @@ class Tokens extends \SplFixedArray
      */
     private function unregisterFoundToken($token): void
     {
+        if (null === $token) {
+            return;
+        }
+
         // inlined extractTokenKind() call on the hot path
         $tokenKind = $token instanceof Token
             ? ($token->isArray() ? $token->getId() : $token->getContent())
             : (\is_array($token) ? $token[0] : $token);
 
-        --$this->foundTokenKinds[$tokenKind];
+        if (1 === $this->foundTokenKinds[$tokenKind]) {
+            unset($this->foundTokenKinds[$tokenKind]);
+        } else {
+            --$this->foundTokenKinds[$tokenKind];
+        }
     }
 
     /**

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -1049,7 +1049,7 @@ class Tokens extends \SplFixedArray
     public function isAllTokenKindsFound(array $tokenKinds): bool
     {
         foreach ($tokenKinds as $tokenKind) {
-            if (empty($this->foundTokenKinds[$tokenKind])) {
+            if (!isset($this->foundTokenKinds[$tokenKind])) {
                 return false;
             }
         }
@@ -1065,7 +1065,7 @@ class Tokens extends \SplFixedArray
     public function isAnyTokenKindsFound(array $tokenKinds): bool
     {
         foreach ($tokenKinds as $tokenKind) {
-            if (!empty($this->foundTokenKinds[$tokenKind])) {
+            if (isset($this->foundTokenKinds[$tokenKind])) {
                 return true;
             }
         }

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -1392,10 +1392,6 @@ class Tokens extends \SplFixedArray
             ? ($token->isArray() ? $token->getId() : $token->getContent())
             : (\is_array($token) ? $token[0] : $token);
 
-        if (!isset($this->foundTokenKinds[$tokenKind])) {
-            return;
-        }
-
         --$this->foundTokenKinds[$tokenKind];
     }
 

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -1382,7 +1382,7 @@ class Tokens extends \SplFixedArray
     }
 
     /**
-     * Unregister token as found.
+     * Unregister token as not found.
      *
      * @param array{int}|string|Token $token token prototype
      */

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -297,7 +297,9 @@ class Tokens extends \SplFixedArray
     {
         $this->changed = true;
         $this->namespaceDeclarations = null;
-        $this->unregisterFoundToken($this[$index]);
+        if (isset($this[$index])) {
+            $this->unregisterFoundToken($this[$index]);
+        }
 
         parent::offsetUnset($index);
     }
@@ -319,7 +321,9 @@ class Tokens extends \SplFixedArray
             $this->changed = true;
             $this->namespaceDeclarations = null;
 
-            $this->unregisterFoundToken($this[$index]);
+            if (isset($this[$index])) {
+                $this->unregisterFoundToken($this[$index]);
+            }
             $this->registerFoundToken($newval);
         }
 
@@ -1378,16 +1382,12 @@ class Tokens extends \SplFixedArray
     }
 
     /**
-     * Register token as found.
+     * Unregister token as found.
      *
      * @param array{int}|string|Token $token token prototype
      */
     private function unregisterFoundToken($token): void
     {
-        if (null === $token) {
-            return;
-        }
-
         // inlined extractTokenKind() call on the hot path
         $tokenKind = $token instanceof Token
             ? ($token->isArray() ? $token->getId() : $token->getContent())

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -1743,6 +1743,20 @@ EOF
         );
     }
 
+    public function testFindingToken(): void
+    {
+        $tokens = Tokens::fromCode('<?php $x;');
+
+        self::assertTrue($tokens->isTokenKindFound(T_VARIABLE));
+
+        $tokens->offsetUnset(1);
+        $tokens->offsetUnset(1); // 2nd unset of the same index should not crash anything
+        self::assertFalse($tokens->isTokenKindFound(T_VARIABLE));
+
+        $tokens[1] = new Token([T_VARIABLE, '$x']);
+        self::assertTrue($tokens->isTokenKindFound(T_VARIABLE));
+    }
+
     private function getBlockEdgeCachingTestTokens(): Tokens
     {
         Tokens::clearCache();


### PR DESCRIPTION
Commits:
1. [Remove unused condition](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7139/commits/cb5716c1242aeeb99a25eae22208cb6cb2bb52ac) - the value of `$tokenKind` could be `null` (like in the test added in 2nd commit) in condition `if (!isset($this->foundTokenKinds[$tokenKind])) {` and would work because the `null` would be implicitly cast to `''`.
2. [Add test for double call of `Tokens:::offsetUnset` on the same index](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7139/commits/c007edf4d058c9694af7bbe90ee0cd0972728e35) - class `Tokens` should not crash in such scenario
3.  [Fix](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7139/commits/f320cebb71cbea0748e5fbbc1f3917f8da23e9f1) - approach that updated all indices used in`$this->foundTokenKinds` to be integers or strings.