### PR TITLE
DX: Use relative fixture path as integration test case's name

### DIFF
--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -156,7 +156,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
                 continue;
             }
 
-            $tests[substr($file->getPathname(), \strlen(static::getFixturesDir()) + 1)] = [
+            $tests[substr($file->getPathname(), \strlen(realpath(__DIR__.'/../../')) + 1)] = [
                 $factory->create($file),
             ];
         }

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -156,7 +156,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
                 continue;
             }
 
-            $tests[$file->getPathname()] = [
+            $tests[substr($file->getPathname(), \strlen(static::getFixturesDir()) + 1)] = [
                 $factory->create($file),
             ];
         }


### PR DESCRIPTION
Before:

<img width="1619" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/71720cce-2710-48c1-9a54-ddf17d132a7b">

After:

<img width="1312" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/dc2fdc9b-293d-4413-b56f-6d3981a19449">

