### PR TITLE
DX: Copy-pasteable `class::getPriority` for phpDoc diffs

### DIFF
--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -254,9 +254,9 @@ final class FixerFactoryTest extends TestCase
             $phpDoc = $method->getDocComment();
 
             if (false === $phpDoc) {
-                $fixersPhpDocIssues[$fixerName] = sprintf("PHPDoc for %s::getPriority is missing.\nExpected:\n%s", $fixerName, $expectedMessage);
+                $fixersPhpDocIssues[$fixerName] = sprintf("PHPDoc for %s::getPriority is missing.\nExpected:\n%s", $fixers[$fixerName]['short_classname'], $expectedMessage);
             } elseif ($expectedMessage !== $phpDoc) {
-                $fixersPhpDocIssues[$fixerName] = sprintf("PHPDoc for %s::getPriority is not as expected.\nExpected:\n%s", $fixerName, $expectedMessage);
+                $fixersPhpDocIssues[$fixerName] = sprintf("PHPDoc for %s::getPriority is not as expected.\nExpected:\n%s", $fixers[$fixerName]['short_classname'], $expectedMessage);
             }
         }
 
@@ -267,7 +267,7 @@ final class FixerFactoryTest extends TestCase
             ksort($fixersPhpDocIssues);
 
             foreach ($fixersPhpDocIssues as $fixerName => $issue) {
-                $message .= sprintf("\n--------------------------------------------------\n%s\n%s", $fixers[$fixerName]['short_classname'], $issue);
+                $message .= sprintf("\n--------------------------------------------------\n[%s] %s", $fixerName, $issue);
             }
 
             self::fail($message);


### PR DESCRIPTION
Before:

<img width="1548" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/c86deeb7-e53b-48c5-b12a-f5230dd6215d">

After:

<img width="1548" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/8bb491a8-79fa-4713-b365-2139e82d30d8">

Now, `StringLengthToEmptyFixer::getPriority` can be copied, and then with double-shift in PHPStorm it can be opened directly to the `getPriority()` method, so it can be updated.