### PR TITLE
DX: store cache to file only if content will get modified

### DIFF
--- a/src/Cache/FileCacheManager.php
+++ b/src/Cache/FileCacheManager.php
@@ -65,7 +65,9 @@ final class FileCacheManager implements CacheManagerInterface
 
     public function __destruct()
     {
-        $this->writeCache();
+        if (0 !== $this->writeCounter) {
+            $this->writeCache();
+        }
     }
 
     /**

--- a/src/Cache/FileCacheManager.php
+++ b/src/Cache/FileCacheManager.php
@@ -44,6 +44,8 @@ final class FileCacheManager implements CacheManagerInterface
 
     private int $writeCounter = 0;
 
+    private bool $signatureWasUpdated = false;
+
     /**
      * @var CacheInterface
      */
@@ -65,7 +67,7 @@ final class FileCacheManager implements CacheManagerInterface
 
     public function __destruct()
     {
-        if (0 !== $this->writeCounter) {
+        if (true === $this->signatureWasUpdated || 0 !== $this->writeCounter) {
             $this->writeCache();
         }
     }
@@ -121,6 +123,7 @@ final class FileCacheManager implements CacheManagerInterface
 
         if (null === $cache || !$this->signature->equals($cache->getSignature())) {
             $cache = new Cache($this->signature);
+            $this->signatureWasUpdated = true;
         }
 
         $this->cache = $cache;

--- a/tests/Cache/FileCacheManagerTest.php
+++ b/tests/Cache/FileCacheManagerTest.php
@@ -91,7 +91,7 @@ final class FileCacheManagerTest extends TestCase
         unset($manager);
     }
 
-    public function testUsesCacheIfCachedSignatureIsEqual(): void
+    public function testUsesCacheIfCachedSignatureIsEqualAndNoFileWasUpdated(): void
     {
         $cachedSignature = $this->prophesize(SignatureInterface::class)->reveal();
 
@@ -105,7 +105,7 @@ final class FileCacheManagerTest extends TestCase
 
         $handlerProphecy = $this->prophesize(FileHandlerInterface::class);
         $handlerProphecy->read()->shouldBeCalled()->willReturn($cache);
-        $handlerProphecy->write(Argument::is($cache))->shouldBeCalled();
+        $handlerProphecy->write(Argument::is($cache))->shouldNotBeCalled();
         $handler = $handlerProphecy->reveal();
 
         $manager = new FileCacheManager(
@@ -267,7 +267,7 @@ final class FileCacheManagerTest extends TestCase
         $handlerProphecy = $this->prophesize(FileHandlerInterface::class);
         $handlerProphecy->read()->willReturn($cache);
         $handlerProphecy->getFile()->willReturn($cacheFile);
-        $handlerProphecy->write(Argument::is($cache));
+        $handlerProphecy->write(Argument::is($cache))->shouldBeCalled();
         $handler = $handlerProphecy->reveal();
 
         $manager = new FileCacheManager(


### PR DESCRIPTION
while having the counter property, now we can fully skip cache->write() if no content of cache json was modified