### PR TITLE
DX: Allow OS conditions for integration tests

### DIFF
--- a/tests/Fixtures/Integration/misc/meta_insert_64566_tokens.test
+++ b/tests/Fixtures/Integration/misc/meta_insert_64566_tokens.test
@@ -1,6 +1,10 @@
 --TEST--
 Test of super huge file that would require 64566 tokens to be inserted! Basically, this tests Tokens::insertSlices, without which this test would take few hours to execute.
+
+Test is disabled for MacOS because it regularly fails with timeout (see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7141)
 --RULESET--
 {
     "whitespace_after_comma_in_array": true
 }
+--REQUIREMENTS--
+{"os":["Linux","Windows"]}

--- a/tests/Test/AbstractIntegrationCaseFactory.php
+++ b/tests/Test/AbstractIntegrationCaseFactory.php
@@ -105,7 +105,7 @@ abstract class AbstractIntegrationCaseFactory implements IntegrationCaseFactoryI
     /**
      * Parses the '--REQUIREMENTS--' block of a '.test' file and determines requirements.
      *
-     * @return array<string, int>|array{php: int}
+     * @return array{php: int, "php<"?: int, os: list<string>}
      */
     protected function determineRequirements(SplFileInfo $file, ?string $config): array
     {

--- a/tests/Test/AbstractIntegrationCaseFactory.php
+++ b/tests/Test/AbstractIntegrationCaseFactory.php
@@ -111,12 +111,20 @@ abstract class AbstractIntegrationCaseFactory implements IntegrationCaseFactoryI
     {
         $parsed = $this->parseJson($config, [
             'php' => \PHP_VERSION_ID,
+            'os' => ['Linux', 'Darwin', 'Windows']
         ]);
 
         if (!\is_int($parsed['php'])) {
             throw new \InvalidArgumentException(sprintf(
                 'Expected int value like 50509 for "php", got "%s".',
                 get_debug_type($parsed['php']).'#'.$parsed['php'],
+            ));
+        }
+
+        if (!\is_array($parsed['os'])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Expected array of OS names for "os", got "%s".',
+                get_debug_type($parsed['os']).' ('.$parsed['os'].')',
             ));
         }
 

--- a/tests/Test/AbstractIntegrationCaseFactory.php
+++ b/tests/Test/AbstractIntegrationCaseFactory.php
@@ -111,7 +111,7 @@ abstract class AbstractIntegrationCaseFactory implements IntegrationCaseFactoryI
     {
         $parsed = $this->parseJson($config, [
             'php' => \PHP_VERSION_ID,
-            'os' => ['Linux', 'Darwin', 'Windows']
+            'os' => ['Linux', 'Darwin', 'Windows'],
         ]);
 
         if (!\is_int($parsed['php'])) {

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -195,6 +195,17 @@ abstract class AbstractIntegrationTestCase extends TestCase
             self::markTestSkipped(sprintf('PHP %d (or later) is required for "%s", current "%d".', $case->getRequirement('php'), $case->getFileName(), \PHP_VERSION_ID));
         }
 
+        if (!in_array(\PHP_OS, $case->getRequirement('os'), true)) {
+            self::markTestSkipped(
+                sprintf(
+                    'Unsupported OS (%s) for "%s", allowed are: %s.',
+                    \PHP_OS,
+                    $case->getFileName(),
+                    implode(', ', $case->getRequirement('os'))
+                )
+            );
+        }
+
         $input = $case->getInputCode();
         $expected = $case->getExpectedCode();
 

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -195,11 +195,11 @@ abstract class AbstractIntegrationTestCase extends TestCase
             self::markTestSkipped(sprintf('PHP %d (or later) is required for "%s", current "%d".', $case->getRequirement('php'), $case->getFileName(), \PHP_VERSION_ID));
         }
 
-        if (!in_array(\PHP_OS, $case->getRequirement('os'), true)) {
+        if (!\in_array(PHP_OS, $case->getRequirement('os'), true)) {
             self::markTestSkipped(
                 sprintf(
                     'Unsupported OS (%s) for "%s", allowed are: %s.',
-                    \PHP_OS,
+                    PHP_OS,
                     $case->getFileName(),
                     implode(', ', $case->getRequirement('os'))
                 )

--- a/tests/Test/IntegrationCase.php
+++ b/tests/Test/IntegrationCase.php
@@ -105,7 +105,11 @@ final class IntegrationCase
         return $this->inputCode;
     }
 
-    public function getRequirement(string $name): int
+    /**
+     * @return int|array<string>
+     * @phpstan-return ($name is 'php' ? int : array<string>)
+     */
+    public function getRequirement(string $name)
     {
         if (!\array_key_exists($name, $this->requirements)) {
             throw new \InvalidArgumentException(sprintf(

--- a/tests/Test/IntegrationCase.php
+++ b/tests/Test/IntegrationCase.php
@@ -35,9 +35,7 @@ final class IntegrationCase
     private ?string $inputCode;
 
     /**
-     * Env requirements (possible keys: 'php' or 'php<').
-     *
-     * @var array<string, int>|array{php: int}
+     * @var array{php: int, "php<"?: int, os: list<string>}
      */
     private array $requirements;
 
@@ -54,7 +52,7 @@ final class IntegrationCase
 
     /**
      * @param array{checkPriority: bool, deprecations: list<string>, isExplicitPriorityCheck?: bool} $settings
-     * @param array<string, int>|array{php: int}                                                     $requirements
+     * @param array{php: int, "php<"?: int, os: list<string>}                                        $requirements
      * @param array{indent: string, lineEnding: string}                                              $config
      */
     public function __construct(
@@ -106,9 +104,7 @@ final class IntegrationCase
     }
 
     /**
-     * @return array<string>|int
-     *
-     * @phpstan-return ($name is 'php' ? int : array<string>)
+     * @return mixed
      */
     public function getRequirement(string $name)
     {
@@ -124,7 +120,7 @@ final class IntegrationCase
     }
 
     /**
-     * @return array<string, int>|array{php: int}
+     * @return array{php: int, "php<"?: int, os: list<string>}
      */
     public function getRequirements(): array
     {

--- a/tests/Test/IntegrationCase.php
+++ b/tests/Test/IntegrationCase.php
@@ -106,7 +106,8 @@ final class IntegrationCase
     }
 
     /**
-     * @return int|array<string>
+     * @return array<string>|int
+     *
      * @phpstan-return ($name is 'php' ? int : array<string>)
      */
     public function getRequirement(string $name)


### PR DESCRIPTION
Approach mentioned in #7141, fixes problems with MacOS checks.

<img width="886" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/0eb7d710-9dd9-41eb-9021-91f8d9fda839">
