### PR TITLE
feature: Introduce `ReturnToYieldFromFixer`

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2826,7 +2826,7 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\ReturnNotation\\ReturnAssignmentFixer <./../src/Fixer/ReturnNotation/ReturnAssignmentFixer.php>`_
 -  `return_to_yield_from <./rules/array_notation/return_to_yield_from.rst>`_
 
-   When function return type is iterable (``iterable``, ``Traversable``, ``Iterator`` and ``IteratorAggregate``) and it starts with ``return`` then it must be changed to ``yield from``.
+   When function return type is iterable (``iterable``, ``Iterator`` and ``Traversable``) and it starts with ``return`` then it must be changed to ``yield from``.
 
    `Source PhpCsFixer\\Fixer\\ArrayNotation\\ReturnToYieldFromFixer <./../src/Fixer/ArrayNotation/ReturnToYieldFromFixer.php>`_
 -  `return_type_declaration <./rules/function_notation/return_type_declaration.rst>`_

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2826,7 +2826,7 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\ReturnNotation\\ReturnAssignmentFixer <./../src/Fixer/ReturnNotation/ReturnAssignmentFixer.php>`_
 -  `return_to_yield_from <./rules/array_notation/return_to_yield_from.rst>`_
 
-   When function return type is iterable (``iterable``, ``Iterator`` and ``Traversable``) and it starts with ``return`` then it must be changed to ``yield from``.
+   When function return type is ``iterable``, and it returns an array explicitly, then it must be changed to ``yield from``.
 
    `Source PhpCsFixer\\Fixer\\ArrayNotation\\ReturnToYieldFromFixer <./../src/Fixer/ArrayNotation/ReturnToYieldFromFixer.php>`_
 -  `return_type_declaration <./rules/function_notation/return_type_declaration.rst>`_

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2824,6 +2824,11 @@ List of Available Rules
    Part of rule set `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ReturnNotation\\ReturnAssignmentFixer <./../src/Fixer/ReturnNotation/ReturnAssignmentFixer.php>`_
+-  `return_to_yield_from <./rules/array_notation/return_to_yield_from.rst>`_
+
+   When function return type is iterable and it starts with ``return`` then it must be changed to ``yield from``.
+
+   `Source PhpCsFixer\\Fixer\\ArrayNotation\\ReturnToYieldFromFixer <./../src/Fixer/ArrayNotation/ReturnToYieldFromFixer.php>`_
 -  `return_type_declaration <./rules/function_notation/return_type_declaration.rst>`_
 
    Adjust spacing around colon in return type declarations and backed enum types.

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2826,7 +2826,7 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\ReturnNotation\\ReturnAssignmentFixer <./../src/Fixer/ReturnNotation/ReturnAssignmentFixer.php>`_
 -  `return_to_yield_from <./rules/array_notation/return_to_yield_from.rst>`_
 
-   When function return type is iterable and it starts with ``return`` then it must be changed to ``yield from``.
+   When function return type is iterable (``iterable``, ``Traversable``, ``Iterator`` and ``IteratorAggregate``) and it starts with ``return`` then it must be changed to ``yield from``.
 
    `Source PhpCsFixer\\Fixer\\ArrayNotation\\ReturnToYieldFromFixer <./../src/Fixer/ArrayNotation/ReturnToYieldFromFixer.php>`_
 -  `return_type_declaration <./rules/function_notation/return_type_declaration.rst>`_

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2826,7 +2826,7 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\ReturnNotation\\ReturnAssignmentFixer <./../src/Fixer/ReturnNotation/ReturnAssignmentFixer.php>`_
 -  `return_to_yield_from <./rules/array_notation/return_to_yield_from.rst>`_
 
-   When function return type is ``iterable``, and it returns an array explicitly, then it must be changed to ``yield from``.
+   If the function explicitly returns an array, and has the return type ``iterable``, then ``yield from`` must be used instead of ``return``.
 
    `Source PhpCsFixer\\Fixer\\ArrayNotation\\ReturnToYieldFromFixer <./../src/Fixer/ArrayNotation/ReturnToYieldFromFixer.php>`_
 -  `return_type_declaration <./rules/function_notation/return_type_declaration.rst>`_

--- a/doc/rules/array_notation/return_to_yield_from.rst
+++ b/doc/rules/array_notation/return_to_yield_from.rst
@@ -2,9 +2,8 @@
 Rule ``return_to_yield_from``
 =============================
 
-When function return type is iterable (``iterable``, ``Iterator`` and
-``Traversable``) and it starts with ``return`` then it must be changed to
-``yield from``.
+When function return type is ``iterable``, and it returns an array explicitly,
+then it must be changed to ``yield from``.
 
 Examples
 --------

--- a/doc/rules/array_notation/return_to_yield_from.rst
+++ b/doc/rules/array_notation/return_to_yield_from.rst
@@ -2,9 +2,9 @@
 Rule ``return_to_yield_from``
 =============================
 
-When function return type is iterable (``iterable``, ``Traversable``,
-``Iterator`` and ``IteratorAggregate``) and it starts with ``return`` then it
-must be changed to ``yield from``.
+When function return type is iterable (``iterable``, ``Iterator`` and
+``Traversable``) and it starts with ``return`` then it must be changed to
+``yield from``.
 
 Examples
 --------

--- a/doc/rules/array_notation/return_to_yield_from.rst
+++ b/doc/rules/array_notation/return_to_yield_from.rst
@@ -2,8 +2,8 @@
 Rule ``return_to_yield_from``
 =============================
 
-When function return type is ``iterable``, and it returns an array explicitly,
-then it must be changed to ``yield from``.
+If the function explicitly returns an array, and has the return type
+``iterable``, then ``yield from`` must be used instead of ``return``.
 
 Examples
 --------

--- a/doc/rules/array_notation/return_to_yield_from.rst
+++ b/doc/rules/array_notation/return_to_yield_from.rst
@@ -2,8 +2,9 @@
 Rule ``return_to_yield_from``
 =============================
 
-When function return type is iterable and it starts with ``return`` then it must
-be changed to ``yield from``.
+When function return type is iterable (``iterable``, ``Traversable``,
+``Iterator`` and ``IteratorAggregate``) and it starts with ``return`` then it
+must be changed to ``yield from``.
 
 Examples
 --------

--- a/doc/rules/array_notation/return_to_yield_from.rst
+++ b/doc/rules/array_notation/return_to_yield_from.rst
@@ -1,0 +1,21 @@
+=============================
+Rule ``return_to_yield_from``
+=============================
+
+When function return type is iterable and it starts with ``return`` then it must
+be changed to ``yield from``.
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php function giveMeData(): iterable {
+   -    return [1, 2, 3];
+   +    yield from [1, 2, 3];
+    }

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -59,7 +59,7 @@ Array Notation
   Array index should always be written by using square braces.
 - `return_to_yield_from <./array_notation/return_to_yield_from.rst>`_
 
-  When function return type is iterable (``iterable``, ``Traversable``, ``Iterator`` and ``IteratorAggregate``) and it starts with ``return`` then it must be changed to ``yield from``.
+  When function return type is iterable (``iterable``, ``Iterator`` and ``Traversable``) and it starts with ``return`` then it must be changed to ``yield from``.
 - `trim_array_spaces <./array_notation/trim_array_spaces.rst>`_
 
   Arrays should be formatted like function/method arguments, without leading or trailing single line space.

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -59,7 +59,7 @@ Array Notation
   Array index should always be written by using square braces.
 - `return_to_yield_from <./array_notation/return_to_yield_from.rst>`_
 
-  When function return type is ``iterable``, and it returns an array explicitly, then it must be changed to ``yield from``.
+  If the function explicitly returns an array, and has the return type ``iterable``, then ``yield from`` must be used instead of ``return``.
 - `trim_array_spaces <./array_notation/trim_array_spaces.rst>`_
 
   Arrays should be formatted like function/method arguments, without leading or trailing single line space.

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -59,7 +59,7 @@ Array Notation
   Array index should always be written by using square braces.
 - `return_to_yield_from <./array_notation/return_to_yield_from.rst>`_
 
-  When function return type is iterable and it starts with ``return`` then it must be changed to ``yield from``.
+  When function return type is iterable (``iterable``, ``Traversable``, ``Iterator`` and ``IteratorAggregate``) and it starts with ``return`` then it must be changed to ``yield from``.
 - `trim_array_spaces <./array_notation/trim_array_spaces.rst>`_
 
   Arrays should be formatted like function/method arguments, without leading or trailing single line space.

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -57,6 +57,9 @@ Array Notation
 - `normalize_index_brace <./array_notation/normalize_index_brace.rst>`_
 
   Array index should always be written by using square braces.
+- `return_to_yield_from <./array_notation/return_to_yield_from.rst>`_
+
+  When function return type is iterable and it starts with ``return`` then it must be changed to ``yield from``.
 - `trim_array_spaces <./array_notation/trim_array_spaces.rst>`_
 
   Arrays should be formatted like function/method arguments, without leading or trailing single line space.

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -59,7 +59,7 @@ Array Notation
   Array index should always be written by using square braces.
 - `return_to_yield_from <./array_notation/return_to_yield_from.rst>`_
 
-  When function return type is iterable (``iterable``, ``Iterator`` and ``Traversable``) and it starts with ``return`` then it must be changed to ``yield from``.
+  When function return type is ``iterable``, and it returns an array explicitly, then it must be changed to ``yield from``.
 - `trim_array_spaces <./array_notation/trim_array_spaces.rst>`_
 
   Arrays should be formatted like function/method arguments, without leading or trailing single line space.

--- a/src/Fixer/ArrayNotation/ReturnToYieldFromFixer.php
+++ b/src/Fixer/ArrayNotation/ReturnToYieldFromFixer.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\ArrayNotation;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ */
+final class ReturnToYieldFromFixer extends AbstractFixer
+{
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'When function return type is iterable and it starts with `return` then it must be changed to `yield from`.',
+            [new CodeSample('<?php function giveMeData(): iterable {
+    return [1, 2, 3];
+}
+')],
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound([T_ARRAY, CT::T_ARRAY_SQUARE_BRACE_OPEN]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Must run before YieldFromArrayToYieldsFixer.
+     * Must run after PhpUnitDataProviderReturnTypeFixer, PhpdocToReturnTypeFixer.
+     */
+    public function getPriority(): int
+    {
+        return 1;
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        $functionsAnalyzer = new FunctionsAnalyzer();
+
+        foreach ($tokens->findGivenKind(T_FUNCTION) as $index => $token) {
+            $returnType = $functionsAnalyzer->getFunctionReturnType($tokens, $index);
+            if (null === $returnType || 'iterable' !== strtolower($returnType->getName())) {
+                continue;
+            }
+
+            $functionBodyStartIndex = $tokens->getNextTokenOfKind($index, ['{', ';']);
+            if (!$tokens[$functionBodyStartIndex]->equals('{')) {
+                continue;
+            }
+
+            $returnIndex = $tokens->getNextMeaningfulToken($functionBodyStartIndex);
+
+            if (!$tokens[$returnIndex]->isGivenKind(T_RETURN)) {
+                continue;
+            }
+
+            $tokens[$returnIndex] = new Token([T_YIELD_FROM, 'yield from']);
+        }
+    }
+}

--- a/src/Fixer/ArrayNotation/ReturnToYieldFromFixer.php
+++ b/src/Fixer/ArrayNotation/ReturnToYieldFromFixer.php
@@ -18,30 +18,19 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\Tokenizer\Analyzer\NamespaceUsesAnalyzer;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
-use PhpCsFixer\Utils;
 
 /**
  * @author Kuba Werłos <werlos@gmail.com>
  */
 final class ReturnToYieldFromFixer extends AbstractFixer
 {
-    private const SUPPORTED_TYPES = [
-        'iterable' => 'iterable',
-        'iterator' => 'Iterator',
-        'traversable' => 'Traversable',
-    ];
-
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            sprintf(
-                'When function return type is iterable (%s) and it starts with `return` then it must be changed to `yield from`.',
-                Utils::naturalLanguageJoinWithBackticks(self::SUPPORTED_TYPES)
-            ),
+            'When function return type is `iterable`, and it returns an array explicitly, then it must be changed to `yield from`.',
             [new CodeSample('<?php function giveMeData(): iterable {
     return [1, 2, 3];
 }
@@ -51,7 +40,7 @@ final class ReturnToYieldFromFixer extends AbstractFixer
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isTokenKindFound(T_RETURN);
+        return $tokens->isAnyTokenKindsFound([T_ARRAY, CT::T_ARRAY_SQUARE_BRACE_OPEN]);
     }
 
     /**
@@ -78,6 +67,11 @@ final class ReturnToYieldFromFixer extends AbstractFixer
 
     private function shouldBeFixed(Tokens $tokens, int $returnIndex): bool
     {
+        $nextIndex = $tokens->getNextMeaningfulToken($returnIndex);
+        if (!$tokens[$nextIndex]->isGivenKind([T_ARRAY, CT::T_ARRAY_SQUARE_BRACE_OPEN])) {
+            return false;
+        }
+
         $beforeReturnIndex = $tokens->getPrevMeaningfulToken($returnIndex);
         if (!$tokens[$beforeReturnIndex]->equals('{')) {
             return false;
@@ -88,48 +82,6 @@ final class ReturnToYieldFromFixer extends AbstractFixer
             return false;
         }
 
-        $returnType = strtolower($tokens[$returnTypeIndex]->getContent());
-        if (!isset(self::SUPPORTED_TYPES[$returnType])) {
-            return false;
-        }
-
-        $beforeReturnTypeIndex = $tokens->getPrevMeaningfulToken($returnTypeIndex);
-        if ($tokens[$beforeReturnTypeIndex]->isGivenKind(CT::T_TYPE_COLON)) {
-            return !$this->isTypeImportedFromVendor($tokens, $returnTypeIndex);
-        }
-
-        if (!$tokens[$beforeReturnTypeIndex]->isGivenKind(T_NS_SEPARATOR)) {
-            return false;
-        }
-
-        $beforeBeforeReturnTypeIndex = $tokens->getPrevMeaningfulToken($beforeReturnTypeIndex);
-
-        return $tokens[$beforeBeforeReturnTypeIndex]->isGivenKind(CT::T_TYPE_COLON);
-    }
-
-    private function isTypeImportedFromVendor(Tokens $tokens, int $returnTypeIndex): bool
-    {
-        $returnType = strtolower($tokens[$returnTypeIndex]->getContent());
-        if ('iterable' === $returnType) {
-            return false;
-        }
-
-        foreach ($tokens->getNamespaceDeclarations() as $namespace) {
-            if ($returnTypeIndex < $namespace->getScopeStartIndex()) {
-                continue;
-            }
-            if ($returnTypeIndex > $namespace->getScopeEndIndex()) {
-                continue;
-            }
-
-            foreach ((new NamespaceUsesAnalyzer())->getDeclarationsInNamespace($tokens, $namespace) as $use) {
-                $importFullName = ltrim($use->getFullName(), '\\');
-                if (str_ends_with(strtolower($importFullName), '\\'.$returnType)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return 'iterable' === strtolower($tokens[$returnTypeIndex]->getContent());
     }
 }

--- a/src/Fixer/ArrayNotation/ReturnToYieldFromFixer.php
+++ b/src/Fixer/ArrayNotation/ReturnToYieldFromFixer.php
@@ -31,9 +31,8 @@ final class ReturnToYieldFromFixer extends AbstractFixer
 {
     private const SUPPORTED_TYPES = [
         'iterable' => 'iterable',
-        'traversable' => 'Traversable',
         'iterator' => 'Iterator',
-        'iteratoraggregate' => 'IteratorAggregate',
+        'traversable' => 'Traversable',
     ];
 
     public function getDefinition(): FixerDefinitionInterface

--- a/src/Fixer/ArrayNotation/YieldFromArrayToYieldsFixer.php
+++ b/src/Fixer/ArrayNotation/YieldFromArrayToYieldsFixer.php
@@ -52,6 +52,7 @@ final class YieldFromArrayToYieldsFixer extends AbstractFixer
      * {@inheritdoc}
      *
      * Must run before BlankLineBeforeStatementFixer, NoExtraBlankLinesFixer, NoMultipleStatementsPerLineFixer, NoWhitespaceInBlankLineFixer, StatementIndentationFixer.
+     * Must run after ReturnToYieldFromFixer.
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -110,7 +110,7 @@ final class Foo {
     /**
      * {@inheritdoc}
      *
-     * Must run before FullyQualifiedStrictTypesFixer, NoSuperfluousPhpdocTagsFixer, PhpdocAlignFixer, ReturnTypeDeclarationFixer.
+     * Must run before FullyQualifiedStrictTypesFixer, NoSuperfluousPhpdocTagsFixer, PhpdocAlignFixer, ReturnToYieldFromFixer, ReturnTypeDeclarationFixer.
      * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
      */
     public function getPriority(): int

--- a/src/Fixer/NamespaceNotation/CleanNamespaceFixer.php
+++ b/src/Fixer/NamespaceNotation/CleanNamespaceFixer.php
@@ -52,7 +52,7 @@ final class CleanNamespaceFixer extends AbstractFixer
      */
     public function getPriority(): int
     {
-        return 1;
+        return 3;
     }
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void

--- a/src/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixer.php
@@ -65,12 +65,12 @@ class FooTest extends TestCase {
     /**
      * {@inheritdoc}
      *
-     * Must run before ReturnTypeDeclarationFixer.
+     * Must run before ReturnToYieldFromFixer, ReturnTypeDeclarationFixer.
      * Must run after CleanNamespaceFixer.
      */
     public function getPriority(): int
     {
-        return 0;
+        return 2;
     }
 
     public function isRisky(): bool

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -679,6 +679,7 @@ final class FixerFactoryTest extends TestCase
                 'php_unit_dedicate_assert',
             ],
             'php_unit_data_provider_return_type' => [
+                'return_to_yield_from',
                 'return_type_declaration',
             ],
             'php_unit_dedicate_assert' => [
@@ -769,6 +770,7 @@ final class FixerFactoryTest extends TestCase
             'phpdoc_to_return_type' => [
                 'fully_qualified_strict_types',
                 'no_superfluous_phpdoc_tags',
+                'return_to_yield_from',
                 'return_type_declaration',
             ],
             'phpdoc_types' => [
@@ -792,6 +794,9 @@ final class FixerFactoryTest extends TestCase
             ],
             'return_assignment' => [
                 'blank_line_before_statement',
+            ],
+            'return_to_yield_from' => [
+                'yield_from_array_to_yields',
             ],
             'semicolon_after_instruction' => [
                 'simplified_if_return',

--- a/tests/Fixer/ArrayNotation/ReturnToYieldFromFixerTest.php
+++ b/tests/Fixer/ArrayNotation/ReturnToYieldFromFixerTest.php
@@ -56,5 +56,18 @@ final class ReturnToYieldFromFixerTest extends AbstractFixerTestCase
             '<?php function foo(): ITERABLE { yield from [1, 2, 3]; }',
             '<?php function foo(): ITERABLE { return [1, 2, 3]; }',
         ];
+
+        yield [
+            '<?php
+                function foo(): iterable { yield from [1, 2]; }
+                function bar(): array { return [3, 4]; }
+                function baz(): int { return 5; }
+            ',
+            '<?php
+                function foo(): iterable { return [1, 2]; }
+                function bar(): array { return [3, 4]; }
+                function baz(): int { return 5; }
+            ',
+        ];
     }
 }

--- a/tests/Fixer/ArrayNotation/ReturnToYieldFromFixerTest.php
+++ b/tests/Fixer/ArrayNotation/ReturnToYieldFromFixerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\ArrayNotation;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\ArrayNotation\ReturnToYieldFromFixer
+ */
+final class ReturnToYieldFromFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<array{0: string, 1?: string}>
+     */
+    public static function provideFixCases(): iterable
+    {
+        yield ['<?php function foo() { return [1, 2, 3]; }'];
+
+        yield ['<?php function foo(): iterable { if (true) { return [1]; } else { return [2]; } }'];
+
+        yield ['<?php
+            abstract class Foo {
+                abstract public function bar(): iterable;
+                public function baz(): array { return []; }
+            }
+        '];
+
+        yield [
+            '<?php function foo(): iterable { yield from [1, 2, 3]; }',
+            '<?php function foo(): iterable { return [1, 2, 3]; }',
+        ];
+
+        yield [
+            '<?php function foo(): ITERABLE { yield from [1, 2, 3]; }',
+            '<?php function foo(): ITERABLE { return [1, 2, 3]; }',
+        ];
+    }
+}

--- a/tests/Fixer/ArrayNotation/ReturnToYieldFromFixerTest.php
+++ b/tests/Fixer/ArrayNotation/ReturnToYieldFromFixerTest.php
@@ -60,58 +60,6 @@ final class ReturnToYieldFromFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
-            '<?php function foo(): Traversable { yield from getGenerator(); }',
-            '<?php function foo(): Traversable { return getGenerator(); }',
-        ];
-
-        yield [
-            '<?php function foo(): \Traversable { yield from getGenerator(); }',
-            '<?php function foo(): \Traversable { return getGenerator(); }',
-        ];
-
-        yield [
-            '<?php function foo(): Iterator { yield from getGenerator(); }',
-            '<?php function foo(): Iterator { return getGenerator(); }',
-        ];
-
-        yield [
-            '<?php function foo(): IteratorAggregate { return getGenerator(); }',
-        ];
-
-        yield [
-            '<?php use BetterStuff\Traversable; function foo(): Traversable { return getGenerator(); }',
-        ];
-
-        yield [
-            '<?php use BetterStuff\Traversable; function foo(): \Traversable { yield from getGenerator(); }',
-            '<?php use BetterStuff\Traversable; function foo(): \Traversable { return getGenerator(); }',
-        ];
-
-        yield [
-            '<?php use Traversable; function foo(): Traversable { yield from getGenerator(); }',
-            '<?php use Traversable; function foo(): Traversable { return getGenerator(); }',
-        ];
-
-        yield [
-            '<?php use \Traversable; function foo(): Traversable { yield from getGenerator(); }',
-            '<?php use \Traversable; function foo(): Traversable { return getGenerator(); }',
-        ];
-
-        yield [
-            '<?php namespace N; use Traversable; function foo(): Traversable { yield from getGenerator(); }',
-            '<?php namespace N; use Traversable; function foo(): Traversable { return getGenerator(); }',
-        ];
-
-        yield [
-            '<?php namespace N; use BetterStuff\Traversable; function foo(): Traversable { return getGenerator(); }',
-        ];
-
-        yield [
-            '<?php namespace N; use \Traversable; function foo(): Traversable { yield from getGenerator(); }',
-            '<?php namespace N; use \Traversable; function foo(): Traversable { return getGenerator(); }',
-        ];
-
-        yield [
             '<?php
                 function foo(): iterable { yield from [1, 2]; }
                 function bar(): array { return [3, 4]; }
@@ -121,53 +69,6 @@ final class ReturnToYieldFromFixerTest extends AbstractFixerTestCase
                 function foo(): iterable { return [1, 2]; }
                 function bar(): array { return [3, 4]; }
                 function baz(): int { return 5; }
-            ',
-        ];
-
-        yield [
-            '<?php
-                namespace Namespace1 {
-                    use Foo\Traversable;
-                    function f1(): Traversable { return getGenerator(); }
-                }
-                namespace Namespace2 {
-                    use Traversable;
-                    function f2(): Traversable { yield from getGenerator(); }
-                }
-                namespace Namespace3 {
-                    use Bar\Traversable;
-                    function f3(): Traversable { return getGenerator(); }
-                }
-                namespace Namespace4 {
-                    use \Traversable;
-                    function f4(): Traversable { yield from getGenerator(); }
-                }
-                namespace Namespace5 {
-                    use \Foo\Bar\Baz\Traversable;
-                    function f5(): Traversable { return getGenerator(); }
-                }
-            ',
-            '<?php
-                namespace Namespace1 {
-                    use Foo\Traversable;
-                    function f1(): Traversable { return getGenerator(); }
-                }
-                namespace Namespace2 {
-                    use Traversable;
-                    function f2(): Traversable { return getGenerator(); }
-                }
-                namespace Namespace3 {
-                    use Bar\Traversable;
-                    function f3(): Traversable { return getGenerator(); }
-                }
-                namespace Namespace4 {
-                    use \Traversable;
-                    function f4(): Traversable { return getGenerator(); }
-                }
-                namespace Namespace5 {
-                    use \Foo\Bar\Baz\Traversable;
-                    function f5(): Traversable { return getGenerator(); }
-                }
             ',
         ];
     }

--- a/tests/Fixer/ArrayNotation/ReturnToYieldFromFixerTest.php
+++ b/tests/Fixer/ArrayNotation/ReturnToYieldFromFixerTest.php
@@ -143,7 +143,7 @@ final class ReturnToYieldFromFixerTest extends AbstractFixerTestCase
                     function f4(): Traversable { yield from getGenerator(); }
                 }
                 namespace Namespace5 {
-                    use \For\Bar\Baz\Traversable;
+                    use \Foo\Bar\Baz\Traversable;
                     function f5(): Traversable { return getGenerator(); }
                 }
             ',
@@ -165,7 +165,7 @@ final class ReturnToYieldFromFixerTest extends AbstractFixerTestCase
                     function f4(): Traversable { return getGenerator(); }
                 }
                 namespace Namespace5 {
-                    use \For\Bar\Baz\Traversable;
+                    use \Foo\Bar\Baz\Traversable;
                     function f5(): Traversable { return getGenerator(); }
                 }
             ',

--- a/tests/Fixer/ArrayNotation/ReturnToYieldFromFixerTest.php
+++ b/tests/Fixer/ArrayNotation/ReturnToYieldFromFixerTest.php
@@ -132,7 +132,7 @@ final class ReturnToYieldFromFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
-            '<?php function foo(): array|iterable { return [1, 2, 3]; }',
+            '<?php function foo(): Bar|iterable { return [1, 2, 3]; }',
         ];
     }
 }

--- a/tests/Fixer/ArrayNotation/ReturnToYieldFromFixerTest.php
+++ b/tests/Fixer/ArrayNotation/ReturnToYieldFromFixerTest.php
@@ -75,7 +75,6 @@ final class ReturnToYieldFromFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
-            '<?php function foo(): IteratorAggregate { yield from getGenerator(); }',
             '<?php function foo(): IteratorAggregate { return getGenerator(); }',
         ];
 
@@ -104,7 +103,7 @@ final class ReturnToYieldFromFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
-            '<?php namespace N; use BetterStuff\Traversable; function foo(): Traversable { yield from getGenerator(); }',
+            '<?php namespace N; use BetterStuff\Traversable; function foo(): Traversable { return getGenerator(); }',
         ];
 
         yield [

--- a/tests/Fixer/ArrayNotation/ReturnToYieldFromFixerTest.php
+++ b/tests/Fixer/ArrayNotation/ReturnToYieldFromFixerTest.php
@@ -38,6 +38,8 @@ final class ReturnToYieldFromFixerTest extends AbstractFixerTestCase
     {
         yield ['<?php function foo() { return [1, 2, 3]; }'];
 
+        yield ['<?php function foo(): MyAwesomeIterableType { return [1, 2, 3]; }'];
+
         yield ['<?php function foo(): iterable { if (true) { return [1]; } else { return [2]; } }'];
 
         yield ['<?php
@@ -58,6 +60,59 @@ final class ReturnToYieldFromFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
+            '<?php function foo(): Traversable { yield from getGenerator(); }',
+            '<?php function foo(): Traversable { return getGenerator(); }',
+        ];
+
+        yield [
+            '<?php function foo(): \Traversable { yield from getGenerator(); }',
+            '<?php function foo(): \Traversable { return getGenerator(); }',
+        ];
+
+        yield [
+            '<?php function foo(): Iterator { yield from getGenerator(); }',
+            '<?php function foo(): Iterator { return getGenerator(); }',
+        ];
+
+        yield [
+            '<?php function foo(): IteratorAggregate { yield from getGenerator(); }',
+            '<?php function foo(): IteratorAggregate { return getGenerator(); }',
+        ];
+
+        yield [
+            '<?php use BetterStuff\Traversable; function foo(): Traversable { return getGenerator(); }',
+        ];
+
+        yield [
+            '<?php use BetterStuff\Traversable; function foo(): \Traversable { yield from getGenerator(); }',
+            '<?php use BetterStuff\Traversable; function foo(): \Traversable { return getGenerator(); }',
+        ];
+
+        yield [
+            '<?php use Traversable; function foo(): Traversable { yield from getGenerator(); }',
+            '<?php use Traversable; function foo(): Traversable { return getGenerator(); }',
+        ];
+
+        yield [
+            '<?php use \Traversable; function foo(): Traversable { yield from getGenerator(); }',
+            '<?php use \Traversable; function foo(): Traversable { return getGenerator(); }',
+        ];
+
+        yield [
+            '<?php namespace N; use Traversable; function foo(): Traversable { yield from getGenerator(); }',
+            '<?php namespace N; use Traversable; function foo(): Traversable { return getGenerator(); }',
+        ];
+
+        yield [
+            '<?php namespace N; use BetterStuff\Traversable; function foo(): Traversable { yield from getGenerator(); }',
+        ];
+
+        yield [
+            '<?php namespace N; use \Traversable; function foo(): Traversable { yield from getGenerator(); }',
+            '<?php namespace N; use \Traversable; function foo(): Traversable { return getGenerator(); }',
+        ];
+
+        yield [
             '<?php
                 function foo(): iterable { yield from [1, 2]; }
                 function bar(): array { return [3, 4]; }
@@ -67,6 +122,53 @@ final class ReturnToYieldFromFixerTest extends AbstractFixerTestCase
                 function foo(): iterable { return [1, 2]; }
                 function bar(): array { return [3, 4]; }
                 function baz(): int { return 5; }
+            ',
+        ];
+
+        yield [
+            '<?php
+                namespace Namespace1 {
+                    use Foo\Traversable;
+                    function f1(): Traversable { return getGenerator(); }
+                }
+                namespace Namespace2 {
+                    use Traversable;
+                    function f2(): Traversable { yield from getGenerator(); }
+                }
+                namespace Namespace3 {
+                    use Bar\Traversable;
+                    function f3(): Traversable { return getGenerator(); }
+                }
+                namespace Namespace4 {
+                    use \Traversable;
+                    function f4(): Traversable { yield from getGenerator(); }
+                }
+                namespace Namespace5 {
+                    use \For\Bar\Baz\Traversable;
+                    function f5(): Traversable { return getGenerator(); }
+                }
+            ',
+            '<?php
+                namespace Namespace1 {
+                    use Foo\Traversable;
+                    function f1(): Traversable { return getGenerator(); }
+                }
+                namespace Namespace2 {
+                    use Traversable;
+                    function f2(): Traversable { return getGenerator(); }
+                }
+                namespace Namespace3 {
+                    use Bar\Traversable;
+                    function f3(): Traversable { return getGenerator(); }
+                }
+                namespace Namespace4 {
+                    use \Traversable;
+                    function f4(): Traversable { return getGenerator(); }
+                }
+                namespace Namespace5 {
+                    use \For\Bar\Baz\Traversable;
+                    function f5(): Traversable { return getGenerator(); }
+                }
             ',
         ];
     }

--- a/tests/Fixtures/Integration/priority/php_unit_data_provider_return_type,return_to_yield_from.test
+++ b/tests/Fixtures/Integration/priority/php_unit_data_provider_return_type,return_to_yield_from.test
@@ -1,0 +1,27 @@
+--TEST--
+Integration of fixers: php_unit_data_provider_return_type,return_to_yield_from.
+--RULESET--
+{"php_unit_data_provider_return_type": true, "return_to_yield_from": true}
+--EXPECT--
+<?php
+class FooTest extends TestCase {
+    /**
+     * @dataProvider provideFooCases
+     */
+    function testFoo() {}
+    function provideFooCases(): iterable {
+        yield from [[1], [2], [3]];
+    }
+}
+
+--INPUT--
+<?php
+class FooTest extends TestCase {
+    /**
+     * @dataProvider provideFooCases
+     */
+    function testFoo() {}
+    function provideFooCases() {
+        return [[1], [2], [3]];
+    }
+}

--- a/tests/Fixtures/Integration/priority/phpdoc_to_return_type,return_to_yield_from.test
+++ b/tests/Fixtures/Integration/priority/phpdoc_to_return_type,return_to_yield_from.test
@@ -1,0 +1,21 @@
+--TEST--
+Integration of fixers: phpdoc_to_return_type,return_to_yield_from.
+--RULESET--
+{"phpdoc_to_return_type": true, "return_to_yield_from": true}
+--EXPECT--
+<?php
+/**
+ * @return iterable
+ */
+function foo(): iterable {
+    yield from [1, 2, 3];
+}
+
+--INPUT--
+<?php
+/**
+ * @return iterable
+ */
+function foo() {
+    return [1, 2, 3];
+}

--- a/tests/Fixtures/Integration/priority/return_to_yield_from,yield_from_array_to_yields.test
+++ b/tests/Fixtures/Integration/priority/return_to_yield_from,yield_from_array_to_yields.test
@@ -1,0 +1,21 @@
+--TEST--
+Integration of fixers: return_to_yield_from,yield_from_array_to_yields.
+--RULESET--
+{"return_to_yield_from": true, "yield_from_array_to_yields": true}
+--EXPECT--
+<?php function foo(): iterable {
+     
+        yield 1;
+        yield 2;
+        yield 3;
+    
+}
+
+--INPUT--
+<?php function foo(): iterable {
+    return [
+        1,
+        2,
+        3,
+    ];
+}


### PR DESCRIPTION
This will conclude trasforming:
```php
public function dattaProvvider()
{
    return [
        [1, 2],
        [3, 4],
    ];
}
```
into nice data provider with yields
