### PR TITLE
DX: remove unnecessary arrays from data providers

### DIFF
--- a/tests/Console/SelfUpdate/NewVersionCheckerTest.php
+++ b/tests/Console/SelfUpdate/NewVersionCheckerTest.php
@@ -70,8 +70,6 @@ final class NewVersionCheckerTest extends TestCase
 
     public static function provideCompareVersionsCases(): iterable
     {
-        $cases = [];
-
         foreach ([
             ['1.0.0-alpha', '1.0.0', -1],
             ['1.0.0-beta', '1.0.0', -1],
@@ -82,22 +80,23 @@ final class NewVersionCheckerTest extends TestCase
             ['1.0.0', '2.0.0', -1],
         ] as $case) {
             // X.Y.Z vs. X.Y.Z
-            $cases[] = $case;
+            yield $case;
 
             // vX.Y.Z vs. X.Y.Z
             $case[0] = 'v'.$case[0];
-            $cases[] = $case;
+
+            yield $case;
 
             // vX.Y.Z vs. vX.Y.Z
             $case[1] = 'v'.$case[1];
-            $cases[] = $case;
+
+            yield $case;
 
             // X.Y.Z vs. vX.Y.Z
             $case[0] = substr($case[0], 1);
-            $cases[] = $case;
-        }
 
-        return $cases;
+            yield $case;
+        }
     }
 
     private function createGithubClientStub(): GithubClientInterface

--- a/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
+++ b/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
@@ -69,7 +69,6 @@ final class ShortScalarCastFixerTest extends AbstractFixerTestCase
 
     public static function provideNoFixCases(): iterable
     {
-        $cases = [];
         $types = ['string', 'array', 'object'];
 
         if (\PHP_VERSION_ID < 8_00_00) {
@@ -77,13 +76,14 @@ final class ShortScalarCastFixerTest extends AbstractFixerTestCase
         }
 
         foreach ($types as $cast) {
-            $cases[] = [sprintf('<?php $b=(%s) $d;', $cast)];
-            $cases[] = [sprintf('<?php $b=( %s ) $d;', $cast)];
-            $cases[] = [sprintf('<?php $b=(%s ) $d;', ucfirst($cast))];
-            $cases[] = [sprintf('<?php $b=(%s ) $d;', strtoupper($cast))];
-        }
+            yield [sprintf('<?php $b=(%s) $d;', $cast)];
 
-        return $cases;
+            yield [sprintf('<?php $b=( %s ) $d;', $cast)];
+
+            yield [sprintf('<?php $b=(%s ) $d;', ucfirst($cast))];
+
+            yield [sprintf('<?php $b=(%s ) $d;', strtoupper($cast))];
+        }
     }
 
     /**

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -373,9 +373,7 @@ private $d = 123;
 
     public static function provideFixClassesCases(): iterable
     {
-        $cases = [];
-
-        $cases[] = ['<?php
+        yield ['<?php
 class SomeClass1
 {
     // This comment
@@ -387,7 +385,7 @@ class SomeClass1
 }
 '];
 
-        $cases[] = [
+        yield [
             '<?php
 class SomeClass2
 {
@@ -411,7 +409,7 @@ class SomeClass2
             ',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 class SomeClass3
 {
@@ -425,7 +423,7 @@ class SomeClass3
 }
 ', ];
 
-        $cases[] = [
+        yield [
             '<?php
 class SomeClass1
 {
@@ -502,7 +500,7 @@ class SomeClass1
 }
 ', ];
 
-        $cases[] = ['<?php
+        yield ['<?php
 class SomeClass
 {
     // comment
@@ -513,7 +511,7 @@ class SomeClass
 }
 '];
 
-        $cases[] = ['<?php
+        yield ['<?php
 class SomeClass
 {
     // This comment
@@ -525,7 +523,7 @@ class SomeClass
 }
 '];
 
-        $cases[] = [
+        yield [
             '<?php
 class SomeClass
 {
@@ -551,7 +549,7 @@ class SomeClass
 ',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 class SomeClass
 {
@@ -573,7 +571,7 @@ class SomeClass
 ',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 class SomeClass
 {
@@ -595,7 +593,7 @@ class SomeClass
 ',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 abstract class MethodTest2
 {
@@ -656,7 +654,7 @@ function some1(){ echo 1;}
 function some2(){ echo 2;}',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 
 /*
@@ -701,7 +699,7 @@ final class NullLinter implements LinterInterface
         // do not touch anonymous functions (since PHP doesn't allow
         // for class attributes being functions :(, we only have to test
         // those used within methods)
-        $cases[] = [
+        yield [
             '<?php
 class MethodTestAnonymous
 {
@@ -722,7 +720,7 @@ class MethodTestAnonymous
 }',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 class MethodTest1
 {
@@ -821,7 +819,7 @@ class MethodTest1
         ];
 
         // spaces between methods
-        $cases[] = [
+        yield [
             '<?php
 abstract class MethodTest3
 {
@@ -865,7 +863,7 @@ abstract class MethodTest3
     }
 }', ];
         // don't change correct code
-        $cases[] = [
+        yield [
             '<?php
 class SmallHelperException extends \Exception
 {
@@ -889,7 +887,7 @@ class MethodTest123124124
         ];
 
         // do not touch function out of class scope
-        $cases[] = [
+        yield [
             '<?php
 function some0() {
 
@@ -913,7 +911,7 @@ function some2() {
 ',
         ];
 
-        $cases[] = [
+        yield [
             '<?php interface A {
 public function B1(); // allowed comment
 
@@ -923,7 +921,8 @@ public function B1(); // allowed comment
                 public function C(); // allowed comment
             }',
         ];
-        $cases[] = [
+
+        yield [
             '<?php class Foo {
                 var $a;
 
@@ -935,7 +934,7 @@ public function B1(); // allowed comment
             }',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
                 class A
                 {
@@ -957,8 +956,6 @@ public function B1(); // allowed comment
                 }
             ',
         ];
-
-        return $cases;
     }
 
     /**
@@ -971,10 +968,8 @@ public function B1(); // allowed comment
 
     public static function provideFixTraitsCases(): iterable
     {
-        $cases = [];
-
         // do not touch well formatted traits
-        $cases[] = [
+        yield [
             '<?php
 trait OkTrait
 {
@@ -991,7 +986,7 @@ trait OkTrait
 }',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 trait ezcReflectionReturnInfo {
     public $x = 1;
@@ -1020,7 +1015,7 @@ trait ezcReflectionReturnInfo {
 }',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 trait SomeReturnInfo {
     function getReturnType()
@@ -1051,8 +1046,6 @@ trait SomeReturnInfo {
     abstract public function getWorld();
 }',
         ];
-
-        return $cases;
     }
 
     /**
@@ -1065,8 +1058,7 @@ trait SomeReturnInfo {
 
     public static function provideFixInterfaceCases(): iterable
     {
-        $cases = [];
-        $cases[] = [
+        yield [
             '<?php
 interface TestInterface
 {
@@ -1100,7 +1092,7 @@ interface TestInterface
         ];
 
         // do not touch well formatted interfaces
-        $cases[] = [
+        yield [
             '<?php
 interface TestInterfaceOK
 {
@@ -1111,7 +1103,7 @@ interface TestInterfaceOK
         ];
 
         // method after trait use
-        $cases[] = [
+        yield [
             '<?php
 trait ezcReflectionReturnInfo {
     function getReturnDescription() {}
@@ -1134,8 +1126,6 @@ class ezcReflectionMethod extends ReflectionMethod {
 
 }',
         ];
-
-        return $cases;
     }
 
     /**

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -376,12 +376,12 @@ A#
 
     public static function provideFixingInterfacesCases(): iterable
     {
-        $cases = array_merge(
+        yield from array_merge(
             self::provideClassyCases('interface'),
             self::provideClassyExtendingCases('interface')
         );
 
-        $cases[] = [
+        yield [
             '<?php
 interface Test extends
   /*a*/    /*b*/TestInterface1   , \A\B\C  ,  /* test */
@@ -407,8 +407,6 @@ TestInterface3, /**/     TestInterface4   ,
         /**/TestInterface65    {}
             ',
         ];
-
-        return $cases;
     }
 
     public static function provideFixingTraitsCases(): iterable

--- a/tests/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixerTest.php
@@ -44,9 +44,7 @@ final class NoBlankLinesAfterClassOpeningFixerTest extends AbstractFixerTestCase
 
     public static function provideFixCases(): iterable
     {
-        $cases = [];
-
-        $cases[] = [
+        yield [
             '<?php
 class Good
 {
@@ -66,7 +64,7 @@ class Good
 }',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 class Good
 {
@@ -92,7 +90,7 @@ class Good
 }',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 interface Good
 {
@@ -113,7 +111,7 @@ interface Good
         ];
 
         // check if some fancy whitespaces aren't modified
-        $cases[] = [
+        yield [
             '<?php
 class Good
 {public
@@ -128,7 +126,7 @@ class Good
         ];
 
         // check if line with spaces is removed when next token is indented
-        $cases[] = [
+        yield [
             '<?php
 class Foo
 {
@@ -145,7 +143,7 @@ class Foo
         ];
 
         // check if line with spaces is removed when next token is not indented
-        $cases[] = [
+        yield [
             '<?php
 class Foo
 {
@@ -160,15 +158,11 @@ function bar() {}
 }
 ',
         ];
-
-        return $cases;
     }
 
     public static function provideFixTraitsCases(): iterable
     {
-        $cases = [];
-
-        $cases[] = [
+        yield [
             '<?php
 trait Good
 {
@@ -187,8 +181,6 @@ trait Good
     public function firstMethod() {}
 }',
         ];
-
-        return $cases;
     }
 
     /**

--- a/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
+++ b/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
@@ -274,105 +274,113 @@ echo 1;
 
     public static function provideGetCommentBlockCases(): iterable
     {
-        yield from [
-            [
-                '<?php // a',
-                1,
-                1,
-                false,
-            ],
-            [
-                '<?php
+        yield [
+            '<?php // a',
+            1,
+            1,
+            false,
+        ];
+
+        yield [
+            '<?php
                     // This comment could be nicely formatted.
                     //
                     //
                     // For that, it could have some empty comment lines inside.
                     //           ',
-                2,
-                11,
-                false,
-            ],
-            [
-                '<?php
+            2,
+            11,
+            false,
+        ];
+
+        yield [
+            '<?php
 /**///',
-                1,
-                1,
-                true,
-            ],
-            [
-                '<?php
+            1,
+            1,
+            true,
+        ];
+
+        yield [
+            '<?php
 //
 //
 
 #
 #
 ',
-                5,
-                8,
-                true,
-            ],
-            [
-                '<?php
+            5,
+            8,
+            true,
+        ];
+
+        yield [
+            '<?php
 //
 //
 
 //
 //
 ',
-                5,
-                8,
-                true,
-            ],
-            [
-                '<?php
+            5,
+            8,
+            true,
+        ];
+
+        yield [
+            '<?php
 //
 //
 
 //
 //
 ',
-                1,
-                3,
-                true,
-            ],
-            [
-                str_replace("\n", "\r", "<?php\n//\n//\n\n//\n//\n"),
-                1,
-                3,
-                true,
-            ],
-            [
-                str_replace("\n", "\r\n", "<?php\n//\n//\n\n//\n//\n"),
-                1,
-                3,
-                true,
-            ],
-            [
-                '<?php
+            1,
+            3,
+            true,
+        ];
+
+        yield [
+            str_replace("\n", "\r", "<?php\n//\n//\n\n//\n//\n"),
+            1,
+            3,
+            true,
+        ];
+
+        yield [
+            str_replace("\n", "\r\n", "<?php\n//\n//\n\n//\n//\n"),
+            1,
+            3,
+            true,
+        ];
+
+        yield [
+            '<?php
 //
 
 //
 ',
-                1,
-                1,
-                true,
-            ],
-            [
-                '<?php
+            1,
+            1,
+            true,
+        ];
+
+        yield [
+            '<?php
 //
 //
               $a;  ',
-                1,
-                4,
-                true,
-            ],
-            [
-                '<?php
+            1,
+            4,
+            true,
+        ];
+
+        yield [
+            '<?php
 //',
-                1,
-                1,
-                true,
-            ],
+            1,
+            1,
+            true,
         ];
 
         $src = '<?php

--- a/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
+++ b/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
@@ -274,7 +274,7 @@ echo 1;
 
     public static function provideGetCommentBlockCases(): iterable
     {
-        $cases = [
+        yield from [
             [
                 '<?php // a',
                 1,
@@ -383,13 +383,13 @@ echo 1;
           #                        c12';
 
         foreach ([2, 4, 6] as $i) {
-            $cases[] = [$src, $i, 7, false];
+            yield [$src, $i, 7, false];
         }
 
-        $cases[] = [$src, 8, 8, false];
-        $cases[] = [$src, 10, 11, false];
-        $cases[] = [$src, 12, 12, false];
+        yield [$src, 8, 8, false];
 
-        return $cases;
+        yield [$src, 10, 11, false];
+
+        yield [$src, 12, 12, false];
     }
 }

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -1073,15 +1073,17 @@ switch ($foo) {
             ]);
         };
 
-        foreach ($cases as &$case) {
+        foreach ($cases as $case) {
             $case[0] = $replaceCommentText($case[0]);
 
             if (isset($case[1])) {
                 $case[1] = $replaceCommentText($case[1]);
             }
+
+            yield $case;
         }
 
-        return array_merge($cases, [
+        yield from [
             [
                 '<?php
 switch ($foo) {
@@ -1108,7 +1110,7 @@ switch ($foo) {
         baz();
 }',
             ],
-        ]);
+        ];
     }
 
     /**

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -1083,9 +1083,8 @@ switch ($foo) {
             yield $case;
         }
 
-        yield from [
-            [
-                '<?php
+        yield [
+            '<?php
 switch ($foo) {
     case 1:
         foo();
@@ -1098,7 +1097,7 @@ switch ($foo) {
     default:
         baz();
 }',
-                '<?php
+            '<?php
 switch ($foo) {
     case 1:
         foo();
@@ -1109,7 +1108,6 @@ switch ($foo) {
     default:
         baz();
 }',
-            ],
         ];
     }
 

--- a/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
@@ -171,7 +171,7 @@ else?><?php echo 5;',
                 }
             ';
 
-        $cases = self::generateCases($expected, $input);
+        yield from self::generateCases($expected, $input);
 
         $expected =
             '<?php
@@ -188,7 +188,7 @@ else?><?php echo 5;',
                 }
             ';
 
-        $cases = array_merge($cases, self::generateCases($expected));
+        yield from self::generateCases($expected);
 
         $expected =
             '<?php
@@ -209,9 +209,9 @@ else?><?php echo 5;',
                 }
             ';
 
-        $cases = array_merge($cases, self::generateCases($expected));
+        yield from self::generateCases($expected);
 
-        $cases[] = [
+        yield [
             '<?php
                 if ($a)
                     echo 1789;
@@ -229,7 +229,7 @@ else?><?php echo 5;',
             ',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
                 if ($a)
                     echo 1789;
@@ -245,8 +245,6 @@ else?><?php echo 5;',
                     echo 4;
             ',
         ];
-
-        return $cases;
     }
 
     /**
@@ -679,8 +677,6 @@ else?><?php echo 5;',
 
     public static function provideBlockDetectionCases(): iterable
     {
-        $cases = [];
-
         $source = '<?php
                     if ($a)
                         echo 1;
@@ -690,10 +686,14 @@ else?><?php echo 5;',
                     else
                         echo 4;
                     ';
-        $cases[] = [[2, 11], $source, 13];
-        $cases[] = [[13, 24], $source, 26];
-        $cases[] = [[13, 24], $source, 26];
-        $cases[] = [[26, 39], $source, 41];
+
+        yield [[2, 11], $source, 13];
+
+        yield [[13, 24], $source, 26];
+
+        yield [[13, 24], $source, 26];
+
+        yield [[26, 39], $source, 41];
 
         $source = '<?php
                     if ($a) {
@@ -710,11 +710,12 @@ else?><?php echo 5;',
                     } else
                         echo 1;
                     ';
-        $cases[] = [[2, 25], $source, 27];
-        $cases[] = [[27, 40], $source, 42];
-        $cases[] = [[59, 72], $source, 74];
 
-        return $cases;
+        yield [[2, 25], $source, 27];
+
+        yield [[27, 40], $source, 42];
+
+        yield [[59, 72], $source, 74];
     }
 
     /**

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
@@ -45,7 +45,7 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
 
     public static function provideFixCases(): iterable
     {
-        $cases = self::createTestCases([
+        yield from self::createTestCases([
             ['
 /**
  * Foo.
@@ -339,7 +339,7 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
 '],
         ]);
 
-        $cases[] = [
+        yield [
             '<?php
 
 /**
@@ -347,8 +347,6 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
  */
 ',
         ];
-
-        return $cases;
     }
 
     /**

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
@@ -59,7 +59,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
 
     public static function provideFixAllCases(): iterable
     {
-        $cases = self::createTestCases([
+        yield from self::createTestCases([
             ['
 /**
  * @Foo
@@ -318,7 +318,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
  */'],
         ]);
 
-        $cases[] = [
+        yield [
             '<?php
 
 /**
@@ -326,8 +326,6 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
  */
 ',
         ];
-
-        return $cases;
     }
 
     /**

--- a/tests/Fixer/Operator/IncrementStyleFixerTest.php
+++ b/tests/Fixer/Operator/IncrementStyleFixerTest.php
@@ -55,118 +55,144 @@ final class IncrementStyleFixerTest extends AbstractFixerTestCase
 
     public static function provideFixPreIncrementCases(): iterable
     {
-        yield from [
-            [
-                '<?php ++$a;',
-                '<?php $a++;',
-            ],
-            [
-                '<?php ++$$a;',
-                '<?php $$a++;',
-            ],
-            [
-                '<?php ++${"a"};',
-                '<?php ${"a"}++;',
-            ],
-            [
-                '<?php --$a;',
-                '<?php $a--;',
-            ],
-            [
-                '<?php foo(); ++$a;',
-                '<?php foo(); $a++;',
-            ],
-            [
-                '<?php if (true) { ++$a; }',
-                '<?php if (true) { $a++; }',
-            ],
-            [
-                '<?php if (true) {} ++$a;',
-                '<?php if (true) {} $a++;',
-            ],
-            [
-                '<?php for ($i = 0; $i < $count; ++$i) {}',
-                '<?php for ($i = 0; $i < $count; $i++) {}',
-            ],
-            [
-                '<?php ++$a->foo;',
-                '<?php $a->foo++;',
-            ],
-            [
-                '<?php ++$a->{"foo"};',
-                '<?php $a->{"foo"}++;',
-            ],
-            [
-                '<?php ++$a->$b;',
-                '<?php $a->$b++;',
-            ],
-            [
-                '<?php ++Foo\Bar::$bar;',
-                '<?php Foo\Bar::$bar++;',
-            ],
-            [
-                '<?php ++$a::$bar;',
-                '<?php $a::$bar++;',
-            ],
-            [
-                '<?php ++$a[0];',
-                '<?php $a[0]++;',
-            ],
-            [
-                '<?php ++$a[$b];',
-                '<?php $a[$b]++;',
-            ],
+        yield [
+            '<?php ++$a;',
+            '<?php $a++;',
+        ];
 
-            ['<?php $a = $b++;'],
-            ['<?php $a + $b++;'],
-            ['<?php $a++ + $b;'],
-            ['<?php foo($b++);'],
-            ['<?php foo($a, $b++);'],
-            ['<?php $a[$b++];'],
-            ['<?php echo $a++;'],
+        yield [
+            '<?php ++$$a;',
+            '<?php $$a++;',
+        ];
 
-            ['<?php $a = ++$b;'],
-            ['<?php $a + ++$b;'],
-            ['<?php ++$a + $b;'],
-            ['<?php foo(++$b);'],
-            ['<?php foo($a, ++$b);'],
-            ['<?php $a[++$b];'],
-            ['<?php echo ++$a;'],
-            ['<?= ++$a;'],
+        yield [
+            '<?php ++${"a"};',
+            '<?php ${"a"}++;',
+        ];
 
-            [
-                '<?php class Test {
+        yield [
+            '<?php --$a;',
+            '<?php $a--;',
+        ];
+
+        yield [
+            '<?php foo(); ++$a;',
+            '<?php foo(); $a++;',
+        ];
+
+        yield [
+            '<?php if (true) { ++$a; }',
+            '<?php if (true) { $a++; }',
+        ];
+
+        yield [
+            '<?php if (true) {} ++$a;',
+            '<?php if (true) {} $a++;',
+        ];
+
+        yield [
+            '<?php for ($i = 0; $i < $count; ++$i) {}',
+            '<?php for ($i = 0; $i < $count; $i++) {}',
+        ];
+
+        yield [
+            '<?php ++$a->foo;',
+            '<?php $a->foo++;',
+        ];
+
+        yield [
+            '<?php ++$a->{"foo"};',
+            '<?php $a->{"foo"}++;',
+        ];
+
+        yield [
+            '<?php ++$a->$b;',
+            '<?php $a->$b++;',
+        ];
+
+        yield [
+            '<?php ++Foo\Bar::$bar;',
+            '<?php Foo\Bar::$bar++;',
+        ];
+
+        yield [
+            '<?php ++$a::$bar;',
+            '<?php $a::$bar++;',
+        ];
+
+        yield [
+            '<?php ++$a[0];',
+            '<?php $a[0]++;',
+        ];
+
+        yield [
+            '<?php ++$a[$b];',
+            '<?php $a[$b]++;',
+        ];
+
+        yield ['<?php $a = $b++;'];
+
+        yield ['<?php $a + $b++;'];
+
+        yield ['<?php $a++ + $b;'];
+
+        yield ['<?php foo($b++);'];
+
+        yield ['<?php foo($a, $b++);'];
+
+        yield ['<?php $a[$b++];'];
+
+        yield ['<?php echo $a++;'];
+
+        yield ['<?php $a = ++$b;'];
+
+        yield ['<?php $a + ++$b;'];
+
+        yield ['<?php ++$a + $b;'];
+
+        yield ['<?php foo(++$b);'];
+
+        yield ['<?php foo($a, ++$b);'];
+
+        yield ['<?php $a[++$b];'];
+
+        yield ['<?php echo ++$a;'];
+
+        yield ['<?= ++$a;'];
+
+        yield [
+            '<?php class Test {
     public function foo() {
         $a = 123;
         ++self::$st;
     }
 }',
-                '<?php class Test {
+            '<?php class Test {
     public function foo() {
         $a = 123;
         self::$st++;
     }
 }',
-            ],
+        ];
 
-            [
-                '<?php class Test {
+        yield [
+            '<?php class Test {
     public function foo() {
         $a = 123;
         ++static::$st;
     }
 }',
-                '<?php class Test {
+            '<?php class Test {
     public function foo() {
         $a = 123;
         static::$st++;
     }
 }',
-            ],
-            [
-                '<?php if ($foo) ++$a;',
-                '<?php if ($foo) $a++;',
-            ],
+        ];
+
+        yield [
+            '<?php if ($foo) ++$a;',
+            '<?php if ($foo) $a++;',
         ];
 
         if (\PHP_VERSION_ID < 8_00_00) {

--- a/tests/Fixer/Operator/IncrementStyleFixerTest.php
+++ b/tests/Fixer/Operator/IncrementStyleFixerTest.php
@@ -48,14 +48,14 @@ final class IncrementStyleFixerTest extends AbstractFixerTestCase
 
     public static function provideFixPostIncrementCases(): iterable
     {
-        return array_map(static function (array $case): array {
-            return array_reverse($case);
-        }, self::provideFixPreIncrementCases());
+        foreach (self::provideFixPreIncrementCases() as $case) {
+            yield array_reverse($case);
+        }
     }
 
     public static function provideFixPreIncrementCases(): iterable
     {
-        $cases = [
+        yield from [
             [
                 '<?php ++$a;',
                 '<?php $a++;',
@@ -170,22 +170,20 @@ final class IncrementStyleFixerTest extends AbstractFixerTestCase
         ];
 
         if (\PHP_VERSION_ID < 8_00_00) {
-            $cases[] = [
+            yield [
                 '<?php ++$a->$b::$c->${$d}->${$e}::f(1 + 2 * 3)->$g::$h;',
                 '<?php $a->$b::$c->${$d}->${$e}::f(1 + 2 * 3)->$g::$h++;',
             ];
 
-            $cases[] = [
+            yield [
                 '<?php ++$a{0};',
                 '<?php $a{0}++;',
             ];
 
-            $cases[] = [
+            yield [
                 '<?php ++${$a}->{$b."foo"}->bar[$c]->$baz;',
                 '<?php ${$a}->{$b."foo"}->bar[$c]->$baz++;',
             ];
         }
-
-        return $cases;
     }
 }

--- a/tests/Fixer/PhpTag/EchoTagSyntaxFixerTest.php
+++ b/tests/Fixer/PhpTag/EchoTagSyntaxFixerTest.php
@@ -114,13 +114,11 @@ EOT
             ['<?php <fn> \'Foo\'; ?> <?php <fn> \'Bar\'; ?>', '<?= \'Foo\'; ?> <?= \'Bar\'; ?>'],
             ['<?php <fn> foo();', '<?=foo();'],
         ];
-        $result = [];
+
         foreach ([EchoTagSyntaxFixer::LONG_FUNCTION_ECHO, EchoTagSyntaxFixer::LONG_FUNCTION_PRINT] as $fn) {
             foreach ($cases as $case) {
-                $result[] = [str_replace('<fn>', $fn, $case[0]), str_replace('<fn>', $fn, $case[1]), $fn];
+                yield [str_replace('<fn>', $fn, $case[0]), str_replace('<fn>', $fn, $case[1]), $fn];
             }
         }
-
-        return $result;
     }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitStrictFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitStrictFixerTest.php
@@ -117,15 +117,13 @@ final class PhpUnitStrictFixerTest extends AbstractFixerTestCase
 
     public static function provideNoFixWithWrongNumberOfArgumentsCases(): iterable
     {
-        $cases = [];
-
         foreach (self::getMethodsMap() as $candidate => $fix) {
-            $cases[sprintf('do not change call to "%s" without arguments.', $candidate)] = [
+            yield sprintf('do not change call to "%s" without arguments.', $candidate) => [
                 self::generateTest(sprintf('$this->%s();', $candidate)),
             ];
 
             foreach ([1, 4, 5, 10] as $argumentCount) {
-                $cases[sprintf('do not change call to "%s" with #%d arguments.', $candidate, $argumentCount)] = [
+                yield sprintf('do not change call to "%s" with #%d arguments.', $candidate, $argumentCount) => [
                     self::generateTest(
                         sprintf(
                             '$this->%s(%s);',
@@ -136,8 +134,6 @@ final class PhpUnitStrictFixerTest extends AbstractFixerTestCase
                 ];
             }
         }
-
-        return $cases;
     }
 
     public function testInvalidConfig(): void

--- a/tests/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixerTest.php
@@ -326,9 +326,7 @@ EOF;
 
     public static function provideInlineTypehintingDocsBeforeFlowBreakCases(): iterable
     {
-        $cases = [];
-
-        $cases[] = [<<<'EOF'
+        yield [<<<'EOF'
 <?php
 function parseTag($tag)
 {
@@ -343,7 +341,7 @@ function parseTag($tag)
 EOF
         ];
 
-        $cases[] = [<<<'EOF'
+        yield [<<<'EOF'
 <?php
 function parseTag($tag)
 {
@@ -358,7 +356,7 @@ function parseTag($tag)
 EOF
         ];
 
-        $cases[] = [<<<'EOF'
+        yield [<<<'EOF'
 <?php
 function parseTag($tag)
 {
@@ -375,7 +373,7 @@ FOO:
 EOF
         ];
 
-        $cases[] = [<<<'EOF'
+        yield [<<<'EOF'
 <?php
 function parseTag($tag)
 {
@@ -392,7 +390,7 @@ function parseTag($tag)
 EOF
         ];
 
-        $cases[] = [<<<'EOF'
+        yield [<<<'EOF'
 <?php
 function parseTag($tag)
 {
@@ -408,7 +406,5 @@ function parseTag($tag)
 }
 EOF
         ];
-
-        return $cases;
     }
 }

--- a/tests/Fixer/Phpdoc/PhpdocIndentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocIndentFixerTest.php
@@ -35,13 +35,11 @@ final class PhpdocIndentFixerTest extends AbstractFixerTestCase
 
     public static function provideFixIndentCases(): iterable
     {
-        $cases = [];
+        yield ['<?php /** @var Foo $foo */ ?>'];
 
-        $cases[] = ['<?php /** @var Foo $foo */ ?>'];
+        yield ['<?php /** foo */'];
 
-        $cases[] = ['<?php /** foo */'];
-
-        $cases[] = [
+        yield [
             '<?php
 /**
  * Do not indent
@@ -84,7 +82,7 @@ class DocBlocks
 }',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 class DocBlocks
 {
@@ -153,7 +151,7 @@ class DocBlocks
 }',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 /**
  * Final class should also not be indented
@@ -178,7 +176,7 @@ final class DocBlocks
 }',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
     if (1) {
         class Foo {
@@ -209,7 +207,7 @@ final class DocBlocks
     }',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 /**
  * Variable
@@ -296,19 +294,19 @@ $partialFix = true;
     }',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
     $user = $event->getForm()->getData();  /** @var User $user */
     echo "Success";',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
     $user = $event->getForm()->getData();/** @var User $user */
     echo "Success";',
         ];
 
-        $cases[] = [
+        yield [
             "<?php
 class DocBlocks
 {
@@ -337,7 +335,7 @@ class DocBlocks
 }",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 /**
  * Used to write a value to a session key.
@@ -356,7 +354,7 @@ function write(\$name) {}
 ",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
     class Foo
     {
@@ -369,7 +367,7 @@ function write(\$name) {}
     }',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 /**
  * docs
@@ -380,7 +378,7 @@ $foo = $bar;
 ',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 function foo()
 {
@@ -389,7 +387,7 @@ function foo()
 }',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 
 /**
@@ -401,7 +399,7 @@ class Foo
 }',
         ];
 
-        $cases[] = [
+        yield [
             '<?php
 class Application
 {
@@ -412,7 +410,5 @@ class Dispatcher
 }
 ',
         ];
-
-        return $cases;
     }
 }

--- a/tests/Fixer/Phpdoc/PhpdocInlineTagNormalizerFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocInlineTagNormalizerFixerTest.php
@@ -37,7 +37,7 @@ final class PhpdocInlineTagNormalizerFixerTest extends AbstractFixerTestCase
 
     public static function provideFixCases(): iterable
     {
-        $cases = [
+        yield from [
             [
                 '<?php
     /**
@@ -100,36 +100,42 @@ final class PhpdocInlineTagNormalizerFixerTest extends AbstractFixerTestCase
         ];
 
         foreach (['example', 'id', 'internal', 'inheritdoc', 'link', 'source', 'toc', 'tutorial'] as $tag) {
-            $cases[] = [
+            yield [
                 sprintf("<?php\n     /**\n      * {@%s}a\n      */\n", $tag),
                 sprintf("<?php\n     /**\n      * @{%s}a\n      */\n", $tag),
             ];
-            $cases[] = [
+
+            yield [
                 sprintf("<?php\n     /**\n      * {@%s} b\n      */\n", $tag),
                 sprintf("<?php\n     /**\n      * {{@%s}} b\n      */\n", $tag),
             ];
-            $cases[] = [
+
+            yield [
                 sprintf("<?php\n     /**\n      * c {@%s}\n      */\n", $tag),
                 sprintf("<?php\n     /**\n      * c @{{%s}}\n      */\n", $tag),
             ];
-            $cases[] = [
+
+            yield [
                 sprintf("<?php\n     /**\n      * c {@%s test}\n      */\n", $tag),
                 sprintf("<?php\n     /**\n      * c @{{%s test}}\n      */\n", $tag),
             ];
             // test unbalanced { tags
-            $cases[] = [
+            yield [
                 sprintf("<?php\n     /**\n      * c {@%s test}\n      */\n", $tag),
                 sprintf("<?php\n     /**\n      * c {@%s test}}\n      */\n", $tag),
             ];
-            $cases[] = [
+
+            yield [
                 sprintf("<?php\n     /**\n      * c {@%s test}\n      */\n", $tag),
                 sprintf("<?php\n     /**\n      * c {{@%s test}\n      */\n", $tag),
             ];
-            $cases[] = [
+
+            yield [
                 sprintf("<?php\n     /**\n      * c {@%s test}\n      */\n", $tag),
                 sprintf("<?php\n     /**\n      * c {@%s test}}\n      */\n", $tag),
             ];
-            $cases[] = [
+
+            yield [
                 sprintf("<?php\n     /**\n      * c {@%s test}\n      */\n", $tag),
                 sprintf("<?php\n     /**\n      * c @{{%s test}}}\n      */\n", $tag),
             ];
@@ -137,27 +143,25 @@ final class PhpdocInlineTagNormalizerFixerTest extends AbstractFixerTestCase
 
         // don't auto inline tags
         foreach (['example', 'id', 'internal', 'inheritdoc', 'foo', 'link', 'source', 'toc', 'tutorial'] as $tag) {
-            $cases[] = [
+            yield [
                 sprintf("<?php\n     /**\n      * @%s\n      */\n", $tag),
             ];
         }
 
         // don't touch well formatted tags
         foreach (['example', 'id', 'internal', 'inheritdoc', 'foo', 'link', 'source', 'toc', 'tutorial'] as $tag) {
-            $cases[] = [
+            yield [
                 sprintf("<?php\n     /**\n      * {@%s}\n      */\n", $tag),
             ];
         }
 
         // invalid syntax
-        $cases[] = [
+        yield [
             '<?php
     /**
      * {@link https://symfony.com/rfc/rfc1035.text)
      */
     $someVar = "hello";',
         ];
-
-        return $cases;
     }
 }

--- a/tests/Fixer/Phpdoc/PhpdocInlineTagNormalizerFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocInlineTagNormalizerFixerTest.php
@@ -37,9 +37,8 @@ final class PhpdocInlineTagNormalizerFixerTest extends AbstractFixerTestCase
 
     public static function provideFixCases(): iterable
     {
-        yield from [
-            [
-                '<?php
+        yield [
+            '<?php
     /**
      * {link} { LINK }
      * { test }
@@ -54,7 +53,7 @@ final class PhpdocInlineTagNormalizerFixerTest extends AbstractFixerTestCase
      * end comment {@inheritdoc here we are done} @foo {1}
      */
 ',
-                '<?php
+            '<?php
     /**
      * {link} { LINK }
      * { test }
@@ -69,34 +68,35 @@ final class PhpdocInlineTagNormalizerFixerTest extends AbstractFixerTestCase
      * end comment {@inheritdoc here we are done} @foo {1}
      */
 ',
-            ],
-            [
-                '<?php
+        ];
+
+        yield [
+            '<?php
     /**
      * {@foo}
      * @{ bar }
      */',
-                '<?php
+            '<?php
     /**
      * @{ foo }
      * @{ bar }
      */',
-                [
-                    'tags' => ['foo'],
-                ],
-            ],
             [
-                '<?php
+                'tags' => ['foo'],
+            ],
+        ];
+
+        yield [
+            '<?php
     /**
      * @inheritDoc
      * {@inheritDoc}
      */',
-                '<?php
+            '<?php
     /**
      * @inheritDoc
      * @{ inheritDoc }
      */',
-            ],
         ];
 
         foreach (['example', 'id', 'internal', 'inheritdoc', 'link', 'source', 'toc', 'tutorial'] as $tag) {

--- a/tests/Fixer/Whitespace/IndentationTypeFixerTest.php
+++ b/tests/Fixer/Whitespace/IndentationTypeFixerTest.php
@@ -36,125 +36,123 @@ final class IndentationTypeFixerTest extends AbstractFixerTestCase
 
     public static function provideFixCases(): iterable
     {
-        $cases = [];
-
-        $cases[] = [
+        yield [
             '<?php
         echo ALPHA;',
             "<?php
 \t\techo ALPHA;",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
         echo BRAVO;',
             "<?php
 \t\techo BRAVO;",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
         echo CHARLIE;',
             "<?php
  \t\techo CHARLIE;",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
         echo DELTA;',
             "<?php
   \t\techo DELTA;",
         ];
 
-        $cases[] = [
+        yield [
             "<?php
         echo 'ECHO';",
             "<?php
    \t\techo 'ECHO';",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
         echo FOXTROT;',
             "<?php
 \t \techo FOXTROT;",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
         echo GOLF;',
             "<?php
 \t  \techo GOLF;",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
         echo HOTEL;',
             "<?php
 \t   \techo HOTEL;",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
         echo INDIA;',
             "<?php
 \t    echo INDIA;",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
         echo JULIET;',
             "<?php
  \t   \techo JULIET;",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
         echo KILO;',
             "<?php
   \t  \techo KILO;",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
         echo MIKE;',
             "<?php
    \t \techo MIKE;",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
         echo NOVEMBER;',
             "<?php
     \techo NOVEMBER;",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
          echo OSCAR;',
             "<?php
 \t \t echo OSCAR;",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
           echo PAPA;',
             "<?php
 \t \t  echo PAPA;",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
            echo QUEBEC;',
             "<?php
 \t \t   echo QUEBEC;",
         ];
 
-        $cases[] = [
+        yield [
             '<?php $x = "a: \t";',
         ];
 
-        $cases[] = [
+        yield [
             "<?php
 \$x = \"
 \tLike
@@ -162,7 +160,7 @@ final class IndentationTypeFixerTest extends AbstractFixerTestCase
 \tdog\";",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
     /**
      * Test that tabs in docblocks are converted to spaces.
@@ -181,7 +179,7 @@ final class IndentationTypeFixerTest extends AbstractFixerTestCase
 \t */",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
         /**
          * Test that tabs in docblocks are converted to spaces.
@@ -192,7 +190,7 @@ final class IndentationTypeFixerTest extends AbstractFixerTestCase
 \t\t */",
         ];
 
-        $cases[] = [
+        yield [
             '<?php
     /*
      | Test that tabs in comments are converted to spaces    '."\t".'.
@@ -203,7 +201,7 @@ final class IndentationTypeFixerTest extends AbstractFixerTestCase
 \t */",
         ];
 
-        $cases[] = [
+        yield [
             "<?php
     /**
      * This variable
@@ -216,11 +214,9 @@ final class IndentationTypeFixerTest extends AbstractFixerTestCase
 \t */",
         ];
 
-        $cases[] = [
+        yield [
             "<?php\necho 1;\n?>\r\n\t\$a = ellow;",
         ];
-
-        return $cases;
     }
 
     /**
@@ -235,23 +231,21 @@ final class IndentationTypeFixerTest extends AbstractFixerTestCase
 
     public static function provideMessyWhitespacesCases(): iterable
     {
-        $cases = [];
-
-        $cases[] = [
+        yield [
             "<?php
 \t\techo KILO;",
             '<?php
         echo KILO;',
         ];
 
-        $cases[] = [
+        yield [
             "<?php
 \t\t   echo QUEBEC;",
             '<?php
            echo QUEBEC;',
         ];
 
-        $cases[] = [
+        yield [
             "<?php
 \t/**
 \t * This variable
@@ -264,7 +258,7 @@ final class IndentationTypeFixerTest extends AbstractFixerTestCase
      */",
         ];
 
-        $cases['mix indentation'] = [
+        yield 'mix indentation' => [
             "<?php
 \t\t/*
 \t\t * multiple indentation
@@ -277,7 +271,7 @@ final class IndentationTypeFixerTest extends AbstractFixerTestCase
 \t     */",
         ];
 
-        $cases[] = [
+        yield [
             "<?php
 function myFunction() {
 \t\$foo        = 1;
@@ -293,8 +287,6 @@ function myFunction() {
     $middleVar  = 1;
 }',
         ];
-
-        return $cases;
     }
 
     /**
@@ -309,13 +301,13 @@ function myFunction() {
 
     public static function provideMessyWhitespacesReversedCases(): iterable
     {
-        return array_filter(
-            self::provideMessyWhitespacesCases(),
-            static function (string $key): bool {
-                return !str_contains($key, 'mix indentation');
-            },
-            ARRAY_FILTER_USE_KEY
-        );
+        foreach (self::provideMessyWhitespacesCases() as $name => $case) {
+            if ('mix indentation' === $name) {
+                continue;
+            }
+
+            yield $name => $case;
+        }
     }
 
     /**

--- a/tests/Fixer/Whitespace/LineEndingFixerTest.php
+++ b/tests/Fixer/Whitespace/LineEndingFixerTest.php
@@ -36,42 +36,40 @@ final class LineEndingFixerTest extends AbstractFixerTestCase
 
     public static function provideFixCases(): iterable
     {
-        $cases = self::provideCommonCases();
+        yield from self::provideCommonCases();
 
-        $cases[] = [
+        yield [
             "<?php \$b = \" \$a \r\n 123\"; \$a = <<<TEST\nAAAAA \n |\nTEST;\n",
             "<?php \$b = \" \$a \r\n 123\"; \$a = <<<TEST\r\nAAAAA \r\n |\r\nTEST;\n", // both cases
         ];
 
-        $cases[] = [
+        yield [
             "<?php \$b = \" \$a \r\n 123\"; \$a = <<<TEST\nAAAAA \n |\nTEST;\n",
             "<?php \$b = \" \$a \r\n 123\"; \$a = <<<TEST\r\nAAAAA \n |\r\nTEST;\r\n", // both cases
         ];
 
-        $cases['T_INLINE_HTML'] = [
+        yield 'T_INLINE_HTML' => [
             "<?php ?>\nZ\r\n<?php ?>\nZ\r\n",
         ];
 
-        $cases['!T_CONSTANT_ENCAPSED_STRING'] = [
+        yield '!T_CONSTANT_ENCAPSED_STRING' => [
             "<?php \$a=\"a\r\n\";",
         ];
 
-        $cases[] = [
+        yield [
             "<?php echo 'foo',\n\n'bar';",
             "<?php echo 'foo',\r\r\n'bar';",
         ];
 
-        $cases['T_CLOSE_TAG'] = [
+        yield 'T_CLOSE_TAG' => [
             "<?php\n?>\n<?php\n",
             "<?php\n?>\r\n<?php\n",
         ];
 
-        $cases['T_CLOSE_TAG II'] = [
+        yield 'T_CLOSE_TAG II' => [
             "<?php\n?>\n<?php\n?>\n<?php\n",
             "<?php\n?>\r\n<?php\n?>\r\n<?php\n",
         ];
-
-        return $cases;
     }
 
     /**


### PR DESCRIPTION
Manual changes that will not be picked up by `ReturnToYieldFromFixer`.