### PR TITLE
DX: refactor `ErrorOutputTest`

### DIFF
--- a/tests/Console/Output/ErrorOutputTest.php
+++ b/tests/Console/Output/ErrorOutputTest.php
@@ -87,12 +87,13 @@ Files that were not fixed due to errors reported during %s:
         [$exceptionLineNumber, $error] = self::getErrorAndLineNumber(); // note: keep call and __LINE__ separated with one line break
         ++$lineNumber;
 
-        return [
-            [$error, OutputInterface::VERBOSITY_NORMAL, $lineNumber, $exceptionLineNumber, 'VN'],
-            [$error, OutputInterface::VERBOSITY_VERBOSE, $lineNumber, $exceptionLineNumber, 'VV'],
-            [$error, OutputInterface::VERBOSITY_VERY_VERBOSE, $lineNumber, $exceptionLineNumber, 'VVV'],
-            [$error, OutputInterface::VERBOSITY_DEBUG, $lineNumber, $exceptionLineNumber, 'DEBUG'],
-        ];
+        yield [$error, OutputInterface::VERBOSITY_NORMAL, $lineNumber, $exceptionLineNumber, 'VN'];
+
+        yield [$error, OutputInterface::VERBOSITY_VERBOSE, $lineNumber, $exceptionLineNumber, 'VV'];
+
+        yield [$error, OutputInterface::VERBOSITY_VERY_VERBOSE, $lineNumber, $exceptionLineNumber, 'VVV'];
+
+        yield [$error, OutputInterface::VERBOSITY_DEBUG, $lineNumber, $exceptionLineNumber, 'DEBUG'];
     }
 
     public function testLintingExceptionOutputsAppliedFixersAndDiff(): void


### PR DESCRIPTION
This case is extremely edgy, it checks the backtrace of an error produced in itself.