### PR TITLE
bug: Fix names resolving in `no_superfluous_phpdoc_tags` fixer

### DIFF
--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -531,7 +531,7 @@ class Foo {
 
         $annotationTypes = $this->toComparableNames($annotation->getTypes(), $currentSymbol, $symbolShortNames);
 
-        if (['null'] === $annotationTypes) {
+        if ([] === $annotationTypes || ['null'] === $annotationTypes) {
             return false;
         }
 
@@ -545,7 +545,18 @@ class Foo {
             $actualTypes[] = 'null';
         }
 
-        return $annotationTypes === $this->toComparableNames($actualTypes, $currentSymbol, $symbolShortNames);
+        $actualTypes = $this->toComparableNames($actualTypes, $currentSymbol, $symbolShortNames);
+
+        if ($annotationTypes === $actualTypes) {
+            return true;
+        }
+
+        // retry comparison with annotation type unioned with null
+        // phpstan implies the null presence from the native type
+        $annotationTypes[] = 'null';
+        $annotationTypes = $this->toComparableNames($annotationTypes, null, []);
+
+        return $annotationTypes === $actualTypes;
     }
 
     /**

--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -159,8 +159,7 @@ class Foo {
                 $content = $this->removeSuperfluousInheritDoc($content);
             }
 
-            $namespaceAnalysis = (new NamespacesAnalyzer())->getNamespaceAt($tokens, $index);
-            $namespace = $namespaceAnalysis->getFullName();
+            $namespace = (new NamespacesAnalyzer())->getNamespaceAt($tokens, $index)->getFullName();
             if ('' === $namespace) {
                 $namespace = null;
             }
@@ -566,10 +565,7 @@ class Foo {
 
         // retry comparison with annotation type unioned with null
         // phpstan implies the null presence from the native type
-        $annotationTypes[] = 'null';
-        $annotationTypes = $this->toComparableNames($annotationTypes, null, null, []);
-
-        return $annotationTypes === $actualTypes;
+        return $actualTypes === $this->toComparableNames(array_merge($annotationTypes, ['null']), null, null, []);
     }
 
     /**

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -278,12 +278,12 @@ class Foo {
 }',
         ];
 
-        yield 'same typehint with null implied from native type' => [
+        yield 'same typehint with null implied from native type - param type' => [
             '<?php
 class Foo {
     /**
      */
-    public function setAttribute(string $value = null): void
+    public function setAttribute(?string $value, string $value2 = null): void
     {
     }
 }',
@@ -291,10 +291,52 @@ class Foo {
 class Foo {
     /**
      * @param string $value
+     * @param string $value2
      */
-    public function setAttribute(string $value = null): void
+    public function setAttribute(?string $value, string $value2 = null): void
     {
     }
+}',
+        ];
+
+        yield 'same typehint with null implied from native type - return type' => [
+            '<?php
+class Foo {
+    /**
+     */
+    public function getX(): ?X
+    {
+    }
+}',
+            '<?php
+class Foo {
+    /**
+     * @return X
+     */
+    public function getX(): ?X
+    {
+    }
+}',
+        ];
+
+        yield 'same typehint with null implied from native type - property' => [
+            '<?php
+class Foo {
+    /**  */
+    public ?bool $enabled;
+}',
+            '<?php
+class Foo {
+    /** @var bool */
+    public ?bool $enabled;
+}',
+        ];
+
+        yield 'same typehint with null but native type without null - invalid phpdoc must be kept unfixed' => [
+            '<?php
+class Foo {
+    /** @var bool|null */
+    public bool $enabled;
 }',
         ];
 

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -238,6 +238,26 @@ class Foo {
 }',
         ];
 
+        yield 'same typehint with null implied from native type' => [
+            '<?php
+class Foo {
+    /**
+     */
+    public function setAttribute(string $value = null): void
+    {
+    }
+}',
+            '<?php
+class Foo {
+    /**
+     * @param string $value
+     */
+    public function setAttribute(string $value = null): void
+    {
+    }
+}',
+        ];
+
         yield 'multiple arguments' => [
             '<?php
 class Foo {

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -206,7 +206,7 @@ class Foo {
 }',
         ];
 
-        yield 'same typehint with leading backslash' => [
+        yield 'same typehint with leading backslash - global' => [
             '<?php
 class Foo {
     /**
@@ -222,7 +222,27 @@ class Foo {
 }',
         ];
 
-        yield 'same typehint without leading backslash' => [
+        yield 'same typehint with leading backslash - namespaced' => [
+            '<?php
+namespace Xxx;
+
+class Foo {
+    /**
+     */
+    public function doFoo(Model\Invoice $bar) {}
+}',
+            '<?php
+namespace Xxx;
+
+class Foo {
+    /**
+     * @param \Xxx\Model\Invoice $bar
+     */
+    public function doFoo(Model\Invoice $bar) {}
+}',
+        ];
+
+        yield 'same typehint without leading backslash - global' => [
             '<?php
 class Foo {
     /**
@@ -235,6 +255,26 @@ class Foo {
      * @param Bar $bar
      */
     public function doFoo(\Bar $bar) {}
+}',
+        ];
+
+        yield 'same typehint without leading backslash - namespaced' => [
+            '<?php
+namespace Xxx;
+
+class Foo {
+    /**
+     */
+    public function doFoo(\Xxx\Bar $bar) {}
+}',
+            '<?php
+namespace Xxx;
+
+class Foo {
+    /**
+     * @param Bar $bar
+     */
+    public function doFoo(\Xxx\Bar $bar) {}
 }',
         ];
 

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -206,6 +206,38 @@ class Foo {
 }',
         ];
 
+        yield 'same typehint with leading backslash' => [
+            '<?php
+class Foo {
+    /**
+     */
+    public function doFoo(Bar $bar) {}
+}',
+            '<?php
+class Foo {
+    /**
+     * @param \Bar $bar
+     */
+    public function doFoo(Bar $bar) {}
+}',
+        ];
+
+        yield 'same typehint without leading backslash' => [
+            '<?php
+class Foo {
+    /**
+     */
+    public function doFoo(\Bar $bar) {}
+}',
+            '<?php
+class Foo {
+    /**
+     * @param Bar $bar
+     */
+    public function doFoo(\Bar $bar) {}
+}',
+        ];
+
         yield 'multiple arguments' => [
             '<?php
 class Foo {


### PR DESCRIPTION
fix #5474

- leading `\` always implies a FQCN
- CN /wo leading `\` must be resolved using `use`s and NS, for both native and phpdoc types
- `null` in native type implies `null` in phpdoc type - https://phpstan.org/r/7932c1fd-1bdb-4cf9-a18d-15b474a37ee6