### PR TITLE
bug: Fix detecting classy invokation in catch

### DIFF
--- a/src/Tokenizer/Analyzer/ClassyAnalyzer.php
+++ b/src/Tokenizer/Analyzer/ClassyAnalyzer.php
@@ -57,6 +57,10 @@ final class ClassyAnalyzer
             return true;
         }
 
+        if (\PHP_VERSION_ID >= 8_00_00 && $nextToken->equals(')') && $prevToken->equals('(') && $tokens[$tokens->getPrevMeaningfulToken($prev)]->isGivenKind(T_CATCH)) {
+            return true;
+        }
+
         if (AttributeAnalyzer::isAttribute($tokens, $index)) {
             return true;
         }

--- a/tests/Fixer/Import/GlobalNamespaceImportFixerTest.php
+++ b/tests/Fixer/Import/GlobalNamespaceImportFixerTest.php
@@ -714,6 +714,95 @@ class Abc {
 }
 INPUT
             ],
+            'try catch' => [
+                <<<'EXPECTED'
+<?php
+namespace Test;
+use Exception;
+try {
+} catch (Exception $e) {
+}
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+namespace Test;
+try {
+} catch (\Exception $e) {
+}
+INPUT
+            ],
+            'try catch with comments' => [
+                <<<'EXPECTED'
+<?php
+namespace Test;
+use Exception;
+try {
+} catch (/* ... */ Exception $e /* ... */) {
+}
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+namespace Test;
+try {
+} catch (/* ... */ \Exception $e /* ... */) {
+}
+INPUT
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixImportClasses80Cases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFixImportClasses80(string $expected, string $input): void
+    {
+        $this->fixer->configure(['import_classes' => true]);
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixImportClasses80Cases(): iterable
+    {
+        return [
+            'try catch without variable' => [
+                <<<'EXPECTED'
+<?php
+namespace Test;
+use Exception;
+try {
+} catch (Exception) {
+}
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+namespace Test;
+try {
+} catch (\Exception) {
+}
+INPUT
+            ],
+            'try catch without variable and comments' => [
+                <<<'EXPECTED'
+<?php
+namespace Test;
+use Exception;
+try {
+} catch (/* non-capturing catch */ Exception /* just because! */) {
+}
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+namespace Test;
+try {
+} catch (/* non-capturing catch */ \Exception /* just because! */) {
+}
+INPUT
+            ],
         ];
     }
 
@@ -926,6 +1015,99 @@ use Bar;
 new Foo();
 new Bar();
 new Baz();
+INPUT
+            ],
+            'try catch' => [
+                <<<'EXPECTED'
+<?php
+namespace Test;
+use Exception;
+try {
+} catch (\Exception $e) {
+}
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+namespace Test;
+use Exception;
+try {
+} catch (Exception $e) {
+}
+INPUT
+            ],
+            'try catch with comments' => [
+                <<<'EXPECTED'
+<?php
+namespace Test;
+use Exception;
+try {
+} catch (/* ... */ \Exception $e /* ... */) {
+}
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+namespace Test;
+use Exception;
+try {
+} catch (/* ... */ Exception $e /* ... */) {
+}
+INPUT
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixFullyQualifyClasses80Cases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFixFullyQualifyClasses80(string $expected, string $input): void
+    {
+        $this->fixer->configure(['import_classes' => false]);
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixFullyQualifyClasses80Cases(): iterable
+    {
+        return [
+            'try catch without variable' => [
+                <<<'EXPECTED'
+<?php
+namespace Test;
+use Exception;
+try {
+} catch (\Exception) {
+}
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+namespace Test;
+use Exception;
+try {
+} catch (Exception) {
+}
+INPUT
+            ],
+            'try catch without variable and comments' => [
+                <<<'EXPECTED'
+<?php
+namespace Test;
+use Exception;
+try {
+} catch (/* non-capturing catch */ \Exception /* just because! */) {
+}
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+namespace Test;
+use Exception;
+try {
+} catch (/* non-capturing catch */ Exception /* just because! */) {
+}
 INPUT
             ],
         ];

--- a/tests/Tokenizer/Analyzer/ClassyAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ClassyAnalyzerTest.php
@@ -158,6 +158,26 @@ final class ClassyAnalyzerTest extends TestCase
                 [3 => false, 8 => false],
             ];
         }
+
+        yield [
+            '<?php try {} catch (Foo $e) {}',
+            [9 => true],
+        ];
+
+        yield [
+            '<?php try {} catch (\Foo $e) {}',
+            [10 => true],
+        ];
+
+        yield [
+            '<?php try {} catch (/* ... */ Foo $e /* ... */) {}',
+            [11 => true],
+        ];
+
+        yield [
+            '<?php try {} catch (/* ... */ \Foo $e /* ... */) {}',
+            [12 => true],
+        ];
     }
 
     /**
@@ -197,6 +217,26 @@ final class ClassyAnalyzerTest extends TestCase
         yield [
             '<?php #[AnAttribute] class Foo {}',
             [2 => true],
+        ];
+
+        yield [
+            '<?php try {} catch (Foo) {}',
+            [9 => true],
+        ];
+
+        yield [
+            '<?php try {} catch (\Foo) {}',
+            [10 => true],
+        ];
+
+        yield [
+            '<?php try {} catch (/* non-capturing catch */ Foo /* just because! */) {}',
+            [11 => true],
+        ];
+
+        yield [
+            '<?php try {} catch (/* non-capturing catch */ \Foo /* just because! */) {}',
+            [12 => true],
         ];
     }
 


### PR DESCRIPTION
Classes in "catch" block are not detected when there's no union or intersection with another exception.

Therefore, `GlobalNamespaceImportFixer` doesn't correctly fix those cases.