### PR TITLE
bug: YieldFromArrayToYieldsFixer - fix handling the comment before the first array element

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
+        run: vendor/bin/paraunit run ${{ matrix.phpunit-flags || '--exclude-group auto-review' }} tests/Fixer/ArrayNotation/YieldFromArrayToYieldsFixerTest.php
 
       - name: Collect code coverage
         if: matrix.calculate-code-coverage == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run ${{ matrix.phpunit-flags || '--exclude-group auto-review' }} tests/Fixer/ArrayNotation/YieldFromArrayToYieldsFixerTest.php
+        run: vendor/bin/paraunit run ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
 
       - name: Collect code coverage
         if: matrix.calculate-code-coverage == 'yes'

--- a/src/Fixer/ArrayNotation/YieldFromArrayToYieldsFixer.php
+++ b/src/Fixer/ArrayNotation/YieldFromArrayToYieldsFixer.php
@@ -80,6 +80,7 @@ final class YieldFromArrayToYieldsFixer extends AbstractFixer
             $arrayHasTrailingComma = false;
 
             $inserts[$startIndex] = [new Token([T_YIELD, 'yield']), new Token([T_WHITESPACE, ' '])];
+
             foreach ($this->findArrayItemCommaIndex(
                 $tokens,
                 $tokens->getNextMeaningfulToken($startIndex),

--- a/src/Fixer/ArrayNotation/YieldFromArrayToYieldsFixer.php
+++ b/src/Fixer/ArrayNotation/YieldFromArrayToYieldsFixer.php
@@ -79,11 +79,13 @@ final class YieldFromArrayToYieldsFixer extends AbstractFixer
 
             $arrayHasTrailingComma = false;
 
+            $startIndex = $tokens->getNextMeaningfulToken($startIndex);
+
             $inserts[$startIndex] = [new Token([T_YIELD, 'yield']), new Token([T_WHITESPACE, ' '])];
 
             foreach ($this->findArrayItemCommaIndex(
                 $tokens,
-                $tokens->getNextMeaningfulToken($startIndex),
+                $startIndex,
                 $tokens->getPrevMeaningfulToken($endIndex),
             ) as $commaIndex) {
                 $nextItemIndex = $tokens->getNextMeaningfulToken($commaIndex);

--- a/tests/Fixer/ArrayNotation/YieldFromArrayToYieldsFixerTest.php
+++ b/tests/Fixer/ArrayNotation/YieldFromArrayToYieldsFixerTest.php
@@ -120,6 +120,27 @@ final class YieldFromArrayToYieldsFixerTest extends AbstractFixerTestCase
         yield [
             '<?php function f() {
                  '.'
+                    yield 1;
+                    // duo
+                    yield 2;
+                    // tres
+                    yield 3;
+                '.'
+            }',
+            '<?php function f() {
+                yield from [
+                    1,
+                    // duo
+                    2,
+                    // tres
+                    3,
+                ];
+            }',
+        ];
+
+        yield [
+            '<?php function f() {
+                 '.'
                     yield random_key() => true;
                     yield "foo" => foo(1, 2);
                     yield "bar" => function ($x, $y) { return max($x, $y); };

--- a/tests/Fixer/ArrayNotation/YieldFromArrayToYieldsFixerTest.php
+++ b/tests/Fixer/ArrayNotation/YieldFromArrayToYieldsFixerTest.php
@@ -120,6 +120,7 @@ final class YieldFromArrayToYieldsFixerTest extends AbstractFixerTestCase
         yield [
             '<?php function f() {
                  '.'
+                    // uno
                     yield 1;
                     // duo
                     yield 2;
@@ -129,6 +130,7 @@ final class YieldFromArrayToYieldsFixerTest extends AbstractFixerTestCase
             }',
             '<?php function f() {
                 yield from [
+                    // uno
                     1,
                     // duo
                     2,

--- a/tests/Fixer/ArrayNotation/YieldFromArrayToYieldsFixerTest.php
+++ b/tests/Fixer/ArrayNotation/YieldFromArrayToYieldsFixerTest.php
@@ -122,7 +122,7 @@ final class YieldFromArrayToYieldsFixerTest extends AbstractFixerTestCase
                  '.'
                     // uno
                     yield 1;
-                    // duo
+                    // dos
                     yield 2;
                     // tres
                     yield 3;
@@ -132,7 +132,7 @@ final class YieldFromArrayToYieldsFixerTest extends AbstractFixerTestCase
                 yield from [
                     // uno
                     1,
-                    // duo
+                    // dos
                     2,
                     // tres
                     3,


### PR DESCRIPTION
FIxes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7181#discussion_r1282789577