### PR TITLE
feature: BlankLineBeforeStatementFixer - separate handling for enum cases

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -125,7 +125,7 @@ List of Available Rules
 
    - | ``statements``
      | List of statements which must be preceded by an empty line.
-     | Allowed values: a subset of ``['break', 'case', 'continue', 'declare', 'default', 'do', 'exit', 'for', 'foreach', 'goto', 'if', 'include', 'include_once', 'phpdoc', 'require', 'require_once', 'return', 'switch', 'throw', 'try', 'while', 'yield', 'yield_from']``
+     | Allowed values: a subset of ``['break', 'case', 'continue', 'declare', 'default', 'do', 'enum_case', 'exit', 'for', 'foreach', 'goto', 'if', 'include', 'include_once', 'phpdoc', 'require', 'require_once', 'return', 'switch', 'throw', 'try', 'while', 'yield', 'yield_from']``
      | Default value: ``['break', 'continue', 'declare', 'return', 'throw', 'try']``
 
 

--- a/doc/rules/whitespace/blank_line_before_statement.rst
+++ b/doc/rules/whitespace/blank_line_before_statement.rst
@@ -12,7 +12,7 @@ Configuration
 
 List of statements which must be preceded by an empty line.
 
-Allowed values: a subset of ``['break', 'case', 'continue', 'declare', 'default', 'do', 'exit', 'for', 'foreach', 'goto', 'if', 'include', 'include_once', 'phpdoc', 'require', 'require_once', 'return', 'switch', 'throw', 'try', 'while', 'yield', 'yield_from']``
+Allowed values: a subset of ``['break', 'case', 'continue', 'declare', 'default', 'do', 'enum_case', 'exit', 'for', 'foreach', 'goto', 'if', 'include', 'include_once', 'phpdoc', 'require', 'require_once', 'return', 'switch', 'throw', 'try', 'while', 'yield', 'yield_from']``
 
 Default value: ``['break', 'continue', 'declare', 'return', 'throw', 'try']``
 

--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -24,6 +24,7 @@ use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
@@ -44,6 +45,7 @@ final class BlankLineBeforeStatementFixer extends AbstractFixer implements Confi
         'declare' => T_DECLARE,
         'default' => T_DEFAULT,
         'do' => T_DO,
+        'enum_case' => CT::T_ENUM_CASE,
         'exit' => T_EXIT,
         'for' => T_FOR,
         'foreach' => T_FOREACH,

--- a/src/Tokenizer/CT.php
+++ b/src/Tokenizer/CT.php
@@ -58,6 +58,7 @@ final class CT
     public const T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_CLOSE = 10037;
     public const T_DYNAMIC_CLASS_CONSTANT_FETCH_CURLY_BRACE_OPEN = 10038;
     public const T_DYNAMIC_CLASS_CONSTANT_FETCH_CURLY_BRACE_CLOSE = 10039;
+    public const T_ENUM_CASE = 10040;
 
     private function __construct()
     {

--- a/src/Tokenizer/Transformer/EnumCaseTransformer.php
+++ b/src/Tokenizer/Transformer/EnumCaseTransformer.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer\Transformer;
+
+use PhpCsFixer\Tokenizer\AbstractTransformer;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * Transforms `T_CASE` of enum cases into `CT::T_ENUM_CASE`.
+ *
+ * @internal
+ *
+ * @author John Paul E. Balandan, CPA <paulbalandan@gmail.com>
+ */
+final class EnumCaseTransformer extends AbstractTransformer
+{
+    public function getRequiredPhpVersionId(): int
+    {
+        return 8_01_00;
+    }
+
+    public function process(Tokens $tokens, Token $token, int $index): void
+    {
+        if (!\defined('T_ENUM') || !$token->isGivenKind(T_ENUM)) {
+            return;
+        }
+
+        $braceOpenIndex = $tokens->getNextTokenOfKind($index, ['{']);
+        $braceCloseIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $braceOpenIndex);
+
+        for ($i = $braceOpenIndex; $i < $braceCloseIndex; ++$i) {
+            if ($tokens[$i]->isGivenKind(T_SWITCH)) {
+                $switchBraceOpenIndex = $tokens->getNextTokenOfKind($i, ['{']);
+                $switchBraceCloseIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $switchBraceOpenIndex);
+
+                // skip switch cases
+                $i += $switchBraceCloseIndex;
+
+                continue;
+            }
+
+            if ($tokens[$i]->isGivenKind(T_CASE)) {
+                $tokens[$i] = new Token([CT::T_ENUM_CASE, $tokens[$i]->getContent()]);
+            }
+        }
+    }
+
+    public function getCustomTokens(): array
+    {
+        return [
+            CT::T_ENUM_CASE,
+        ];
+    }
+}

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -1496,22 +1496,22 @@ do {
     }
 
     /**
+     * @param list<string> $statements
+     *
      * @dataProvider provideFix81Cases
      *
      * @requires PHP 8.1
      */
-    public function testFix81(string $expected, ?string $input = null): void
+    public function testFix81(string $expected, ?string $input, array $statements): void
     {
-        $this->fixer->configure([
-            'statements' => ['case'],
-        ]);
+        $this->fixer->configure(['statements' => $statements]);
 
         $this->doTest($expected, $input);
     }
 
     public static function provideFix81Cases(): iterable
     {
-        yield 'enum' => [
+        yield 'fixing enum case and switch case' => [
             '<?php
 enum Suit {
     case Hearts;
@@ -1568,6 +1568,123 @@ enum UserStatus: string {
     }
 }
 ',
+            ['case', 'enum_case'],
+        ];
+
+        yield 'fixing enum case only' => [
+            '<?php
+enum Suit {
+    case Hearts;
+
+    case Diamonds;
+
+    case Clubs;
+
+
+    case Spades;
+}
+
+enum UserStatus: string {
+    case Pending = "P";
+
+    case Active = "A";
+
+    public function label(): string {
+        switch ($a) {
+            case 1:
+                return 1;
+            case 2:
+                return 2;
+        }
+
+        return "label";
+    }
+}
+',
+            '<?php
+enum Suit {
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+
+
+    case Spades;
+}
+
+enum UserStatus: string {
+    case Pending = "P";
+    case Active = "A";
+
+    public function label(): string {
+        switch ($a) {
+            case 1:
+                return 1;
+            case 2:
+                return 2;
+        }
+
+        return "label";
+    }
+}
+',
+            ['enum_case'],
+        ];
+
+        yield 'fixing switch case only' => [
+            '<?php
+enum Suit {
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+
+
+    case Spades;
+}
+
+enum UserStatus: string {
+    case Pending = "P";
+    case Active = "A";
+
+    public function label(): string {
+        switch ($a) {
+            case 1:
+                return 1;
+
+            case 2:
+                return 2;
+        }
+
+        return "label";
+    }
+}
+',
+            '<?php
+enum Suit {
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+
+
+    case Spades;
+}
+
+enum UserStatus: string {
+    case Pending = "P";
+    case Active = "A";
+
+    public function label(): string {
+        switch ($a) {
+            case 1:
+                return 1;
+            case 2:
+                return 2;
+        }
+
+        return "label";
+    }
+}
+',
+            ['case'],
         ];
     }
 

--- a/tests/Tokenizer/Transformer/EnumCaseTransformerTest.php
+++ b/tests/Tokenizer/Transformer/EnumCaseTransformerTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Tokenizer\Transformer;
+
+use PhpCsFixer\Tests\Test\AbstractTransformerTestCase;
+use PhpCsFixer\Tokenizer\CT;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Tokenizer\Transformer\EnumCaseTransformer
+ *
+ * @requires PHP 8.1
+ */
+final class EnumCaseTransformerTest extends AbstractTransformerTestCase
+{
+    /**
+     * @param array<int, int> $expectedTokens
+     *
+     * @dataProvider provideProcessCases
+     */
+    public function testProcess(string $source, array $expectedTokens): void
+    {
+        $this->doTest($source, $expectedTokens, [CT::T_ENUM_CASE]);
+    }
+
+    public static function provideProcessCases(): iterable
+    {
+        yield 'pure enum' => [
+            '<?php
+enum Foo
+{
+    case One;
+    case Two;
+}
+',
+            [
+                7 => CT::T_ENUM_CASE,
+                12 => CT::T_ENUM_CASE,
+            ],
+        ];
+
+        yield 'pure enum with switch' => [
+            '<?php
+enum Foo
+{
+    case One;
+    case Two;
+
+    public static function getLowerName(self $instance): string
+    {
+        switch ($instance->name) {
+            case \'One\':
+            case \'Two\':
+                return strtolower($instance->name);
+        }
+    }
+}
+',
+            [
+                7 => CT::T_ENUM_CASE,
+                12 => CT::T_ENUM_CASE,
+            ],
+        ];
+
+        yield 'backed enum' => [
+            '<?php
+enum Suit: string
+{
+    case Hearts = \'hearts\';
+    case Spades = \'spades\';
+    case Clubs = \'clubs\';
+    case Diamonds = \'diamonds\';
+}
+',
+            [
+                10 => CT::T_ENUM_CASE,
+                19 => CT::T_ENUM_CASE,
+                28 => CT::T_ENUM_CASE,
+                37 => CT::T_ENUM_CASE,
+            ],
+        ];
+
+        yield 'backed enum with switch' => [
+            '<?php
+enum Suit: string
+{
+    case Hearts = \'hearts\';
+    case Spades = \'spades\';
+    case Clubs = \'clubs\';
+    case Diamonds = \'diamonds\';
+
+    public static function getUppercasedValue(self $instance): string
+    {
+        switch ($instance->value) {
+            case \'hearts\':
+            case \'spades\':
+                return strtoupper($instance->value);
+
+            default:
+                return $instance->value;
+        }
+    }
+}
+',
+            [
+                10 => CT::T_ENUM_CASE,
+                19 => CT::T_ENUM_CASE,
+                28 => CT::T_ENUM_CASE,
+                37 => CT::T_ENUM_CASE,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Adds an `enum_case` token to separate switch case from enum case.

Closes #6747 
Needs #7200 