### PR TITLE
feature: `BlankLineBeforeStatementFixer` - skip enum cases

### DIFF
--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -266,6 +266,10 @@ function getValues() {
                 continue;
             }
 
+            if ($token->isGivenKind(T_CASE) && $analyzer->isEnumCase($index)) {
+                continue;
+            }
+
             $insertBlankLineIndex = $this->getInsertBlankLineIndex($tokens, $index);
             $prevNonWhitespace = $tokens->getPrevNonWhitespace($insertBlankLineIndex);
 

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -633,6 +633,9 @@ final class TokensAnalyzer
         return $tokens[$beforeStartIndex]->isGivenKind(T_DO);
     }
 
+    /**
+     * @throws \LogicException when provided index does not point to token containing T_CASE
+     */
     public function isEnumCase(int $caseIndex): bool
     {
         $tokens = $this->tokens;

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -633,6 +633,28 @@ final class TokensAnalyzer
         return $tokens[$beforeStartIndex]->isGivenKind(T_DO);
     }
 
+    public function isEnumCase(int $caseIndex): bool
+    {
+        $tokens = $this->tokens;
+        $token = $tokens[$caseIndex];
+
+        if (!$token->isGivenKind(T_CASE)) {
+            throw new \LogicException(sprintf(
+                'No T_CASE given at index %d, got %s instead.',
+                $caseIndex,
+                $token->getName() ?? $token->getContent()
+            ));
+        }
+
+        if (!\defined('T_ENUM') || !$tokens->isTokenKindFound(T_ENUM)) {
+            return false;
+        }
+
+        $prevIndex = $tokens->getPrevTokenOfKind($caseIndex, [[T_ENUM], [T_SWITCH]]);
+
+        return null !== $prevIndex && $tokens[$prevIndex]->isGivenKind(T_ENUM);
+    }
+
     public function isSuperGlobal(int $index): bool
     {
         static $superNames = [

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -1515,9 +1515,7 @@ do {
             '<?php
 enum Suit {
     case Hearts;
-
     case Diamonds;
-
     case Clubs;
 
 
@@ -1526,7 +1524,6 @@ enum Suit {
 
 enum UserStatus: string {
     case Pending = "P";
-
     case Active = "A";
 
     public function label(): string {


### PR DESCRIPTION
Alternative to #7201 
Closes #6747 