### PR TITLE
bug: `HeaderCommentFixer` must run before `BlankLinesBeforeNamespaceFixer`

### DIFF
--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -118,7 +118,7 @@ echo 1;
     /**
      * {@inheritdoc}
      *
-     * Must run before SingleLineCommentStyleFixer.
+     * Must run before BlankLinesBeforeNamespaceFixer, SingleBlankLineBeforeNamespaceFixer, SingleLineCommentStyleFixer.
      * Must run after DeclareStrictTypesFixer, NoBlankLinesAfterPhpdocFixer.
      */
     public function getPriority(): int

--- a/src/Fixer/NamespaceNotation/BlankLinesBeforeNamespaceFixer.php
+++ b/src/Fixer/NamespaceNotation/BlankLinesBeforeNamespaceFixer.php
@@ -56,7 +56,7 @@ final class BlankLinesBeforeNamespaceFixer extends AbstractFixer implements Whit
     /**
      * {@inheritdoc}
      *
-     * Must run after BlankLineAfterOpeningTagFixer.
+     * Must run after BlankLineAfterOpeningTagFixer, HeaderCommentFixer.
      */
     public function getPriority(): int
     {

--- a/src/Fixer/NamespaceNotation/BlankLinesBeforeNamespaceFixer.php
+++ b/src/Fixer/NamespaceNotation/BlankLinesBeforeNamespaceFixer.php
@@ -60,7 +60,7 @@ final class BlankLinesBeforeNamespaceFixer extends AbstractFixer implements Whit
      */
     public function getPriority(): int
     {
-        return 0;
+        return -31;
     }
 
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface

--- a/src/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixer.php
+++ b/src/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixer.php
@@ -50,6 +50,16 @@ final class SingleBlankLineBeforeNamespaceFixer extends AbstractProxyFixer imple
         return $tokens->isTokenKindFound(T_NAMESPACE);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * Must run after HeaderCommentFixer.
+     */
+    public function getPriority(): int
+    {
+        return parent::getPriority();
+    }
+
     protected function createProxyFixers(): array
     {
         $blankLineBeforeNamespace = new BlankLinesBeforeNamespaceFixer();

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -470,6 +470,8 @@ final class FixerFactoryTest extends TestCase
                 'ordered_imports',
             ],
             'header_comment' => [
+                'blank_lines_before_namespace',
+                'single_blank_line_before_namespace',
                 'single_line_comment_style',
             ],
             'implode_call' => [

--- a/tests/Fixtures/Integration/priority/header_comment,blank_lines_before_namespace.test
+++ b/tests/Fixtures/Integration/priority/header_comment,blank_lines_before_namespace.test
@@ -1,0 +1,19 @@
+--TEST--
+Integration of fixers: header_comment,blank_lines_before_namespace.
+--RULESET--
+{ "header_comment": { "header": "" }, "blank_lines_before_namespace": true }
+--EXPECT--
+<?php
+
+namespace Foo;
+class Bar {}
+
+--INPUT--
+<?php
+
+/*
+ * Header.
+ */
+
+namespace Foo;
+class Bar {}

--- a/tests/Fixtures/Integration/priority/header_comment,single_blank_line_before_namespace.test
+++ b/tests/Fixtures/Integration/priority/header_comment,single_blank_line_before_namespace.test
@@ -1,0 +1,19 @@
+--TEST--
+Integration of fixers: header_comment,single_blank_line_before_namespace.
+--RULESET--
+{ "header_comment": { "header": "" }, "single_blank_line_before_namespace": true}
+--EXPECT--
+<?php
+
+namespace Foo;
+class Bar {}
+
+--INPUT--
+<?php
+
+/*
+ * Header.
+ */
+
+namespace Foo;
+class Bar {}


### PR DESCRIPTION
The other priority is added because `SingleBlankLineBeforeNamespaceFixer` proxies to `BlankLinesBeforeNamespaceFixer`.