### PR TITLE
DX: Do not mark "long term ideas" as stale

### DIFF
--- a/.github/workflows/issues_and_pull_requests.yml
+++ b/.github/workflows/issues_and_pull_requests.yml
@@ -11,6 +11,7 @@ env:
   DAYS_BEFORE_ISSUE_STALE: 90
   DAYS_BEFORE_PR_CLOSE: 14
   DAYS_BEFORE_PR_STALE: 90
+  EXEMPT_MILESTONES: "long-term-ideas"
 
 jobs:
   handle_stale:
@@ -19,6 +20,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
+      # Config reference: https://github.com/actions/stale
       - name: "Handle stale issues and pull requests"
         uses: "actions/stale@v8"
         with:
@@ -27,6 +29,7 @@ jobs:
           days-before-issue-stale: "${{ env.DAYS_BEFORE_ISSUE_STALE }}"
           days-before-pr-close: "${{ env.DAYS_BEFORE_PR_CLOSE }}"
           days-before-pr-stale: "${{ env.DAYS_BEFORE_PR_STALE }}"
+          exempt-milestones: "${{ env.EXEMPT_MILESTONES }}"
           labels-to-add-when-unstale: "status/to verify"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           stale-issue-label: "status/stale"


### PR DESCRIPTION
I've been thinking about labels whitelist too, but for now I decided to limit it to `long-term-ideas` milestone. Issues like #2803 should not be closed as they are important until they're implemented. But if we come up with some label that we want to use for marking such issues/PRs to be excluded from `actions/stale`, we can do it too.

I've been considering excluding issues/PRs with specific assignees too, what do you think?