### PR TITLE
minor: PhpdocAlignFixerTest - convert CUSTOM tags test to not rely on non-custom tag from TAGS_WITH_NAME

### DIFF
--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -1284,13 +1284,13 @@ class Foo {}
         ',
         ];
 
-        yield 'custom tags' => [
-            ['tags' => ['param', 'phpstan-param']],
+        yield 'CUSTOM tags' => [
+            ['tags' => ['param', 'xxxxxxxxxxxxx']],
             '<?php
     /**
      * @param         EngineInterface $templating
      * @param         string          $format
-     * @phpstan-param int             $code       An HTTP response status code
+     * @xxxxxxxxxxxxx int             $code       An HTTP response status code
      * @param         bool            $debug
      * @param         mixed           &$reference A parameter passed by reference
      */
@@ -1300,7 +1300,7 @@ class Foo {}
     /**
      * @param  EngineInterface $templating
      * @param string      $format
-     * @phpstan-param  int  $code       An HTTP response status code
+     * @xxxxxxxxxxxxx  int  $code       An HTTP response status code
      * @param    bool         $debug
      * @param  mixed    &$reference     A parameter passed by reference
      */

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -1285,12 +1285,12 @@ class Foo {}
         ];
 
         yield 'CUSTOM tags' => [
-            ['tags' => ['param', 'xxxxxxxxxxxxx']],
+            ['tags' => ['param', 'xxx-xxxxxxxxx']],
             '<?php
     /**
      * @param         EngineInterface $templating
      * @param         string          $format
-     * @xxxxxxxxxxxxx int             $code       An HTTP response status code
+     * @xxx-xxxxxxxxx int             $code       An HTTP response status code
      * @param         bool            $debug
      * @param         mixed           &$reference A parameter passed by reference
      */
@@ -1300,7 +1300,7 @@ class Foo {}
     /**
      * @param  EngineInterface $templating
      * @param string      $format
-     * @xxxxxxxxxxxxx  int  $code       An HTTP response status code
+     * @xxx-xxxxxxxxx  int  $code       An HTTP response status code
      * @param    bool         $debug
      * @param  mixed    &$reference     A parameter passed by reference
      */


### PR DESCRIPTION



minor appendix i came up after checking #7120