### PR TITLE
DX: Improve Composer scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,16 +82,11 @@
     "scripts": {
         "cs:check": "@php php-cs-fixer fix --dry-run --diff",
         "cs:fix": "@php php-cs-fixer fix",
-        "dev-tools:check": [
-            "./dev-tools/check_file_permissions.sh",
-            "./dev-tools/check_trailing_spaces.sh"
-        ],
-        "dev-tools:docs": "@php dev-tools/doc.php",
-        "dev-tools:install": "@composer -d dev-tools install",
-        "docs": "@dev-tools:docs",
+        "docs": "@php dev-tools/doc.php",
+        "install-tools": "@composer -d dev-tools install",
         "mess-detector": "@php dev-tools/vendor/bin/phpmd . ansi dev-tools/mess-detector/phpmd.xml --exclude vendor/*,dev-tools/vendor/*,dev-tools/phpstan/*,tests/Fixtures/*",
-        "phpstan": "@php -d memory_limit=256M dev-tools/vendor/bin/phpstan analyse",
-        "phpstan:baseline": "@php -d memory_limit=256M dev-tools/vendor/bin/phpstan analyse --generate-baseline=./dev-tools/phpstan/baseline.php",
+        "phpstan": "@php -d memory_limit=512M dev-tools/vendor/bin/phpstan analyse",
+        "phpstan:baseline": "@php -d memory_limit=512M dev-tools/vendor/bin/phpstan analyse --generate-baseline=./dev-tools/phpstan/baseline.php",
         "qa": "@quality-assurance",
         "quality-assurance": [
             "Composer\\Config::disableProcessTimeout",
@@ -99,6 +94,10 @@
             "@test"
         ],
         "sa": "@static-analysis",
+        "self-check": [
+            "./dev-tools/check_file_permissions.sh",
+            "./dev-tools/check_trailing_spaces.sh"
+        ],
         "static-analysis": [
             "@phpstan",
             "@cs:check"
@@ -116,16 +115,15 @@
     "scripts-descriptions": {
         "cs:check": "Check coding standards",
         "cs:fix": "Fix coding standards",
-        "dev-tools:check": "Check DEV environment's requirements",
-        "dev-tools:docs": "Regenerate docs",
-        "dev-tools:install": "Install DEV tools",
         "docs": "Regenerate docs",
         "mess-detector": "Analyse code with Mess Detector",
+        "install-tools": "Install DEV tools",
         "phpstan": "Run PHPStan analysis",
         "phpstan:baseline": "Dump PHPStan baseline file - use only for updating, do not add new errors when possible",
         "qa": "Run QA suite",
         "quality-assurance": "Run QA suite",
         "sa": "Run static analysis",
+        "self-check": "Run set of self-checks ensuring repository's validity",
         "static-analysis": "Run static analysis",
         "test": "Run tests",
         "test:all": "Run all tests",

--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,10 @@
         "sort-packages": true
     },
     "scripts": {
+        "post-autoload-dump": [
+            "@install-tools"
+        ],
+
         "cs:check": "@php php-cs-fixer fix --dry-run --diff",
         "cs:fix": "@php php-cs-fixer fix",
         "docs": "@php dev-tools/doc.php",
@@ -120,6 +124,7 @@
         "install-tools": "Install DEV tools",
         "phpstan": "Run PHPStan analysis",
         "phpstan:baseline": "Dump PHPStan baseline file - use only for updating, do not add new errors when possible",
+        "post-autoload-dump": "Run additional tasks after installing/updating main dependencies",
         "qa": "Run QA suite",
         "quality-assurance": "Run QA suite",
         "sa": "Run static analysis",

--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,10 @@
         "docs": "@php dev-tools/doc.php",
         "install-tools": "@composer -d dev-tools install",
         "mess-detector": "@php dev-tools/vendor/bin/phpmd . ansi dev-tools/mess-detector/phpmd.xml --exclude vendor/*,dev-tools/vendor/*,dev-tools/phpstan/*,tests/Fixtures/*",
+        "normalize": [
+            "@composer normalize -d dev-tools --dry-run ../composer.json",
+            "@composer normalize -d dev-tools --dry-run composer.json"
+        ],
         "phpstan": "@php -d memory_limit=512M dev-tools/vendor/bin/phpstan analyse",
         "phpstan:baseline": "@php -d memory_limit=512M dev-tools/vendor/bin/phpstan analyse --generate-baseline=./dev-tools/phpstan/baseline.php",
         "qa": "@quality-assurance",
@@ -121,6 +125,7 @@
         "docs": "Regenerate docs",
         "install-tools": "Install DEV tools",
         "mess-detector": "Analyse code with Mess Detector",
+        "normalize": "Run normalization for composer.json files",
         "phpstan": "Run PHPStan analysis",
         "phpstan:baseline": "Dump PHPStan baseline file - use only for updating, do not add new errors when possible",
         "post-autoload-dump": "Run additional tasks after installing/updating main dependencies",

--- a/composer.json
+++ b/composer.json
@@ -86,11 +86,11 @@
         "cs:check": "@php php-cs-fixer fix --dry-run --diff",
         "cs:fix": "@php php-cs-fixer fix",
         "docs": "@php dev-tools/doc.php",
-        "install-tools": "@composer -d dev-tools install",
+        "install-tools": "@composer --working-dir=dev-tools install",
         "mess-detector": "@php dev-tools/vendor/bin/phpmd . ansi dev-tools/mess-detector/phpmd.xml --exclude vendor/*,dev-tools/vendor/*,dev-tools/phpstan/*,tests/Fixtures/*",
         "normalize": [
-            "@composer normalize -d dev-tools --dry-run ../composer.json",
-            "@composer normalize -d dev-tools --dry-run composer.json"
+            "@composer normalize --working-dir=dev-tools --dry-run ../composer.json",
+            "@composer normalize --working-dir=dev-tools --dry-run composer.json"
         ],
         "phpstan": "@php -d memory_limit=512M dev-tools/vendor/bin/phpstan analyse",
         "phpstan:baseline": "@php -d memory_limit=512M dev-tools/vendor/bin/phpstan analyse --generate-baseline=./dev-tools/phpstan/baseline.php",

--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,8 @@
         "qa": "@quality-assurance",
         "quality-assurance": [
             "Composer\\Config::disableProcessTimeout",
+            "@install-tools --quiet",
+            "@normalize",
             "@sa",
             "@test"
         ],

--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,8 @@
             "Composer\\Config::disableProcessTimeout",
             "@install-tools --quiet",
             "@normalize",
+            "@self-check",
+            "@mess-detector",
             "@sa",
             "@test"
         ],

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,6 @@
         "post-autoload-dump": [
             "@install-tools"
         ],
-
         "cs:check": "@php php-cs-fixer fix --dry-run --diff",
         "cs:fix": "@php php-cs-fixer fix",
         "docs": "@php dev-tools/doc.php",
@@ -120,8 +119,8 @@
         "cs:check": "Check coding standards",
         "cs:fix": "Fix coding standards",
         "docs": "Regenerate docs",
-        "mess-detector": "Analyse code with Mess Detector",
         "install-tools": "Install DEV tools",
+        "mess-detector": "Analyse code with Mess Detector",
         "phpstan": "Run PHPStan analysis",
         "phpstan:baseline": "Dump PHPStan baseline file - use only for updating, do not add new errors when possible",
         "post-autoload-dump": "Run additional tasks after installing/updating main dependencies",

--- a/dev-tools/check_file_permissions.sh
+++ b/dev-tools/check_file_permissions.sh
@@ -6,7 +6,7 @@ files_with_wrong_permissions=$(
         ':!*.sh' \
         ':!php-cs-fixer' \
         ':!dev-tools/*.php' \
-    | grep -P "^100755 " \
+    | grep -E "^100755 " \
     | sort -fh
 )
 


### PR DESCRIPTION
This PR addresses @keradus' comments from #6839 + adds more improvements.

- Treat `dev-tools` subdirectory as technical detail that should not be exposed to developers
- improve name and description for script that runs `check_*` Bash scripts
- Bump memory limit for PHPStan
- Automatically install `dev-tools` after installing/updating main dependencies
- Add `normalize` script (so it's possible to check if `composer.json` and `dev-tools/composer.json` are OK)