### PR TITLE
DX: Fix detecting trailing spaces

### DIFF
--- a/dev-tools/check_trailing_spaces.sh
+++ b/dev-tools/check_trailing_spaces.sh
@@ -2,7 +2,7 @@
 set -eu
 
 files_with_trailing_spaces=$(
-    git grep -EIn "\\s$" \
+    git grep -n "\\s$" \
         ':!doc/rules/*' \
         ':!tests/Fixtures/*' \
     | sort -fh

--- a/dev-tools/check_trailing_spaces.sh
+++ b/dev-tools/check_trailing_spaces.sh
@@ -2,7 +2,7 @@
 set -eu
 
 files_with_trailing_spaces=$(
-    git grep -n "\\s$" \
+    git grep -In "\\s$" \
         ':!doc/rules/*' \
         ':!tests/Fixtures/*' \
     | sort -fh

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1); 
+declare(strict_types=1);
 
 /*
  * This file is part of PHP CS Fixer.

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types=1); 
 
 /*
  * This file is part of PHP CS Fixer.


### PR DESCRIPTION
Possibly it's MacOS-related, but when I run this script locally, it does not find trailing spaces, but all lines ending with `s`. After the fix it properly works both [in CI (Ubuntu)](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/actions/runs/5820387755/job/15780652318?pr=7216#step:11:12), and on MacOS.

<img width="783" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/3a7334ce-80f4-4ef9-be23-66a64c19ca1d">
