### PR TITLE
DX: Allow funding for Wirone

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: keradus
+github: [keradus, Wirone]


### PR DESCRIPTION
Based on [docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository#about-funding-files) there can be multiple users to sponsor. I was recently accepted by GitHub, @keradus decision is yours if you want to display it here 🙂.