### PR TITLE
minor: use JSON_THROW_ON_ERROR for trivial cases

### DIFF
--- a/src/Console/Report/FixReport/GitlabReporter.php
+++ b/src/Console/Report/FixReport/GitlabReporter.php
@@ -69,7 +69,7 @@ final class GitlabReporter implements ReporterInterface
             }
         }
 
-        $jsonString = json_encode($report);
+        $jsonString = json_encode($report, JSON_THROW_ON_ERROR);
 
         return $reportSummary->isDecoratedOutput() ? OutputFormatter::escape($jsonString) : $jsonString;
     }

--- a/src/Console/Report/FixReport/JsonReporter.php
+++ b/src/Console/Report/FixReport/JsonReporter.php
@@ -54,7 +54,7 @@ final class JsonReporter implements ReporterInterface
             'memory' => round($reportSummary->getMemory() / 1024 / 1024, 3),
         ];
 
-        $json = json_encode($json);
+        $json = json_encode($json, JSON_THROW_ON_ERROR);
 
         return $reportSummary->isDecoratedOutput() ? OutputFormatter::escape($json) : $json;
     }

--- a/src/Console/Report/ListSetsReport/JsonReporter.php
+++ b/src/Console/Report/ListSetsReport/JsonReporter.php
@@ -45,6 +45,6 @@ final class JsonReporter implements ReporterInterface
             ];
         }
 
-        return json_encode($json, JSON_PRETTY_PRINT);
+        return json_encode($json, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
     }
 }

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -1036,7 +1036,7 @@ class Tokens extends \SplFixedArray
             $this->rewind();
         }
 
-        return json_encode($output, JSON_PRETTY_PRINT | JSON_NUMERIC_CHECK);
+        return json_encode($output, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_NUMERIC_CHECK);
     }
 
     /**

--- a/src/ToolInfo.php
+++ b/src/ToolInfo.php
@@ -46,7 +46,7 @@ final class ToolInfo implements ToolInfoInterface
         }
 
         if (null === $this->composerInstallationDetails) {
-            $composerInstalled = json_decode(file_get_contents($this->getComposerInstalledFile()), true);
+            $composerInstalled = json_decode(file_get_contents($this->getComposerInstalledFile()), true, 512, JSON_THROW_ON_ERROR);
 
             $packages = $composerInstalled['packages'] ?? $composerInstalled;
 

--- a/tests/AutoReview/ComposerFileTest.php
+++ b/tests/AutoReview/ComposerFileTest.php
@@ -29,7 +29,7 @@ final class ComposerFileTest extends TestCase
     public function testScriptAreHavingDescriptions(): void
     {
         $composerJsonContent = file_get_contents(__DIR__.'/../../composer.json');
-        $composerJson = json_decode($composerJsonContent, true);
+        $composerJson = json_decode($composerJsonContent, true, 512, JSON_THROW_ON_ERROR);
 
         $scripts = array_keys($composerJson['scripts']);
         $descriptions = array_keys($composerJson['scripts-descriptions']);

--- a/tests/AutoReview/DocumentationTest.php
+++ b/tests/AutoReview/DocumentationTest.php
@@ -160,7 +160,7 @@ final class DocumentationTest extends TestCase
     public function testInstallationDocHasCorrectMinimumVersion(): void
     {
         $composerJsonContent = file_get_contents(__DIR__.'/../../composer.json');
-        $composerJson = json_decode($composerJsonContent, true);
+        $composerJson = json_decode($composerJsonContent, true, 512, JSON_THROW_ON_ERROR);
         $phpVersion = $composerJson['require']['php'];
         $minimumVersion = ltrim(substr($phpVersion, 0, strpos($phpVersion, ' ')), '^');
 

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -114,7 +114,7 @@ final class CacheTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $json = json_encode($data);
+        $json = json_encode($data, JSON_THROW_ON_ERROR);
 
         Cache::fromJson($json);
     }

--- a/tests/Smoke/InstallViaComposerTest.php
+++ b/tests/Smoke/InstallViaComposerTest.php
@@ -94,7 +94,7 @@ final class InstallViaComposerTest extends AbstractSmokeTestCase
 
         file_put_contents(
             $tmpPath.'/composer.json',
-            json_encode($initialComposerFileState, JSON_PRETTY_PRINT)
+            json_encode($initialComposerFileState, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT)
         );
 
         self::assertCommandsWork($this->stepsToVerifyInstallation, $tmpPath);
@@ -136,7 +136,7 @@ final class InstallViaComposerTest extends AbstractSmokeTestCase
 
         file_put_contents(
             $tmpPath.'/composer.json',
-            json_encode($initialComposerFileState, JSON_PRETTY_PRINT)
+            json_encode($initialComposerFileState, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT)
         );
 
         $cwd = __DIR__.'/../..';

--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -117,13 +117,13 @@ final class PharTest extends AbstractSmokeTestCase
             $json = self::executePharCommand(sprintf(
                 'fix %s --dry-run --format=json --rules=\'%s\' --using-cache=%s',
                 __FILE__,
-                json_encode(['concat_space' => ['spacing' => 'one']]),
+                json_encode(['concat_space' => ['spacing' => 'one']], JSON_THROW_ON_ERROR),
                 $usingCache,
             ))->getOutput();
 
             self::assertJson($json);
 
-            $report = json_decode($json, true);
+            $report = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
             self::assertIsArray($report);
             self::assertArrayHasKey('files', $report);
             self::assertCount(1, $report['files']);

--- a/tests/Test/AbstractIntegrationCaseFactory.php
+++ b/tests/Test/AbstractIntegrationCaseFactory.php
@@ -227,11 +227,7 @@ abstract class AbstractIntegrationCaseFactory implements IntegrationCaseFactoryI
         if ((null === $encoded || '' === $encoded) && null !== $template) {
             $decoded = [];
         } else {
-            $decoded = json_decode($encoded, true);
-
-            if (JSON_ERROR_NONE !== json_last_error()) {
-                throw new \InvalidArgumentException(sprintf('Malformed JSON: "%s", error: "%s".', $encoded, json_last_error_msg()));
-            }
+            $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
         }
 
         if (null !== $template) {

--- a/tests/Test/AbstractTransformerTestCase.php
+++ b/tests/Test/AbstractTransformerTestCase.php
@@ -172,7 +172,7 @@ abstract class AbstractTransformerTestCase extends TestCase
 
         foreach ($expectedTokens as $index => $tokenIdOrContent) {
             if (\is_string($tokenIdOrContent)) {
-                self::assertTrue($tokens[$index]->equals($tokenIdOrContent), sprintf('The token at index %d should be %s, got %s', $index, json_encode($tokenIdOrContent), $tokens[$index]->toJson()));
+                self::assertTrue($tokens[$index]->equals($tokenIdOrContent), sprintf('The token at index %d should be %s, got %s', $index, json_encode($tokenIdOrContent, JSON_THROW_ON_ERROR), $tokens[$index]->toJson()));
 
                 continue;
             }

--- a/tests/Test/Assert/AssertJsonSchemaTrait.php
+++ b/tests/Test/Assert/AssertJsonSchemaTrait.php
@@ -21,7 +21,7 @@ trait AssertJsonSchemaTrait
 {
     private static function assertJsonSchema(string $schemaFile, string $json): void
     {
-        $data = json_decode($json);
+        $data = json_decode($json, null, 512, JSON_THROW_ON_ERROR);
         $validator = new Validator();
         $validator->validate($data, (object) ['$ref' => 'file://'.realpath($schemaFile)]);
 

--- a/tests/TextDiffTest.php
+++ b/tests/TextDiffTest.php
@@ -78,7 +78,7 @@ final class TextDiffTest extends TestCase
             yield [$expected, $format, false];
         }
 
-        $expected = substr(json_encode($expected), 1, -1);
+        $expected = substr(json_encode($expected, JSON_THROW_ON_ERROR), 1, -1);
 
         yield [$expected, 'json', true];
 

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -1895,7 +1895,7 @@ $bar;',
             $token = $tokens[$index];
             $expectedPrototype = $expectedToken->getPrototype();
 
-            self::assertTrue($token->equals($expectedPrototype), sprintf('The token at index %d should be %s, got %s', $index, json_encode($expectedPrototype), $token->toJson()));
+            self::assertTrue($token->equals($expectedPrototype), sprintf('The token at index %d should be %s, got %s', $index, json_encode($expectedPrototype, JSON_THROW_ON_ERROR), $token->toJson()));
         }
     }
 }


### PR DESCRIPTION
manual error handling for cases when we use custom exception class or msg is not modified

this PR covers the cases when error handling was basically missing