### PR TITLE
feat: Support for attributes in `method_argument_space`

### DIFF
--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -103,7 +103,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurab
     /**
      * {@inheritdoc}
      *
-     * Must run before ArrayIndentationFixer.
+     * Must run before ArrayIndentationFixer, StatementIndentationFixer.
      * Must run after CombineNestedDirnameFixer, FunctionDeclarationFixer, ImplodeCallFixer, LambdaNotUsedImportFixer, NoMultilineWhitespaceAroundDoubleArrowFixer, NoUselessSprintfFixer, PowToExponentiationFixer, StrictParamFixer.
      */
     public function getPriority(): int

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -330,8 +330,17 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurab
                 continue;
             }
 
-            if ($token->equals(',') && !$tokens[$tokens->getNextMeaningfulToken($index)]->equals(')')) {
+            $isAttribute = $token->isGivenKind(CT::T_ATTRIBUTE_CLOSE);
+
+            if (
+                ($token->equals(',') || $isAttribute)
+                && !$tokens[$tokens->getNextMeaningfulToken($index)]->equals(')')
+            ) {
                 $this->fixNewline($tokens, $index, $indentation);
+
+                if ($isAttribute) {
+                    $index = $tokens->findBlockStart(Tokens::BLOCK_TYPE_ATTRIBUTE, $index);
+                }
             }
         }
 

--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -64,7 +64,7 @@ else {
      * {@inheritdoc}
      *
      * Must run before HeredocIndentationFixer.
-     * Must run after ClassAttributesSeparationFixer, CurlyBracesPositionFixer, YieldFromArrayToYieldsFixer.
+     * Must run after ClassAttributesSeparationFixer, CurlyBracesPositionFixer, MethodArgumentSpaceFixer, YieldFromArrayToYieldsFixer.
      */
     public function getPriority(): int
     {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -498,6 +498,7 @@ final class FixerFactoryTest extends TestCase
             ],
             'method_argument_space' => [
                 'array_indentation',
+                'statement_indentation',
             ],
             'modernize_strpos' => [
                 'binary_operator_spaces',

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -1101,6 +1101,97 @@ $fn = fn(
     }
 
     /**
+     * @dataProvider provideFix80Cases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFix80(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFix80Cases(): iterable
+    {
+        yield 'multiple attributes' => [
+            '<?php
+class MyClass
+{
+    public function __construct(
+        private string $id,
+        #[Foo]
+        #[Bar]
+        private ?string $name = null,
+    ) {}
+}',
+            '<?php
+class MyClass
+{
+    public function __construct(
+        private string $id,
+        #[Foo] #[Bar] private ?string $name = null,
+    ) {}
+}',
+        ];
+
+        yield 'single attribute markup with comma separated list' => [
+            '<?php
+class MyClass
+{
+    public function __construct(
+        private string $id,
+        #[Foo, Bar]
+        private ?string $name = null,
+    ) {}
+}',
+            '<?php
+class MyClass
+{
+    public function __construct(
+        private string $id,
+        #[Foo, Bar] private ?string $name = null,
+    ) {}
+}',
+        ];
+
+        yield 'attributes with arguments' => [
+            '<?php
+class MyClass
+{
+    public function __construct(
+        private string $id,
+        #[Foo(value: 1234, otherValue: [1, 2, 3])]
+        #[Bar(Bar::BAZ, array(\'[\',\']\'))]
+        private ?string $name = null,
+    ) {}
+}',
+            '<?php
+class MyClass
+{
+    public function __construct(
+        private string $id,
+        #[Foo(value: 1234, otherValue: [1, 2, 3])] #[Bar(Bar::BAZ, array(\'[\',\']\'))] private ?string $name = null,
+    ) {}
+}',
+        ];
+
+        yield 'fully qualified attributes' => [
+            '<?php
+function foo(
+    #[\Foo\Bar]
+    $bar,
+    #[\Foo\Baz]
+    $baz,
+    #[\Foo\Buzz]
+    $buzz
+) {}',
+            '<?php
+function foo(
+    #[\Foo\Bar] $bar, #[\Foo\Baz] $baz, #[\Foo\Buzz] $buzz
+) {}',
+        ];
+    }
+
+    /**
      * @dataProvider provideFix81Cases
      *
      * @requires PHP 8.1

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -1189,6 +1189,25 @@ function foo(
     #[\Foo\Bar] $bar, #[\Foo\Baz] $baz, #[\Foo\Buzz] $buzz
 ) {}',
         ];
+
+        yield 'multiline attributes' => [
+            '<?php
+function foo(
+    $foo,
+    #[
+    Foo\Bar,
+    Foo\Baz,
+    Foo\Buzz(a: \'astral\', b: 1234),
+]
+    $bar
+) {}',
+            '<?php
+function foo($foo, #[
+    Foo\Bar,
+    Foo\Baz,
+    Foo\Buzz(a: \'astral\', b: 1234),
+] $bar) {}',
+        ];
     }
 
     /**

--- a/tests/Fixtures/Integration/priority/method_argument_space,statement_indentation.test
+++ b/tests/Fixtures/Integration/priority/method_argument_space,statement_indentation.test
@@ -2,6 +2,8 @@
 Integration of fixers: method_argument_space,statement_indentation.
 --RULESET--
 {"method_argument_space": {"on_multiline" : "ensure_fully_multiline"}, "statement_indentation": true}
+--REQUIREMENTS--
+{"php": 80000}
 --EXPECT--
 <?php
 function foo(

--- a/tests/Fixtures/Integration/priority/method_argument_space,statement_indentation.test
+++ b/tests/Fixtures/Integration/priority/method_argument_space,statement_indentation.test
@@ -1,0 +1,23 @@
+--TEST--
+Integration of fixers: method_argument_space,statement_indentation.
+--RULESET--
+{"method_argument_space": {"on_multiline" : "ensure_fully_multiline"}, "statement_indentation": true}
+--EXPECT--
+<?php
+function foo(
+    $foo,
+    #[
+        Foo\Bar,
+        Foo\Baz,
+        Foo\Buzz(a: 'astral', b: 1234),
+    ]
+    $bar
+) {}
+
+--INPUT--
+<?php
+function foo($foo, #[
+    Foo\Bar,
+    Foo\Baz,
+    Foo\Buzz(a: 'astral', b: 1234),
+] $bar) {}


### PR DESCRIPTION
Fixes #6546.

Example snippet from the issue fixed with changes provided in this PR:
<img width="982" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/9a1699dd-fd82-4c95-9617-2b7618a73a1c">