### PR TITLE
feat: Make Doctrine dependencies optional

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -1,5 +1,7 @@
 {
     "symbol-whitelist" : [
+        "Doctrine\\Common\\Annotations\\DocLexer",
+        "Doctrine\\Common\\Lexer\\Token",
         "Symfony\\Component\\EventDispatcher\\Event",
         "Symfony\\Contracts\\EventDispatcher\\Event",
         "Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface",

--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -1,5 +1,6 @@
 {
     "symbol-whitelist" : [
+        "Doctrine\\Common\\Annotations\\CachedReader",
         "Doctrine\\Common\\Annotations\\DocLexer",
         "Doctrine\\Common\\Lexer\\Token",
         "Symfony\\Component\\EventDispatcher\\Event",

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,6 @@
         "ext-tokenizer": "*",
         "composer/semver": "^3.3",
         "composer/xdebug-handler": "^3.0.3",
-        "doctrine/annotations": "^2",
-        "doctrine/lexer": "^2 || ^3",
         "sebastian/diff": "^4.0 || ^5.0",
         "symfony/console": "^5.4 || ^6.0",
         "symfony/event-dispatcher": "^5.4 || ^6.0",
@@ -40,6 +38,8 @@
         "symfony/stopwatch": "^5.4 || ^6.0"
     },
     "require-dev": {
+        "doctrine/annotations": "^2",
+        "doctrine/lexer": "^2 || ^3",
         "facile-it/paraunit": "^1.3 || ^2.0",
         "justinrainbow/json-schema": "^5.2",
         "keradus/cli-executor": "^2.0",
@@ -58,7 +58,9 @@
     },
     "suggest": {
         "ext-dom": "For handling output formats in XML",
-        "ext-mbstring": "For handling non-UTF8 characters."
+        "ext-mbstring": "For handling non-UTF8 characters.",
+        "doctrine/annotations": "Required (^2) if you want to use @DoctrineAnnotation rule set (or single fixers related to Doctrine Annotations)",
+        "doctrine/lexer": "Required (^2 || ^3) if you want to use @DoctrineAnnotation rule set (or single fixers related to Doctrine Annotations)"
     },
     "autoload": {
         "psr-4": {

--- a/dev-tools/build.sh
+++ b/dev-tools/build.sh
@@ -4,6 +4,10 @@ set -eu
 # ensure that deps will work on lowest supported PHP version
 composer config platform.php 7.4
 
+# Include Doctrine Annotations and Lexer in the PHAR build (for people that use `@DoctrineAnnotation rule set).
+# Only add requirement to the composer.json, it will be installed later.
+composer require doctrine/annotations:"^2" doctrine/lexer:"^2 || ^3" --no-update
+
 # install package deps without dev-deps / remove already installed dev-deps
 # box can ignore dev-deps, but dev-deps, when installed, may lower version of prod-deps
 composer update --no-interaction --no-progress --no-dev --prefer-stable --optimize-autoloader

--- a/src/AbstractDoctrineAnnotationFixer.php
+++ b/src/AbstractDoctrineAnnotationFixer.php
@@ -41,6 +41,13 @@ abstract class AbstractDoctrineAnnotationFixer extends AbstractFixer implements 
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
+        if (
+            !class_exists('Doctrine\Common\Annotations\DocLexer')
+            || !class_exists('Doctrine\Common\Lexer\Token')
+        ) {
+            throw new \RuntimeException('You need to install `doctrine/annotations` and `doctrine/lexer` to be able to use '.static::class);
+        }
+
         // fetch indices one time, this is safe as we never add or remove a token during fixing
         $analyzer = new TokensAnalyzer($tokens);
         $this->classyElements = $analyzer->getClassyElements();

--- a/tests/AutoReview/ComposerFileTest.php
+++ b/tests/AutoReview/ComposerFileTest.php
@@ -65,6 +65,22 @@ final class ComposerFileTest extends TestCase
         }
     }
 
+    public function testDoctrineSuggestionsContainProperVersionConstraints(): void
+    {
+        $composerJson = self::readComposerJson();
+        $doctrinePackages = ['doctrine/annotations', 'doctrine/lexer'];
+
+        foreach ($doctrinePackages as $package) {
+            $suggestion = $composerJson['suggest'][$package];
+            $constraint = $composerJson['require-dev'][$package];
+
+            self::assertSame(
+                "Required ({$constraint}) if you want to use @DoctrineAnnotation rule set (or single fixers related to Doctrine Annotations)",
+                $suggestion
+            );
+        }
+    }
+
     /**
      * @return array<string, mixed>
      */


### PR DESCRIPTION
Fixes #7250.

How it looks when Doctrine packages are not installed:

<img width="1177" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/6dae9ff5-9fa5-4690-89c9-82323a965814">
