### PR TITLE
fix: PhpdocTypesFixer - do not crash for type having space

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocTypesFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesFixer.php
@@ -142,7 +142,7 @@ final class PhpdocTypesFixer extends AbstractPhpdocTypesFixer implements Configu
                 // normalize shape/callable/generic identifiers too
                 // TODO parse them as inner types and this will be not needed then
                 $value = Preg::replaceCallback(
-                    '/^(\??\s*)([^()[\]{}<>\'"]++)([()[\]{}<>])/',
+                    '/^(\??\s*)([^()[\]{}<>\'"]+)(?<!\s)(\s*[\s()[\]{}<>])/',
                     fn ($matches) => $matches[1].$this->normalize($matches[2]).$matches[3],
                     $value
                 );

--- a/src/Fixer/Phpdoc/PhpdocTypesFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesFixer.php
@@ -142,7 +142,7 @@ final class PhpdocTypesFixer extends AbstractPhpdocTypesFixer implements Configu
                 // normalize shape/callable/generic identifiers too
                 // TODO parse them as inner types and this will be not needed then
                 $value = Preg::replaceCallback(
-                    '/^(\??\s*)([^()[\]{}<>\'"]+)(?<!\s)(\s*[\s()[\]{}<>])/',
+                    '/^(\??\s*)([^()[\]{}<>\'"]++)([()[\]{}<>])/',
                     fn ($matches) => $matches[1].$this->normalize($matches[2]).$matches[3],
                     $value
                 );

--- a/tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
@@ -304,6 +304,36 @@ final class PhpdocTypesFixerTest extends AbstractFixerTestCase
      */
 ',
         ];
+
+        yield 'param with extra braces' => [
+            '<?php /** @param int {1} $value */',
+            '<?php /** @param INT {1} $value */',
+        ];
+
+        yield 'param with extra brackets' => [
+            '<?php /** @param int [2] $value */',
+            '<?php /** @param INT [2] $value */',
+        ];
+
+        yield 'param with extra chevrons' => [
+            '<?php /** @param int <3> $value */',
+            '<?php /** @param INT <3> $value */',
+        ];
+
+        yield 'param with extra parentheses' => [
+            '<?php /** @param int (4) $value */',
+            '<?php /** @param INT (4) $value */',
+        ];
+
+        yield 'param with union type and extra parentheses' => [
+            '<?php /** @param float|int (123) $value */',
+            '<?php /** @param FLOAT|INT (123) $value */',
+        ];
+
+        yield 'return with union type and extra parentheses' => [
+            '<?php /** @return float|int (number) count of something */',
+            '<?php /** @return FLOAT|INT (number) count of something */',
+        ];
     }
 
     public function testWrongConfig(): void

--- a/tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
@@ -305,29 +305,19 @@ final class PhpdocTypesFixerTest extends AbstractFixerTestCase
 ',
         ];
 
-        yield 'param with extra braces' => [
-            '<?php /** @param int {1} $value */',
-            '<?php /** @param INT {1} $value */',
-        ];
-
-        yield 'param with extra brackets' => [
-            '<?php /** @param int [2] $value */',
-            '<?php /** @param INT [2] $value */',
-        ];
-
         yield 'param with extra chevrons' => [
-            '<?php /** @param int <3> $value */',
-            '<?php /** @param INT <3> $value */',
+            '<?php /** @param array <3> $value */',
+            '<?php /** @param ARRAY <3> $value */',
         ];
 
         yield 'param with extra parentheses' => [
-            '<?php /** @param int (4) $value */',
-            '<?php /** @param INT (4) $value */',
+            '<?php /** @param \Closure (int) $value */',
+            '<?php /** @param \Closure (INT) $value */',
         ];
 
         yield 'param with union type and extra parentheses' => [
-            '<?php /** @param float|int (123) $value */',
-            '<?php /** @param FLOAT|INT (123) $value */',
+            '<?php /** @param \Closure (float|int) $value */',
+            '<?php /** @param \Closure (FLOAT|INT) $value */',
         ];
 
         yield 'return with union type and extra parentheses' => [


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7267