### PR TITLE
fix: Handle superfluous asterisk in `no_superfluous_phpdoc_tags`

### DIFF
--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -290,7 +290,7 @@ final class Annotation
             }
 
             $matchingResult = Preg::match(
-                '{^(?:\s*\*|/\*\*)\s*@'.$name.'\s+'.TypeExpression::REGEX_TYPES.'(?:(?:[*\h\v]|\&?[\.\$]).*)?\r?$}is',
+                '{^(?:\s*\*|/\*\*)[\s\*]*@'.$name.'\s+'.TypeExpression::REGEX_TYPES.'(?:(?:[*\h\v]|\&?[\.\$]).*)?\r?$}is',
                 $this->lines[0]->getContent(),
                 $matches
             );

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -2435,6 +2435,14 @@ class Foo {
     public function foo() {}
 }',
         ];
+
+        yield 'superfluous asterisk in corrupted phpDoc' => [
+            '<?php
+class Foo {
+    /** * @return Baz */
+    public function doFoo($bar) {}
+}',
+        ];
     }
 
     /**

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -2443,6 +2443,19 @@ class Foo {
     public function doFoo($bar) {}
 }',
         ];
+
+        yield 'superfluous return type after superfluous asterisk in corrupted phpDoc' => [
+            '<?php
+class Foo {
+    /**  */
+    public function doFoo($bar): Baz {}
+}',
+            '<?php
+class Foo {
+    /** * @return Baz */
+    public function doFoo($bar): Baz {}
+}',
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes #7278