### PR TITLE
feat: Move `single_line_empty_body` to `@PER-CS2.0`

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -3008,7 +3008,7 @@ List of Available Rules
 
    Empty body of class, interface, trait, enum or function must be abbreviated as ``{}`` and placed on the same line as the previous symbol, separated by a single space.
 
-   Part of rule set `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
+   Part of rule sets `@PER-CS2.0 <./ruleSets/PER-CS2.0.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Basic\\SingleLineEmptyBodyFixer <./../src/Fixer/Basic/SingleLineEmptyBodyFixer.php>`_
 -  `single_line_throw <./rules/function_notation/single_line_throw.rst>`_

--- a/doc/ruleSets/PER-CS2.0.rst
+++ b/doc/ruleSets/PER-CS2.0.rst
@@ -8,3 +8,4 @@ Rules
 -----
 
 - `@PER-CS1.0 <./PER-CS1.0.rst>`_
+- `single_line_empty_body <./../rules/basic/single_line_empty_body.rst>`_

--- a/doc/ruleSets/PhpCsFixer.rst
+++ b/doc/ruleSets/PhpCsFixer.rst
@@ -7,7 +7,7 @@ Rule set as used by the PHP-CS-Fixer development team, highly opinionated.
 Rules
 -----
 
-- `@PER <./PER.rst>`_
+- `@PER-CS2.0 <./PER-CS2.0.rst>`_
 - `@Symfony <./Symfony.rst>`_
 - `array_indentation <./../rules/whitespace/array_indentation.rst>`_
 - `blank_line_before_statement <./../rules/whitespace/blank_line_before_statement.rst>`_ with config:
@@ -58,7 +58,6 @@ Rules
 - `return_assignment <./../rules/return_notation/return_assignment.rst>`_
 - `self_static_accessor <./../rules/class_notation/self_static_accessor.rst>`_
 - `single_line_comment_style <./../rules/comment/single_line_comment_style.rst>`_
-- `single_line_empty_body <./../rules/basic/single_line_empty_body.rst>`_
 - `whitespace_after_comma_in_array <./../rules/array_notation/whitespace_after_comma_in_array.rst>`_ with config:
 
   ``['ensure_single_space' => true]``

--- a/doc/ruleSets/PhpCsFixerRisky.rst
+++ b/doc/ruleSets/PhpCsFixerRisky.rst
@@ -7,7 +7,7 @@ Rule set as used by the PHP-CS-Fixer development team, highly opinionated. This 
 Rules
 -----
 
-- `@PER:risky <./PERRisky.rst>`_
+- `@PER-CS2.0:risky <./PER-CS2.0Risky.rst>`_
 - `@Symfony:risky <./SymfonyRisky.rst>`_
 - `comment_to_phpdoc <./../rules/comment/comment_to_phpdoc.rst>`_
 - `final_internal_class <./../rules/class_notation/final_internal_class.rst>`_

--- a/doc/rules/basic/single_line_empty_body.rst
+++ b/doc/rules/basic/single_line_empty_body.rst
@@ -26,7 +26,8 @@ Example #1
 Rule sets
 ---------
 
-The rule is part of the following rule set:
+The rule is part of the following rule sets:
 
+- `@PER-CS2.0 <./../../ruleSets/PER-CS2.0.rst>`_
 - `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
 

--- a/src/RuleSet/Sets/PERCS2x0RiskySet.php
+++ b/src/RuleSet/Sets/PERCS2x0RiskySet.php
@@ -21,7 +21,7 @@ use PhpCsFixer\RuleSet\AbstractRuleSetDescription;
  *
  * PER Coding Style v2.0.
  *
- * @see https://github.com/php-fig/per-coding-style/blob/1.0.0/spec.md
+ * @see https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md
  */
 final class PERCS2x0RiskySet extends AbstractRuleSetDescription
 {

--- a/src/RuleSet/Sets/PERCS2x0Set.php
+++ b/src/RuleSet/Sets/PERCS2x0Set.php
@@ -21,7 +21,7 @@ use PhpCsFixer\RuleSet\AbstractRuleSetDescription;
  *
  * PER Coding Style v2.0.
  *
- * @see https://github.com/php-fig/per-coding-style/blob/1.0.0/spec.md
+ * @see https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md
  */
 final class PERCS2x0Set extends AbstractRuleSetDescription
 {
@@ -34,6 +34,7 @@ final class PERCS2x0Set extends AbstractRuleSetDescription
     {
         return [
             '@PER-CS1.0' => true,
+            'single_line_empty_body' => true,
         ];
     }
 

--- a/src/RuleSet/Sets/PhpCsFixerRiskySet.php
+++ b/src/RuleSet/Sets/PhpCsFixerRiskySet.php
@@ -24,7 +24,7 @@ final class PhpCsFixerRiskySet extends AbstractRuleSetDescription
     public function getRules(): array
     {
         return [
-            '@PER:risky' => true,
+            '@PER-CS2.0:risky' => true,
             '@Symfony:risky' => true,
             'comment_to_phpdoc' => true,
             'final_internal_class' => true,

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -24,7 +24,7 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
     public function getRules(): array
     {
         return [
-            '@PER' => true,
+            '@PER-CS2.0' => true,
             '@Symfony' => true,
             'array_indentation' => true,
             'blank_line_before_statement' => [
@@ -115,7 +115,6 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
             'return_assignment' => true,
             'self_static_accessor' => true,
             'single_line_comment_style' => true,
-            'single_line_empty_body' => true,
             'single_line_throw' => false,
             'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
         ];

--- a/tests/Fixtures/Integration/set/@PER-CS2.0.test-out.php
+++ b/tests/Fixtures/Integration/set/@PER-CS2.0.test-out.php
@@ -41,9 +41,7 @@ class Foo extends Bar implements FooInterfaceA
 class Aaa implements
     Bbb,
     Ccc,
-    Ddd
-{
-}
+    Ddd {}
 
 $a = new Foo();
 $b = (bool) 1;


### PR DESCRIPTION
Fixes #7269.

Initially `single_line_empty_body` was added to `@PhpCsFixer`, but since #7249 was merged, we can move it to PER-CS v2 ([reference](https://github.com/php-fig/per-coding-style/compare/1.0.0...2.0.0#diff-bc6661da34ecae62fbe724bb93fd69b91a7f81143f2683a81163231de7e3b545R515)).