### PR TITLE
docs: cleanup old mention of `--show-progress=estimating` in docs

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -87,13 +87,13 @@ The ``--stop-on-violation`` flag stops the execution upon first file that needs 
 The ``--show-progress`` option allows you to choose the way process progress is rendered:
 
 * ``none``: disables progress output;
-* ``dots``: same as ``estimating`` but using all terminal columns instead of default 80.
+* ``dots``: multiline progress output with number of files and percentage on each line. Note that with this option, the files list is evaluated before processing to get the total number of files and then kept in memory to avoid using the file iterator twice. This has an impact on memory usage so using this option is not recommended on very large projects;
 
 If the option is not provided, it defaults to ``dots`` unless a config file that disables output is used, in which case it defaults to ``none``. This option has no effect if the verbosity of the command is less than ``verbose``.
 
 .. code-block:: console
 
-    php php-cs-fixer.phar fix --verbose --show-progress=estimating
+    php php-cs-fixer.phar fix --verbose --show-progress=dots
 
 The command can also read from standard input, in which case it won't
 automatically fix anything:


### PR DESCRIPTION
just a small cleanup of the documentation. it was still mentioning `--show-progress=estimating` which was long removed (see #3374).