### PR TITLE
fix: `OrderedTraitsFixer` - better support for multiple traits in one `use` statement

### DIFF
--- a/src/Fixer/ClassNotation/OrderedTraitsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedTraitsFixer.php
@@ -205,7 +205,7 @@ final class OrderedTraitsFixer extends AbstractFixer implements ConfigurableFixe
             );
         }
 
-        if($beforeOverrideCount < count($tokens) ){
+        if ($beforeOverrideCount < $tokens->count()) {
             $tokens->clearEmptyTokens();
         }
     }

--- a/src/Fixer/ClassNotation/OrderedTraitsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedTraitsFixer.php
@@ -195,12 +195,18 @@ final class OrderedTraitsFixer extends AbstractFixer implements ConfigurableFixe
             array_values($sortedElements)
         );
 
+        $beforeOverrideCount = $tokens->count();
+
         foreach (array_reverse($sortedElements, true) as $index => $tokensToInsert) {
             $tokens->overrideRange(
                 $index,
                 $index + \count($elements[$index]) - 1,
                 $tokensToInsert
             );
+        }
+
+        if($beforeOverrideCount < count($tokens) ){
+            $tokens->clearEmptyTokens();
         }
     }
 }

--- a/tests/Fixer/ClassNotation/OrderedTraitsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedTraitsFixerTest.php
@@ -302,6 +302,20 @@ class Foo {
     use A;
 }',
         ];
+        yield 'simple and with namespace' => [
+            '<?php
+
+class User
+{
+    use Test\B, TestA;
+}',
+            '<?php
+
+class User
+{
+    use TestA, Test\B;
+}'
+        ];
     }
 
     /**

--- a/tests/Fixer/ClassNotation/OrderedTraitsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedTraitsFixerTest.php
@@ -302,6 +302,7 @@ class Foo {
     use A;
 }',
         ];
+
         yield 'simple and with namespace' => [
             '<?php
 
@@ -314,7 +315,7 @@ class User
 class User
 {
     use TestA, Test\B;
-}'
+}',
         ];
     }
 


### PR DESCRIPTION
Due to simple traits and traits with namespace being on the same line, the closing curly brace within the class that contains these traits disappears.