### PR TITLE
feat(`@PER-CS2.0`): Add `concat_space` to the ruleset

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -317,7 +317,7 @@ List of Available Rules
      | Default value: ``'none'``
 
 
-   Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PER-CS2.0 <./ruleSets/PER-CS2.0.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Operator\\ConcatSpaceFixer <./../src/Fixer/Operator/ConcatSpaceFixer.php>`_
 -  `constant_case <./rules/casing/constant_case.rst>`_

--- a/doc/ruleSets/PER-CS2.0.rst
+++ b/doc/ruleSets/PER-CS2.0.rst
@@ -8,8 +8,8 @@ Rules
 -----
 
 - `@PER-CS1.0 <./PER-CS1.0.rst>`_
-- `single_line_empty_body <./../rules/basic/single_line_empty_body.rst>`_
 - `concat_space <./../rules/operator/concat_space.rst>`_ with config:
 
   ``['spacing' => 'one']``
 
+- `single_line_empty_body <./../rules/basic/single_line_empty_body.rst>`_

--- a/doc/ruleSets/PER-CS2.0.rst
+++ b/doc/ruleSets/PER-CS2.0.rst
@@ -9,3 +9,7 @@ Rules
 
 - `@PER-CS1.0 <./PER-CS1.0.rst>`_
 - `single_line_empty_body <./../rules/basic/single_line_empty_body.rst>`_
+- `concat_space <./../rules/operator/concat_space.rst>`_ with config:
+
+  ``['spacing' => 'one']``
+

--- a/doc/rules/operator/concat_space.rst
+++ b/doc/rules/operator/concat_space.rst
@@ -63,6 +63,14 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+- `@PER <./../../ruleSets/PER.rst>`_ with config:
+
+  ``['spacing' => 'one']``
+
+- `@PER-CS2.0 <./../../ruleSets/PER-CS2.0.rst>`_ with config:
+
+  ``['spacing' => 'one']``
+
 - `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
 - `@Symfony <./../../ruleSets/Symfony.rst>`_
 

--- a/src/RuleSet/Sets/PERCS2x0Set.php
+++ b/src/RuleSet/Sets/PERCS2x0Set.php
@@ -34,6 +34,7 @@ final class PERCS2x0Set extends AbstractRuleSetDescription
     {
         return [
             '@PER-CS1.0' => true,
+            'concat_space' => ['spacing' => 'one'],
             'single_line_empty_body' => true,
         ];
     }

--- a/tests/Fixtures/Integration/set/@PER-CS2.0.test-in.php
+++ b/tests/Fixtures/Integration/set/@PER-CS2.0.test-in.php
@@ -19,6 +19,8 @@ class Foo extends Bar implements FooInterfaceA{
                 BazClass::bar($arg2, $arg3);
         }
 
+        $combined = $a.$b;
+
         STATIC::baz();
     }
 

--- a/tests/Fixtures/Integration/set/@PER-CS2.0.test-out.php
+++ b/tests/Fixtures/Integration/set/@PER-CS2.0.test-out.php
@@ -29,6 +29,8 @@ class Foo extends Bar implements FooInterfaceA
             BazClass::bar($arg2, $arg3);
         }
 
+        $combined = $a . $b;
+
         static::baz();
     }
 


### PR DESCRIPTION
It is the opinion of the PER-CS Working Group that this should be required all the way back to PSR-2, as the concat operator is a binary operator, and therefore should have wrapping spaces.  However, the PSR2 and PSR12 rulesets are so old that it's probably not wise to change settings in them at this point, so we'll just add it to the latest and move on with life.

I am getting an odd error locally, which I am not sure is caused by my changes here.  Specifically, `composer self-check` fails with this:

```
tests/UtilsTest.php:407:     * @dataProvider provideToStringCases
tests/UtilsTest.php:53:     * @dataProvider provideCamelCaseToUnderscoreCases
tests/WhitespacesFixerConfigTest.php:29:     * @dataProvider provideFixCases
tests/WordMatcherTest.php:29:     * @param string[] $candidates
tests/WordMatcherTest.php:31:     * @dataProvider provideMatchCases
Script ./dev-tools/check_trailing_spaces.sh handling the self-check event returned with error code 3
```

But I never touched `WordMatcherTest.php` at all, so I'm unclear what it's complaining about.  Please advise and I'll try to fix it. 