### PR TITLE
fix(`YodaStyleFixer`): do not touch `require(_once)`, `include(_once)` and `yield from` statements

### DIFF
--- a/src/Fixer/ControlStructure/YodaStyleFixer.php
+++ b/src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -347,12 +347,13 @@ return $foo === count($bar);
 
     private function getCompareFixableInfo(Tokens $tokens, int $index, bool $yoda): ?array
     {
-        $left = $this->getLeftSideCompareFixableInfo($tokens, $index);
         $right = $this->getRightSideCompareFixableInfo($tokens, $index);
 
         if (!$yoda && $this->isOfLowerPrecedenceAssignment($tokens[$tokens->getNextMeaningfulToken($right['end'])])) {
             return null;
         }
+
+        $left = $this->getLeftSideCompareFixableInfo($tokens, $index);
 
         if ($this->isListStatement($tokens, $left['start'], $left['end']) || $this->isListStatement($tokens, $right['start'], $right['end'])) {
             return null; // do not fix lists assignment inside statements
@@ -440,6 +441,11 @@ return $foo === count($bar);
                 T_THROW,        // throw
                 T_COALESCE,
                 T_YIELD,        // yield
+                T_YIELD_FROM,
+                T_REQUIRE,
+                T_REQUIRE_ONCE,
+                T_INCLUDE,
+                T_INCLUDE_ONCE,
             ];
         }
 

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -223,26 +223,6 @@ if ($a = $obj instanceof A === true) {
         ];
 
         yield [
-            '<?php $a = 1 === include_once $a ? 1 : 2;',
-            '<?php $a = include_once $a === 1 ? 1 : 2;',
-        ];
-
-        yield [
-            '<?php echo 1 === include $a ? 1 : 2;',
-            '<?php echo include $a === 1 ? 1 : 2;',
-        ];
-
-        yield [
-            '<?php echo 1 === require_once $a ? 1 : 2;',
-            '<?php echo require_once $a === 1 ? 1 : 2;',
-        ];
-
-        yield [
-            '<?php echo 1 === require $a ? 1 : 2;',
-            '<?php echo require $a === 1 ? 1 : 2;',
-        ];
-
-        yield [
             '<?php switch(1 === $a){
                     case true: echo 1;
                 };',
@@ -866,6 +846,31 @@ switch ($a) {
         break;
 }
 ',
+        ];
+
+        yield 'require' => [
+            '<?php require 1 === $var ? "A.php" : "B.php";',
+            '<?php require $var === 1 ? "A.php" : "B.php";',
+        ];
+
+        yield 'require_once' => [
+            '<?php require_once 1 === $var ? "A.php" : "B.php";',
+            '<?php require_once $var === 1 ? "A.php" : "B.php";',
+        ];
+
+        yield 'include' => [
+            '<?php include 1 === $var ? "A.php" : "B.php";',
+            '<?php include $var === 1 ? "A.php" : "B.php";',
+        ];
+
+        yield 'include_once' => [
+            '<?php include_once 1 === $var ? "A.php" : "B.php";',
+            '<?php include_once $var === 1 ? "A.php" : "B.php";',
+        ];
+
+        yield 'yield from' => [
+            '<?php function test() {return yield from 1 === $a ? $c : $d;};',
+            '<?php function test() {return yield from $a === 1 ? $c : $d;};',
         ];
     }
 


### PR DESCRIPTION

closes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7280

The removed tests show we would no longer support some very exotic use case of `(require|include)(_once)+` statements,
but I think that is no issue compared to the fix this PR offers.