### PR TITLE
fix(method_argument_space): inject new line after trailing space on current line

### DIFF
--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -360,6 +360,10 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurab
         if ($tokens[$index + 2]->isComment()) {
             $nextMeaningfulTokenIndex = $tokens->getNextMeaningfulToken($index + 2);
             if (!$this->isNewline($tokens[$nextMeaningfulTokenIndex - 1])) {
+                if ($tokens[$nextMeaningfulTokenIndex - 1]->isWhitespace()) {
+                    $tokens->clearAt($nextMeaningfulTokenIndex - 1);
+                }
+
                 $tokens->ensureWhitespaceAtIndex($nextMeaningfulTokenIndex, 0, $this->whitespacesConfig->getLineEnding().$indentation);
             }
 

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -1004,6 +1004,20 @@ $example = function () use ($message1,$message2) {
         $f);# comment4
 ',
         ];
+
+        yield [
+            '<?php
+foo(
+    /* bar */
+    "baz"
+);
+            ',
+            '<?php
+foo(
+    /* bar */ "baz"
+);
+            ',
+        ];
     }
 
     /**


### PR DESCRIPTION
closes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7291

The issues was perceived as a priority issue, however the issue is within the MethodArgumentSpaceFixer.
It creates a stream with multiple space-tokens which is not allowed.
