### PR TITLE
feat: Deprecate `NewWithBracesFixer` and proxy to `NewWithParenthesesFixer`

### DIFF
--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -299,7 +299,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Only booleans are allowed in an if condition, mixed given\\.$#',
 	'count' => 2,
-	'path' => __DIR__ . '/../../src/Fixer/Operator/NewWithBracesFixer.php',
+	'path' => __DIR__ . '/../../src/Fixer/Operator/NewWithParenthesesFixer.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Only booleans are allowed in a negated boolean, mixed given\\.$#',

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1331,6 +1331,25 @@ List of Available Rules
 
    All instances created with ``new`` keyword must (not) be followed by braces.
 
+   *warning deprecated*   Use ``new_with_parentheses`` instead.
+
+   Configuration options:
+
+   - | ``named_class``
+     | Whether named classes should be followed by parentheses.
+     | Allowed types: ``bool``
+     | Default value: ``true``
+   - | ``anonymous_class``
+     | Whether anonymous classes should be followed by parentheses.
+     | Allowed types: ``bool``
+     | Default value: ``true``
+
+
+   `Source PhpCsFixer\\Fixer\\Operator\\NewWithBracesFixer <./../src/Fixer/Operator/NewWithBracesFixer.php>`_
+-  `new_with_parentheses <./rules/operator/new_with_parentheses.rst>`_
+
+   All instances created with ``new`` keyword must (not) be followed by parentheses.
+
    Configuration options:
 
    - | ``named_class``
@@ -1345,7 +1364,7 @@ List of Available Rules
 
    Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PER-CS <./ruleSets/PER-CS.rst>`_ `@PER-CS1.0 <./ruleSets/PER-CS1.0.rst>`_ `@PER-CS2.0 <./ruleSets/PER-CS2.0.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
-   `Source PhpCsFixer\\Fixer\\Operator\\NewWithBracesFixer <./../src/Fixer/Operator/NewWithBracesFixer.php>`_
+   `Source PhpCsFixer\\Fixer\\Operator\\NewWithParenthesesFixer <./../src/Fixer/Operator/NewWithParenthesesFixer.php>`_
 -  `non_printable_character <./rules/basic/non_printable_character.rst>`_
 
    Remove Zero-width space (ZWSP), Non-breaking space (NBSP) and other invisible unicode symbols.

--- a/doc/ruleSets/PSR12.rst
+++ b/doc/ruleSets/PSR12.rst
@@ -27,7 +27,7 @@ Rules
 - `declare_equal_normalize <./../rules/language_construct/declare_equal_normalize.rst>`_
 - `lowercase_cast <./../rules/cast_notation/lowercase_cast.rst>`_
 - `lowercase_static_reference <./../rules/casing/lowercase_static_reference.rst>`_
-- `new_with_braces <./../rules/operator/new_with_braces.rst>`_
+- `new_with_parentheses <./../rules/operator/new_with_parentheses.rst>`_
 - `no_blank_lines_after_class_opening <./../rules/class_notation/no_blank_lines_after_class_opening.rst>`_
 - `no_leading_import_slash <./../rules/import/no_leading_import_slash.rst>`_
 - `no_whitespace_in_blank_line <./../rules/whitespace/no_whitespace_in_blank_line.rst>`_

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -551,9 +551,12 @@ Operator
 - `long_to_shorthand_operator <./operator/long_to_shorthand_operator.rst>`_
 
   Shorthand notation for operators should be used if possible.
-- `new_with_braces <./operator/new_with_braces.rst>`_
+- `new_with_braces <./operator/new_with_braces.rst>`_ *(deprecated)*
 
   All instances created with ``new`` keyword must (not) be followed by braces.
+- `new_with_parentheses <./operator/new_with_parentheses.rst>`_
+
+  All instances created with ``new`` keyword must (not) be followed by parentheses.
 - `no_space_around_double_colon <./operator/no_space_around_double_colon.rst>`_
 
   There must be no space around double colons (also called Scope Resolution Operator or Paamayim Nekudotayim).

--- a/doc/rules/operator/new_with_parentheses.rst
+++ b/doc/rules/operator/new_with_parentheses.rst
@@ -1,16 +1,9 @@
-========================
-Rule ``new_with_braces``
-========================
+=============================
+Rule ``new_with_parentheses``
+=============================
 
-All instances created with ``new`` keyword must (not) be followed by braces.
-
-Warning
--------
-
-This rule is deprecated and will be removed in the next major version
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You should use ``new_with_parentheses`` instead.
+All instances created with ``new`` keyword must (not) be followed by
+parentheses.
 
 Configuration
 -------------
@@ -79,3 +72,17 @@ With configuration: ``['named_class' => false]``.
 
    -$x = new X();
    +$x = new X;
+
+Rule sets
+---------
+
+The rule is part of the following rule sets:
+
+- `@PER <./../../ruleSets/PER.rst>`_
+- `@PER-CS <./../../ruleSets/PER-CS.rst>`_
+- `@PER-CS1.0 <./../../ruleSets/PER-CS1.0.rst>`_
+- `@PER-CS2.0 <./../../ruleSets/PER-CS2.0.rst>`_
+- `@PSR12 <./../../ruleSets/PSR12.rst>`_
+- `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
+- `@Symfony <./../../ruleSets/Symfony.rst>`_
+

--- a/src/Fixer/ClassNotation/ClassDefinitionFixer.php
+++ b/src/Fixer/ClassNotation/ClassDefinitionFixer.php
@@ -102,7 +102,7 @@ $foo = new class(){};
      * {@inheritdoc}
      *
      * Must run before BracesFixer, SingleLineEmptyBodyFixer.
-     * Must run after NewWithBracesFixer.
+     * Must run after NewWithBracesFixer, NewWithParenthesesFixer.
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/NewWithBracesFixer.php
+++ b/src/Fixer/Operator/NewWithBracesFixer.php
@@ -14,38 +14,38 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Fixer\Operator;
 
-use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\AbstractProxyFixer;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
-use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\Fixer\DeprecatedFixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
-use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
-use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\Tokenizer\CT;
-use PhpCsFixer\Tokenizer\Token;
-use PhpCsFixer\Tokenizer\Tokens;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @deprecated
  */
-final class NewWithBracesFixer extends AbstractFixer implements ConfigurableFixerInterface
+final class NewWithBracesFixer extends AbstractProxyFixer implements ConfigurableFixerInterface, DeprecatedFixerInterface
 {
+    private NewWithParenthesesFixer $newWithParenthesesFixer;
+
+    public function __construct()
+    {
+        $this->newWithParenthesesFixer = new NewWithParenthesesFixer();
+
+        parent::__construct();
+    }
+
     public function getDefinition(): FixerDefinitionInterface
     {
+        $fixerDefinition = $this->newWithParenthesesFixer->getDefinition();
+
         return new FixerDefinition(
             'All instances created with `new` keyword must (not) be followed by braces.',
-            [
-                new CodeSample("<?php\n\n\$x = new X;\n\$y = new class {};\n"),
-                new CodeSample(
-                    "<?php\n\n\$y = new class() {};\n",
-                    ['anonymous_class' => false]
-                ),
-                new CodeSample(
-                    "<?php\n\n\$x = new X();\n",
-                    ['named_class' => false]
-                ),
-            ]
+            $fixerDefinition->getCodeSamples(),
+            $fixerDefinition->getDescription(),
+            $fixerDefinition->getRiskyDescription(),
         );
     }
 
@@ -56,145 +56,32 @@ final class NewWithBracesFixer extends AbstractFixer implements ConfigurableFixe
      */
     public function getPriority(): int
     {
-        return 37;
+        return $this->newWithParenthesesFixer->getPriority();
     }
 
-    public function isCandidate(Tokens $tokens): bool
+    public function configure(array $configuration): void
     {
-        return $tokens->isTokenKindFound(T_NEW);
+        $this->newWithParenthesesFixer->configure($configuration);
+
+        parent::configure($configuration);
     }
 
-    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    public function getSuccessorsNames(): array
     {
-        static $nextTokenKinds = null;
+        return [
+            $this->newWithParenthesesFixer->getName(),
+        ];
+    }
 
-        if (null === $nextTokenKinds) {
-            $nextTokenKinds = [
-                '?',
-                ';',
-                ',',
-                '(',
-                ')',
-                '[',
-                ']',
-                ':',
-                '<',
-                '>',
-                '+',
-                '-',
-                '*',
-                '/',
-                '%',
-                '&',
-                '^',
-                '|',
-                [T_CLASS],
-                [T_IS_SMALLER_OR_EQUAL],
-                [T_IS_GREATER_OR_EQUAL],
-                [T_IS_EQUAL],
-                [T_IS_NOT_EQUAL],
-                [T_IS_IDENTICAL],
-                [T_IS_NOT_IDENTICAL],
-                [T_CLOSE_TAG],
-                [T_LOGICAL_AND],
-                [T_LOGICAL_OR],
-                [T_LOGICAL_XOR],
-                [T_BOOLEAN_AND],
-                [T_BOOLEAN_OR],
-                [T_SL],
-                [T_SR],
-                [T_INSTANCEOF],
-                [T_AS],
-                [T_DOUBLE_ARROW],
-                [T_POW],
-                [T_SPACESHIP],
-                [CT::T_ARRAY_SQUARE_BRACE_OPEN],
-                [CT::T_ARRAY_SQUARE_BRACE_CLOSE],
-                [CT::T_BRACE_CLASS_INSTANTIATION_OPEN],
-                [CT::T_BRACE_CLASS_INSTANTIATION_CLOSE],
-            ];
-
-            if (\defined('T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG')) { // @TODO: drop condition when PHP 8.1+ is required
-                $nextTokenKinds[] = [T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG];
-                $nextTokenKinds[] = [T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG];
-            }
-        }
-
-        for ($index = $tokens->count() - 3; $index > 0; --$index) {
-            if (!$tokens[$index]->isGivenKind(T_NEW)) {
-                continue;
-            }
-
-            $nextIndex = $tokens->getNextTokenOfKind($index, $nextTokenKinds);
-
-            // new anonymous class definition
-            if ($tokens[$nextIndex]->isGivenKind(T_CLASS)) {
-                $nextIndex = $tokens->getNextMeaningfulToken($nextIndex);
-
-                if ($this->configuration['anonymous_class']) {
-                    $this->ensureBracesAt($tokens, $nextIndex);
-                } else {
-                    $this->ensureNoBracesAt($tokens, $nextIndex);
-                }
-
-                continue;
-            }
-
-            // entrance into array index syntax - need to look for exit
-
-            while ($tokens[$nextIndex]->equals('[') || $tokens[$nextIndex]->isGivenKind(CT::T_ARRAY_INDEX_CURLY_BRACE_OPEN)) {
-                $nextIndex = $tokens->findBlockEnd(Tokens::detectBlockType($tokens[$nextIndex])['type'], $nextIndex);
-                $nextIndex = $tokens->getNextMeaningfulToken($nextIndex);
-            }
-
-            if ($this->configuration['named_class']) {
-                $this->ensureBracesAt($tokens, $nextIndex);
-            } else {
-                $this->ensureNoBracesAt($tokens, $nextIndex);
-            }
-        }
+    protected function createProxyFixers(): array
+    {
+        return [
+            $this->newWithParenthesesFixer,
+        ];
     }
 
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
-        return new FixerConfigurationResolver([
-            (new FixerOptionBuilder('named_class', 'Whether named classes should be followed by parentheses.'))
-                ->setAllowedTypes(['bool'])
-                ->setDefault(true)
-                ->getOption(),
-            (new FixerOptionBuilder('anonymous_class', 'Whether anonymous classes should be followed by parentheses.'))
-                ->setAllowedTypes(['bool'])
-                ->setDefault(true)
-                ->getOption(),
-        ]);
-    }
-
-    private function ensureBracesAt(Tokens $tokens, int $index): void
-    {
-        $token = $tokens[$index];
-
-        if (!$token->equals('(') && !$token->isObjectOperator()) {
-            $tokens->insertAt(
-                $tokens->getPrevMeaningfulToken($index) + 1,
-                [new Token('('), new Token(')')]
-            );
-        }
-    }
-
-    private function ensureNoBracesAt(Tokens $tokens, int $index): void
-    {
-        if (!$tokens[$index]->equals('(')) {
-            return;
-        }
-
-        $closingIndex = $tokens->getNextMeaningfulToken($index);
-
-        // constructor has arguments - braces can not be removed
-        if (!$tokens[$closingIndex]->equals(')')) {
-            return;
-        }
-
-        $tokens->clearTokenAndMergeSurroundingWhitespace($closingIndex);
-        $tokens->clearTokenAndMergeSurroundingWhitespace($index);
+        return $this->newWithParenthesesFixer->createConfigurationDefinition();
     }
 }

--- a/src/Fixer/Operator/NewWithParenthesesFixer.php
+++ b/src/Fixer/Operator/NewWithParenthesesFixer.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Operator;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ */
+final class NewWithParenthesesFixer extends AbstractFixer implements ConfigurableFixerInterface
+{
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'All instances created with `new` keyword must (not) be followed by parentheses.',
+            [
+                new CodeSample("<?php\n\n\$x = new X;\n\$y = new class {};\n"),
+                new CodeSample(
+                    "<?php\n\n\$y = new class() {};\n",
+                    ['anonymous_class' => false]
+                ),
+                new CodeSample(
+                    "<?php\n\n\$x = new X();\n",
+                    ['named_class' => false]
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Must run before ClassDefinitionFixer.
+     */
+    public function getPriority(): int
+    {
+        return 37;
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_NEW);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        static $nextTokenKinds = null;
+
+        if (null === $nextTokenKinds) {
+            $nextTokenKinds = [
+                '?',
+                ';',
+                ',',
+                '(',
+                ')',
+                '[',
+                ']',
+                ':',
+                '<',
+                '>',
+                '+',
+                '-',
+                '*',
+                '/',
+                '%',
+                '&',
+                '^',
+                '|',
+                [T_CLASS],
+                [T_IS_SMALLER_OR_EQUAL],
+                [T_IS_GREATER_OR_EQUAL],
+                [T_IS_EQUAL],
+                [T_IS_NOT_EQUAL],
+                [T_IS_IDENTICAL],
+                [T_IS_NOT_IDENTICAL],
+                [T_CLOSE_TAG],
+                [T_LOGICAL_AND],
+                [T_LOGICAL_OR],
+                [T_LOGICAL_XOR],
+                [T_BOOLEAN_AND],
+                [T_BOOLEAN_OR],
+                [T_SL],
+                [T_SR],
+                [T_INSTANCEOF],
+                [T_AS],
+                [T_DOUBLE_ARROW],
+                [T_POW],
+                [T_SPACESHIP],
+                [CT::T_ARRAY_SQUARE_BRACE_OPEN],
+                [CT::T_ARRAY_SQUARE_BRACE_CLOSE],
+                [CT::T_BRACE_CLASS_INSTANTIATION_OPEN],
+                [CT::T_BRACE_CLASS_INSTANTIATION_CLOSE],
+            ];
+
+            if (\defined('T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG')) { // @TODO: drop condition when PHP 8.1+ is required
+                $nextTokenKinds[] = [T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG];
+                $nextTokenKinds[] = [T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG];
+            }
+        }
+
+        for ($index = $tokens->count() - 3; $index > 0; --$index) {
+            if (!$tokens[$index]->isGivenKind(T_NEW)) {
+                continue;
+            }
+
+            $nextIndex = $tokens->getNextTokenOfKind($index, $nextTokenKinds);
+
+            // new anonymous class definition
+            if ($tokens[$nextIndex]->isGivenKind(T_CLASS)) {
+                $nextIndex = $tokens->getNextMeaningfulToken($nextIndex);
+
+                if ($this->configuration['anonymous_class']) {
+                    $this->ensureParenthesesAt($tokens, $nextIndex);
+                } else {
+                    $this->ensureNoParenthesesAt($tokens, $nextIndex);
+                }
+
+                continue;
+            }
+
+            // entrance into array index syntax - need to look for exit
+
+            while ($tokens[$nextIndex]->equals('[') || $tokens[$nextIndex]->isGivenKind(CT::T_ARRAY_INDEX_CURLY_BRACE_OPEN)) {
+                $nextIndex = $tokens->findBlockEnd(Tokens::detectBlockType($tokens[$nextIndex])['type'], $nextIndex);
+                $nextIndex = $tokens->getNextMeaningfulToken($nextIndex);
+            }
+
+            if ($this->configuration['named_class']) {
+                $this->ensureParenthesesAt($tokens, $nextIndex);
+            } else {
+                $this->ensureNoParenthesesAt($tokens, $nextIndex);
+            }
+        }
+    }
+
+    protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('named_class', 'Whether named classes should be followed by parentheses.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(true)
+                ->getOption(),
+            (new FixerOptionBuilder('anonymous_class', 'Whether anonymous classes should be followed by parentheses.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(true)
+                ->getOption(),
+        ]);
+    }
+
+    private function ensureParenthesesAt(Tokens $tokens, int $index): void
+    {
+        $token = $tokens[$index];
+
+        if (!$token->equals('(') && !$token->isObjectOperator()) {
+            $tokens->insertAt(
+                $tokens->getPrevMeaningfulToken($index) + 1,
+                [new Token('('), new Token(')')]
+            );
+        }
+    }
+
+    private function ensureNoParenthesesAt(Tokens $tokens, int $index): void
+    {
+        if (!$tokens[$index]->equals('(')) {
+            return;
+        }
+
+        $closingIndex = $tokens->getNextMeaningfulToken($index);
+
+        // constructor has arguments - parentheses can not be removed
+        if (!$tokens[$closingIndex]->equals(')')) {
+            return;
+        }
+
+        $tokens->clearTokenAndMergeSurroundingWhitespace($closingIndex);
+        $tokens->clearTokenAndMergeSurroundingWhitespace($index);
+    }
+}

--- a/src/RuleSet/Sets/PSR12Set.php
+++ b/src/RuleSet/Sets/PSR12Set.php
@@ -42,7 +42,7 @@ final class PSR12Set extends AbstractRuleSetDescription
             'declare_equal_normalize' => true,
             'lowercase_cast' => true,
             'lowercase_static_reference' => true,
-            'new_with_braces' => true,
+            'new_with_parentheses' => true,
             'no_blank_lines_after_class_opening' => true,
             'no_leading_import_slash' => true,
             'no_whitespace_in_blank_line' => true,

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -535,6 +535,9 @@ final class FixerFactoryTest extends TestCase
             'new_with_braces' => [
                 'class_definition',
             ],
+            'new_with_parentheses' => [
+                'class_definition',
+            ],
             'no_alias_functions' => [
                 'implode_call',
                 'php_unit_dedicate_assert',

--- a/tests/Fixer/Operator/NewWithParenthesesFixerTest.php
+++ b/tests/Fixer/Operator/NewWithParenthesesFixerTest.php
@@ -1,0 +1,869 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Operator;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Operator\NewWithParenthesesFixer
+ */
+final class NewWithParenthesesFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixNamedWithDefaultConfigurationCases
+     */
+    public function testFixNamedWithDefaultConfiguration(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixNamedWithDefaultConfigurationCases(): iterable
+    {
+        yield ['<?php $x = new X(foo(/**/));'];
+
+        yield ['<?php $xyz = new X(new Y(new Z(/**/ foo())));'];
+
+        yield ['<?php $self = new self(a);'];
+
+        yield [
+            '<?php class A { public function B(){ $static = new static(new \SplFileInfo(__FILE__)); }}',
+        ];
+
+        yield [
+            '<?php $static = new self(new \SplFileInfo(__FILE__));',
+        ];
+
+        yield [
+            '<?php $x = new X/**/ /**/ /**//**//**/ /**//**/   (/**/ /**/ /**//**//**/ /**//**/)/**/ /**/ /**//**//**/ /**//**/;/**/ /**/ /**//**//**/ /**//**/',
+        ];
+
+        yield [
+            '<?php $x = new X();',
+            '<?php $x = new X;',
+        ];
+
+        yield [
+            '<?php $y = new Y() ;',
+            '<?php $y = new Y ;',
+        ];
+
+        yield [
+            '<?php $x = new Z() /**/;//',
+            '<?php $x = new Z /**/;//',
+        ];
+
+        yield [
+            '<?php $foo = new $foo();',
+            '<?php $foo = new $foo;',
+        ];
+
+        yield [
+            '<?php
+                    $bar1 = new $foo[0]->bar();
+                    $bar2 = new $foo[0][1]->bar();
+                ',
+        ];
+
+        yield [
+            '<?php $xyz = new X(new Y(new Z()));',
+            '<?php $xyz = new X(new Y(new Z));',
+        ];
+
+        yield [
+            '<?php $foo = (new $bar())->foo;',
+            '<?php $foo = (new $bar)->foo;',
+        ];
+
+        yield [
+            '<?php $foo = (new $bar((new Foo())->bar))->foo;',
+            '<?php $foo = (new $bar((new Foo)->bar))->foo;',
+        ];
+
+        yield [
+            '<?php $self = new self();',
+            '<?php $self = new self;',
+        ];
+
+        yield [
+            '<?php $static = new static();',
+            '<?php $static = new static;',
+        ];
+
+        yield [
+            '<?php $a = array( "key" => new DateTime(), );',
+            '<?php $a = array( "key" => new DateTime, );',
+        ];
+
+        yield [
+            '<?php $a = array( "key" => new DateTime() );',
+            '<?php $a = array( "key" => new DateTime );',
+        ];
+
+        yield [
+            '<?php $a = new $b[$c]();',
+            '<?php $a = new $b[$c];',
+        ];
+
+        yield [
+            '<?php $a = new $b[$c][0]();',
+            '<?php $a = new $b[$c][0];',
+        ];
+
+        yield [
+            '<?php $a = new $b[$c[$d ? foo() : bar("bar[...]") - 1]]();',
+            '<?php $a = new $b[$c[$d ? foo() : bar("bar[...]") - 1]];',
+        ];
+
+        yield [
+            '<?php $a = new $b[\'class\']();',
+            '<?php $a = new $b[\'class\'];',
+        ];
+
+        yield [
+            '<?php $a = new $b[\'class\'] ($foo[\'bar\']);',
+        ];
+
+        yield [
+            '<?php $a = new $b[\'class\'] () ;',
+        ];
+
+        yield [
+            '<?php $a = new $b[$c] ($hello[$world]) ;',
+        ];
+
+        yield [
+            "<?php \$a = new \$b['class']()\r\n\t ;",
+            "<?php \$a = new \$b['class']\r\n\t ;",
+        ];
+
+        yield [
+            '<?php $a = $b ? new DateTime() : $b;',
+            '<?php $a = $b ? new DateTime : $b;',
+        ];
+
+        yield [
+            '<?php new self::$adapters[$name]["adapter"]();',
+            '<?php new self::$adapters[$name]["adapter"];',
+        ];
+
+        yield [
+            '<?php $a = new \Exception()?> <?php echo 1;',
+            '<?php $a = new \Exception?> <?php echo 1;',
+        ];
+
+        yield [
+            '<?php $b = new \StdClass() /**/?>',
+            '<?php $b = new \StdClass /**/?>',
+        ];
+
+        yield [
+            '<?php $a = new Foo() instanceof Foo;',
+            '<?php $a = new Foo instanceof Foo;',
+        ];
+
+        yield [
+            '<?php
+                    $a = new Foo() + 1;
+                    $a = new Foo() - 1;
+                    $a = new Foo() * 1;
+                    $a = new Foo() / 1;
+                    $a = new Foo() % 1;
+                ',
+            '<?php
+                    $a = new Foo + 1;
+                    $a = new Foo - 1;
+                    $a = new Foo * 1;
+                    $a = new Foo / 1;
+                    $a = new Foo % 1;
+                ',
+        ];
+
+        yield [
+            '<?php
+                    $a = new Foo() & 1;
+                    $a = new Foo() | 1;
+                    $a = new Foo() ^ 1;
+                    $a = new Foo() << 1;
+                    $a = new Foo() >> 1;
+                ',
+            '<?php
+                    $a = new Foo & 1;
+                    $a = new Foo | 1;
+                    $a = new Foo ^ 1;
+                    $a = new Foo << 1;
+                    $a = new Foo >> 1;
+                ',
+        ];
+
+        yield [
+            '<?php
+                    $a = new Foo() and 1;
+                    $a = new Foo() or 1;
+                    $a = new Foo() xor 1;
+                    $a = new Foo() && 1;
+                    $a = new Foo() || 1;
+                ',
+            '<?php
+                    $a = new Foo and 1;
+                    $a = new Foo or 1;
+                    $a = new Foo xor 1;
+                    $a = new Foo && 1;
+                    $a = new Foo || 1;
+                ',
+        ];
+
+        yield [
+            '<?php
+                    if (new DateTime() > $this->startDate) {}
+                    if (new DateTime() >= $this->startDate) {}
+                    if (new DateTime() < $this->startDate) {}
+                    if (new DateTime() <= $this->startDate) {}
+                    if (new DateTime() == $this->startDate) {}
+                    if (new DateTime() != $this->startDate) {}
+                    if (new DateTime() <> $this->startDate) {}
+                    if (new DateTime() === $this->startDate) {}
+                    if (new DateTime() !== $this->startDate) {}
+                ',
+            '<?php
+                    if (new DateTime > $this->startDate) {}
+                    if (new DateTime >= $this->startDate) {}
+                    if (new DateTime < $this->startDate) {}
+                    if (new DateTime <= $this->startDate) {}
+                    if (new DateTime == $this->startDate) {}
+                    if (new DateTime != $this->startDate) {}
+                    if (new DateTime <> $this->startDate) {}
+                    if (new DateTime === $this->startDate) {}
+                    if (new DateTime !== $this->startDate) {}
+                ',
+        ];
+
+        yield [
+            '<?php $a = new \stdClass() ? $b : $c;',
+            '<?php $a = new \stdClass ? $b : $c;',
+        ];
+
+        yield [
+            '<?php foreach (new Collection() as $x) {}',
+            '<?php foreach (new Collection as $x) {}',
+        ];
+
+        yield [
+            '<?php $a = [(string) new Foo() => 1];',
+            '<?php $a = [(string) new Foo => 1];',
+        ];
+
+        yield [
+            '<?php $a = [ "key" => new DateTime(), ];',
+            '<?php $a = [ "key" => new DateTime, ];',
+        ];
+
+        yield [
+            '<?php $a = [ "key" => new DateTime() ];',
+            '<?php $a = [ "key" => new DateTime ];',
+        ];
+
+        yield [
+            '<?php
+                    $a = new Foo() ** 1;
+                ',
+            '<?php
+                    $a = new Foo ** 1;
+                ',
+        ];
+
+        yield [
+            '<?php
+                    $a = new Foo() <=> 1;
+                ',
+            '<?php
+                    $a = new Foo <=> 1;
+                ',
+        ];
+
+        yield [
+            "<?php \$a = new \$b['class']/* */()\r\n\t ;",
+        ];
+
+        yield [
+            "<?php \$a = new \$b['class'] /* */()\r\n\t ;",
+        ];
+
+        yield [
+            "<?php \$a = new \$b['class']()/* */;",
+            "<?php \$a = new \$b['class']/* */;",
+        ];
+
+        yield [
+            "<?php \$a = new \$b['class']() /* */;",
+            "<?php \$a = new \$b['class'] /* */;",
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixNamedWithoutParenthesesCases
+     */
+    public function testFixNamedWithoutParentheses(string $expected, ?string $input = null): void
+    {
+        $this->fixer->configure(['named_class' => false]);
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixNamedWithoutParenthesesCases(): iterable
+    {
+        yield ['<?php $x = new X(foo(/**/));'];
+
+        yield ['<?php $xyz = new X(new Y(new Z(/**/ foo())));'];
+
+        yield ['<?php $self = new self(a);'];
+
+        yield [
+            '<?php $bar1 = new $foo->bar["baz"];',
+            '<?php $bar1 = new $foo->bar["baz"]();',
+        ];
+
+        yield [
+            '<?php class A { public function B(){ $static = new static(new \SplFileInfo(__FILE__)); }}',
+        ];
+
+        yield [
+            '<?php $static = new self(new \SplFileInfo(__FILE__));',
+        ];
+
+        yield [
+            '<?php $x = new X/**/ /**/ /**//**//**/ /**//**/   /**/ /**/ /**//**//**/ /**//**//**/ /**/ /**//**//**/ /**//**/;/**/ /**/ /**//**//**/ /**//**/',
+            '<?php $x = new X/**/ /**/ /**//**//**/ /**//**/   (/**/ /**/ /**//**//**/ /**//**/)/**/ /**/ /**//**//**/ /**//**/;/**/ /**/ /**//**//**/ /**//**/',
+        ];
+
+        yield [
+            '<?php $x = new X;',
+            '<?php $x = new X();',
+        ];
+
+        yield [
+            '<?php $y = new Y ;',
+            '<?php $y = new Y() ;',
+        ];
+
+        yield [
+            '<?php $x = new Z /**/;//',
+            '<?php $x = new Z() /**/;//',
+        ];
+
+        yield [
+            '<?php $foo = new $foo;',
+            '<?php $foo = new $foo();',
+        ];
+
+        yield [
+            '<?php $xyz = new X(new Y(new Z));',
+            '<?php $xyz = new X(new Y(new Z()));',
+        ];
+
+        yield [
+            '<?php $foo = (new $bar)->foo;',
+            '<?php $foo = (new $bar())->foo;',
+        ];
+
+        yield [
+            '<?php $foo = (new $bar((new Foo)->bar))->foo;',
+            '<?php $foo = (new $bar((new Foo())->bar))->foo;',
+        ];
+
+        yield [
+            '<?php $self = new self;',
+            '<?php $self = new self();',
+        ];
+
+        yield [
+            '<?php $static = new static;',
+            '<?php $static = new static();',
+        ];
+
+        yield [
+            '<?php $a = array( "key" => new DateTime, );',
+            '<?php $a = array( "key" => new DateTime(), );',
+        ];
+
+        yield [
+            '<?php $a = array( "key" => new DateTime );',
+            '<?php $a = array( "key" => new DateTime() );',
+        ];
+
+        yield [
+            '<?php $a = new $b[$c];',
+            '<?php $a = new $b[$c]();',
+        ];
+
+        yield [
+            '<?php $a = new $b[$c][0];',
+            '<?php $a = new $b[$c][0]();',
+        ];
+
+        yield [
+            '<?php $a = new $b[$c[$d ? foo() : bar("bar[...]") - 1]];',
+            '<?php $a = new $b[$c[$d ? foo() : bar("bar[...]") - 1]]();',
+        ];
+
+        yield [
+            '<?php $a = new $b[\'class\'];',
+            '<?php $a = new $b[\'class\']();',
+        ];
+
+        yield [
+            '<?php $a = new $b[\'class\'] ($foo[\'bar\']);',
+        ];
+
+        yield [
+            '<?php $a = new $b[\'class\']  ;',
+            '<?php $a = new $b[\'class\'] () ;',
+        ];
+
+        yield [
+            '<?php $a = new $b[$c] ($hello[$world]) ;',
+        ];
+
+        yield [
+            "<?php \$a = new \$b['class']\r\n\t ;",
+            "<?php \$a = new \$b['class']()\r\n\t ;",
+        ];
+
+        yield [
+            '<?php $a = $b ? new DateTime : $b;',
+            '<?php $a = $b ? new DateTime() : $b;',
+        ];
+
+        yield [
+            '<?php new self::$adapters[$name]["adapter"];',
+            '<?php new self::$adapters[$name]["adapter"]();',
+        ];
+
+        yield [
+            '<?php $a = new \Exception?> <?php echo 1;',
+            '<?php $a = new \Exception()?> <?php echo 1;',
+        ];
+
+        yield [
+            '<?php $b = new \StdClass /**/?>',
+            '<?php $b = new \StdClass() /**/?>',
+        ];
+
+        yield [
+            '<?php $a = new Foo instanceof Foo;',
+            '<?php $a = new Foo() instanceof Foo;',
+        ];
+
+        yield [
+            '<?php
+                    $a = new Foo + 1;
+                    $a = new Foo - 1;
+                    $a = new Foo * 1;
+                    $a = new Foo / 1;
+                    $a = new Foo % 1;
+                ',
+            '<?php
+                    $a = new Foo() + 1;
+                    $a = new Foo() - 1;
+                    $a = new Foo() * 1;
+                    $a = new Foo() / 1;
+                    $a = new Foo() % 1;
+                ',
+        ];
+
+        yield [
+            '<?php
+                    $a = new Foo & 1;
+                    $a = new Foo | 1;
+                    $a = new Foo ^ 1;
+                    $a = new Foo << 1;
+                    $a = new Foo >> 1;
+                ',
+            '<?php
+                    $a = new Foo() & 1;
+                    $a = new Foo() | 1;
+                    $a = new Foo() ^ 1;
+                    $a = new Foo() << 1;
+                    $a = new Foo() >> 1;
+                ',
+        ];
+
+        yield [
+            '<?php
+                    $a = new Foo and 1;
+                    $a = new Foo or 1;
+                    $a = new Foo xor 1;
+                    $a = new Foo && 1;
+                    $a = new Foo || 1;
+                ',
+            '<?php
+                    $a = new Foo() and 1;
+                    $a = new Foo() or 1;
+                    $a = new Foo() xor 1;
+                    $a = new Foo() && 1;
+                    $a = new Foo() || 1;
+                ',
+        ];
+
+        yield [
+            '<?php
+                    if (new DateTime > $this->startDate) {}
+                    if (new DateTime >= $this->startDate) {}
+                    if (new DateTime < $this->startDate) {}
+                    if (new DateTime <= $this->startDate) {}
+                    if (new DateTime == $this->startDate) {}
+                    if (new DateTime != $this->startDate) {}
+                    if (new DateTime <> $this->startDate) {}
+                    if (new DateTime === $this->startDate) {}
+                    if (new DateTime !== $this->startDate) {}
+                ',
+            '<?php
+                    if (new DateTime() > $this->startDate) {}
+                    if (new DateTime() >= $this->startDate) {}
+                    if (new DateTime() < $this->startDate) {}
+                    if (new DateTime() <= $this->startDate) {}
+                    if (new DateTime() == $this->startDate) {}
+                    if (new DateTime() != $this->startDate) {}
+                    if (new DateTime() <> $this->startDate) {}
+                    if (new DateTime() === $this->startDate) {}
+                    if (new DateTime() !== $this->startDate) {}
+                ',
+        ];
+
+        yield [
+            '<?php $a = new \stdClass ? $b : $c;',
+            '<?php $a = new \stdClass() ? $b : $c;',
+        ];
+
+        yield [
+            '<?php foreach (new Collection as $x) {}',
+            '<?php foreach (new Collection() as $x) {}',
+        ];
+
+        yield [
+            '<?php $a = [(string) new Foo => 1];',
+            '<?php $a = [(string) new Foo() => 1];',
+        ];
+
+        yield [
+            '<?php $a = [ "key" => new DateTime, ];',
+            '<?php $a = [ "key" => new DateTime(), ];',
+        ];
+
+        yield [
+            '<?php $a = [ "key" => new DateTime ];',
+            '<?php $a = [ "key" => new DateTime() ];',
+        ];
+
+        yield [
+            '<?php
+                    $a = new Foo ** 1;
+                ',
+            '<?php
+                    $a = new Foo() ** 1;
+                ',
+        ];
+
+        yield [
+            '<?php
+                    $a = new Foo <=> 1;
+                ',
+            '<?php
+                    $a = new Foo() <=> 1;
+                ',
+        ];
+
+        yield [
+            "<?php \$a = new \$b['class']/* */\r\n\t ;",
+            "<?php \$a = new \$b['class']/* */()\r\n\t ;",
+        ];
+
+        yield [
+            "<?php \$a = new \$b['class'] /* */\r\n\t ;",
+            "<?php \$a = new \$b['class'] /* */()\r\n\t ;",
+        ];
+
+        yield [
+            "<?php \$a = new \$b['class']/* */;",
+            "<?php \$a = new \$b['class']()/* */;",
+        ];
+
+        yield [
+            "<?php \$a = new \$b['class'] /* */;",
+            "<?php \$a = new \$b['class']() /* */;",
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixAnonymousWithDefaultConfigurationCases
+     */
+    public function testFixAnonymousWithDefaultConfiguration(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixAnonymousWithDefaultConfigurationCases(): iterable
+    {
+        yield ['<?php $a = new class($a) {use SomeTrait;};'];
+
+        yield ['<?php $a = new class(foo(/**/)) implements Foo{};'];
+
+        yield ['<?php $a = new class($c["d"]) /**/ extends Bar1{};'];
+
+        yield ['<?php $a = new class($e->f  )  extends Bar2 implements Foo{};'];
+
+        yield ['<?php $a = new class( /**/ $g )    extends Bar3 implements Foo, Foo2{};'];
+
+        yield ['<?php $a = new class( $h  /**/) {}?>'];
+
+        yield [
+            '<?php
+                    $a = new Foo() <=> 1;
+                ',
+            '<?php
+                    $a = new Foo <=> 1;
+                ',
+        ];
+
+        yield [
+            '<?php
+                    $a = new class() {use SomeTrait;};
+                    $a = new class() implements Foo{};
+                    $a = new class() /**/ extends Bar1{};
+                    $a = new class()  extends Bar2 implements Foo{};
+                    $a = new class()    extends Bar3 implements Foo, Foo2{};
+                    $a = new class() {}?>
+                ',
+            '<?php
+                    $a = new class {use SomeTrait;};
+                    $a = new class implements Foo{};
+                    $a = new class /**/ extends Bar1{};
+                    $a = new class  extends Bar2 implements Foo{};
+                    $a = new class    extends Bar3 implements Foo, Foo2{};
+                    $a = new class {}?>
+                ',
+        ];
+
+        yield [
+            '<?php
+                    class A {
+                        public function B() {
+                            $static = new static(new class(){});
+                        }
+                    }
+                ',
+            '<?php
+                    class A {
+                        public function B() {
+                            $static = new static(new class{});
+                        }
+                    }
+                ',
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixAnonymousWithoutParenthesesCases
+     */
+    public function testFixAnonymousWithoutParentheses(string $expected, ?string $input = null): void
+    {
+        $this->fixer->configure(['anonymous_class' => false]);
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixAnonymousWithoutParenthesesCases(): iterable
+    {
+        yield ['<?php $a = new class($a) {use SomeTrait;};'];
+
+        yield ['<?php $a = new class(foo(/**/)) implements Foo{};'];
+
+        yield ['<?php $a = new class($c["d"]) /**/ extends Bar1{};'];
+
+        yield ['<?php $a = new class($e->f  )  extends Bar2 implements Foo{};'];
+
+        yield ['<?php $a = new class( /**/ $g )    extends Bar3 implements Foo, Foo2{};'];
+
+        yield ['<?php $a = new class( $h  /**/) {}?>'];
+
+        yield [
+            '<?php
+                    $a = new class {use SomeTrait;};
+                    $a = new class implements Foo{};
+                    $a = new class /**/ extends Bar1{};
+                    $a = new class  extends Bar2 implements Foo{};
+                    $a = new class    extends Bar3 implements Foo, Foo2{};
+                    $a = new class    {}?>
+                ',
+            '<?php
+                    $a = new class() {use SomeTrait;};
+                    $a = new class() implements Foo{};
+                    $a = new class() /**/ extends Bar1{};
+                    $a = new class()  extends Bar2 implements Foo{};
+                    $a = new class()    extends Bar3 implements Foo, Foo2{};
+                    $a = new class ( )  {}?>
+                ',
+        ];
+
+        yield [
+            '<?php
+                    class A {
+                        public function B() {
+                            $static = new static(new class{});
+                        }
+                    }
+                ',
+            '<?php
+                    class A {
+                        public function B() {
+                            $static = new static(new class(){});
+                        }
+                    }
+                ',
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixPre80Cases
+     *
+     * @requires PHP <8.0
+     */
+    public function testFixPre80(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixPre80Cases(): iterable
+    {
+        yield [
+            '<?php $a = new $b{$c}();',
+            '<?php $a = new $b{$c};',
+        ];
+
+        yield [
+            '<?php $a = new $b{$c}{0}{1}() ?>',
+            '<?php $a = new $b{$c}{0}{1} ?>',
+        ];
+
+        yield [
+            '<?php $a = new $b{$c}[1]{0}[2]();',
+            '<?php $a = new $b{$c}[1]{0}[2];',
+        ];
+    }
+
+    /**
+     * @dataProvider provideFix80Cases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFix80(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFix80Cases(): iterable
+    {
+        yield [
+            '<?php $a = new (foo());',
+        ];
+
+        yield [
+            '<?php
+
+class Bar {
+    public function __construct(int $a = null) {
+        echo $a;
+    }
+};
+
+$foo = "B";
+
+$a = new ($foo."ar");',
+        ];
+
+        yield [
+            '<?php
+                $bar1 = new $foo[0]?->bar();
+                $bar2 = new $foo[0][1]?->bar();
+            ',
+        ];
+
+        yield [
+            '<?php $a = new
+                #[Internal]
+                class(){};
+            ',
+            '<?php $a = new
+                #[Internal]
+                class{};
+            ',
+        ];
+    }
+
+    /**
+     * @dataProvider provideFix81Cases
+     *
+     * @requires PHP 8.1
+     */
+    public function testFix81(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFix81Cases(): iterable
+    {
+        yield [
+            '<?php
+function test(
+    $foo = new A(),
+    $baz = new C(x: 2),
+) {
+}
+
+class Test {
+    public function __construct(
+        public $prop = new Foo(),
+    ) {}
+}
+
+static $x = new Foo();
+
+const C = new Foo();
+
+function test2($param = new Foo()) {}
+',
+            '<?php
+function test(
+    $foo = new A,
+    $baz = new C(x: 2),
+) {
+}
+
+class Test {
+    public function __construct(
+        public $prop = new Foo,
+    ) {}
+}
+
+static $x = new Foo;
+
+const C = new Foo;
+
+function test2($param = new Foo) {}
+',
+        ];
+    }
+}

--- a/tests/Fixtures/Integration/priority/new_with_parentheses,class_definition.test
+++ b/tests/Fixtures/Integration/priority/new_with_parentheses,class_definition.test
@@ -1,0 +1,11 @@
+--TEST--
+Integration of fixers: new_with_parentheses,class_definition.
+--RULESET--
+{"new_with_parentheses": true, "class_definition": {"space_before_parenthesis": true}}
+--EXPECT--
+<?php
+return new class () implements Foo {};
+
+--INPUT--
+<?php
+return new class implements Foo {};

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -309,6 +309,7 @@ abstract class AbstractFixerTestCase extends TestCase
                 'method_chaining_indentation',
                 'native_constant_invocation',
                 'new_with_braces',
+                'new_with_parentheses',
                 'no_short_echo_tag',
                 'not_operator_with_space',
                 'not_operator_with_successor_space',


### PR DESCRIPTION
This pull request

- [x] deprecates the `NewWithBracesFixer` and proxies to the `NewWithParenthesesFixer`

Related to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/5915#issuecomment-974674378.
Follows https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7328#issuecomment-1736909937.
