### PR TITLE
feat: Rename `CurlyBraceTransformer` to `BraceTransformer`

### DIFF
--- a/src/Tokenizer/Transformer/BraceTransformer.php
+++ b/src/Tokenizer/Transformer/BraceTransformer.php
@@ -34,7 +34,7 @@ use PhpCsFixer\Tokenizer\Tokens;
  *
  * @internal
  */
-final class CurlyBraceTransformer extends AbstractTransformer
+final class BraceTransformer extends AbstractTransformer
 {
     public function getRequiredPhpVersionId(): int
     {

--- a/tests/AutoReview/TransformerTest.php
+++ b/tests/AutoReview/TransformerTest.php
@@ -78,15 +78,15 @@ final class TransformerTest extends TestCase
             $transformers[$transformer->getName()] = $transformer;
         }
 
-        yield [$transformers['attribute'], $transformers['curly_brace']];
+        yield [$transformers['attribute'], $transformers['brace']];
 
         yield [$transformers['attribute'], $transformers['square_brace']];
 
-        yield [$transformers['curly_brace'], $transformers['brace_class_instantiation']];
+        yield [$transformers['brace'], $transformers['brace_class_instantiation']];
 
-        yield [$transformers['curly_brace'], $transformers['import']];
+        yield [$transformers['brace'], $transformers['import']];
 
-        yield [$transformers['curly_brace'], $transformers['use']];
+        yield [$transformers['brace'], $transformers['use']];
 
         yield [$transformers['name_qualified'], $transformers['namespace_operator']];
 

--- a/tests/Tokenizer/Transformer/BraceTransformerTest.php
+++ b/tests/Tokenizer/Transformer/BraceTransformerTest.php
@@ -23,9 +23,9 @@ use PhpCsFixer\Tokenizer\Tokens;
  *
  * @internal
  *
- * @covers \PhpCsFixer\Tokenizer\Transformer\CurlyBraceTransformer
+ * @covers \PhpCsFixer\Tokenizer\Transformer\BraceTransformer
  */
-final class CurlyBraceTransformerTest extends AbstractTransformerTestCase
+final class BraceTransformerTest extends AbstractTransformerTestCase
 {
     /**
      * @param array<int, int> $expectedTokens


### PR DESCRIPTION
This pull request

- [x] renames the (internal) `CurlyBraceTransformer` to `BraceTransformer`

Related to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/5915#issuecomment-974674378.
Follows https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7328#issuecomment-1736909937.

💁‍♂️ Looks like it's not used anywhere, maybe we should remove or use it where it makes sense?