### PR TITLE
fix: Replace mention of bracket with parenthesis

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1034,7 +1034,7 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\FunctionNotation\\ImplodeCallFixer <./../src/Fixer/FunctionNotation/ImplodeCallFixer.php>`_
 -  `include <./rules/control_structure/include.rst>`_
 
-   Include/Require and file path should be divided with a single space. File path should not be placed under brackets.
+   Include/Require and file path should be divided with a single space. File path should not be placed within parentheses.
 
    Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 

--- a/doc/rules/control_structure/include.rst
+++ b/doc/rules/control_structure/include.rst
@@ -3,7 +3,7 @@ Rule ``include``
 ================
 
 Include/Require and file path should be divided with a single space. File path
-should not be placed under brackets.
+should not be placed within parentheses.
 
 Examples
 --------

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -281,7 +281,7 @@ Control Structure
   Empty loop-condition must be in configured style.
 - `include <./control_structure/include.rst>`_
 
-  Include/Require and file path should be divided with a single space. File path should not be placed under brackets.
+  Include/Require and file path should be divided with a single space. File path should not be placed within parentheses.
 - `no_alternative_syntax <./control_structure/no_alternative_syntax.rst>`_
 
   Replace control structure alternative syntax to use braces.

--- a/src/Fixer/Alias/EregToPregFixer.php
+++ b/src/Fixer/Alias/EregToPregFixer.php
@@ -97,7 +97,7 @@ final class EregToPregFixer extends AbstractFixer
 
                 // findSequence also returns the tokens, but we're only interested in the indices, i.e.:
                 // 0 => function name,
-                // 1 => bracket "("
+                // 1 => parenthesis "("
                 // 2 => quoted string passed as 1st parameter
                 $match = array_keys($match);
 

--- a/src/Fixer/ControlStructure/IncludeFixer.php
+++ b/src/Fixer/ControlStructure/IncludeFixer.php
@@ -32,7 +32,7 @@ final class IncludeFixer extends AbstractFixer
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Include/Require and file path should be divided with a single space. File path should not be placed under brackets.',
+            'Include/Require and file path should be divided with a single space. File path should not be placed within parentheses.',
             [
                 new CodeSample(
                     '<?php

--- a/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+++ b/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
@@ -136,7 +136,7 @@ $object->method1()
 
                 $content = $previous->getContent();
                 if (str_starts_with($content, $lineEnding) && $tokens[$index - 2]->isComment()) {
-                    // if there is comment between closing bracket and semicolon
+                    // if there is comment between closing parenthesis and semicolon
 
                     // unset whitespace and semicolon
                     $tokens->clearAt($previousIndex);


### PR DESCRIPTION
This pull request

- [x] replaces mentions of **bracket** with **parenthesis** where applicable

Related to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/5915#issuecomment-974674378.
Follows https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7328#issuecomment-1736909937.
