### PR TITLE
chore: Use type declaration instead of type hint

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1322,7 +1322,7 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\FunctionNotation\\NativeFunctionInvocationFixer <./../src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php>`_
 -  `native_function_type_declaration_casing <./rules/casing/native_function_type_declaration_casing.rst>`_
 
-   Native type hints for functions should use the correct case.
+   Native type declarations for functions should use the correct case.
 
    Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 

--- a/doc/rules/casing/native_function_type_declaration_casing.rst
+++ b/doc/rules/casing/native_function_type_declaration_casing.rst
@@ -2,7 +2,7 @@
 Rule ``native_function_type_declaration_casing``
 ================================================
 
-Native type hints for functions should use the correct case.
+Native type declarations for functions should use the correct case.
 
 Examples
 --------

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -137,7 +137,7 @@ Casing
   Function defined by PHP should be called using the correct casing.
 - `native_function_type_declaration_casing <./casing/native_function_type_declaration_casing.rst>`_
 
-  Native type hints for functions should use the correct case.
+  Native type declarations for functions should use the correct case.
 
 Cast Notation
 -------------

--- a/src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
+++ b/src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
@@ -91,7 +91,7 @@ final class NativeFunctionTypeDeclarationCasingFixer extends AbstractFixer
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Native type hints for functions should use the correct case.',
+            'Native type declarations for functions should use the correct case.',
             [
                 new CodeSample("<?php\nclass Bar {\n    public function Foo(CALLABLE \$bar)\n    {\n        return 1;\n    }\n}\n"),
                 new CodeSample(

--- a/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
@@ -47,11 +47,11 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
 
     public static function provideFixCases(): iterable
     {
-        yield 'typehint already defined' => [
+        yield 'type declaration already defined' => [
             '<?php /** @param int $foo */ function foo(int $foo) {}',
         ];
 
-        yield 'typehint already defined with wrong phpdoc typehint' => [
+        yield 'type declaration already defined with wrong phpdoc type' => [
             '<?php /** @param string $foo */ function foo(int $foo) {}',
         ];
 

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -36,7 +36,7 @@ final class NoSuperfluousPhpdocTagsFixerTest extends AbstractFixerTestCase
 
     public static function provideFixCases(): iterable
     {
-        yield 'no typehint' => [
+        yield 'no type declaration' => [
             '<?php
 class Foo {
     /**
@@ -48,7 +48,7 @@ class Foo {
 }',
         ];
 
-        yield 'same typehint' => [
+        yield 'same type declaration' => [
             '<?php
 class Foo {
     /**
@@ -64,7 +64,7 @@ class Foo {
 }',
         ];
 
-        yield 'same optional typehint' => [
+        yield 'same optional type declaration' => [
             '<?php
 class Foo {
     /**
@@ -80,7 +80,7 @@ class Foo {
 }',
         ];
 
-        yield 'same typehint with description' => [
+        yield 'same type declaration with description' => [
             '<?php
 class Foo {
     /**
@@ -190,7 +190,7 @@ class Foo {
 }',
         ];
 
-        yield 'same typehint with different casing' => [
+        yield 'same type declaration with different casing' => [
             '<?php
 class Foo {
     /**
@@ -206,7 +206,7 @@ class Foo {
 }',
         ];
 
-        yield 'same typehint with leading backslash - global' => [
+        yield 'same type declaration with leading backslash - global' => [
             '<?php
 class Foo {
     /**
@@ -222,7 +222,7 @@ class Foo {
 }',
         ];
 
-        yield 'same typehint with leading backslash - namespaced' => [
+        yield 'same type declaration with leading backslash - namespaced' => [
             '<?php
 namespace Xxx;
 
@@ -242,7 +242,7 @@ class Foo {
 }',
         ];
 
-        yield 'same typehint without leading backslash - global' => [
+        yield 'same type declaration without leading backslash - global' => [
             '<?php
 class Foo {
     /**
@@ -258,7 +258,7 @@ class Foo {
 }',
         ];
 
-        yield 'same typehint without leading backslash - namespaced' => [
+        yield 'same type declaration without leading backslash - namespaced' => [
             '<?php
 namespace Xxx;
 
@@ -278,7 +278,7 @@ class Foo {
 }',
         ];
 
-        yield 'same typehint with null implied from native type - param type' => [
+        yield 'same type declaration with null implied from native type - param type' => [
             '<?php
 class Foo {
     /**
@@ -299,7 +299,7 @@ class Foo {
 }',
         ];
 
-        yield 'same typehint with null implied from native type - return type' => [
+        yield 'same type declaration with null implied from native type - return type' => [
             '<?php
 class Foo {
     /**
@@ -319,7 +319,7 @@ class Foo {
 }',
         ];
 
-        yield 'same typehint with null implied from native type - property' => [
+        yield 'same type declaration with null implied from native type - property' => [
             '<?php
 class Foo {
     /**  */
@@ -332,7 +332,7 @@ class Foo {
 }',
         ];
 
-        yield 'same typehint with null but native type without null - invalid phpdoc must be kept unfixed' => [
+        yield 'same type declaration with null but native type without null - invalid phpdoc must be kept unfixed' => [
             '<?php
 class Foo {
     /** @var bool|null */
@@ -469,7 +469,7 @@ class Foo {
 }',
         ];
 
-        yield 'with special type hints' => [
+        yield 'with special type declarations' => [
             '<?php
 class Foo {
     /**
@@ -1302,7 +1302,7 @@ class Foo {
 }',
         ];
 
-        yield 'same type hint' => [
+        yield 'same type declaration' => [
             '<?php
 class Foo {
     /**
@@ -1321,7 +1321,7 @@ class Foo {
 }',
         ];
 
-        yield 'same type hint with description' => [
+        yield 'same type declaration with description' => [
             '<?php
 class Foo {
     /**
@@ -1416,7 +1416,7 @@ use Foo\Bar as Baz;
 function foo(Baz $bar): Baz {}',
         ];
 
-        yield 'with scalar type hints' => [
+        yield 'with scalar type declarations' => [
             '<?php
 class Foo {
     /**
@@ -1477,7 +1477,7 @@ trait Foo {}',
             ['remove_inheritdoc' => true],
         ];
 
-        yield 'same nullable type hint' => [
+        yield 'same nullable type declaration' => [
             '<?php
 class Foo {
     /**
@@ -1496,7 +1496,7 @@ class Foo {
 }',
         ];
 
-        yield 'same nullable type hint reversed' => [
+        yield 'same nullable type declaration reversed' => [
             '<?php
 class Foo {
     /**
@@ -1515,7 +1515,7 @@ class Foo {
 }',
         ];
 
-        yield 'same nullable type hint with description' => [
+        yield 'same nullable type declaration with description' => [
             '<?php
 class Foo {
     /**
@@ -1527,7 +1527,7 @@ class Foo {
 }',
         ];
 
-        yield 'same optional nullable type hint' => [
+        yield 'same optional nullable type declaration' => [
             '<?php
 class Foo {
     /**
@@ -1626,7 +1626,7 @@ use Foo\Bar as Baz;
 function foo(?Baz $bar): ?Baz {}',
         ];
 
-        yield 'with nullable special type hints' => [
+        yield 'with nullable special type declarations' => [
             '<?php
 class Foo {
     /**
@@ -2040,7 +2040,7 @@ class Foo {
 }',
         ];
 
-        yield 'phpdoc does not match property typehint' => [
+        yield 'phpdoc does not match property type declaration' => [
             '<?php
 class Foo {
     /**

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -1302,7 +1302,7 @@ class Foo {
 }',
         ];
 
-        yield 'same type declaration' => [
+        yield 'same type declaration (with extra empty line)' => [
             '<?php
 class Foo {
     /**
@@ -1321,7 +1321,7 @@ class Foo {
 }',
         ];
 
-        yield 'same type declaration with description' => [
+        yield 'same type declaration (with return type) with description' => [
             '<?php
 class Foo {
     /**

--- a/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
@@ -109,7 +109,7 @@ trait SomeTrait
 
         $expected = sprintf('<?php
 /**
- * Please do not use @return %s|static|self|this|$static|$self|@static|@self|@this as return type hint
+ * Please do not use @return %s|static|self|this|$static|$self|@static|@self|@this as return type declaration
  */
 class F
 {
@@ -127,7 +127,7 @@ class F
 
         $input = sprintf('<?php
 /**
- * Please do not use @return %s|static|self|this|$static|$self|@static|@self|@this as return type hint
+ * Please do not use @return %s|static|self|this|$static|$self|@static|@self|@this as return type declaration
  */
 class F
 {


### PR DESCRIPTION
This pull request

- [x] replaces mentions of **type hint** and **typehint** with **type declaration**

Somewhat related to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7330#discussion_r1338768402.

💁‍♂️ Also see https://www.php.net/manual/en/language.types.declarations.php. A lot of people keep using **type hint** instead of **type declarations**, but they are officially called **type declarations**, so I believe it makes sense to consistently use the official wording. Maybe we can even convince some people to use the official wording.