### PR TITLE
deps: Prevent using PHPCSFixer along with `unfinalize` package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,9 @@
         "symfony/phpunit-bridge": "^6.2.3",
         "symfony/yaml": "^5.4 || ^6.0"
     },
+    "conflict": {
+        "stevebauman/unfinalize": "*"
+    },
     "suggest": {
         "ext-dom": "For handling output formats in XML",
         "ext-mbstring": "For handling non-UTF8 characters."


### PR DESCRIPTION
[`stevebauman/unfinalize`](https://github.com/stevebauman/unfinalize) is a package that uses PHPCSFixer as an engine for doing thing that contradicts with good practices this projects aims to deliver to the PHP community. I believe we should block installing that package next to our tool.

PS. It also prevents Fixer's installation during `unfinalize` development, so basically it won't be possible to build PHAR on their side.