### PR TITLE
fix: `FunctionToConstantFixer` should run before `NativeConstantInvocationFixer`

### DIFF
--- a/src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
+++ b/src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
@@ -96,10 +96,11 @@ namespace {
      * {@inheritdoc}
      *
      * Must run before GlobalNamespaceImportFixer.
+     * Must run after FunctionToConstantFixer.
      */
     public function getPriority(): int
     {
-        return 10;
+        return 1;
     }
 
     public function isCandidate(Tokens $tokens): bool

--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -45,7 +45,7 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
      */
     public function getPriority(): int
     {
-        return 2;
+        return 3;
     }
 
     public function isCandidate(Tokens $tokens): bool

--- a/src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+++ b/src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
@@ -38,7 +38,7 @@ final class CombineConsecutiveIssetsFixer extends AbstractFixer
      */
     public function getPriority(): int
     {
-        return 3;
+        return 4;
     }
 
     public function isCandidate(Tokens $tokens): bool

--- a/src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+++ b/src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
@@ -96,12 +96,12 @@ final class FunctionToConstantFixer extends AbstractFixer implements Configurabl
     /**
      * {@inheritdoc}
      *
-     * Must run before NativeFunctionCasingFixer, NoExtraBlankLinesFixer, NoSinglelineWhitespaceBeforeSemicolonsFixer, NoTrailingWhitespaceFixer, NoWhitespaceInBlankLineFixer, SelfStaticAccessorFixer.
+     * Must run before NativeConstantInvocationFixer, NativeFunctionCasingFixer, NoExtraBlankLinesFixer, NoSinglelineWhitespaceBeforeSemicolonsFixer, NoTrailingWhitespaceFixer, NoWhitespaceInBlankLineFixer, SelfStaticAccessorFixer.
      * Must run after NoSpacesAfterFunctionNameFixer, NoSpacesInsideParenthesisFixer, SpacesInsideParenthesesFixer.
      */
     public function getPriority(): int
     {
-        return 1;
+        return 2;
     }
 
     public function isCandidate(Tokens $tokens): bool

--- a/src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
+++ b/src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
@@ -55,7 +55,7 @@ function foo( \$bar, \$baz )
      */
     public function getPriority(): int
     {
-        return 2;
+        return 3;
     }
 
     public function getSuccessorsNames(): array

--- a/src/Fixer/Whitespace/SpacesInsideParenthesesFixer.php
+++ b/src/Fixer/Whitespace/SpacesInsideParenthesesFixer.php
@@ -71,7 +71,7 @@ function foo(\$bar, \$baz)
      */
     public function getPriority(): int
     {
-        return 2;
+        return 3;
     }
 
     public function isCandidate(Tokens $tokens): bool

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -448,6 +448,7 @@ final class FixerFactoryTest extends TestCase
                 'method_argument_space',
             ],
             'function_to_constant' => [
+                'native_constant_invocation',
                 'native_function_casing',
                 'no_extra_blank_lines',
                 'no_singleline_whitespace_before_semicolons',

--- a/tests/Fixtures/Integration/priority/function_to_constant,native_constant_invocation.test
+++ b/tests/Fixtures/Integration/priority/function_to_constant,native_constant_invocation.test
@@ -1,0 +1,13 @@
+--TEST--
+Integration of fixers: function_to_constant,native_constant_invocation.
+--RULESET--
+{"function_to_constant": true, "native_constant_invocation": true}
+--EXPECT--
+<?php
+
+echo \M_PI;
+
+--INPUT--
+<?php
+
+echo pi();


### PR DESCRIPTION
The `FunctionToConstantFixer` should run before `NativeConstantInvocationFixer` to ensure all constants get fixed.