### PR TITLE
docs: Sort options in documentation

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -103,12 +103,12 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``min_line_breaks``
-     | Minimum line breaks that should exist before namespace declaration.
-     | Allowed types: ``int``
-     | Default value: ``2``
    - | ``max_line_breaks``
      | Maximum line breaks that should exist before namespace declaration.
+     | Allowed types: ``int``
+     | Default value: ``2``
+   - | ``min_line_breaks``
+     | Minimum line breaks that should exist before namespace declaration.
      | Allowed types: ``int``
      | Default value: ``2``
 
@@ -171,18 +171,18 @@ List of Available Rules
      | Whether single line lambda notation should be allowed.
      | Allowed types: ``bool``
      | Default value: ``false``
-   - | ``position_after_functions_and_oop_constructs``
-     | Whether the opening brace should be placed on "next" or "same" line after classy constructs (non-anonymous classes, interfaces, traits, methods and non-lambda functions).
-     | Allowed values: ``'next'`` and ``'same'``
-     | Default value: ``'next'``
-   - | ``position_after_control_structures``
-     | Whether the opening brace should be placed on "next" or "same" line after control structures.
-     | Allowed values: ``'next'`` and ``'same'``
-     | Default value: ``'same'``
    - | ``position_after_anonymous_constructs``
      | Whether the opening brace should be placed on "next" or "same" line after anonymous constructs (anonymous classes and lambda functions).
      | Allowed values: ``'next'`` and ``'same'``
      | Default value: ``'same'``
+   - | ``position_after_control_structures``
+     | Whether the opening brace should be placed on "next" or "same" line after control structures.
+     | Allowed values: ``'next'`` and ``'same'``
+     | Default value: ``'same'``
+   - | ``position_after_functions_and_oop_constructs``
+     | Whether the opening brace should be placed on "next" or "same" line after classy constructs (non-anonymous classes, interfaces, traits, methods and non-lambda functions).
+     | Allowed values: ``'next'`` and ``'same'``
+     | Default value: ``'next'``
 
 
    `Source PhpCsFixer\\Fixer\\Basic\\BracesFixer <./../src/Fixer/Basic/BracesFixer.php>`_
@@ -192,14 +192,18 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``control_structures_opening_brace``
-     | The position of the opening brace of control structures‘ body.
+   - | ``allow_single_line_anonymous_functions``
+     | Allow anonymous functions to have opening and closing braces on the same line.
+     | Allowed types: ``bool``
+     | Default value: ``true``
+   - | ``allow_single_line_empty_anonymous_classes``
+     | Allow anonymous classes to have opening and closing braces on the same line.
+     | Allowed types: ``bool``
+     | Default value: ``true``
+   - | ``anonymous_classes_opening_brace``
+     | The position of the opening brace of anonymous classes‘ body.
      | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
      | Default value: ``'same_line'``
-   - | ``functions_opening_brace``
-     | The position of the opening brace of functions‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
-     | Default value: ``'next_line_unless_newline_at_signature_end'``
    - | ``anonymous_functions_opening_brace``
      | The position of the opening brace of anonymous functions‘ body.
      | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
@@ -208,18 +212,14 @@ List of Available Rules
      | The position of the opening brace of classes‘ body.
      | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
      | Default value: ``'next_line_unless_newline_at_signature_end'``
-   - | ``anonymous_classes_opening_brace``
-     | The position of the opening brace of anonymous classes‘ body.
+   - | ``control_structures_opening_brace``
+     | The position of the opening brace of control structures‘ body.
      | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
      | Default value: ``'same_line'``
-   - | ``allow_single_line_empty_anonymous_classes``
-     | Allow anonymous classes to have opening and closing braces on the same line.
-     | Allowed types: ``bool``
-     | Default value: ``true``
-   - | ``allow_single_line_anonymous_functions``
-     | Allow anonymous functions to have opening and closing braces on the same line.
-     | Allowed types: ``bool``
-     | Default value: ``true``
+   - | ``functions_opening_brace``
+     | The position of the opening brace of functions‘ body.
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
+     | Default value: ``'next_line_unless_newline_at_signature_end'``
 
 
    Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PER-CS <./ruleSets/PER-CS.rst>`_ `@PER-CS1.0 <./ruleSets/PER-CS1.0.rst>`_ `@PER-CS2.0 <./ruleSets/PER-CS2.0.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
@@ -261,6 +261,10 @@ List of Available Rules
 
    Configuration options:
 
+   - | ``inline_constructor_arguments``
+     | Whether constructor argument list in anonymous classes should be single line.
+     | Allowed types: ``bool``
+     | Default value: ``true``
    - | ``multi_line_extends_each_single_line``
      | Whether definitions should be multiline.
      | Allowed types: ``bool``
@@ -277,10 +281,6 @@ List of Available Rules
      | Whether there should be a single space after the parenthesis of anonymous class (PSR12) or not.
      | Allowed types: ``bool``
      | Default value: ``false``
-   - | ``inline_constructor_arguments``
-     | Whether constructor argument list in anonymous classes should be single line.
-     | Allowed types: ``bool``
-     | Default value: ``true``
 
 
    Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PER-CS <./ruleSets/PER-CS.rst>`_ `@PER-CS1.0 <./ruleSets/PER-CS1.0.rst>`_ `@PER-CS2.0 <./ruleSets/PER-CS2.0.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
@@ -426,14 +426,18 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``control_structures_opening_brace``
-     | The position of the opening brace of control structures‘ body.
+   - | ``allow_single_line_anonymous_functions``
+     | Allow anonymous functions to have opening and closing braces on the same line.
+     | Allowed types: ``bool``
+     | Default value: ``true``
+   - | ``allow_single_line_empty_anonymous_classes``
+     | Allow anonymous classes to have opening and closing braces on the same line.
+     | Allowed types: ``bool``
+     | Default value: ``true``
+   - | ``anonymous_classes_opening_brace``
+     | The position of the opening brace of anonymous classes‘ body.
      | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
      | Default value: ``'same_line'``
-   - | ``functions_opening_brace``
-     | The position of the opening brace of functions‘ body.
-     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
-     | Default value: ``'next_line_unless_newline_at_signature_end'``
    - | ``anonymous_functions_opening_brace``
      | The position of the opening brace of anonymous functions‘ body.
      | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
@@ -442,18 +446,14 @@ List of Available Rules
      | The position of the opening brace of classes‘ body.
      | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
      | Default value: ``'next_line_unless_newline_at_signature_end'``
-   - | ``anonymous_classes_opening_brace``
-     | The position of the opening brace of anonymous classes‘ body.
+   - | ``control_structures_opening_brace``
+     | The position of the opening brace of control structures‘ body.
      | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
      | Default value: ``'same_line'``
-   - | ``allow_single_line_empty_anonymous_classes``
-     | Allow anonymous classes to have opening and closing braces on the same line.
-     | Allowed types: ``bool``
-     | Default value: ``true``
-   - | ``allow_single_line_anonymous_functions``
-     | Allow anonymous functions to have opening and closing braces on the same line.
-     | Allowed types: ``bool``
-     | Default value: ``true``
+   - | ``functions_opening_brace``
+     | The position of the opening brace of functions‘ body.
+     | Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
+     | Default value: ``'next_line_unless_newline_at_signature_end'``
 
 
    `Source PhpCsFixer\\Fixer\\Basic\\CurlyBracesPositionFixer <./../src/Fixer/Basic/CurlyBracesPositionFixer.php>`_
@@ -588,42 +588,42 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``ignored_tags``
-     | List of tags that must not be treated as Doctrine Annotations.
-     | Allowed types: ``array``
-     | Default value: ``['abstract', 'access', 'code', 'deprec', 'encode', 'exception', 'final', 'ingroup', 'inheritdoc', 'inheritDoc', 'magic', 'name', 'toc', 'tutorial', 'private', 'static', 'staticvar', 'staticVar', 'throw', 'api', 'author', 'category', 'copyright', 'deprecated', 'example', 'filesource', 'global', 'ignore', 'internal', 'license', 'link', 'method', 'package', 'param', 'property', 'property-read', 'property-write', 'return', 'see', 'since', 'source', 'subpackage', 'throws', 'todo', 'TODO', 'usedBy', 'uses', 'var', 'version', 'after', 'afterClass', 'backupGlobals', 'backupStaticAttributes', 'before', 'beforeClass', 'codeCoverageIgnore', 'codeCoverageIgnoreStart', 'codeCoverageIgnoreEnd', 'covers', 'coversDefaultClass', 'coversNothing', 'dataProvider', 'depends', 'expectedException', 'expectedExceptionCode', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp', 'group', 'large', 'medium', 'preserveGlobalState', 'requires', 'runTestsInSeparateProcesses', 'runInSeparateProcess', 'small', 'test', 'testdox', 'ticket', 'uses', 'SuppressWarnings', 'noinspection', 'package_version', 'enduml', 'startuml', 'psalm', 'phpstan', 'template', 'fix', 'FIXME', 'fixme', 'override']``
-   - | ``around_parentheses``
-     | Whether to fix spaces around parentheses.
-     | Allowed types: ``bool``
-     | Default value: ``true``
-   - | ``around_commas``
-     | Whether to fix spaces around commas.
-     | Allowed types: ``bool``
-     | Default value: ``true``
-   - | ``before_argument_assignments``
-     | Whether to add, remove or ignore spaces before argument assignment operator.
-     | Allowed types: ``null`` and ``bool``
-     | Default value: ``false``
    - | ``after_argument_assignments``
      | Whether to add, remove or ignore spaces after argument assignment operator.
      | Allowed types: ``null`` and ``bool``
      | Default value: ``false``
-   - | ``before_array_assignments_equals``
-     | Whether to add, remove or ignore spaces before array ``=`` assignment operator.
+   - | ``after_array_assignments_colon``
+     | Whether to add, remove or ignore spaces after array assignment ``:`` operator.
      | Allowed types: ``null`` and ``bool``
      | Default value: ``true``
    - | ``after_array_assignments_equals``
      | Whether to add, remove or ignore spaces after array assignment ``=`` operator.
      | Allowed types: ``null`` and ``bool``
      | Default value: ``true``
+   - | ``around_commas``
+     | Whether to fix spaces around commas.
+     | Allowed types: ``bool``
+     | Default value: ``true``
+   - | ``around_parentheses``
+     | Whether to fix spaces around parentheses.
+     | Allowed types: ``bool``
+     | Default value: ``true``
+   - | ``before_argument_assignments``
+     | Whether to add, remove or ignore spaces before argument assignment operator.
+     | Allowed types: ``null`` and ``bool``
+     | Default value: ``false``
    - | ``before_array_assignments_colon``
      | Whether to add, remove or ignore spaces before array ``:`` assignment operator.
      | Allowed types: ``null`` and ``bool``
      | Default value: ``true``
-   - | ``after_array_assignments_colon``
-     | Whether to add, remove or ignore spaces after array assignment ``:`` operator.
+   - | ``before_array_assignments_equals``
+     | Whether to add, remove or ignore spaces before array ``=`` assignment operator.
      | Allowed types: ``null`` and ``bool``
      | Default value: ``true``
+   - | ``ignored_tags``
+     | List of tags that must not be treated as Doctrine Annotations.
+     | Allowed types: ``array``
+     | Default value: ``['abstract', 'access', 'code', 'deprec', 'encode', 'exception', 'final', 'ingroup', 'inheritdoc', 'inheritDoc', 'magic', 'name', 'toc', 'tutorial', 'private', 'static', 'staticvar', 'staticVar', 'throw', 'api', 'author', 'category', 'copyright', 'deprecated', 'example', 'filesource', 'global', 'ignore', 'internal', 'license', 'link', 'method', 'package', 'param', 'property', 'property-read', 'property-write', 'return', 'see', 'since', 'source', 'subpackage', 'throws', 'todo', 'TODO', 'usedBy', 'uses', 'var', 'version', 'after', 'afterClass', 'backupGlobals', 'backupStaticAttributes', 'before', 'beforeClass', 'codeCoverageIgnore', 'codeCoverageIgnoreStart', 'codeCoverageIgnoreEnd', 'covers', 'coversDefaultClass', 'coversNothing', 'dataProvider', 'depends', 'expectedException', 'expectedExceptionCode', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp', 'group', 'large', 'medium', 'preserveGlobalState', 'requires', 'runTestsInSeparateProcesses', 'runInSeparateProcess', 'small', 'test', 'testdox', 'ticket', 'uses', 'SuppressWarnings', 'noinspection', 'package_version', 'enduml', 'startuml', 'psalm', 'phpstan', 'template', 'fix', 'FIXME', 'fixme', 'override']``
 
 
    Part of rule set `@DoctrineAnnotation <./ruleSets/DoctrineAnnotation.rst>`_
@@ -751,10 +751,6 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``single_quoted``
-     | Whether to fix single-quoted strings.
-     | Allowed types: ``bool``
-     | Default value: ``false``
    - | ``double_quoted``
      | Whether to fix double-quoted strings.
      | Allowed types: ``bool``
@@ -763,6 +759,10 @@ List of Available Rules
      | Whether to fix heredoc syntax.
      | Allowed types: ``bool``
      | Default value: ``true``
+   - | ``single_quoted``
+     | Whether to fix single-quoted strings.
+     | Allowed types: ``bool``
+     | Default value: ``false``
 
 
    Part of rule set `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
@@ -819,28 +819,28 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``annotation_include``
-     | Class level attribute or annotation tags that must be set in order to fix the class (case insensitive).
-     | warning:: This option is deprecated and will be removed in the next major version. Use ``include`` to configure PHPDoc annotations tags and attributes.
-     | Allowed types: ``array``
-     | Default value: ``['@internal']``
    - | ``annotation_exclude``
      | Class level attribute or annotation tags that must be omitted to fix the class, even if all of the white list ones are used as well (case insensitive).
      | warning:: This option is deprecated and will be removed in the next major version. Use ``exclude`` to configure PHPDoc annotations tags and attributes.
      | Allowed types: ``array``
      | Default value: ``['@final', '@Entity', '@ORM\\Entity', '@ORM\\Mapping\\Entity', '@Mapping\\Entity', '@Document', '@ODM\\Document']``
-   - | ``include``
+   - | ``annotation_include``
      | Class level attribute or annotation tags that must be set in order to fix the class (case insensitive).
+     | warning:: This option is deprecated and will be removed in the next major version. Use ``include`` to configure PHPDoc annotations tags and attributes.
      | Allowed types: ``array``
-     | Default value: ``['internal']``
-   - | ``exclude``
-     | Class level attribute or annotation tags that must be omitted to fix the class, even if all of the white list ones are used as well (case insensitive).
-     | Allowed types: ``array``
-     | Default value: ``['final', 'Entity', 'ORM\\Entity', 'ORM\\Mapping\\Entity', 'Mapping\\Entity', 'Document', 'ODM\\Document']``
+     | Default value: ``['@internal']``
    - | ``consider_absent_docblock_as_internal_class``
      | Whether classes without any DocBlock should be fixed to final.
      | Allowed types: ``bool``
      | Default value: ``false``
+   - | ``exclude``
+     | Class level attribute or annotation tags that must be omitted to fix the class, even if all of the white list ones are used as well (case insensitive).
+     | Allowed types: ``array``
+     | Default value: ``['final', 'Entity', 'ORM\\Entity', 'ORM\\Mapping\\Entity', 'Mapping\\Entity', 'Document', 'ODM\\Document']``
+   - | ``include``
+     | Class level attribute or annotation tags that must be set in order to fix the class (case insensitive).
+     | Allowed types: ``array``
+     | Default value: ``['internal']``
 
 
    Part of rule set `@PhpCsFixer:risky <./ruleSets/PhpCsFixerRisky.rst>`_
@@ -910,12 +910,12 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``closure_function_spacing``
-     | Spacing to use before open parenthesis for closures.
-     | Allowed values: ``'none'`` and ``'one'``
-     | Default value: ``'one'``
    - | ``closure_fn_spacing``
      | Spacing to use before open parenthesis for short arrow functions.
+     | Allowed values: ``'none'`` and ``'one'``
+     | Default value: ``'one'``
+   - | ``closure_function_spacing``
+     | Spacing to use before open parenthesis for closures.
      | Allowed values: ``'none'`` and ``'one'``
      | Default value: ``'one'``
    - | ``trailing_comma_single_line``
@@ -974,6 +974,10 @@ List of Available Rules
 
    Configuration options:
 
+   - | ``case_sensitive``
+     | Whether tags should be replaced only if they have exact same casing.
+     | Allowed types: ``bool``
+     | Default value: ``false``
    - | ``fix_annotation``
      | Whether annotation tags should be fixed.
      | Allowed types: ``bool``
@@ -986,10 +990,6 @@ List of Available Rules
      | A map of tags to replace.
      | Allowed types: ``array``
      | Default value: ``[]``
-   - | ``case_sensitive``
-     | Whether tags should be replaced only if they have exact same casing.
-     | Allowed types: ``bool``
-     | Default value: ``false``
 
 
    Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
@@ -1010,6 +1010,10 @@ List of Available Rules
 
    Configuration options:
 
+   - | ``import_classes``
+     | Whether to import, not import or ignore global classes.
+     | Allowed values: ``false``, ``null`` and ``true``
+     | Default value: ``true``
    - | ``import_constants``
      | Whether to import, not import or ignore global constants.
      | Allowed values: ``false``, ``null`` and ``true``
@@ -1018,10 +1022,6 @@ List of Available Rules
      | Whether to import, not import or ignore global functions.
      | Allowed values: ``false``, ``null`` and ``true``
      | Default value: ``null``
-   - | ``import_classes``
-     | Whether to import, not import or ignore global classes.
-     | Allowed values: ``false``, ``null`` and ``true``
-     | Default value: ``true``
 
 
    Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
@@ -1038,14 +1038,14 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``header``
-     | Proper header content.
-     | Allowed types: ``string``
-     | This option is required.
    - | ``comment_type``
      | Comment syntax type.
      | Allowed values: ``'comment'`` and ``'PHPDoc'``
      | Default value: ``'comment'``
+   - | ``header``
+     | Proper header content.
+     | Allowed types: ``string``
+     | This option is required.
    - | ``location``
      | The location of the inserted header.
      | Allowed values: ``'after_declare_strict'`` and ``'after_open'``
@@ -1237,14 +1237,6 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``keep_multiple_spaces_after_comma``
-     | Whether keep multiple spaces after comma.
-     | Allowed types: ``bool``
-     | Default value: ``false``
-   - | ``on_multiline``
-     | Defines how to handle function arguments lists that contain newlines.
-     | Allowed values: ``'ensure_fully_multiline'``, ``'ensure_single_line'`` and ``'ignore'``
-     | Default value: ``'ensure_fully_multiline'``
    - | ``after_heredoc``
      | Whether the whitespace between heredoc end and comma should be removed.
      | Allowed types: ``bool``
@@ -1253,6 +1245,14 @@ List of Available Rules
      | Defines how to handle argument attributes when function definition is multiline.
      | Allowed values: ``'ignore'``, ``'same_line'`` and ``'standalone'``
      | Default value: ``'standalone'``
+   - | ``keep_multiple_spaces_after_comma``
+     | Whether keep multiple spaces after comma.
+     | Allowed types: ``bool``
+     | Default value: ``false``
+   - | ``on_multiline``
+     | Defines how to handle function arguments lists that contain newlines.
+     | Allowed values: ``'ensure_fully_multiline'``, ``'ensure_single_line'`` and ``'ignore'``
+     | Default value: ``'ensure_fully_multiline'``
 
 
    Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PER-CS <./ruleSets/PER-CS.rst>`_ `@PER-CS1.0 <./ruleSets/PER-CS1.0.rst>`_ `@PER-CS2.0 <./ruleSets/PER-CS2.0.rst>`_ `@PHP73Migration <./ruleSets/PHP73Migration.rst>`_ `@PHP74Migration <./ruleSets/PHP74Migration.rst>`_ `@PHP80Migration <./ruleSets/PHP80Migration.rst>`_ `@PHP81Migration <./ruleSets/PHP81Migration.rst>`_ `@PHP82Migration <./ruleSets/PHP82Migration.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
@@ -1315,6 +1315,10 @@ List of Available Rules
 
    Configuration options:
 
+   - | ``exclude``
+     | List of constants to ignore.
+     | Allowed types: ``array``
+     | Default value: ``['null', 'false', 'true']``
    - | ``fix_built_in``
      | Whether to fix constants returned by ``get_defined_constants``. User constants are not accounted in this list and must be specified in the include one.
      | Allowed types: ``bool``
@@ -1323,10 +1327,6 @@ List of Available Rules
      | List of additional constants to fix.
      | Allowed types: ``array``
      | Default value: ``[]``
-   - | ``exclude``
-     | List of constants to ignore.
-     | Allowed types: ``array``
-     | Default value: ``['null', 'false', 'true']``
    - | ``scope``
      | Only fix constant invocations that are made within a namespace or fix all.
      | Allowed values: ``'all'`` and ``'namespaced'``
@@ -1398,12 +1398,12 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``named_class``
-     | Whether named classes should be followed by parentheses.
-     | Allowed types: ``bool``
-     | Default value: ``true``
    - | ``anonymous_class``
      | Whether anonymous classes should be followed by parentheses.
+     | Allowed types: ``bool``
+     | Default value: ``true``
+   - | ``named_class``
+     | Whether named classes should be followed by parentheses.
      | Allowed types: ``bool``
      | Default value: ``true``
 
@@ -1415,12 +1415,12 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``named_class``
-     | Whether named classes should be followed by parentheses.
-     | Allowed types: ``bool``
-     | Default value: ``true``
    - | ``anonymous_class``
      | Whether anonymous classes should be followed by parentheses.
+     | Allowed types: ``bool``
+     | Default value: ``true``
+   - | ``named_class``
+     | Whether named classes should be followed by parentheses.
      | Allowed types: ``bool``
      | Default value: ``true``
 
@@ -1745,12 +1745,12 @@ List of Available Rules
      | Whether type ``mixed`` without description is allowed (``true``) or considered superfluous (``false``).
      | Allowed types: ``bool``
      | Default value: ``false``
-   - | ``remove_inheritdoc``
-     | Remove ``@inheritDoc`` tags.
-     | Allowed types: ``bool``
-     | Default value: ``false``
    - | ``allow_unused_params``
      | Whether ``param`` annotation without actual signature is allowed (``true``) or considered superfluous (``false``).
+     | Allowed types: ``bool``
+     | Default value: ``false``
+   - | ``remove_inheritdoc``
+     | Remove ``@inheritDoc`` tags.
      | Allowed types: ``bool``
      | Default value: ``false``
 
@@ -2084,6 +2084,10 @@ List of Available Rules
 
    Configuration options:
 
+   - | ``case_sensitive``
+     | Whether the sorting should be case sensitive.
+     | Allowed types: ``bool``
+     | Default value: ``false``
    - | ``order``
      | List of strings defining order of elements.
      | Allowed types: ``array``
@@ -2092,10 +2096,6 @@ List of Available Rules
      | How multiple occurrences of same type statements should be sorted.
      | Allowed values: ``'alpha'`` and ``'none'``
      | Default value: ``'none'``
-   - | ``case_sensitive``
-     | Whether the sorting should be case sensitive.
-     | Allowed types: ``bool``
-     | Default value: ``false``
 
 
    Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PER-CS <./ruleSets/PER-CS.rst>`_ `@PER-CS1.0 <./ruleSets/PER-CS1.0.rst>`_ `@PER-CS2.0 <./ruleSets/PER-CS2.0.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
@@ -2107,18 +2107,18 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``sort_algorithm``
-     | Whether the statements should be sorted alphabetically or by length, or not sorted.
-     | Allowed values: ``'alpha'``, ``'length'`` and ``'none'``
-     | Default value: ``'alpha'``
-   - | ``imports_order``
-     | Defines the order of import types.
-     | Allowed types: ``array`` and ``null``
-     | Default value: ``null``
    - | ``case_sensitive``
      | Whether the sorting should be case sensitive.
      | Allowed types: ``bool``
      | Default value: ``false``
+   - | ``imports_order``
+     | Defines the order of import types.
+     | Allowed types: ``array`` and ``null``
+     | Default value: ``null``
+   - | ``sort_algorithm``
+     | Whether the statements should be sorted alphabetically or by length, or not sorted.
+     | Allowed values: ``'alpha'``, ``'length'`` and ``'none'``
+     | Default value: ``'alpha'``
 
 
    Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PER-CS <./ruleSets/PER-CS.rst>`_ `@PER-CS1.0 <./ruleSets/PER-CS1.0.rst>`_ `@PER-CS2.0 <./ruleSets/PER-CS2.0.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
@@ -2130,18 +2130,18 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``order``
-     | How the interfaces should be ordered.
-     | Allowed values: ``'alpha'`` and ``'length'``
-     | Default value: ``'alpha'``
-   - | ``direction``
-     | Which direction the interfaces should be ordered.
-     | Allowed values: ``'ascend'`` and ``'descend'``
-     | Default value: ``'ascend'``
    - | ``case_sensitive``
      | Whether the sorting should be case sensitive.
      | Allowed types: ``bool``
      | Default value: ``false``
+   - | ``direction``
+     | Which direction the interfaces should be ordered.
+     | Allowed values: ``'ascend'`` and ``'descend'``
+     | Default value: ``'ascend'``
+   - | ``order``
+     | How the interfaces should be ordered.
+     | Allowed values: ``'alpha'`` and ``'length'``
+     | Default value: ``'alpha'``
 
 
    `Source PhpCsFixer\\Fixer\\ClassNotation\\OrderedInterfacesFixer <./../src/Fixer/ClassNotation/OrderedInterfacesFixer.php>`_
@@ -2168,18 +2168,18 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``sort_algorithm``
-     | Whether the types should be sorted alphabetically, or not sorted.
-     | Allowed values: ``'alpha'`` and ``'none'``
-     | Default value: ``'alpha'``
-   - | ``null_adjustment``
-     | Forces the position of ``null`` (overrides ``sort_algorithm``).
-     | Allowed values: ``'always_first'``, ``'always_last'`` and ``'none'``
-     | Default value: ``'always_first'``
    - | ``case_sensitive``
      | Whether the sorting should be case sensitive.
      | Allowed types: ``bool``
      | Default value: ``false``
+   - | ``null_adjustment``
+     | Forces the position of ``null`` (overrides ``sort_algorithm``).
+     | Allowed values: ``'always_first'``, ``'always_last'`` and ``'none'``
+     | Default value: ``'always_first'``
+   - | ``sort_algorithm``
+     | Whether the types should be sorted alphabetically, or not sorted.
+     | Allowed values: ``'alpha'`` and ``'none'``
+     | Default value: ``'alpha'``
 
 
    Part of rule set `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
@@ -2206,14 +2206,14 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``tags``
-     | The tags that should be aligned. Allowed values are tags with name (``'param', 'property', 'property-read', 'property-write', 'phpstan-param', 'phpstan-property', 'phpstan-property-read', 'phpstan-property-write', 'phpstan-assert', 'phpstan-assert-if-true', 'phpstan-assert-if-false', 'psalm-param', 'psalm-param-out', 'psalm-property', 'psalm-property-read', 'psalm-property-write', 'psalm-assert', 'psalm-assert-if-true', 'psalm-assert-if-false'``), tags with method signature (``'method', 'phpstan-method', 'psalm-method'``) and any custom tag with description (e.g. ``@tag <desc>``).
-     | Allowed types: ``array``
-     | Default value: ``['method', 'param', 'property', 'return', 'throws', 'type', 'var']``
    - | ``align``
      | How comments should be aligned.
      | Allowed values: ``'left'`` and ``'vertical'``
      | Default value: ``'vertical'``
+   - | ``tags``
+     | The tags that should be aligned. Allowed values are tags with name (``'param', 'property', 'property-read', 'property-write', 'phpstan-param', 'phpstan-property', 'phpstan-property-read', 'phpstan-property-write', 'phpstan-assert', 'phpstan-assert-if-true', 'phpstan-assert-if-false', 'psalm-param', 'psalm-param-out', 'psalm-property', 'psalm-property-read', 'psalm-property-write', 'psalm-assert', 'psalm-assert-if-true', 'psalm-assert-if-false'``), tags with method signature (``'method', 'phpstan-method', 'psalm-method'``) and any custom tag with description (e.g. ``@tag <desc>``).
+     | Allowed types: ``array``
+     | Default value: ``['method', 'param', 'property', 'return', 'throws', 'type', 'var']``
 
 
    Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
@@ -2258,12 +2258,12 @@ List of Available Rules
      | Whether const blocks should be single or multi line.
      | Allowed values: ``'multi'``, ``'single'`` and ``null``
      | Default value: ``'multi'``
-   - | ``property``
-     | Whether property doc blocks should be single or multi line.
-     | Allowed values: ``'multi'``, ``'single'`` and ``null``
-     | Default value: ``'multi'``
    - | ``method``
      | Whether method doc blocks should be single or multi line.
+     | Allowed values: ``'multi'``, ``'single'`` and ``null``
+     | Default value: ``'multi'``
+   - | ``property``
+     | Whether property doc blocks should be single or multi line.
      | Allowed values: ``'multi'``, ``'single'`` and ``null``
      | Default value: ``'multi'``
 
@@ -2545,18 +2545,18 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``sort_algorithm``
-     | The sorting algorithm to apply.
-     | Allowed values: ``'alpha'`` and ``'none'``
-     | Default value: ``'alpha'``
-   - | ``null_adjustment``
-     | Forces the position of ``null`` (overrides ``sort_algorithm``).
-     | Allowed values: ``'always_first'``, ``'always_last'`` and ``'none'``
-     | Default value: ``'always_first'``
    - | ``case_sensitive``
      | Whether the sorting should be case sensitive.
      | Allowed types: ``bool``
      | Default value: ``false``
+   - | ``null_adjustment``
+     | Forces the position of ``null`` (overrides ``sort_algorithm``).
+     | Allowed values: ``'always_first'``, ``'always_last'`` and ``'none'``
+     | Default value: ``'always_first'``
+   - | ``sort_algorithm``
+     | The sorting algorithm to apply.
+     | Allowed values: ``'alpha'`` and ``'none'``
+     | Default value: ``'alpha'``
 
 
    Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
@@ -3181,14 +3181,14 @@ List of Available Rules
      | List of constructs which must contain a single space.
      | Allowed values: a subset of ``['yield_from']``
      | Default value: ``['yield_from']``
-   - | ``constructs_preceded_by_a_single_space``
-     | List of constructs which must be preceded by a single space.
-     | Allowed values: a subset of ``['as', 'use_lambda']``
-     | Default value: ``['as', 'use_lambda']``
    - | ``constructs_followed_by_a_single_space``
      | List of constructs which must be followed by a single space.
      | Allowed values: a subset of ``['abstract', 'as', 'attribute', 'break', 'case', 'catch', 'class', 'clone', 'comment', 'const', 'const_import', 'continue', 'do', 'echo', 'else', 'elseif', 'enum', 'extends', 'final', 'finally', 'for', 'foreach', 'function', 'function_import', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof', 'insteadof', 'interface', 'match', 'named_argument', 'namespace', 'new', 'open_tag_with_echo', 'php_doc', 'php_open', 'print', 'private', 'protected', 'public', 'readonly', 'require', 'require_once', 'return', 'static', 'switch', 'throw', 'trait', 'try', 'type_colon', 'use', 'use_lambda', 'use_trait', 'var', 'while', 'yield', 'yield_from']``
      | Default value: ``['abstract', 'as', 'attribute', 'break', 'case', 'catch', 'class', 'clone', 'comment', 'const', 'const_import', 'continue', 'do', 'echo', 'else', 'elseif', 'enum', 'extends', 'final', 'finally', 'for', 'foreach', 'function', 'function_import', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof', 'insteadof', 'interface', 'match', 'named_argument', 'namespace', 'new', 'open_tag_with_echo', 'php_doc', 'php_open', 'print', 'private', 'protected', 'public', 'readonly', 'require', 'require_once', 'return', 'static', 'switch', 'throw', 'trait', 'try', 'type_colon', 'use', 'use_lambda', 'use_trait', 'var', 'while', 'yield', 'yield_from']``
+   - | ``constructs_preceded_by_a_single_space``
+     | List of constructs which must be preceded by a single space.
+     | Allowed values: a subset of ``['as', 'use_lambda']``
+     | Default value: ``['as', 'use_lambda']``
 
 
    Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
@@ -3489,6 +3489,10 @@ List of Available Rules
 
    Configuration options:
 
+   - | ``always_move_variable``
+     | Whether variables should always be on non assignable side when applying Yoda style.
+     | Allowed types: ``bool``
+     | Default value: ``false``
    - | ``equal``
      | Style for equal (``==``, ``!=``) statements.
      | Allowed types: ``bool`` and ``null``
@@ -3501,10 +3505,6 @@ List of Available Rules
      | Style for less and greater than (``<``, ``<=``, ``>``, ``>=``) statements.
      | Allowed types: ``bool`` and ``null``
      | Default value: ``null``
-   - | ``always_move_variable``
-     | Whether variables should always be on non assignable side when applying Yoda style.
-     | Allowed types: ``bool``
-     | Default value: ``false``
 
 
    Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_

--- a/doc/rules/basic/braces.rst
+++ b/doc/rules/basic/braces.rst
@@ -37,16 +37,15 @@ Allowed types: ``bool``
 
 Default value: ``false``
 
-``position_after_functions_and_oop_constructs``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``position_after_anonymous_constructs``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Whether the opening brace should be placed on "next" or "same" line after classy
-constructs (non-anonymous classes, interfaces, traits, methods and non-lambda
-functions).
+Whether the opening brace should be placed on "next" or "same" line after
+anonymous constructs (anonymous classes and lambda functions).
 
 Allowed values: ``'next'`` and ``'same'``
 
-Default value: ``'next'``
+Default value: ``'same'``
 
 ``position_after_control_structures``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -58,15 +57,16 @@ Allowed values: ``'next'`` and ``'same'``
 
 Default value: ``'same'``
 
-``position_after_anonymous_constructs``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``position_after_functions_and_oop_constructs``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Whether the opening brace should be placed on "next" or "same" line after
-anonymous constructs (anonymous classes and lambda functions).
+Whether the opening brace should be placed on "next" or "same" line after classy
+constructs (non-anonymous classes, interfaces, traits, methods and non-lambda
+functions).
 
 Allowed values: ``'next'`` and ``'same'``
 
-Default value: ``'same'``
+Default value: ``'next'``
 
 Examples
 --------

--- a/doc/rules/basic/braces_position.rst
+++ b/doc/rules/basic/braces_position.rst
@@ -7,23 +7,32 @@ Braces must be placed as configured.
 Configuration
 -------------
 
-``control_structures_opening_brace``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``allow_single_line_anonymous_functions``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The position of the opening brace of control structures‘ body.
+Allow anonymous functions to have opening and closing braces on the same line.
+
+Allowed types: ``bool``
+
+Default value: ``true``
+
+``allow_single_line_empty_anonymous_classes``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Allow anonymous classes to have opening and closing braces on the same line.
+
+Allowed types: ``bool``
+
+Default value: ``true``
+
+``anonymous_classes_opening_brace``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The position of the opening brace of anonymous classes‘ body.
 
 Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
 
 Default value: ``'same_line'``
-
-``functions_opening_brace``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The position of the opening brace of functions‘ body.
-
-Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
-
-Default value: ``'next_line_unless_newline_at_signature_end'``
 
 ``anonymous_functions_opening_brace``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -43,32 +52,23 @@ Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line
 
 Default value: ``'next_line_unless_newline_at_signature_end'``
 
-``anonymous_classes_opening_brace``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``control_structures_opening_brace``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The position of the opening brace of anonymous classes‘ body.
+The position of the opening brace of control structures‘ body.
 
 Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
 
 Default value: ``'same_line'``
 
-``allow_single_line_empty_anonymous_classes``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``functions_opening_brace``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Allow anonymous classes to have opening and closing braces on the same line.
+The position of the opening brace of functions‘ body.
 
-Allowed types: ``bool``
+Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
 
-Default value: ``true``
-
-``allow_single_line_anonymous_functions``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Allow anonymous functions to have opening and closing braces on the same line.
-
-Allowed types: ``bool``
-
-Default value: ``true``
+Default value: ``'next_line_unless_newline_at_signature_end'``
 
 Examples
 --------

--- a/doc/rules/basic/curly_braces_position.rst
+++ b/doc/rules/basic/curly_braces_position.rst
@@ -15,23 +15,32 @@ You should use ``braces_position`` instead.
 Configuration
 -------------
 
-``control_structures_opening_brace``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``allow_single_line_anonymous_functions``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The position of the opening brace of control structures‘ body.
+Allow anonymous functions to have opening and closing braces on the same line.
+
+Allowed types: ``bool``
+
+Default value: ``true``
+
+``allow_single_line_empty_anonymous_classes``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Allow anonymous classes to have opening and closing braces on the same line.
+
+Allowed types: ``bool``
+
+Default value: ``true``
+
+``anonymous_classes_opening_brace``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The position of the opening brace of anonymous classes‘ body.
 
 Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
 
 Default value: ``'same_line'``
-
-``functions_opening_brace``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The position of the opening brace of functions‘ body.
-
-Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
-
-Default value: ``'next_line_unless_newline_at_signature_end'``
 
 ``anonymous_functions_opening_brace``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -51,32 +60,23 @@ Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line
 
 Default value: ``'next_line_unless_newline_at_signature_end'``
 
-``anonymous_classes_opening_brace``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``control_structures_opening_brace``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The position of the opening brace of anonymous classes‘ body.
+The position of the opening brace of control structures‘ body.
 
 Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
 
 Default value: ``'same_line'``
 
-``allow_single_line_empty_anonymous_classes``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``functions_opening_brace``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Allow anonymous classes to have opening and closing braces on the same line.
+The position of the opening brace of functions‘ body.
 
-Allowed types: ``bool``
+Allowed values: ``'next_line_unless_newline_at_signature_end'`` and ``'same_line'``
 
-Default value: ``true``
-
-``allow_single_line_anonymous_functions``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Allow anonymous functions to have opening and closing braces on the same line.
-
-Allowed types: ``bool``
-
-Default value: ``true``
+Default value: ``'next_line_unless_newline_at_signature_end'``
 
 Examples
 --------

--- a/doc/rules/class_notation/class_definition.rst
+++ b/doc/rules/class_notation/class_definition.rst
@@ -8,6 +8,15 @@ should be one space.
 Configuration
 -------------
 
+``inline_constructor_arguments``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whether constructor argument list in anonymous classes should be single line.
+
+Allowed types: ``bool``
+
+Default value: ``true``
+
 ``multi_line_extends_each_single_line``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -44,15 +53,6 @@ Whether there should be a single space after the parenthesis of anonymous class
 Allowed types: ``bool``
 
 Default value: ``false``
-
-``inline_constructor_arguments``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Whether constructor argument list in anonymous classes should be single line.
-
-Allowed types: ``bool``
-
-Default value: ``true``
 
 Examples
 --------

--- a/doc/rules/class_notation/final_internal_class.rst
+++ b/doc/rules/class_notation/final_internal_class.rst
@@ -15,18 +15,6 @@ Changing classes to ``final`` might cause code execution to break.
 Configuration
 -------------
 
-``annotation_include``
-~~~~~~~~~~~~~~~~~~~~~~
-
-.. warning:: This option is deprecated and will be removed in the next major version. Use ``include`` to configure PHPDoc annotations tags and attributes.
-
-Class level attribute or annotation tags that must be set in order to fix the
-class (case insensitive).
-
-Allowed types: ``array``
-
-Default value: ``['@internal']``
-
 ``annotation_exclude``
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -39,15 +27,26 @@ Allowed types: ``array``
 
 Default value: ``['@final', '@Entity', '@ORM\\Entity', '@ORM\\Mapping\\Entity', '@Mapping\\Entity', '@Document', '@ODM\\Document']``
 
-``include``
-~~~~~~~~~~~
+``annotation_include``
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning:: This option is deprecated and will be removed in the next major version. Use ``include`` to configure PHPDoc annotations tags and attributes.
 
 Class level attribute or annotation tags that must be set in order to fix the
 class (case insensitive).
 
 Allowed types: ``array``
 
-Default value: ``['internal']``
+Default value: ``['@internal']``
+
+``consider_absent_docblock_as_internal_class``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whether classes without any DocBlock should be fixed to final.
+
+Allowed types: ``bool``
+
+Default value: ``false``
 
 ``exclude``
 ~~~~~~~~~~~
@@ -59,14 +58,15 @@ Allowed types: ``array``
 
 Default value: ``['final', 'Entity', 'ORM\\Entity', 'ORM\\Mapping\\Entity', 'Mapping\\Entity', 'Document', 'ODM\\Document']``
 
-``consider_absent_docblock_as_internal_class``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``include``
+~~~~~~~~~~~
 
-Whether classes without any DocBlock should be fixed to final.
+Class level attribute or annotation tags that must be set in order to fix the
+class (case insensitive).
 
-Allowed types: ``bool``
+Allowed types: ``array``
 
-Default value: ``false``
+Default value: ``['internal']``
 
 Examples
 --------

--- a/doc/rules/class_notation/ordered_class_elements.rst
+++ b/doc/rules/class_notation/ordered_class_elements.rst
@@ -32,6 +32,15 @@ the order of that specific method.
 Configuration
 -------------
 
+``case_sensitive``
+~~~~~~~~~~~~~~~~~~
+
+Whether the sorting should be case sensitive.
+
+Allowed types: ``bool``
+
+Default value: ``false``
+
 ``order``
 ~~~~~~~~~
 
@@ -49,15 +58,6 @@ How multiple occurrences of same type statements should be sorted.
 Allowed values: ``'alpha'`` and ``'none'``
 
 Default value: ``'none'``
-
-``case_sensitive``
-~~~~~~~~~~~~~~~~~~
-
-Whether the sorting should be case sensitive.
-
-Allowed types: ``bool``
-
-Default value: ``false``
 
 Examples
 --------

--- a/doc/rules/class_notation/ordered_interfaces.rst
+++ b/doc/rules/class_notation/ordered_interfaces.rst
@@ -7,14 +7,14 @@ Orders the interfaces in an ``implements`` or ``interface extends`` clause.
 Configuration
 -------------
 
-``order``
-~~~~~~~~~
+``case_sensitive``
+~~~~~~~~~~~~~~~~~~
 
-How the interfaces should be ordered.
+Whether the sorting should be case sensitive.
 
-Allowed values: ``'alpha'`` and ``'length'``
+Allowed types: ``bool``
 
-Default value: ``'alpha'``
+Default value: ``false``
 
 ``direction``
 ~~~~~~~~~~~~~
@@ -25,14 +25,14 @@ Allowed values: ``'ascend'`` and ``'descend'``
 
 Default value: ``'ascend'``
 
-``case_sensitive``
-~~~~~~~~~~~~~~~~~~
+``order``
+~~~~~~~~~
 
-Whether the sorting should be case sensitive.
+How the interfaces should be ordered.
 
-Allowed types: ``bool``
+Allowed values: ``'alpha'`` and ``'length'``
 
-Default value: ``false``
+Default value: ``'alpha'``
 
 Examples
 --------

--- a/doc/rules/class_notation/ordered_types.rst
+++ b/doc/rules/class_notation/ordered_types.rst
@@ -7,14 +7,14 @@ Sort union types and intersection types using configured order.
 Configuration
 -------------
 
-``sort_algorithm``
+``case_sensitive``
 ~~~~~~~~~~~~~~~~~~
 
-Whether the types should be sorted alphabetically, or not sorted.
+Whether the sorting should be case sensitive.
 
-Allowed values: ``'alpha'`` and ``'none'``
+Allowed types: ``bool``
 
-Default value: ``'alpha'``
+Default value: ``false``
 
 ``null_adjustment``
 ~~~~~~~~~~~~~~~~~~~
@@ -25,14 +25,14 @@ Allowed values: ``'always_first'``, ``'always_last'`` and ``'none'``
 
 Default value: ``'always_first'``
 
-``case_sensitive``
+``sort_algorithm``
 ~~~~~~~~~~~~~~~~~~
 
-Whether the sorting should be case sensitive.
+Whether the types should be sorted alphabetically, or not sorted.
 
-Allowed types: ``bool``
+Allowed values: ``'alpha'`` and ``'none'``
 
-Default value: ``false``
+Default value: ``'alpha'``
 
 Examples
 --------

--- a/doc/rules/comment/header_comment.rst
+++ b/doc/rules/comment/header_comment.rst
@@ -7,15 +7,6 @@ Add, replace or remove header comment.
 Configuration
 -------------
 
-``header``
-~~~~~~~~~~
-
-Proper header content.
-
-Allowed types: ``string``
-
-This option is required.
-
 ``comment_type``
 ~~~~~~~~~~~~~~~~
 
@@ -24,6 +15,15 @@ Comment syntax type.
 Allowed values: ``'comment'`` and ``'PHPDoc'``
 
 Default value: ``'comment'``
+
+``header``
+~~~~~~~~~~
+
+Proper header content.
+
+Allowed types: ``string``
+
+This option is required.
 
 ``location``
 ~~~~~~~~~~~~

--- a/doc/rules/constant_notation/native_constant_invocation.rst
+++ b/doc/rules/constant_notation/native_constant_invocation.rst
@@ -17,6 +17,15 @@ Risky when any of the constants are namespaced or overridden.
 Configuration
 -------------
 
+``exclude``
+~~~~~~~~~~~
+
+List of constants to ignore.
+
+Allowed types: ``array``
+
+Default value: ``['null', 'false', 'true']``
+
 ``fix_built_in``
 ~~~~~~~~~~~~~~~~
 
@@ -35,15 +44,6 @@ List of additional constants to fix.
 Allowed types: ``array``
 
 Default value: ``[]``
-
-``exclude``
-~~~~~~~~~~~
-
-List of constants to ignore.
-
-Allowed types: ``array``
-
-Default value: ``['null', 'false', 'true']``
 
 ``scope``
 ~~~~~~~~~

--- a/doc/rules/control_structure/yoda_style.rst
+++ b/doc/rules/control_structure/yoda_style.rst
@@ -9,6 +9,16 @@ Write conditions in Yoda style (``true``), non-Yoda style (``['equal' => false,
 Configuration
 -------------
 
+``always_move_variable``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whether variables should always be on non assignable side when applying Yoda
+style.
+
+Allowed types: ``bool``
+
+Default value: ``false``
+
 ``equal``
 ~~~~~~~~~
 
@@ -35,16 +45,6 @@ Style for less and greater than (``<``, ``<=``, ``>``, ``>=``) statements.
 Allowed types: ``bool`` and ``null``
 
 Default value: ``null``
-
-``always_move_variable``
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-Whether variables should always be on non assignable side when applying Yoda
-style.
-
-Allowed types: ``bool``
-
-Default value: ``false``
 
 Examples
 --------

--- a/doc/rules/doctrine_annotation/doctrine_annotation_spaces.rst
+++ b/doc/rules/doctrine_annotation/doctrine_annotation_spaces.rst
@@ -14,42 +14,6 @@ assignment operator; there must be one space around array assignment operator.
 Configuration
 -------------
 
-``ignored_tags``
-~~~~~~~~~~~~~~~~
-
-List of tags that must not be treated as Doctrine Annotations.
-
-Allowed types: ``array``
-
-Default value: ``['abstract', 'access', 'code', 'deprec', 'encode', 'exception', 'final', 'ingroup', 'inheritdoc', 'inheritDoc', 'magic', 'name', 'toc', 'tutorial', 'private', 'static', 'staticvar', 'staticVar', 'throw', 'api', 'author', 'category', 'copyright', 'deprecated', 'example', 'filesource', 'global', 'ignore', 'internal', 'license', 'link', 'method', 'package', 'param', 'property', 'property-read', 'property-write', 'return', 'see', 'since', 'source', 'subpackage', 'throws', 'todo', 'TODO', 'usedBy', 'uses', 'var', 'version', 'after', 'afterClass', 'backupGlobals', 'backupStaticAttributes', 'before', 'beforeClass', 'codeCoverageIgnore', 'codeCoverageIgnoreStart', 'codeCoverageIgnoreEnd', 'covers', 'coversDefaultClass', 'coversNothing', 'dataProvider', 'depends', 'expectedException', 'expectedExceptionCode', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp', 'group', 'large', 'medium', 'preserveGlobalState', 'requires', 'runTestsInSeparateProcesses', 'runInSeparateProcess', 'small', 'test', 'testdox', 'ticket', 'uses', 'SuppressWarnings', 'noinspection', 'package_version', 'enduml', 'startuml', 'psalm', 'phpstan', 'template', 'fix', 'FIXME', 'fixme', 'override']``
-
-``around_parentheses``
-~~~~~~~~~~~~~~~~~~~~~~
-
-Whether to fix spaces around parentheses.
-
-Allowed types: ``bool``
-
-Default value: ``true``
-
-``around_commas``
-~~~~~~~~~~~~~~~~~
-
-Whether to fix spaces around commas.
-
-Allowed types: ``bool``
-
-Default value: ``true``
-
-``before_argument_assignments``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Whether to add, remove or ignore spaces before argument assignment operator.
-
-Allowed types: ``null`` and ``bool``
-
-Default value: ``false``
-
 ``after_argument_assignments``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -59,10 +23,10 @@ Allowed types: ``null`` and ``bool``
 
 Default value: ``false``
 
-``before_array_assignments_equals``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``after_array_assignments_colon``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Whether to add, remove or ignore spaces before array ``=`` assignment operator.
+Whether to add, remove or ignore spaces after array assignment ``:`` operator.
 
 Allowed types: ``null`` and ``bool``
 
@@ -77,6 +41,33 @@ Allowed types: ``null`` and ``bool``
 
 Default value: ``true``
 
+``around_commas``
+~~~~~~~~~~~~~~~~~
+
+Whether to fix spaces around commas.
+
+Allowed types: ``bool``
+
+Default value: ``true``
+
+``around_parentheses``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Whether to fix spaces around parentheses.
+
+Allowed types: ``bool``
+
+Default value: ``true``
+
+``before_argument_assignments``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whether to add, remove or ignore spaces before argument assignment operator.
+
+Allowed types: ``null`` and ``bool``
+
+Default value: ``false``
+
 ``before_array_assignments_colon``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -86,14 +77,23 @@ Allowed types: ``null`` and ``bool``
 
 Default value: ``true``
 
-``after_array_assignments_colon``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``before_array_assignments_equals``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Whether to add, remove or ignore spaces after array assignment ``:`` operator.
+Whether to add, remove or ignore spaces before array ``=`` assignment operator.
 
 Allowed types: ``null`` and ``bool``
 
 Default value: ``true``
+
+``ignored_tags``
+~~~~~~~~~~~~~~~~
+
+List of tags that must not be treated as Doctrine Annotations.
+
+Allowed types: ``array``
+
+Default value: ``['abstract', 'access', 'code', 'deprec', 'encode', 'exception', 'final', 'ingroup', 'inheritdoc', 'inheritDoc', 'magic', 'name', 'toc', 'tutorial', 'private', 'static', 'staticvar', 'staticVar', 'throw', 'api', 'author', 'category', 'copyright', 'deprecated', 'example', 'filesource', 'global', 'ignore', 'internal', 'license', 'link', 'method', 'package', 'param', 'property', 'property-read', 'property-write', 'return', 'see', 'since', 'source', 'subpackage', 'throws', 'todo', 'TODO', 'usedBy', 'uses', 'var', 'version', 'after', 'afterClass', 'backupGlobals', 'backupStaticAttributes', 'before', 'beforeClass', 'codeCoverageIgnore', 'codeCoverageIgnoreStart', 'codeCoverageIgnoreEnd', 'covers', 'coversDefaultClass', 'coversNothing', 'dataProvider', 'depends', 'expectedException', 'expectedExceptionCode', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp', 'group', 'large', 'medium', 'preserveGlobalState', 'requires', 'runTestsInSeparateProcesses', 'runInSeparateProcess', 'small', 'test', 'testdox', 'ticket', 'uses', 'SuppressWarnings', 'noinspection', 'package_version', 'enduml', 'startuml', 'psalm', 'phpstan', 'template', 'fix', 'FIXME', 'fixme', 'override']``
 
 Examples
 --------

--- a/doc/rules/function_notation/function_declaration.rst
+++ b/doc/rules/function_notation/function_declaration.rst
@@ -7,19 +7,19 @@ Spaces should be properly placed in a function declaration.
 Configuration
 -------------
 
-``closure_function_spacing``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``closure_fn_spacing``
+~~~~~~~~~~~~~~~~~~~~~~
 
-Spacing to use before open parenthesis for closures.
+Spacing to use before open parenthesis for short arrow functions.
 
 Allowed values: ``'none'`` and ``'one'``
 
 Default value: ``'one'``
 
-``closure_fn_spacing``
-~~~~~~~~~~~~~~~~~~~~~~
+``closure_function_spacing``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Spacing to use before open parenthesis for short arrow functions.
+Spacing to use before open parenthesis for closures.
 
 Allowed values: ``'none'`` and ``'one'``
 

--- a/doc/rules/function_notation/method_argument_space.rst
+++ b/doc/rules/function_notation/method_argument_space.rst
@@ -16,24 +16,6 @@ This fixer covers rules defined in PSR2 ¶4.4, ¶4.6.
 Configuration
 -------------
 
-``keep_multiple_spaces_after_comma``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Whether keep multiple spaces after comma.
-
-Allowed types: ``bool``
-
-Default value: ``false``
-
-``on_multiline``
-~~~~~~~~~~~~~~~~
-
-Defines how to handle function arguments lists that contain newlines.
-
-Allowed values: ``'ensure_fully_multiline'``, ``'ensure_single_line'`` and ``'ignore'``
-
-Default value: ``'ensure_fully_multiline'``
-
 ``after_heredoc``
 ~~~~~~~~~~~~~~~~~
 
@@ -51,6 +33,24 @@ Defines how to handle argument attributes when function definition is multiline.
 Allowed values: ``'ignore'``, ``'same_line'`` and ``'standalone'``
 
 Default value: ``'standalone'``
+
+``keep_multiple_spaces_after_comma``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whether keep multiple spaces after comma.
+
+Allowed types: ``bool``
+
+Default value: ``false``
+
+``on_multiline``
+~~~~~~~~~~~~~~~~
+
+Defines how to handle function arguments lists that contain newlines.
+
+Allowed values: ``'ensure_fully_multiline'``, ``'ensure_single_line'`` and ``'ignore'``
+
+Default value: ``'ensure_fully_multiline'``
 
 Examples
 --------

--- a/doc/rules/import/global_namespace_import.rst
+++ b/doc/rules/import/global_namespace_import.rst
@@ -7,6 +7,15 @@ Imports or fully qualifies global classes/functions/constants.
 Configuration
 -------------
 
+``import_classes``
+~~~~~~~~~~~~~~~~~~
+
+Whether to import, not import or ignore global classes.
+
+Allowed values: ``false``, ``null`` and ``true``
+
+Default value: ``true``
+
 ``import_constants``
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -24,15 +33,6 @@ Whether to import, not import or ignore global functions.
 Allowed values: ``false``, ``null`` and ``true``
 
 Default value: ``null``
-
-``import_classes``
-~~~~~~~~~~~~~~~~~~
-
-Whether to import, not import or ignore global classes.
-
-Allowed values: ``false``, ``null`` and ``true``
-
-Default value: ``true``
 
 Examples
 --------

--- a/doc/rules/import/ordered_imports.rst
+++ b/doc/rules/import/ordered_imports.rst
@@ -7,15 +7,14 @@ Ordering ``use`` statements.
 Configuration
 -------------
 
-``sort_algorithm``
+``case_sensitive``
 ~~~~~~~~~~~~~~~~~~
 
-Whether the statements should be sorted alphabetically or by length, or not
-sorted.
+Whether the sorting should be case sensitive.
 
-Allowed values: ``'alpha'``, ``'length'`` and ``'none'``
+Allowed types: ``bool``
 
-Default value: ``'alpha'``
+Default value: ``false``
 
 ``imports_order``
 ~~~~~~~~~~~~~~~~~
@@ -26,14 +25,15 @@ Allowed types: ``array`` and ``null``
 
 Default value: ``null``
 
-``case_sensitive``
+``sort_algorithm``
 ~~~~~~~~~~~~~~~~~~
 
-Whether the sorting should be case sensitive.
+Whether the statements should be sorted alphabetically or by length, or not
+sorted.
 
-Allowed types: ``bool``
+Allowed values: ``'alpha'``, ``'length'`` and ``'none'``
 
-Default value: ``false``
+Default value: ``'alpha'``
 
 Examples
 --------

--- a/doc/rules/language_construct/single_space_around_construct.rst
+++ b/doc/rules/language_construct/single_space_around_construct.rst
@@ -16,15 +16,6 @@ Allowed values: a subset of ``['yield_from']``
 
 Default value: ``['yield_from']``
 
-``constructs_preceded_by_a_single_space``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-List of constructs which must be preceded by a single space.
-
-Allowed values: a subset of ``['as', 'use_lambda']``
-
-Default value: ``['as', 'use_lambda']``
-
 ``constructs_followed_by_a_single_space``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -33,6 +24,15 @@ List of constructs which must be followed by a single space.
 Allowed values: a subset of ``['abstract', 'as', 'attribute', 'break', 'case', 'catch', 'class', 'clone', 'comment', 'const', 'const_import', 'continue', 'do', 'echo', 'else', 'elseif', 'enum', 'extends', 'final', 'finally', 'for', 'foreach', 'function', 'function_import', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof', 'insteadof', 'interface', 'match', 'named_argument', 'namespace', 'new', 'open_tag_with_echo', 'php_doc', 'php_open', 'print', 'private', 'protected', 'public', 'readonly', 'require', 'require_once', 'return', 'static', 'switch', 'throw', 'trait', 'try', 'type_colon', 'use', 'use_lambda', 'use_trait', 'var', 'while', 'yield', 'yield_from']``
 
 Default value: ``['abstract', 'as', 'attribute', 'break', 'case', 'catch', 'class', 'clone', 'comment', 'const', 'const_import', 'continue', 'do', 'echo', 'else', 'elseif', 'enum', 'extends', 'final', 'finally', 'for', 'foreach', 'function', 'function_import', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof', 'insteadof', 'interface', 'match', 'named_argument', 'namespace', 'new', 'open_tag_with_echo', 'php_doc', 'php_open', 'print', 'private', 'protected', 'public', 'readonly', 'require', 'require_once', 'return', 'static', 'switch', 'throw', 'trait', 'try', 'type_colon', 'use', 'use_lambda', 'use_trait', 'var', 'while', 'yield', 'yield_from']``
+
+``constructs_preceded_by_a_single_space``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+List of constructs which must be preceded by a single space.
+
+Allowed values: a subset of ``['as', 'use_lambda']``
+
+Default value: ``['as', 'use_lambda']``
 
 Examples
 --------

--- a/doc/rules/namespace_notation/blank_lines_before_namespace.rst
+++ b/doc/rules/namespace_notation/blank_lines_before_namespace.rst
@@ -7,19 +7,19 @@ Controls blank lines before a namespace declaration.
 Configuration
 -------------
 
-``min_line_breaks``
+``max_line_breaks``
 ~~~~~~~~~~~~~~~~~~~
 
-Minimum line breaks that should exist before namespace declaration.
+Maximum line breaks that should exist before namespace declaration.
 
 Allowed types: ``int``
 
 Default value: ``2``
 
-``max_line_breaks``
+``min_line_breaks``
 ~~~~~~~~~~~~~~~~~~~
 
-Maximum line breaks that should exist before namespace declaration.
+Minimum line breaks that should exist before namespace declaration.
 
 Allowed types: ``int``
 

--- a/doc/rules/operator/new_with_braces.rst
+++ b/doc/rules/operator/new_with_braces.rst
@@ -15,19 +15,19 @@ You should use ``new_with_parentheses`` instead.
 Configuration
 -------------
 
-``named_class``
-~~~~~~~~~~~~~~~
+``anonymous_class``
+~~~~~~~~~~~~~~~~~~~
 
-Whether named classes should be followed by parentheses.
+Whether anonymous classes should be followed by parentheses.
 
 Allowed types: ``bool``
 
 Default value: ``true``
 
-``anonymous_class``
-~~~~~~~~~~~~~~~~~~~
+``named_class``
+~~~~~~~~~~~~~~~
 
-Whether anonymous classes should be followed by parentheses.
+Whether named classes should be followed by parentheses.
 
 Allowed types: ``bool``
 

--- a/doc/rules/operator/new_with_parentheses.rst
+++ b/doc/rules/operator/new_with_parentheses.rst
@@ -8,19 +8,19 @@ parentheses.
 Configuration
 -------------
 
-``named_class``
-~~~~~~~~~~~~~~~
+``anonymous_class``
+~~~~~~~~~~~~~~~~~~~
 
-Whether named classes should be followed by parentheses.
+Whether anonymous classes should be followed by parentheses.
 
 Allowed types: ``bool``
 
 Default value: ``true``
 
-``anonymous_class``
-~~~~~~~~~~~~~~~~~~~
+``named_class``
+~~~~~~~~~~~~~~~
 
-Whether anonymous classes should be followed by parentheses.
+Whether named classes should be followed by parentheses.
 
 Allowed types: ``bool``
 

--- a/doc/rules/phpdoc/general_phpdoc_tag_rename.rst
+++ b/doc/rules/phpdoc/general_phpdoc_tag_rename.rst
@@ -7,6 +7,15 @@ Renames PHPDoc tags.
 Configuration
 -------------
 
+``case_sensitive``
+~~~~~~~~~~~~~~~~~~
+
+Whether tags should be replaced only if they have exact same casing.
+
+Allowed types: ``bool``
+
+Default value: ``false``
+
 ``fix_annotation``
 ~~~~~~~~~~~~~~~~~~
 
@@ -33,15 +42,6 @@ A map of tags to replace.
 Allowed types: ``array``
 
 Default value: ``[]``
-
-``case_sensitive``
-~~~~~~~~~~~~~~~~~~
-
-Whether tags should be replaced only if they have exact same casing.
-
-Allowed types: ``bool``
-
-Default value: ``false``
 
 Examples
 --------

--- a/doc/rules/phpdoc/no_superfluous_phpdoc_tags.rst
+++ b/doc/rules/phpdoc/no_superfluous_phpdoc_tags.rst
@@ -18,20 +18,20 @@ Allowed types: ``bool``
 
 Default value: ``false``
 
-``remove_inheritdoc``
-~~~~~~~~~~~~~~~~~~~~~
-
-Remove ``@inheritDoc`` tags.
-
-Allowed types: ``bool``
-
-Default value: ``false``
-
 ``allow_unused_params``
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Whether ``param`` annotation without actual signature is allowed (``true``) or
 considered superfluous (``false``).
+
+Allowed types: ``bool``
+
+Default value: ``false``
+
+``remove_inheritdoc``
+~~~~~~~~~~~~~~~~~~~~~
+
+Remove ``@inheritDoc`` tags.
 
 Allowed types: ``bool``
 

--- a/doc/rules/phpdoc/phpdoc_align.rst
+++ b/doc/rules/phpdoc/phpdoc_align.rst
@@ -8,6 +8,15 @@ aligned vertically.
 Configuration
 -------------
 
+``align``
+~~~~~~~~~
+
+How comments should be aligned.
+
+Allowed values: ``'left'`` and ``'vertical'``
+
+Default value: ``'vertical'``
+
 ``tags``
 ~~~~~~~~
 
@@ -24,15 +33,6 @@ The tags that should be aligned. Allowed values are tags with name (``'param',
 Allowed types: ``array``
 
 Default value: ``['method', 'param', 'property', 'return', 'throws', 'type', 'var']``
-
-``align``
-~~~~~~~~~
-
-How comments should be aligned.
-
-Allowed values: ``'left'`` and ``'vertical'``
-
-Default value: ``'vertical'``
 
 Examples
 --------

--- a/doc/rules/phpdoc/phpdoc_line_span.rst
+++ b/doc/rules/phpdoc/phpdoc_line_span.rst
@@ -17,19 +17,19 @@ Allowed values: ``'multi'``, ``'single'`` and ``null``
 
 Default value: ``'multi'``
 
-``property``
-~~~~~~~~~~~~
+``method``
+~~~~~~~~~~
 
-Whether property doc blocks should be single or multi line.
+Whether method doc blocks should be single or multi line.
 
 Allowed values: ``'multi'``, ``'single'`` and ``null``
 
 Default value: ``'multi'``
 
-``method``
-~~~~~~~~~~
+``property``
+~~~~~~~~~~~~
 
-Whether method doc blocks should be single or multi line.
+Whether property doc blocks should be single or multi line.
 
 Allowed values: ``'multi'``, ``'single'`` and ``null``
 

--- a/doc/rules/phpdoc/phpdoc_types_order.rst
+++ b/doc/rules/phpdoc/phpdoc_types_order.rst
@@ -7,14 +7,14 @@ Sorts PHPDoc types.
 Configuration
 -------------
 
-``sort_algorithm``
+``case_sensitive``
 ~~~~~~~~~~~~~~~~~~
 
-The sorting algorithm to apply.
+Whether the sorting should be case sensitive.
 
-Allowed values: ``'alpha'`` and ``'none'``
+Allowed types: ``bool``
 
-Default value: ``'alpha'``
+Default value: ``false``
 
 ``null_adjustment``
 ~~~~~~~~~~~~~~~~~~~
@@ -25,14 +25,14 @@ Allowed values: ``'always_first'``, ``'always_last'`` and ``'none'``
 
 Default value: ``'always_first'``
 
-``case_sensitive``
+``sort_algorithm``
 ~~~~~~~~~~~~~~~~~~
 
-Whether the sorting should be case sensitive.
+The sorting algorithm to apply.
 
-Allowed types: ``bool``
+Allowed values: ``'alpha'`` and ``'none'``
 
-Default value: ``false``
+Default value: ``'alpha'``
 
 Examples
 --------

--- a/doc/rules/string_notation/escape_implicit_backslashes.rst
+++ b/doc/rules/string_notation/escape_implicit_backslashes.rst
@@ -23,15 +23,6 @@ have a uniformed way to have them written all over the codebase.
 Configuration
 -------------
 
-``single_quoted``
-~~~~~~~~~~~~~~~~~
-
-Whether to fix single-quoted strings.
-
-Allowed types: ``bool``
-
-Default value: ``false``
-
 ``double_quoted``
 ~~~~~~~~~~~~~~~~~
 
@@ -49,6 +40,15 @@ Whether to fix heredoc syntax.
 Allowed types: ``bool``
 
 Default value: ``true``
+
+``single_quoted``
+~~~~~~~~~~~~~~~~~
+
+Whether to fix single-quoted strings.
+
+Allowed types: ``bool``
+
+Default value: ``false``
 
 Examples
 --------

--- a/src/Documentation/FixerDocumentGenerator.php
+++ b/src/Documentation/FixerDocumentGenerator.php
@@ -22,6 +22,7 @@ use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerConfiguration\AliasedFixerOption;
 use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
 use PhpCsFixer\FixerConfiguration\DeprecatedFixerOptionInterface;
+use PhpCsFixer\FixerConfiguration\FixerOptionInterface;
 use PhpCsFixer\FixerDefinition\CodeSampleInterface;
 use PhpCsFixer\FixerDefinition\FileSpecificCodeSampleInterface;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSampleInterface;
@@ -129,7 +130,11 @@ final class FixerDocumentGenerator
 
             $configurationDefinition = $fixer->getConfigurationDefinition();
 
-            foreach ($configurationDefinition->getOptions() as $option) {
+            $options = $configurationDefinition->getOptions();
+
+            usort($options, static fn (FixerOptionInterface $a, FixerOptionInterface $b): int => strcmp($a->getName(), $b->getName()));
+
+            foreach ($options as $option) {
                 $optionInfo = "``{$option->getName()}``";
                 $optionInfo .= "\n".str_repeat('~', \strlen($optionInfo));
 

--- a/src/Documentation/FixerDocumentGenerator.php
+++ b/src/Documentation/FixerDocumentGenerator.php
@@ -22,7 +22,6 @@ use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerConfiguration\AliasedFixerOption;
 use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
 use PhpCsFixer\FixerConfiguration\DeprecatedFixerOptionInterface;
-use PhpCsFixer\FixerConfiguration\FixerOptionInterface;
 use PhpCsFixer\FixerDefinition\CodeSampleInterface;
 use PhpCsFixer\FixerDefinition\FileSpecificCodeSampleInterface;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSampleInterface;
@@ -130,11 +129,7 @@ final class FixerDocumentGenerator
 
             $configurationDefinition = $fixer->getConfigurationDefinition();
 
-            $options = $configurationDefinition->getOptions();
-
-            usort($options, static fn (FixerOptionInterface $a, FixerOptionInterface $b): int => strcmp($a->getName(), $b->getName()));
-
-            foreach ($options as $option) {
+            foreach ($configurationDefinition->getOptions() as $option) {
                 $optionInfo = "``{$option->getName()}``";
                 $optionInfo .= "\n".str_repeat('~', \strlen($optionInfo));
 

--- a/src/FixerConfiguration/FixerConfigurationResolver.php
+++ b/src/FixerConfiguration/FixerConfigurationResolver.php
@@ -39,11 +39,11 @@ final class FixerConfigurationResolver implements FixerConfigurationResolverInte
             $this->addOption($option);
         }
 
-        usort($this->options, static fn (FixerOptionInterface $a, FixerOptionInterface $b): int => strcmp($a->getName(), $b->getName()));
-
         if (0 === \count($this->registeredNames)) {
             throw new \LogicException('Options cannot be empty.');
         }
+
+        usort($this->options, static fn (FixerOptionInterface $a, FixerOptionInterface $b): int => strcmp($a->getName(), $b->getName()));
     }
 
     public function getOptions(): array

--- a/src/FixerConfiguration/FixerConfigurationResolver.php
+++ b/src/FixerConfiguration/FixerConfigurationResolver.php
@@ -35,15 +35,15 @@ final class FixerConfigurationResolver implements FixerConfigurationResolverInte
      */
     public function __construct(iterable $options)
     {
-        foreach ($options as $option) {
+        $fixerOptionSorter = new FixerOptionSorter();
+
+        foreach ($fixerOptionSorter->sort($options) as $option) {
             $this->addOption($option);
         }
 
         if (0 === \count($this->registeredNames)) {
             throw new \LogicException('Options cannot be empty.');
         }
-
-        usort($this->options, static fn (FixerOptionInterface $a, FixerOptionInterface $b): int => strcmp($a->getName(), $b->getName()));
     }
 
     public function getOptions(): array

--- a/src/FixerConfiguration/FixerConfigurationResolver.php
+++ b/src/FixerConfiguration/FixerConfigurationResolver.php
@@ -39,6 +39,8 @@ final class FixerConfigurationResolver implements FixerConfigurationResolverInte
             $this->addOption($option);
         }
 
+        usort($this->options, static fn (FixerOptionInterface $a, FixerOptionInterface $b): int => strcmp($a->getName(), $b->getName()));
+
         if (0 === \count($this->registeredNames)) {
             throw new \LogicException('Options cannot be empty.');
         }

--- a/src/FixerConfiguration/FixerOptionSorter.php
+++ b/src/FixerConfiguration/FixerOptionSorter.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\FixerConfiguration;
+
+final class FixerOptionSorter
+{
+    /**
+     * @param iterable<FixerOptionInterface> $options
+     *
+     * @return list<FixerOptionInterface>
+     */
+    public function sort(iterable $options): array
+    {
+        if (!\is_array($options)) {
+            $options = iterator_to_array($options, false);
+        }
+
+        usort($options, static fn (FixerOptionInterface $a, FixerOptionInterface $b): int => strcmp($a->getName(), $b->getName()));
+
+        return $options;
+    }
+}

--- a/src/FixerConfiguration/FixerOptionSorter.php
+++ b/src/FixerConfiguration/FixerOptionSorter.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\FixerConfiguration;
 
+/**
+ * @internal
+ */
 final class FixerOptionSorter
 {
     /**

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -48,8 +48,8 @@ Fixer applying this rule is risky.
 Can break stuff.
 
 Fixer is configurable using following options:
-* functions (a subset of ['foo', 'test']): list of `function` names to fix; defaults to ['foo', 'test']; DEPRECATED alias: funcs
 * deprecated_option (bool): a deprecated option; defaults to false. DEPRECATED: use option `functions` instead.
+* functions (a subset of ['foo', 'test']): list of `function` names to fix; defaults to ['foo', 'test']; DEPRECATED alias: funcs
 
 Fixing examples:
  * Example #1. Fixing with the default configuration.
@@ -87,8 +87,8 @@ Replaces bad stuff with good stuff.
 Can break stuff.
 
 Fixer is configurable using following options:
-* \033[32mfunctions\033[39m (a subset of \e[33m['foo', 'test']\e[39m): list of \033[32m`function`\033[39m names to fix; defaults to \033[33m['foo', 'test']\033[39m; \e[37;41mDEPRECATED\e[39;49m alias: \033[33mfuncs\033[39m
 * \033[32mdeprecated_option\033[39m (\033[33mbool\033[39m): a deprecated option; defaults to \e[33mfalse\e[39m. \033[37;41mDEPRECATED\033[39;49m: use option \e[32m`functions`\e[39m instead.
+* \033[32mfunctions\033[39m (a subset of \e[33m['foo', 'test']\e[39m): list of \033[32m`function`\033[39m names to fix; defaults to \033[33m['foo', 'test']\033[39m; \e[37;41mDEPRECATED\e[39;49m alias: \033[33mfuncs\033[39m
 
 Fixing examples:
  * Example #1. Fixing with the \033[33mdefault\033[39m configuration.

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -30,11 +30,11 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
     public function testConfigureDefaultToFalse(): void
     {
         $defaultConfig = [
+            'inline_constructor_arguments' => true,
             'multi_line_extends_each_single_line' => false,
             'single_item_single_line' => false,
             'single_line' => false,
             'space_before_parenthesis' => false,
-            'inline_constructor_arguments' => true,
         ];
 
         $fixer = new ClassDefinitionFixer();

--- a/tests/FixerConfiguration/FixerConfigurationResolverTest.php
+++ b/tests/FixerConfiguration/FixerConfigurationResolverTest.php
@@ -18,6 +18,7 @@ use PhpCsFixer\FixerConfiguration\AliasedFixerOption;
 use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOption;
+use PhpCsFixer\FixerConfiguration\FixerOptionSorter;
 use PhpCsFixer\Tests\TestCase;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
@@ -65,20 +66,15 @@ final class FixerConfigurationResolverTest extends TestCase
 
     public function testGetOptions(): void
     {
-        $fooOption = new FixerOption('foo', 'Bar.');
-        $bazOption = new FixerOption('baz', 'Qux.');
-
         $options = [
-            $fooOption,
-            $bazOption,
+            new FixerOption('foo', 'Bar.'),
+            new FixerOption('baz', 'Qux.'),
         ];
-
         $configuration = new FixerConfigurationResolver($options);
 
-        $expected = [
-            $bazOption,
-            $fooOption,
-        ];
+        $fixerOptionSorter = new FixerOptionSorter();
+
+        $expected = $fixerOptionSorter->sort($options);
 
         self::assertSame($expected, $configuration->getOptions());
     }

--- a/tests/FixerConfiguration/FixerConfigurationResolverTest.php
+++ b/tests/FixerConfiguration/FixerConfigurationResolverTest.php
@@ -65,13 +65,22 @@ final class FixerConfigurationResolverTest extends TestCase
 
     public function testGetOptions(): void
     {
+        $fooOption = new FixerOption('foo', 'Bar.');
+        $bazOption = new FixerOption('baz', 'Qux.');
+
         $options = [
-            new FixerOption('foo', 'Bar.'),
-            new FixerOption('baz', 'Qux.'),
+            $fooOption,
+            $bazOption,
         ];
+
         $configuration = new FixerConfigurationResolver($options);
 
-        self::assertSame($options, $configuration->getOptions());
+        $expected = [
+            $bazOption,
+            $fooOption,
+        ];
+
+        self::assertSame($expected, $configuration->getOptions());
     }
 
     public function testResolve(): void

--- a/tests/FixerConfiguration/FixerOptionSorterTest.php
+++ b/tests/FixerConfiguration/FixerOptionSorterTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace FixerConfiguration;
+namespace PhpCsFixer\Tests\FixerConfiguration;
 
 use PhpCsFixer\FixerConfiguration\FixerOption;
 use PhpCsFixer\FixerConfiguration\FixerOptionSorter;

--- a/tests/FixerConfiguration/FixerOptionSorterTest.php
+++ b/tests/FixerConfiguration/FixerOptionSorterTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace FixerConfiguration;
+
+use PhpCsFixer\FixerConfiguration\FixerOption;
+use PhpCsFixer\FixerConfiguration\FixerOptionSorter;
+use PhpCsFixer\Tests\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\FixerConfiguration\FixerOptionSorter
+ */
+final class FixerOptionSorterTest extends TestCase
+{
+    public function testSortAcceptsEmptyArray(): void
+    {
+        $unsorted = [];
+
+        $sorter = new FixerOptionSorter();
+
+        $expected = [];
+
+        self::assertSame($expected, $sorter->sort($unsorted));
+    }
+
+    public function testSortSortsArrayOfOptionsByName(): void
+    {
+        $fooOption = new FixerOption('foo', 'Bar.');
+        $bazOption = new FixerOption('baz', 'Qux.');
+
+        $unsorted = [
+            $fooOption,
+            $bazOption,
+        ];
+
+        $sorter = new FixerOptionSorter();
+
+        $expected = [
+            $bazOption,
+            $fooOption,
+        ];
+
+        self::assertSame($expected, $sorter->sort($unsorted));
+    }
+
+    public function testSortAcceptsEmptyIterable(): void
+    {
+        $unsorted = new \ArrayIterator();
+
+        $sorter = new FixerOptionSorter();
+
+        $expected = [];
+
+        self::assertSame($expected, $sorter->sort($unsorted));
+    }
+
+    public function testSortSortsIterableOfOptionsByName(): void
+    {
+        $fooOption = new FixerOption('foo', 'Bar.');
+        $bazOption = new FixerOption('baz', 'Qux.');
+
+        $unsorted = new \ArrayIterator([
+            $fooOption,
+            $bazOption,
+        ]);
+
+        $sorter = new FixerOptionSorter();
+
+        $expected = [
+            $bazOption,
+            $fooOption,
+        ];
+
+        self::assertSame($expected, $sorter->sort($unsorted));
+    }
+}


### PR DESCRIPTION
This pull request

- [x] adjusts the `FixerConfigurationResolver` to keep options sorted by name
- [x] regenerates the documentation