### PR TITLE
deps: revert "prevent using PHPCSFixer along with unfinalize package (#7343)"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,9 +54,6 @@
         "symfony/phpunit-bridge": "^6.2.3",
         "symfony/yaml": "^5.4 || ^6.0"
     },
-    "conflict": {
-        "stevebauman/unfinalize": "*"
-    },
     "suggest": {
         "ext-dom": "For handling output formats in XML",
         "ext-mbstring": "For handling non-UTF8 characters."


### PR DESCRIPTION
This pull request reverts #7343. 

There is no practical use for this `conflict` instruction. It will, however, create conflict in the community. The decision to arbitrarily block a package is outside of the scope of this project.

It's also weird that a single person has the ability to merge such a pull request on a whim with a single approval.