### PR TITLE
feat(NamedArgumentSpaceFixer): introduction

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1307,6 +1307,13 @@ List of Available Rules
    Part of rule set `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Semicolon\\MultilineWhitespaceBeforeSemicolonsFixer <./../src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php>`_
+-  `named_argument_space <./rules/function_notation/named_argument_space.rst>`_
+
+   There MUST NOT be a space between the argument name and colon, and there MUST be a single space between the colon and the argument value.
+
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PER-CS <./ruleSets/PER-CS.rst>`_ `@PER-CS2.0 <./ruleSets/PER-CS2.0.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
+
+   `Source PhpCsFixer\\Fixer\\FunctionNotation\\NamedArgumentSpaceFixer <./../src/Fixer/FunctionNotation/NamedArgumentSpaceFixer.php>`_
 -  `native_constant_invocation <./rules/constant_notation/native_constant_invocation.rst>`_
 
    Add leading ``\`` before constant invocation of internal constant to speed up resolving. Constant name match is case-sensitive, except for ``null``, ``false`` and ``true``.

--- a/doc/ruleSets/PER-CS2.0.rst
+++ b/doc/ruleSets/PER-CS2.0.rst
@@ -17,4 +17,5 @@ Rules
   ``['closure_fn_spacing' => 'none']``
 
 - `method_argument_space <./../rules/function_notation/method_argument_space.rst>`_
+- `named_argument_space <./../rules/function_notation/named_argument_space.rst>`_
 - `single_line_empty_body <./../rules/basic/single_line_empty_body.rst>`_

--- a/doc/rules/function_notation/named_argument_space.rst
+++ b/doc/rules/function_notation/named_argument_space.rst
@@ -1,0 +1,31 @@
+=============================
+Rule ``named_argument_space``
+=============================
+
+There MUST NOT be a space between the argument name and colon, and there MUST be
+a single space between the colon and the argument value.
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -foo(foo  :1);
+   +foo(foo: 1);
+
+Rule sets
+---------
+
+The rule is part of the following rule sets:
+
+- `@PER <./../../ruleSets/PER.rst>`_
+- `@PER-CS <./../../ruleSets/PER-CS.rst>`_
+- `@PER-CS2.0 <./../../ruleSets/PER-CS2.0.rst>`_
+- `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
+

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -380,6 +380,9 @@ Function Notation
 - `method_argument_space <./function_notation/method_argument_space.rst>`_
 
   In method arguments and method call, there MUST NOT be a space before each comma and there MUST be one space after each comma. Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line.
+- `named_argument_space <./function_notation/named_argument_space.rst>`_
+
+  There MUST NOT be a space between the argument name and colon, and there MUST be a single space between the colon and the argument value.
 - `native_function_invocation <./function_notation/native_function_invocation.rst>`_ *(risky)*
 
   Add leading ``\`` before function invocation to speed up resolving.

--- a/src/Fixer/FunctionNotation/NamedArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/NamedArgumentSpaceFixer.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\FunctionNotation;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * If using named arguments, there MUST NOT be a space between the argument name and colon, and there MUST be a single space between the colon and the argument value.
+ *
+ * @see https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md
+ */
+final class NamedArgumentSpaceFixer extends AbstractFixer
+{
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return \PHP_VERSION_ID >= 8_00_00 && $tokens->isTokenKindFound(CT::T_NAMED_ARGUMENT_NAME);
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'There MUST NOT be a space between the argument name and colon, and there MUST be a single space between the colon and the argument value.',
+            [
+                new VersionSpecificCodeSample(
+                    "<?php\nfoo(foo  :1);\n",
+                    new VersionSpecification(8_00_00),
+                ),
+            ],
+        );
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        for ($index = \count($tokens) - 1; $index > 0; --$index) {
+            if (!$tokens[$index]->isGivenKind(CT::T_NAMED_ARGUMENT_NAME)) {
+                continue;
+            }
+
+            $afterColonIndex = $tokens->getNextTokenOfKind($index, [[CT::T_NAMED_ARGUMENT_COLON]]) + 1;
+
+            if ($tokens[$afterColonIndex]->isWhitespace()) {
+                $tokens[$afterColonIndex] = new Token([T_WHITESPACE, ' ']);
+            } elseif (!$tokens[$afterColonIndex]->isWhitespace()) {
+                $tokens->insertAt($afterColonIndex, new Token([T_WHITESPACE, ' ']));
+            }
+
+            if ($tokens[$index + 1]->isWhitespace()) {
+                $tokens->clearAt($index + 1);
+            }
+        }
+    }
+}

--- a/src/RuleSet/Sets/PERCS2x0Set.php
+++ b/src/RuleSet/Sets/PERCS2x0Set.php
@@ -39,6 +39,7 @@ final class PERCS2x0Set extends AbstractRuleSetDescription
                 'closure_fn_spacing' => 'none',
             ],
             'method_argument_space' => true,
+            'named_argument_space' => true,
             'single_line_empty_body' => true,
         ];
     }

--- a/tests/Fixer/FunctionNotation/NamedArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NamedArgumentSpaceFixerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\FunctionNotation;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\FunctionNotation\NamedArgumentSpaceFixer
+ *
+ * @requires PHP 8.0
+ */
+final class NamedArgumentSpaceFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixCases(): iterable
+    {
+        yield [
+            '<?php foo1(a: 1);',
+            '<?php foo1(a   : 1);',
+        ];
+
+        yield [
+            '<?php foo2(a: 1);',
+            '<?php foo2(a:1);',
+        ];
+
+        yield [
+            '<?php foo3(a: 1);',
+            '<?php foo3(a:    1);',
+        ];
+
+        yield [
+            '<?php foo4(a/* X */    : 1);',
+            '<?php foo4(a     /* X */    :    1);',
+        ];
+
+        yield [
+            '<?php foo5(a: 1);',
+            '<?php foo5(a:
+1);',
+        ];
+
+        yield [
+            '<?php foo6(a: 1,g: 2,   h: 1,   j: 9);',
+            '<?php foo6(a   : 1,g:2,   h  :  1,   j:        9);',
+        ];
+    }
+}

--- a/tests/Fixtures/Integration/misc/named_argument_space,method_argument_space.test
+++ b/tests/Fixtures/Integration/misc/named_argument_space,method_argument_space.test
@@ -1,0 +1,13 @@
+--TEST--
+Integration of fixers: named_argument_space,method_argument_space.
+--RULESET--
+{"named_argument_space": true, "method_argument_space": true}
+--REQUIREMENTS--
+{"php": 80000}
+--EXPECT--
+<?php
+$a = foo(bar: 1, baz: 2);
+
+--INPUT--
+<?php
+$a = foo(bar :1,baz:2);


### PR DESCRIPTION
Following https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md

```
If using named arguments, there MUST NOT be a space between the argument name and colon, and there MUST be a single space between the colon and the argument value.
```

closes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6433
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7247 can be updated after this