### PR TITLE
feat(PER-CS2.0): The fn keyword MUST NOT be succeeded by a space.

### DIFF
--- a/doc/ruleSets/PER-CS2.0.rst
+++ b/doc/ruleSets/PER-CS2.0.rst
@@ -12,5 +12,9 @@ Rules
 
   ``['spacing' => 'one']``
 
+- `function_declaration <./../rules/function_notation/function_declaration.rst>`_ with config:
+
+  ``['closure_fn_spacing' => 'none', 'closure_function_spacing' => 'one', 'trailing_comma_single_line' => false]``
+
 - `method_argument_space <./../rules/function_notation/method_argument_space.rst>`_
 - `single_line_empty_body <./../rules/basic/single_line_empty_body.rst>`_

--- a/doc/rules/function_notation/function_declaration.rst
+++ b/doc/rules/function_notation/function_declaration.rst
@@ -94,10 +94,19 @@ Rule sets
 
 The rule is part of the following rule sets:
 
-- `@PER <./../../ruleSets/PER.rst>`_
-- `@PER-CS <./../../ruleSets/PER-CS.rst>`_
+- `@PER <./../../ruleSets/PER.rst>`_ with config:
+
+  ``['closure_fn_spacing' => 'none', 'closure_function_spacing' => 'one', 'trailing_comma_single_line' => false]``
+
+- `@PER-CS <./../../ruleSets/PER-CS.rst>`_ with config:
+
+  ``['closure_fn_spacing' => 'none', 'closure_function_spacing' => 'one', 'trailing_comma_single_line' => false]``
+
 - `@PER-CS1.0 <./../../ruleSets/PER-CS1.0.rst>`_
-- `@PER-CS2.0 <./../../ruleSets/PER-CS2.0.rst>`_
+- `@PER-CS2.0 <./../../ruleSets/PER-CS2.0.rst>`_ with config:
+
+  ``['closure_fn_spacing' => 'none', 'closure_function_spacing' => 'one', 'trailing_comma_single_line' => false]``
+
 - `@PSR2 <./../../ruleSets/PSR2.rst>`_
 - `@PSR12 <./../../ruleSets/PSR12.rst>`_
 - `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_

--- a/src/RuleSet/Sets/PERCS2x0Set.php
+++ b/src/RuleSet/Sets/PERCS2x0Set.php
@@ -35,6 +35,11 @@ final class PERCS2x0Set extends AbstractRuleSetDescription
         return [
             '@PER-CS1.0' => true,
             'concat_space' => ['spacing' => 'one'],
+            'function_declaration' => [
+                'closure_fn_spacing' => 'none',
+                'closure_function_spacing' => 'one',
+                'trailing_comma_single_line' => false,
+            ],
             'method_argument_space' => true,
             'single_line_empty_body' => true,
         ];


### PR DESCRIPTION
@ see https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md

>The fn keyword MUST NOT be succeeded by a space.

after https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7247 can be updated