### PR TITLE
feat: Add `ordered_types` to `@Symfony`

### DIFF
--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -109,6 +109,10 @@ Rules
 
   ``['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha']``
 
+- `ordered_types <./../rules/class_notation/ordered_types.rst>`_ with config:
+
+  ``['null_adjustment' => 'always_last', 'sort_algorithm' => 'none']``
+
 - `php_unit_fqcn_annotation <./../rules/php_unit/php_unit_fqcn_annotation.rst>`_
 - `php_unit_method_casing <./../rules/php_unit/php_unit_method_casing.rst>`_
 - `phpdoc_align <./../rules/phpdoc/phpdoc_align.rst>`_

--- a/doc/rules/class_notation/ordered_types.rst
+++ b/doc/rules/class_notation/ordered_types.rst
@@ -110,9 +110,13 @@ With configuration: ``['sort_algorithm' => 'none', 'null_adjustment' => 'always_
 Rule sets
 ---------
 
-The rule is part of the following rule set:
+The rule is part of the following rule sets:
 
 - `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
+- `@Symfony <./../../ruleSets/Symfony.rst>`_ with config:
+
+  ``['null_adjustment' => 'always_last', 'sort_algorithm' => 'none']``
+
 
 References
 ----------

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -147,6 +147,10 @@ final class SymfonySet extends AbstractRuleSetDescription
                 ],
                 'sort_algorithm' => 'alpha',
             ],
+            'ordered_types' => [
+                'null_adjustment' => 'always_last',
+                'sort_algorithm' => 'none',
+            ],
             'php_unit_fqcn_annotation' => true,
             'php_unit_method_casing' => true,
             'phpdoc_align' => true,


### PR DESCRIPTION
Hi @Wirone 

Symfony coding style already use:
```
'phpdoc_types_order' => [
                'null_adjustment' => 'always_last',
                'sort_algorithm' => 'none',
            ]
```
so I assume same should be applied to the types, ie:
```
'ordered_types' => [
                'null_adjustment' => 'always_last',
                'sort_algorithm' => 'none',
            ]
```