### PR TITLE
feat(TrailingCommaInMultilineFixer): add array destructing support

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -3361,7 +3361,7 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\Operator\\TernaryToNullCoalescingFixer <./../src/Fixer/Operator/TernaryToNullCoalescingFixer.php>`_
 -  `trailing_comma_in_multiline <./rules/control_structure/trailing_comma_in_multiline.rst>`_
 
-   Multi-line arrays, arguments list, parameters list and ``match`` expressions must have a trailing comma.
+   Multi-line arrays, arguments list, parameters list, ``match`` and array destructuring expressions must have a trailing comma.
 
    Configuration options:
 
@@ -3371,11 +3371,11 @@ List of Available Rules
      | Default value: ``false``
    - | ``elements``
      | Where to fix multiline trailing comma (PHP >= 8.0 for ``parameters`` and ``match``).
-     | Allowed values: a subset of ``['arguments', 'arrays', 'match', 'parameters']``
+     | Allowed values: a subset of ``['arguments', 'array_destructuring', 'arrays', 'match', 'parameters']``
      | Default value: ``['arrays']``
 
 
-   Part of rule sets `@PHP73Migration <./ruleSets/PHP73Migration.rst>`_ `@PHP74Migration <./ruleSets/PHP74Migration.rst>`_ `@PHP80Migration <./ruleSets/PHP80Migration.rst>`_ `@PHP81Migration <./ruleSets/PHP81Migration.rst>`_ `@PHP82Migration <./ruleSets/PHP82Migration.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PER-CS <./ruleSets/PER-CS.rst>`_ `@PER-CS2.0 <./ruleSets/PER-CS2.0.rst>`_ `@PHP73Migration <./ruleSets/PHP73Migration.rst>`_ `@PHP74Migration <./ruleSets/PHP74Migration.rst>`_ `@PHP80Migration <./ruleSets/PHP80Migration.rst>`_ `@PHP81Migration <./ruleSets/PHP81Migration.rst>`_ `@PHP82Migration <./ruleSets/PHP82Migration.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ControlStructure\\TrailingCommaInMultilineFixer <./../src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php>`_
 -  `trim_array_spaces <./rules/array_notation/trim_array_spaces.rst>`_

--- a/doc/ruleSets/PER-CS2.0.rst
+++ b/doc/ruleSets/PER-CS2.0.rst
@@ -18,3 +18,7 @@ Rules
 
 - `method_argument_space <./../rules/function_notation/method_argument_space.rst>`_
 - `single_line_empty_body <./../rules/basic/single_line_empty_body.rst>`_
+- `trailing_comma_in_multiline <./../rules/control_structure/trailing_comma_in_multiline.rst>`_ with config:
+
+  ``['elements' => ['arguments', 'array_destructuring', 'arrays', 'match', 'parameters']]``
+

--- a/doc/rules/control_structure/trailing_comma_in_multiline.rst
+++ b/doc/rules/control_structure/trailing_comma_in_multiline.rst
@@ -2,8 +2,8 @@
 Rule ``trailing_comma_in_multiline``
 ====================================
 
-Multi-line arrays, arguments list, parameters list and ``match`` expressions
-must have a trailing comma.
+Multi-line arrays, arguments list, parameters list, ``match`` and array
+destructuring expressions must have a trailing comma.
 
 Configuration
 -------------
@@ -23,7 +23,7 @@ Default value: ``false``
 Where to fix multiline trailing comma (PHP >= 8.0 for ``parameters`` and
 ``match``).
 
-Allowed values: a subset of ``['arguments', 'arrays', 'match', 'parameters']``
+Allowed values: a subset of ``['arguments', 'array_destructuring', 'arrays', 'match', 'parameters']``
 
 Default value: ``['arrays']``
 
@@ -102,6 +102,18 @@ Rule sets
 ---------
 
 The rule is part of the following rule sets:
+
+- `@PER <./../../ruleSets/PER.rst>`_ with config:
+
+  ``['elements' => ['arguments', 'array_destructuring', 'arrays', 'match', 'parameters']]``
+
+- `@PER-CS <./../../ruleSets/PER-CS.rst>`_ with config:
+
+  ``['elements' => ['arguments', 'array_destructuring', 'arrays', 'match', 'parameters']]``
+
+- `@PER-CS2.0 <./../../ruleSets/PER-CS2.0.rst>`_ with config:
+
+  ``['elements' => ['arguments', 'array_destructuring', 'arrays', 'match', 'parameters']]``
 
 - `@PHP73Migration <./../../ruleSets/PHP73Migration.rst>`_ with config:
 

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -329,7 +329,7 @@ Control Structure
   Switch case must not be ended with ``continue`` but with ``break``.
 - `trailing_comma_in_multiline <./control_structure/trailing_comma_in_multiline.rst>`_
 
-  Multi-line arrays, arguments list, parameters list and ``match`` expressions must have a trailing comma.
+  Multi-line arrays, arguments list, parameters list, ``match`` and array destructuring expressions must have a trailing comma.
 - `yoda_style <./control_structure/yoda_style.rst>`_
 
   Write conditions in Yoda style (``true``), non-Yoda style (``['equal' => false, 'identical' => false, 'less_and_greater' => false]``) or ignore those conditions (``null``) based on configuration.

--- a/src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php
+++ b/src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php
@@ -20,7 +20,6 @@ use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
-use PhpCsFixer\FixerConfiguration\InvalidOptionsForEnvException;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
@@ -56,10 +55,12 @@ final class TrailingCommaInMultilineFixer extends AbstractFixer implements Confi
 
     private const MATCH_EXPRESSIONS = 'match';
 
+    private const ARRAY_DESTRUCTURING = 'array_destructuring';
+
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Multi-line arrays, arguments list, parameters list and `match` expressions must have a trailing comma.',
+            'Multi-line arrays, arguments list, parameters list, `match` and array destructuring expressions must have a trailing comma.',
             [
                 new CodeSample("<?php\narray(\n    1,\n    2\n);\n"),
                 new CodeSample(
@@ -84,27 +85,34 @@ final class TrailingCommaInMultilineFixer extends AbstractFixer implements Confi
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isAnyTokenKindsFound([T_ARRAY, CT::T_ARRAY_SQUARE_BRACE_OPEN, '(']);
+        return $tokens->isAnyTokenKindsFound([T_ARRAY, CT::T_ARRAY_SQUARE_BRACE_OPEN, '(', CT::T_DESTRUCTURING_SQUARE_BRACE_OPEN]);
     }
 
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
+        $allOptions = [
+            self::ARRAY_DESTRUCTURING,
+            self::ELEMENTS_ARGUMENTS,
+            self::ELEMENTS_ARRAYS,
+            self::ELEMENTS_PARAMETERS,
+            self::MATCH_EXPRESSIONS,
+        ];
+
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('after_heredoc', 'Whether a trailing comma should also be placed after heredoc end.'))
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)
                 ->getOption(),
-            (new FixerOptionBuilder('elements', sprintf('Where to fix multiline trailing comma (PHP >= 8.0 for `%s` and `%s`).', self::ELEMENTS_PARAMETERS, self::MATCH_EXPRESSIONS))) // @TODO: remove text when PHP 8.0+ is required
+            (new FixerOptionBuilder('elements', sprintf('Where to fix multiline trailing comma (PHP >= 8.0 for `%s` and `%s`).', self::ELEMENTS_PARAMETERS, self::MATCH_EXPRESSIONS))) // @TODO: update text when PHP 8.0+ is required
                 ->setAllowedTypes(['array'])
-                ->setAllowedValues([new AllowedValueSubset([self::ELEMENTS_ARRAYS, self::ELEMENTS_ARGUMENTS, self::ELEMENTS_PARAMETERS, self::MATCH_EXPRESSIONS])])
+                ->setAllowedValues([new AllowedValueSubset($allOptions)])
                 ->setDefault([self::ELEMENTS_ARRAYS])
                 ->setNormalizer(static function (Options $options, $value) {
                     if (\PHP_VERSION_ID < 8_00_00) { // @TODO: drop condition when PHP 8.0+ is required
-                        foreach ([self::ELEMENTS_PARAMETERS, self::MATCH_EXPRESSIONS] as $option) {
-                            if (\in_array($option, $value, true)) {
-                                throw new InvalidOptionsForEnvException(sprintf('"%s" option can only be enabled with PHP 8.0+.', $option));
-                            }
-                        }
+                        $value = array_filter(
+                            $value,
+                            static fn (string $option) => self::ELEMENTS_PARAMETERS !== $option && self::MATCH_EXPRESSIONS !== $option
+                        );
                     }
 
                     return $value;
@@ -115,27 +123,56 @@ final class TrailingCommaInMultilineFixer extends AbstractFixer implements Confi
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
-        $fixArrays = \in_array(self::ELEMENTS_ARRAYS, $this->configuration['elements'], true);
-        $fixArguments = \in_array(self::ELEMENTS_ARGUMENTS, $this->configuration['elements'], true);
-        $fixParameters = \PHP_VERSION_ID >= 8_00_00 && \in_array(self::ELEMENTS_PARAMETERS, $this->configuration['elements'], true); // @TODO: drop condition when PHP 8.0+ is required
-        $fixMatch = \PHP_VERSION_ID >= 8_00_00 && \in_array(self::MATCH_EXPRESSIONS, $this->configuration['elements'], true); // @TODO: drop condition when PHP 8.0+ is required
+        $configuredElements = $this->configuration['elements'];
+
+        $fixArrays = \in_array(self::ELEMENTS_ARRAYS, $configuredElements, true);
+        $fixArguments = \in_array(self::ELEMENTS_ARGUMENTS, $configuredElements, true);
+        $fixParameters = \PHP_VERSION_ID >= 8_00_00 && \in_array(self::ELEMENTS_PARAMETERS, $configuredElements, true); // @TODO: drop condition when PHP 8.0+ is required
+        $fixMatch = \PHP_VERSION_ID >= 8_00_00 && \in_array(self::MATCH_EXPRESSIONS, $configuredElements, true); // @TODO: drop condition when PHP 8.0+ is required
+        $fixDestructuring = \in_array(self::ARRAY_DESTRUCTURING, $configuredElements, true);
 
         for ($index = $tokens->count() - 1; $index >= 0; --$index) {
-            $prevIndex = $tokens->getPrevMeaningfulToken($index);
+            if ($tokens[$index]->isGivenKind(CT::T_DESTRUCTURING_SQUARE_BRACE_OPEN)) {
+                if ($fixDestructuring) { // array destructing short syntax
+                    $this->fixBlock($tokens, $index);
+                }
 
-            if (
-                $fixArrays
-                && (
-                    $tokens[$index]->equals('(') && $tokens[$prevIndex]->isGivenKind(T_ARRAY) // long syntax
-                    || $tokens[$index]->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN) // short syntax
-                )
-            ) {
-                $this->fixBlock($tokens, $index);
+                continue;
+            }
+
+            if ($tokens[$index]->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN)) {
+                if ($fixArrays) { // array short syntax
+                    $this->fixBlock($tokens, $index);
+                }
 
                 continue;
             }
 
             if (!$tokens[$index]->equals('(')) {
+                continue;
+            }
+
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
+
+            if ($tokens[$prevIndex]->isGivenKind(T_ARRAY)) {
+                if ($fixArrays) { // array long syntax
+                    $this->fixBlock($tokens, $index);
+                }
+
+                continue;
+            }
+
+            if ($tokens[$prevIndex]->isGivenKind(T_LIST)) {
+                if ($fixDestructuring) { // array destructing long syntax
+                    $this->fixBlock($tokens, $index);
+                }
+
+                continue;
+            }
+
+            if ($fixMatch && $tokens[$prevIndex]->isGivenKind(T_MATCH)) {
+                $this->fixMatch($tokens, $index);
+
                 continue;
             }
 
@@ -158,10 +195,6 @@ final class TrailingCommaInMultilineFixer extends AbstractFixer implements Confi
                 )
             ) {
                 $this->fixBlock($tokens, $index);
-            }
-
-            if ($fixMatch && $tokens[$prevIndex]->isGivenKind(T_MATCH)) {
-                $this->fixMatch($tokens, $index);
             }
         }
     }

--- a/src/RuleSet/Sets/PERCS2x0Set.php
+++ b/src/RuleSet/Sets/PERCS2x0Set.php
@@ -40,6 +40,15 @@ final class PERCS2x0Set extends AbstractRuleSetDescription
             ],
             'method_argument_space' => true,
             'single_line_empty_body' => true,
+            'trailing_comma_in_multiline' => [
+                'elements' => [
+                    'arguments',
+                    'array_destructuring',
+                    'arrays',
+                    'match',
+                    'parameters',
+                ],
+            ],
         ];
     }
 

--- a/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
+++ b/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Fixer\ControlStructure;
 
-use PhpCsFixer\ConfigurationException\InvalidForEnvFixerConfigurationException;
 use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
@@ -28,30 +27,6 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  */
 final class TrailingCommaInMultilineFixerTest extends AbstractFixerTestCase
 {
-    /**
-     * @requires PHP <8.0
-     *
-     * @dataProvider provideInvalidConfigurationCases
-     *
-     * @param mixed $exceptionMessega
-     * @param mixed $configuration
-     */
-    public function testInvalidConfiguration($exceptionMessega, $configuration): void
-    {
-        $this->expectException(InvalidForEnvFixerConfigurationException::class);
-        $this->expectExceptionMessage($exceptionMessega);
-
-        $this->fixer->configure($configuration);
-    }
-
-    public static function provideInvalidConfigurationCases(): iterable
-    {
-        yield [
-            '[trailing_comma_in_multiline] Invalid configuration for env: "parameters" option can only be enabled with PHP 8.0+.',
-            ['elements' => [TrailingCommaInMultilineFixer::ELEMENTS_PARAMETERS]],
-        ];
-    }
-
     /**
      * @param array<string, mixed> $config
      *
@@ -608,6 +583,19 @@ $a
 ); }};',
             ['elements' => [TrailingCommaInMultilineFixer::ELEMENTS_ARGUMENTS]],
         ];
+
+        yield 'default config does not fix array destructuring' => [
+            '<?php
+            list(
+                $a7,
+                $b7
+            ) = $z7;
+
+            [
+                $x7,
+                $y7
+            ] = $ff7;',
+        ];
     }
 
     /**
@@ -719,6 +707,106 @@ $x = match ($a) { 1 => 0,
             ',
             null,
             ['elements' => ['match']],
+        ];
+    }
+
+    /**
+     * @dataProvider provideArrayDestructuringCases
+     */
+    public function testArrayDestructuring(string $expected, ?string $input = null): void
+    {
+        $this->fixer->configure(['elements' => ['array_destructuring']]);
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideArrayDestructuringCases(): iterable
+    {
+        yield 'simple long array destructuring syntax' => [
+            '<?php
+                list(
+                    $b1,
+                    $c1,
+                ) = $t1;
+
+                list($a1) = $k1;
+            ',
+            '<?php
+                list(
+                    $b1,
+                    $c1
+                ) = $t1;
+
+                list($a1) = $k1;
+            ',
+        ];
+
+        yield 'simple short array destructuring syntax' => [
+            '<?php
+                [
+                    $b2,
+                    $c2,
+                ] = $t2;
+
+                [$v2,$d2] = $p2;
+            ',
+            '<?php
+                [
+                    $b2,
+                    $c2
+                ] = $t2;
+
+                [$v2,$d2] = $p2;
+            ',
+        ];
+
+        yield 'short and long destructuring array syntax' => [
+            '<?php
+                list(
+                    $a3,
+                    $b3,
+                ) = $z3;
+
+                [
+                    $x3,
+                    $y3,
+                ] = $ff3;
+            ',
+            '<?php
+                list(
+                    $a3,
+                    $b3
+                ) = $z3;
+
+                [
+                    $x3,
+                    $y3
+                ] = $ff3;
+            ',
+        ];
+
+        yield [
+            '<?php
+                list(
+                    9 => $ty4,
+                    10 => $gh4,
+                ) = $sd4;
+
+                [
+                    1 => $xa4,
+                    2 => $xb4,
+                ] = $zz4;
+            ',
+            '<?php
+                list(
+                    9 => $ty4,
+                    10 => $gh4
+                ) = $sd4;
+
+                [
+                    1 => $xa4,
+                    2 => $xb4
+                ] = $zz4;
+            ',
         ];
     }
 }


### PR DESCRIPTION
Adding array destructing support.
Added to PER CS (https://www.php-fig.org/per/coding-style/)

```
2.6 Trailing commas

Numerous PHP constructs allow a sequence of values to be separated by a comma, and the final item may have an optional comma. Examples include array key/value pairs, function arguments, closure use statements, match() statement branches, etc.

[...]

If the list is split across multiple lines, then the last item MUST have a trailing comma.
```

