### PR TITLE
fix: `BinaryOperatorSpacesFixer` - align correctly when multiple shifts occurs in single line

### DIFF
--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -937,8 +937,10 @@ $array = [
                                     .$escapedAlignOperator
                                     .')/';
 
-                                if (preg_match($pattern, $line, $matches)) {
-                                    $line = preg_replace($pattern, ' '.trim($matches[0]), $line);
+                                var_dump($pattern);
+
+                                if (Preg::match($pattern, $line, $matches)) {
+                                    $line = Preg::replace($pattern, ' '.trim($matches[0]), $line);
                                 }
                             }
                         }

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -357,37 +357,68 @@ $array = [
                 ->setDefault(self::SINGLE_SPACE)
                 ->setAllowedValues(self::$allowedValues)
                 ->getOption(),
-            (new FixerOptionBuilder('operators', 'Dictionary of `binary operator` => `fix strategy` values that differ from the default strategy. Supported are: '.Utils::naturalLanguageJoinWithBackticks(self::SUPPORTED_OPERATORS).'.'))
+            (new FixerOptionBuilder(
+                'operators',
+                'Dictionary of `binary operator` => `fix strategy` values that differ from the default strategy. Supported are: '.Utils::naturalLanguageJoinWithBackticks(
+                    self::SUPPORTED_OPERATORS
+                ).'.'
+            ))
                 ->setAllowedTypes(['array'])
-                ->setAllowedValues([static function (array $option): bool {
-                    foreach ($option as $operator => $value) {
-                        if (!\in_array($operator, self::SUPPORTED_OPERATORS, true)) {
-                            throw new InvalidOptionsException(
-                                sprintf(
-                                    'Unexpected "operators" key, expected any of %s, got "%s".',
-                                    Utils::naturalLanguageJoin(self::SUPPORTED_OPERATORS),
-                                    \gettype($operator).'#'.$operator
-                                )
-                            );
+                ->setAllowedValues([
+                    static function (array $option): bool {
+                        foreach ($option as $operator => $value) {
+                            if (!\in_array(
+                                $operator,
+                                self::SUPPORTED_OPERATORS,
+                                true
+                            )) {
+                                throw new InvalidOptionsException(
+                                    sprintf(
+                                        'Unexpected "operators" key, expected any of %s, got "%s".',
+                                        Utils::naturalLanguageJoin(
+                                            self::SUPPORTED_OPERATORS
+                                        ),
+                                        \gettype(
+                                            $operator
+                                        ).'#'.$operator
+                                    )
+                                );
+                            }
+
+                            if (!\in_array(
+                                $value,
+                                self::$allowedValues,
+                                true
+                            )) {
+                                throw new InvalidOptionsException(
+                                    sprintf(
+                                        'Unexpected value for operator "%s", expected any of %s, got "%s".',
+                                        $operator,
+                                        Utils::naturalLanguageJoin(
+                                            array_map(
+                                                static fn (
+                                                    $value
+                                                ): string => Utils::toString(
+                                                    $value
+                                                ),
+                                                self::$allowedValues
+                                            )
+                                        ),
+                                        \is_object(
+                                            $value
+                                        ) ? \get_class(
+                                            $value
+                                        ) : (null === $value ? 'null' : \gettype(
+                                            $value
+                                        ).'#'.$value)
+                                    )
+                                );
+                            }
                         }
 
-                        if (!\in_array($value, self::$allowedValues, true)) {
-                            throw new InvalidOptionsException(
-                                sprintf(
-                                    'Unexpected value for operator "%s", expected any of %s, got "%s".',
-                                    $operator,
-                                    Utils::naturalLanguageJoin(array_map(
-                                        static fn ($value): string => Utils::toString($value),
-                                        self::$allowedValues
-                                    )),
-                                    \is_object($value) ? \get_class($value) : (null === $value ? 'null' : \gettype($value).'#'.$value)
-                                )
-                            );
-                        }
-                    }
-
-                    return true;
-                }])
+                        return true;
+                    },
+                ])
                 ->setDefault([])
                 ->getOption(),
         ]);
@@ -449,7 +480,9 @@ $array = [
         // fix white space after operator
         if ($tokens[$index + 1]->isWhitespace()) {
             $content = $tokens[$index + 1]->getContent();
-            if (' ' !== $content && !str_contains($content, "\n") && !$tokens[$tokens->getNextNonWhitespace($index + 1)]->isComment()) {
+            if (' ' !== $content && !str_contains($content, "\n") && !$tokens[$tokens->getNextNonWhitespace(
+                $index + 1
+            )]->isComment()) {
                 $tokens[$index + 1] = new Token([T_WHITESPACE, ' ']);
             }
         } else {
@@ -459,7 +492,9 @@ $array = [
         // fix white space before operator
         if ($tokens[$index - 1]->isWhitespace()) {
             $content = $tokens[$index - 1]->getContent();
-            if (' ' !== $content && !str_contains($content, "\n") && !$tokens[$tokens->getPrevNonWhitespace($index - 1)]->isComment()) {
+            if (' ' !== $content && !str_contains($content, "\n") && !$tokens[$tokens->getPrevNonWhitespace(
+                $index - 1
+            )]->isComment()) {
                 $tokens[$index - 1] = new Token([T_WHITESPACE, ' ']);
             }
         } else {
@@ -576,20 +611,27 @@ $array = [
             ) {
                 if ('=>' === $tokenContent) {
                     for ($index = $tokens->count() - 2; $index > 0; --$index) {
-                        if ($tokens[$index]->isGivenKind(T_DOUBLE_ARROW)) { // always binary operator, never part of declare statement
+                        if ($tokens[$index]->isGivenKind(
+                            T_DOUBLE_ARROW
+                        )) { // always binary operator, never part of declare statement
                             $this->fixWhiteSpaceBeforeOperator($tokensClone, $index, $alignStrategy);
                         }
                     }
                 } elseif ('=' === $tokenContent) {
                     for ($index = $tokens->count() - 2; $index > 0; --$index) {
-                        if ('=' === $tokens[$index]->getContent() && !$this->isEqualPartOfDeclareStatement($tokens, $index) && $this->tokensAnalyzer->isBinaryOperator($index)) {
+                        if ('=' === $tokens[$index]->getContent() && !$this->isEqualPartOfDeclareStatement(
+                            $tokens,
+                            $index
+                        ) && $this->tokensAnalyzer->isBinaryOperator($index)) {
                             $this->fixWhiteSpaceBeforeOperator($tokensClone, $index, $alignStrategy);
                         }
                     }
                 } else {
                     for ($index = $tokens->count() - 2; $index > 0; --$index) {
                         $content = $tokens[$index]->getContent();
-                        if (strtolower($content) === $tokenContent && $this->tokensAnalyzer->isBinaryOperator($index)) { // never part of declare statement
+                        if (strtolower($content) === $tokenContent && $this->tokensAnalyzer->isBinaryOperator(
+                            $index
+                        )) { // never part of declare statement
                             $this->fixWhiteSpaceBeforeOperator($tokensClone, $index, $alignStrategy);
                         }
                     }
@@ -600,8 +642,12 @@ $array = [
         }
     }
 
-    private function injectAlignmentPlaceholdersDefault(Tokens $tokens, int $startAt, int $endAt, string $tokenContent): void
-    {
+    private function injectAlignmentPlaceholdersDefault(
+        Tokens $tokens,
+        int $startAt,
+        int $endAt,
+        string $tokenContent
+    ): void {
         $newLineFoundSinceLastPlaceholder = true;
 
         for ($index = $startAt; $index < $endAt; ++$index) {
@@ -722,7 +768,9 @@ $array = [
                 continue;
             }
 
-            if ($token->isGivenKind(T_ARRAY)) { // don't use "$tokens->isArray()" here, short arrays are handled in the next case
+            if ($token->isGivenKind(
+                T_ARRAY
+            )) { // don't use "$tokens->isArray()" here, short arrays are handled in the next case
                 $yieldFoundSinceLastPlaceholder = false;
                 $from = $tokens->getNextMeaningfulToken($index);
                 $until = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $from);
@@ -928,18 +976,34 @@ $array = [
                             self::ALIGN !== $alignStrategy
                             && self::ALIGN_BY_SCOPE !== $alignStrategy
                         ) {
+                            $escapedAlignOperators = [];
                             foreach (array_keys($this->alignOperatorTokens) as $alignOperatorToken) {
-                                $escapedAlignOperator = preg_quote($alignOperatorToken, '/');
-                                $pattern = '/(?<!'
+                                $escapedAlignOperators[] = preg_quote($alignOperatorToken, '/');
+                            }
+                            $strForAdjust = str_replace(
+                                $placeholder.$tokenContent,
+                                '',
+                                mb_strstr($line, $placeholder.$tokenContent)
+                            );
+
+                            $pattern = '/\s*?('
+                                .implode('|', $escapedAlignOperators)
+                                .')/';
+
+                            if (Preg::match($pattern, $strForAdjust, $matches)) {
+                                $adjustedStr = Preg::replace(
+                                    '/\s*'.preg_quote($matches[1], '/').'/',
+                                    ' '.trim($matches[0]),
+                                    $strForAdjust
+                                );
+                                $line = Preg::replace(
+                                    '/(?<='
                                     .preg_quote($placeholder, '/')
                                     .preg_quote($tokenContent, '/')
-                                    .')\s+('
-                                    .$escapedAlignOperator
-                                    .')/';
-
-                                if (Preg::match($pattern, $line, $matches)) {
-                                    $line = Preg::replace($pattern, ' '.trim($matches[0]), $line);
-                                }
+                                    .').*/',
+                                    $adjustedStr,
+                                    $line
+                                );
                             }
                         }
 

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -924,6 +924,25 @@ $array = [
                     $delta = abs($rightmostSymbol - $currentSymbol);
 
                     if ($delta > 0) {
+                        if (
+                            self::ALIGN !== $alignStrategy
+                            && self::ALIGN_BY_SCOPE !== $alignStrategy
+                        ) {
+                            foreach (array_keys($this->alignOperatorTokens) as $alignOperatorToken) {
+                                $escapedAlignOperator = preg_quote($alignOperatorToken, '/');
+                                $pattern = '/(?<!'
+                                    .preg_quote($placeholder, '/')
+                                    .preg_quote($tokenContent, '/')
+                                    .')\s+('
+                                    .$escapedAlignOperator
+                                    .')/';
+
+                                if (preg_match($pattern, $line, $matches)) {
+                                    $line = preg_replace($pattern, ' '.trim($matches[0]), $line);
+                                }
+                            }
+                        }
+
                         $line = str_replace($placeholder, str_repeat(' ', $delta).$placeholder, $line);
                         $lines[$index] = $line;
                     }

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -937,8 +937,6 @@ $array = [
                                     .$escapedAlignOperator
                                     .')/';
 
-                                var_dump($pattern);
-
                                 if (Preg::match($pattern, $line, $matches)) {
                                     $line = Preg::replace($pattern, ' '.trim($matches[0]), $line);
                                 }

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -556,6 +556,20 @@ $a = $ae?? $b;
             null,
             ['operators' => ['|' => BinaryOperatorSpacesFixer::NO_SPACE]],
         ];
+
+        yield 'multiple shifts in single line' => [
+            '<?php
+
+             $testA = $testB["abc"]    / $testC * 100;
+             $testD = $testE["abcdef"] / $testF * 100;
+            ',
+            '<?php
+
+             $testA = $testB["abc"]/$testC * 100;
+             $testD = $testE["abcdef"]/$testF * 100;
+            ',
+            ['default' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL],
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes #5605 

Hopefully it helps.