### PR TITLE
DX: Improve QA process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,9 @@ jobs:
         include:
           - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
-            job-description: 'tests'
+            job-description: 'tests with Symfony ^5'
             run-tests: 'yes'
+            execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
 
           - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
@@ -51,13 +52,13 @@ jobs:
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.1'
-            job-description: 'Fixer'
+            job-description: 'Fixer with Symfony ^6'
             fixer-mode: 'standard'
             execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.1'
-            job-description: 'tests'
+            job-description: 'tests with Symfony ^6'
             run-tests: 'yes'
             execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,26 +19,29 @@ jobs:
         include:
           - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
-            job-description: 'tests with Symfony ^5'
-            run-tests: 'yes'
+            job-description: 'Fixer with lowest deps'
+            run-fixer: 'yes'
+            run-phpdoc-to-native-type: 'yes' # should be checked on the lowest supported PHP version
+            composer-flags: '--prefer-lowest' # should be checked on the lowest supported PHP version
             execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
 
           - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
-            job-description: 'Fixer with lowest deps'
+            job-description: 'tests with lowest deps'
             run-fixer: 'yes'
             composer-flags: '--prefer-lowest' # should be checked on the lowest supported PHP version
+            execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
 
           - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
-            job-description: 'Fixer with PHPDoc to type rules'
+            job-description: 'Fixer'
+            run-fixer: 'yes'
             run-phpdoc-to-native-type: 'yes' # should be checked on the lowest supported PHP version
 
           - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
-            job-description: 'Fixer with Symfony ^5'
-            run-fixer: 'yes'
-            execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
+            job-description: 'tests'
+            run-tests: 'yes'
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,61 +19,116 @@ jobs:
         include:
           - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
-            job-description: 'with lowest deps'
+            job-description: 'tests'
+            run-tests: 'yes'
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '7.4'
+            job-description: 'Fixer with lowest deps'
+            fixer-mode: 'standard'
             composer-flags: '--prefer-lowest' # should be checked on the lowest supported PHP version
 
           - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
-            job-description: 'with PHPDoc to type rules'
-            phpdoc-to-type-rules: 'yes' # should be checked on the lowest supported PHP version
+            job-description: 'Fixer with PHPDoc to type rules'
+            fixer-mode: 'phpdoc-to-type-rules' # should be checked on the lowest supported PHP version
 
           - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
-            job-description: 'with Symfony ^5'
+            job-description: 'Fixer with Symfony ^5'
+            fixer-mode: 'standard'
             execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.0'
+            job-description: 'Fixer'
+            fixer-mode: 'standard'
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.0'
+            job-description: 'tests'
+            run-tests: 'yes'
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.1'
-            job-description: 'with Symfony ^6'
+            job-description: 'Fixer'
+            fixer-mode: 'standard'
+            execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.1'
+            job-description: 'tests'
+            run-tests: 'yes'
             execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.2'
+            job-description: 'Fixer'
+            fixer-mode: 'standard'
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.2'
             job-description: 'with migration rules'
-            migration-rules: 'yes' # should be checked on the highest supported PHP version
+            fixer-mode: 'migration-rules' # should be checked on the highest supported PHP version
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.2'
             job-description: 'auto-review'
+            run-tests: 'yes'
             phpunit-flags: '--group auto-review'
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.2'
-            job-description: 'with calculating code coverage'
-            calculate-code-coverage: 'yes'
+            job-description: 'tests'
+            run-tests: 'yes'
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.2'
-            job-description: 'with deployment'
-            execute-deployment: 'yes'
+            job-description: 'code coverage'
+            code-coverage: 'yes'
 
           - operating-system: 'ubuntu-20.04'
-            php-version: '8.3'
-            PHP_CS_FIXER_IGNORE_ENV: 1
-            composer-flags: '--ignore-platform-req=PHP'
+            php-version: '8.2'
+            job-description: 'deployment check'
+            execute-deployment: 'yes'
 
           - operating-system: 'windows-latest'
             php-version: '8.2'
-            job-description: 'on Windows'
+            job-description: 'Fixer on Windows'
+            fixer-mode: 'standard'
+            FAST_LINT_TEST_CASES: 1
+
+          - operating-system: 'windows-latest'
+            php-version: '8.2'
+            job-description: 'tests on Windows'
+            run-tests: 'yes'
             FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional systems
 
           - operating-system: 'macos-latest'
             php-version: '8.2'
-            job-description: 'on macOS'
+            job-description: 'Fixer on macOS'
+            fixer-mode: 'standard'
             FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional systems
+
+          - operating-system: 'macos-latest'
+            php-version: '8.2'
+            job-description: 'tests on macOS'
+            run-tests: 'yes'
+            FAST_LINT_TEST_CASES: 1
+
+          - operating-system: 'ubuntu-22.04'
+            php-version: '8.3'
+            job-description: 'Fixer'
+            fixer-mode: 'standard'
+            composer-flags: '--ignore-platform-req=PHP'
+            PHP_CS_FIXER_IGNORE_ENV: 1
+
+          - operating-system: 'ubuntu-22.04'
+            php-version: '8.3'
+            job-description: 'tests'
+            run-tests: 'yes'
+            composer-flags: '--ignore-platform-req=PHP'
+            PHP_CS_FIXER_IGNORE_ENV: 1
 
     name: PHP ${{ matrix.php-version }} ${{ matrix.job-description }}
 
@@ -87,7 +142,7 @@ jobs:
         uses: actions/github-script@v6
         id: code-coverage-driver
         with:
-          script: 'return "${{ matrix.calculate-code-coverage }}" == "yes" ? "pcov" : "none"'
+          script: 'return "${{ matrix.code-coverage }}" == "yes" ? "pcov" : "none"'
           result-encoding: string
 
       - name: Setup PHP
@@ -131,37 +186,38 @@ jobs:
       # execute migration rules before running tests and self-fixing,
       # so that we know that our codebase is future-ready
       - name: Run PHP CS Fixer with migration rules
-        if: matrix.migration-rules == 'yes'
+        if: matrix.fixer-mode == 'migration-rules'
         run: php php-cs-fixer fix --config .php-cs-fixer.php-highest.php -q
 
       - name: Disable time limit for tests when collecting coverage
-        if: matrix.calculate-code-coverage == 'yes'
+        if: matrix.code-coverage == 'yes'
         run: sed 's/enforceTimeLimit="true"/enforceTimeLimit="false"/g' phpunit.xml.dist > phpunit.xml
 
       - name: Run tests
-        if: matrix.calculate-code-coverage != 'yes'
+        if: matrix.run-tests == 'yes'
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
         run: vendor/bin/paraunit run ${{ matrix.phpunit-flags || '--exclude-group auto-review' }}
 
       - name: Collect code coverage
-        if: matrix.calculate-code-coverage == 'yes'
+        if: matrix.code-coverage == 'yes'
         env:
           FAST_LINT_TEST_CASES: 1
         run: vendor/bin/paraunit coverage --testsuite coverage --exclude-group covers-nothing --clover build/logs/clover.xml
 
       - name: Upload coverage results to Coveralls
-        if: matrix.calculate-code-coverage == 'yes'
+        if: matrix.code-coverage == 'yes'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: php vendor/bin/php-coveralls --verbose
 
       - name: Run PHP CS Fixer with PHPDoc to type rules
-        if: matrix.phpdoc-to-type-rules == 'yes'
+        if: matrix.fixer-mode == 'phpdoc-to-type-rules'
         run: php php-cs-fixer check --diff -v --config .php-cs-fixer.php-lowest.php
 
       - name: Run PHP CS Fixer
+        if: matrix.fixer-mode == 'standard'
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           PHP_CS_FIXER_FUTURE_MODE: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
             job-description: 'tests with lowest deps'
-            run-fixer: 'yes'
+            run-tests: 'yes'
             composer-flags: '--prefer-lowest' # should be checked on the lowest supported PHP version
             execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
             php-version: '8.2'
             job-description: 'Fixer on Windows'
             run-fixer: 'yes'
-            FAST_LINT_TEST_CASES: 1
+            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional
 
           - operating-system: 'windows-latest'
             php-version: '8.2'
@@ -125,7 +125,7 @@ jobs:
             php-version: '8.2'
             job-description: 'tests on macOS'
             run-tests: 'yes'
-            FAST_LINT_TEST_CASES: 1
+            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional
 
           - operating-system: 'ubuntu-22.04'
             php-version: '8.3'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,14 @@ jobs:
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.2'
-            job-description: 'with migration rules'
+            job-description: 'Fixer with migration rules'
             run-fixer: 'yes'
+            run-migration-rules: 'yes' # should be checked on the highest supported PHP version
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.2'
+            job-description: 'tests with migration rules'
+            run-tests: 'yes'
             run-migration-rules: 'yes' # should be checked on the highest supported PHP version
 
           - operating-system: 'ubuntu-20.04'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,24 +26,24 @@ jobs:
           - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
             job-description: 'Fixer with lowest deps'
-            fixer-mode: 'standard'
+            run-fixer: 'yes'
             composer-flags: '--prefer-lowest' # should be checked on the lowest supported PHP version
 
           - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
             job-description: 'Fixer with PHPDoc to type rules'
-            fixer-mode: 'phpdoc-to-type-rules' # should be checked on the lowest supported PHP version
+            run-phpdoc-to-native-type: 'yes' # should be checked on the lowest supported PHP version
 
           - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
             job-description: 'Fixer with Symfony ^5'
-            fixer-mode: 'standard'
+            run-fixer: 'yes'
             execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.0'
             job-description: 'Fixer'
-            fixer-mode: 'standard'
+            run-fixer: 'yes'
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.0'
@@ -53,7 +53,7 @@ jobs:
           - operating-system: 'ubuntu-20.04'
             php-version: '8.1'
             job-description: 'Fixer with Symfony ^6'
-            fixer-mode: 'standard'
+            run-fixer: 'yes'
             execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
 
           - operating-system: 'ubuntu-20.04'
@@ -65,12 +65,13 @@ jobs:
           - operating-system: 'ubuntu-20.04'
             php-version: '8.2'
             job-description: 'Fixer'
-            fixer-mode: 'standard'
+            run-fixer: 'yes'
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.2'
             job-description: 'with migration rules'
-            fixer-mode: 'migration-rules' # should be checked on the highest supported PHP version
+            run-fixer: 'yes'
+            run-migration-rules: 'yes' # should be checked on the highest supported PHP version
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.2'
@@ -96,7 +97,7 @@ jobs:
           - operating-system: 'windows-latest'
             php-version: '8.2'
             job-description: 'Fixer on Windows'
-            fixer-mode: 'standard'
+            run-fixer: 'yes'
             FAST_LINT_TEST_CASES: 1
 
           - operating-system: 'windows-latest'
@@ -108,7 +109,7 @@ jobs:
           - operating-system: 'macos-latest'
             php-version: '8.2'
             job-description: 'Fixer on macOS'
-            fixer-mode: 'standard'
+            run-fixer: 'yes'
             FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional systems
 
           - operating-system: 'macos-latest'
@@ -120,7 +121,7 @@ jobs:
           - operating-system: 'ubuntu-22.04'
             php-version: '8.3'
             job-description: 'Fixer'
-            fixer-mode: 'standard'
+            run-fixer: 'yes'
             composer-flags: '--ignore-platform-req=PHP'
             PHP_CS_FIXER_IGNORE_ENV: 1
 
@@ -187,7 +188,7 @@ jobs:
       # execute migration rules before running tests and self-fixing,
       # so that we know that our codebase is future-ready
       - name: Run PHP CS Fixer with migration rules
-        if: matrix.fixer-mode == 'migration-rules'
+        if: matrix.run-migration-rules == 'yes'
         run: php php-cs-fixer fix --config .php-cs-fixer.php-highest.php -q
 
       - name: Disable time limit for tests when collecting coverage
@@ -214,11 +215,11 @@ jobs:
         run: php vendor/bin/php-coveralls --verbose
 
       - name: Run PHP CS Fixer with PHPDoc to type rules
-        if: matrix.fixer-mode == 'phpdoc-to-type-rules'
+        if: matrix.run-phpdoc-to-native-type == 'yes'
         run: php php-cs-fixer check --diff -v --config .php-cs-fixer.php-lowest.php
 
       - name: Run PHP CS Fixer
-        if: matrix.fixer-mode == 'standard'
+        if: matrix.run-fixer == 'yes'
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           PHP_CS_FIXER_FUTURE_MODE: 1


### PR DESCRIPTION
Run tests and Fixer with higher granularity (do not repeat same steps on same runtime). The value of this approach:
- explicit information about it in CI widget within PR: no need to click through jobs to see which step failed
- faster feedback about CS violations: no need to wait for tests (~6 minutes) to see code styling issues (~1 minute)

Previously PR contained also:
- ~~Run dev-tools on PHP 8.2~~ Extracted to #7389
- Calculate code coverage using fast linter (tests are also run with process linter on 8.2, fast linter allows to focus on coverage, not on tests' result)~~ Extracted to #7390
- ~~Fix CI warnings caused by installing dev-tools on `post-autoload-dump` hook. It did not affect main process, but also it wasn't needed at all, because dev-tools are only used locally and in SCA workflow, where are installed explicitly~~ Extracted to #7403

BEFORE (~10m):

<img width="1164" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/7d3e0ab3-e770-4001-a139-951206c4178e">

AFTER (~8m):

<img width="1049" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/f8a44aff-7f5e-4716-8296-a6d583dc0e48">

Gain: CI time reduced ~20% + more explicit summary.