### PR TITLE
feat: Require list of fixers to be a list separated by new lines

### DIFF
--- a/src/Fixer/Alias/BacktickToShellExecFixer.php
+++ b/src/Fixer/Alias/BacktickToShellExecFixer.php
@@ -53,7 +53,12 @@ final class BacktickToShellExecFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before EscapeImplicitBackslashesFixer, ExplicitStringVariableFixer, NativeFunctionInvocationFixer, SingleQuoteFixer.
+     * Must run before:
+     *
+     * - EscapeImplicitBackslashesFixer
+     * - ExplicitStringVariableFixer
+     * - NativeFunctionInvocationFixer
+     * - SingleQuoteFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Alias/EregToPregFixer.php
+++ b/src/Fixer/Alias/EregToPregFixer.php
@@ -60,7 +60,9 @@ final class EregToPregFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after NoUselessConcatOperatorFixer.
+     * Must run after:
+     *
+     * - NoUselessConcatOperatorFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Alias/ModernizeStrposFixer.php
+++ b/src/Fixer/Alias/ModernizeStrposFixer.php
@@ -77,8 +77,22 @@ if (strpos($haystack, $needle) === false) {}
     /**
      * {@inheritdoc}
      *
-     * Must run before BinaryOperatorSpacesFixer, NoExtraBlankLinesFixer, NoSpacesInsideParenthesisFixer, NoTrailingWhitespaceFixer, NotOperatorWithSpaceFixer, NotOperatorWithSuccessorSpaceFixer, PhpUnitDedicateAssertFixer, SingleSpaceAfterConstructFixer, SingleSpaceAroundConstructFixer, SpacesInsideParenthesesFixer.
-     * Must run after StrictComparisonFixer.
+     * Must run before:
+     *
+     * - BinaryOperatorSpacesFixer
+     * - NoExtraBlankLinesFixer
+     * - NoSpacesInsideParenthesisFixer
+     * - NoTrailingWhitespaceFixer
+     * - NotOperatorWithSpaceFixer
+     * - NotOperatorWithSuccessorSpaceFixer
+     * - PhpUnitDedicateAssertFixer
+     * - SingleSpaceAfterConstructFixer
+     * - SingleSpaceAroundConstructFixer
+     * - SpacesInsideParenthesesFixer
+     *
+     * Must run after:
+     *
+     * - StrictComparisonFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Alias/NoAliasFunctionsFixer.php
+++ b/src/Fixer/Alias/NoAliasFunctionsFixer.php
@@ -223,7 +223,10 @@ mbereg_search_getregs();
     /**
      * {@inheritdoc}
      *
-     * Must run before ImplodeCallFixer, PhpUnitDedicateAssertFixer.
+     * Must run before:
+     *
+     * - ImplodeCallFixer
+     * - PhpUnitDedicateAssertFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Alias/NoMixedEchoPrintFixer.php
+++ b/src/Fixer/Alias/NoMixedEchoPrintFixer.php
@@ -68,7 +68,9 @@ final class NoMixedEchoPrintFixer extends AbstractFixer implements ConfigurableF
     /**
      * {@inheritdoc}
      *
-     * Must run after EchoTagSyntaxFixer.
+     * Must run after:
+     *
+     * - EchoTagSyntaxFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Alias/PowToExponentiationFixer.php
+++ b/src/Fixer/Alias/PowToExponentiationFixer.php
@@ -48,7 +48,14 @@ final class PowToExponentiationFixer extends AbstractFunctionReferenceFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before BinaryOperatorSpacesFixer, MethodArgumentSpaceFixer, NativeFunctionCasingFixer, NoSpacesAfterFunctionNameFixer, NoSpacesInsideParenthesisFixer, SpacesInsideParenthesesFixer.
+     * Must run before:
+     *
+     * - BinaryOperatorSpacesFixer
+     * - MethodArgumentSpaceFixer
+     * - NativeFunctionCasingFixer
+     * - NoSpacesAfterFunctionNameFixer
+     * - NoSpacesInsideParenthesisFixer
+     * - SpacesInsideParenthesesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Alias/SetTypeToCastFixer.php
+++ b/src/Fixer/Alias/SetTypeToCastFixer.php
@@ -45,7 +45,10 @@ settype($bar, "null");
     /**
      * {@inheritdoc}
      *
-     * Must run after NoBinaryStringFixer, NoUselessConcatOperatorFixer.
+     * Must run after:
+     *
+     * - NoBinaryStringFixer
+     * - NoUselessConcatOperatorFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ArrayNotation/ArraySyntaxFixer.php
+++ b/src/Fixer/ArrayNotation/ArraySyntaxFixer.php
@@ -70,7 +70,12 @@ final class ArraySyntaxFixer extends AbstractFixer implements ConfigurableFixerI
     /**
      * {@inheritdoc}
      *
-     * Must run before BinaryOperatorSpacesFixer, SingleSpaceAfterConstructFixer, SingleSpaceAroundConstructFixer, TernaryOperatorSpacesFixer.
+     * Must run before:
+     *
+     * - BinaryOperatorSpacesFixer
+     * - SingleSpaceAfterConstructFixer
+     * - SingleSpaceAroundConstructFixer
+     * - TernaryOperatorSpacesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ArrayNotation/NoMultilineWhitespaceAroundDoubleArrowFixer.php
+++ b/src/Fixer/ArrayNotation/NoMultilineWhitespaceAroundDoubleArrowFixer.php
@@ -39,7 +39,10 @@ final class NoMultilineWhitespaceAroundDoubleArrowFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before BinaryOperatorSpacesFixer, MethodArgumentSpaceFixer.
+     * Must run before:
+     *
+     * - BinaryOperatorSpacesFixer
+     * - MethodArgumentSpaceFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ArrayNotation/ReturnToYieldFromFixer.php
+++ b/src/Fixer/ArrayNotation/ReturnToYieldFromFixer.php
@@ -46,8 +46,14 @@ final class ReturnToYieldFromFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before YieldFromArrayToYieldsFixer.
-     * Must run after PhpUnitDataProviderReturnTypeFixer, PhpdocToReturnTypeFixer.
+     * Must run before:
+     *
+     * - YieldFromArrayToYieldsFixer
+     *
+     * Must run after:
+     *
+     * - PhpUnitDataProviderReturnTypeFixer
+     * - PhpdocToReturnTypeFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ArrayNotation/YieldFromArrayToYieldsFixer.php
+++ b/src/Fixer/ArrayNotation/YieldFromArrayToYieldsFixer.php
@@ -59,8 +59,17 @@ final class YieldFromArrayToYieldsFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before BlankLineBeforeStatementFixer, NoExtraBlankLinesFixer, NoMultipleStatementsPerLineFixer, NoWhitespaceInBlankLineFixer, StatementIndentationFixer.
-     * Must run after ReturnToYieldFromFixer.
+     * Must run before:
+     *
+     * - BlankLineBeforeStatementFixer
+     * - NoExtraBlankLinesFixer
+     * - NoMultipleStatementsPerLineFixer
+     * - NoWhitespaceInBlankLineFixer
+     * - StatementIndentationFixer
+     *
+     * Must run after:
+     *
+     * - ReturnToYieldFromFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -139,8 +139,22 @@ class Foo
     /**
      * {@inheritdoc}
      *
-     * Must run before HeredocIndentationFixer.
-     * Must run after ClassAttributesSeparationFixer, ClassDefinitionFixer, EmptyLoopBodyFixer, NoAlternativeSyntaxFixer, NoEmptyStatementFixer, NoUselessElseFixer, SingleLineThrowFixer, SingleSpaceAfterConstructFixer, SingleSpaceAroundConstructFixer, SingleTraitInsertPerStatementFixer.
+     * Must run before:
+     *
+     * - HeredocIndentationFixer
+     *
+     * Must run after:
+     *
+     * - ClassAttributesSeparationFixer
+     * - ClassDefinitionFixer
+     * - EmptyLoopBodyFixer
+     * - NoAlternativeSyntaxFixer
+     * - NoEmptyStatementFixer
+     * - NoUselessElseFixer
+     * - SingleLineThrowFixer
+     * - SingleSpaceAfterConstructFixer
+     * - SingleSpaceAroundConstructFixer
+     * - SingleTraitInsertPerStatementFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Basic/BracesPositionFixer.php
+++ b/src/Fixer/Basic/BracesPositionFixer.php
@@ -136,8 +136,15 @@ $bar = function () { $result = true;
     /**
      * {@inheritdoc}
      *
-     * Must run before SingleLineEmptyBodyFixer, StatementIndentationFixer.
-     * Must run after ControlStructureBracesFixer, NoMultipleStatementsPerLineFixer.
+     * Must run before:
+     *
+     * - SingleLineEmptyBodyFixer
+     * - StatementIndentationFixer
+     *
+     * Must run after:
+     *
+     * - ControlStructureBracesFixer
+     * - NoMultipleStatementsPerLineFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Basic/CurlyBracesPositionFixer.php
+++ b/src/Fixer/Basic/CurlyBracesPositionFixer.php
@@ -71,8 +71,15 @@ final class CurlyBracesPositionFixer extends AbstractProxyFixer implements Confi
     /**
      * {@inheritdoc}
      *
-     * Must run before SingleLineEmptyBodyFixer, StatementIndentationFixer.
-     * Must run after ControlStructureBracesFixer, NoMultipleStatementsPerLineFixer.
+     * Must run before:
+     *
+     * - SingleLineEmptyBodyFixer
+     * - StatementIndentationFixer
+     *
+     * Must run after:
+     *
+     * - ControlStructureBracesFixer
+     * - NoMultipleStatementsPerLineFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Basic/NoMultipleStatementsPerLineFixer.php
+++ b/src/Fixer/Basic/NoMultipleStatementsPerLineFixer.php
@@ -41,8 +41,16 @@ final class NoMultipleStatementsPerLineFixer extends AbstractFixer implements Wh
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesPositionFixer, CurlyBracesPositionFixer.
-     * Must run after ControlStructureBracesFixer, NoEmptyStatementFixer, YieldFromArrayToYieldsFixer.
+     * Must run before:
+     *
+     * - BracesPositionFixer
+     * - CurlyBracesPositionFixer
+     *
+     * Must run after:
+     *
+     * - ControlStructureBracesFixer
+     * - NoEmptyStatementFixer
+     * - YieldFromArrayToYieldsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Basic/PsrAutoloadingFixer.php
+++ b/src/Fixer/Basic/PsrAutoloadingFixer.php
@@ -92,7 +92,9 @@ class InvalidName {}
     /**
      * {@inheritdoc}
      *
-     * Must run before SelfAccessorFixer.
+     * Must run before:
+     *
+     * - SelfAccessorFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Basic/SingleLineEmptyBodyFixer.php
+++ b/src/Fixer/Basic/SingleLineEmptyBodyFixer.php
@@ -39,7 +39,12 @@ final class SingleLineEmptyBodyFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after BracesPositionFixer, ClassDefinitionFixer, CurlyBracesPositionFixer, NoUselessReturnFixer.
+     * Must run after:
+     *
+     * - BracesPositionFixer
+     * - ClassDefinitionFixer
+     * - CurlyBracesPositionFixer
+     * - NoUselessReturnFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Casing/NativeFunctionCasingFixer.php
+++ b/src/Fixer/Casing/NativeFunctionCasingFixer.php
@@ -35,7 +35,11 @@ final class NativeFunctionCasingFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after FunctionToConstantFixer, NoUselessSprintfFixer, PowToExponentiationFixer.
+     * Must run after:
+     *
+     * - FunctionToConstantFixer
+     * - NoUselessSprintfFixer
+     * - PowToExponentiationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/CastNotation/CastSpacesFixer.php
+++ b/src/Fixer/CastNotation/CastSpacesFixer.php
@@ -62,7 +62,9 @@ final class CastSpacesFixer extends AbstractFixer implements ConfigurableFixerIn
     /**
      * {@inheritdoc}
      *
-     * Must run after NoShortBoolCastFixer.
+     * Must run after:
+     *
+     * - NoShortBoolCastFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
+++ b/src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
@@ -50,7 +50,9 @@ final class ModernizeTypesCastingFixer extends AbstractFunctionReferenceFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before NoUnneededControlParenthesesFixer.
+     * Must run before:
+     *
+     * - NoUnneededControlParenthesesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/CastNotation/NoShortBoolCastFixer.php
+++ b/src/Fixer/CastNotation/NoShortBoolCastFixer.php
@@ -26,7 +26,9 @@ final class NoShortBoolCastFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before CastSpacesFixer.
+     * Must run before:
+     *
+     * - CastSpacesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/CastNotation/NoUnsetCastFixer.php
+++ b/src/Fixer/CastNotation/NoUnsetCastFixer.php
@@ -39,7 +39,9 @@ final class NoUnsetCastFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before BinaryOperatorSpacesFixer.
+     * Must run before:
+     *
+     * - BinaryOperatorSpacesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -151,8 +151,18 @@ class Sample
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesFixer, IndentationTypeFixer, NoExtraBlankLinesFixer, StatementIndentationFixer.
-     * Must run after OrderedClassElementsFixer, SingleClassElementPerStatementFixer, VisibilityRequiredFixer.
+     * Must run before:
+     *
+     * - BracesFixer
+     * - IndentationTypeFixer
+     * - NoExtraBlankLinesFixer
+     * - StatementIndentationFixer
+     *
+     * Must run after:
+     *
+     * - OrderedClassElementsFixer
+     * - SingleClassElementPerStatementFixer
+     * - VisibilityRequiredFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/ClassDefinitionFixer.php
+++ b/src/Fixer/ClassNotation/ClassDefinitionFixer.php
@@ -101,8 +101,15 @@ $foo = new class(){};
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesFixer, SingleLineEmptyBodyFixer.
-     * Must run after NewWithBracesFixer, NewWithParenthesesFixer.
+     * Must run before:
+     *
+     * - BracesFixer
+     * - SingleLineEmptyBodyFixer
+     *
+     * Must run after:
+     *
+     * - NewWithBracesFixer
+     * - NewWithParenthesesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/FinalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalClassFixer.php
@@ -47,7 +47,10 @@ class MyApp {}
     /**
      * {@inheritdoc}
      *
-     * Must run before ProtectedToPrivateFixer, SelfStaticAccessorFixer.
+     * Must run before:
+     *
+     * - ProtectedToPrivateFixer
+     * - SelfStaticAccessorFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/FinalInternalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalInternalClassFixer.php
@@ -90,8 +90,14 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurabl
     /**
      * {@inheritdoc}
      *
-     * Must run before ProtectedToPrivateFixer, SelfStaticAccessorFixer.
-     * Must run after PhpUnitInternalClassFixer.
+     * Must run before:
+     *
+     * - ProtectedToPrivateFixer
+     * - SelfStaticAccessorFixer
+     *
+     * Must run after:
+     *
+     * - PhpUnitInternalClassFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixer.php
+++ b/src/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixer.php
@@ -55,7 +55,9 @@ final class Sample
     /**
      * {@inheritdoc}
      *
-     * Must run after OrderedClassElementsFixer.
+     * Must run after:
+     *
+     * - OrderedClassElementsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+++ b/src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
@@ -49,7 +49,9 @@ class Foo
     /**
      * {@inheritdoc}
      *
-     * Must run before OrderedClassElementsFixer.
+     * Must run before:
+     *
+     * - OrderedClassElementsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -235,8 +235,16 @@ Custom values:
     /**
      * {@inheritdoc}
      *
-     * Must run before ClassAttributesSeparationFixer, NoBlankLinesAfterClassOpeningFixer, SpaceAfterSemicolonFixer.
-     * Must run after NoPhp4ConstructorFixer, ProtectedToPrivateFixer.
+     * Must run before:
+     *
+     * - ClassAttributesSeparationFixer
+     * - NoBlankLinesAfterClassOpeningFixer
+     * - SpaceAfterSemicolonFixer
+     *
+     * Must run after:
+     *
+     * - NoPhp4ConstructorFixer
+     * - ProtectedToPrivateFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/OrderedTypesFixer.php
+++ b/src/Fixer/ClassNotation/OrderedTypesFixer.php
@@ -97,8 +97,14 @@ interface Bar
     /**
      * {@inheritdoc}
      *
-     * Must run before TypesSpacesFixer.
-     * Must run after NullableTypeDeclarationFixer, NullableTypeDeclarationForDefaultNullValueFixer.
+     * Must run before:
+     *
+     * - TypesSpacesFixer
+     *
+     * Must run after:
+     *
+     * - NullableTypeDeclarationFixer
+     * - NullableTypeDeclarationForDefaultNullValueFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/PhpdocReadonlyClassCommentToKeywordFixer.php
+++ b/src/Fixer/ClassNotation/PhpdocReadonlyClassCommentToKeywordFixer.php
@@ -31,8 +31,20 @@ final class PhpdocReadonlyClassCommentToKeywordFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before NoEmptyPhpdocFixer, NoExtraBlankLinesFixer, PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - NoEmptyPhpdocFixer
+     * - NoExtraBlankLinesFixer
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
+++ b/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
@@ -54,8 +54,14 @@ final class Sample
     /**
      * {@inheritdoc}
      *
-     * Must run before OrderedClassElementsFixer.
-     * Must run after FinalClassFixer, FinalInternalClassFixer.
+     * Must run before:
+     *
+     * - OrderedClassElementsFixer
+     *
+     * Must run after:
+     *
+     * - FinalClassFixer
+     * - FinalInternalClassFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/SelfAccessorFixer.php
+++ b/src/Fixer/ClassNotation/SelfAccessorFixer.php
@@ -62,7 +62,9 @@ class Sample
     /**
      * {@inheritdoc}
      *
-     * Must run after PsrAutoloadingFixer.
+     * Must run after:
+     *
+     * - PsrAutoloadingFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/SelfStaticAccessorFixer.php
+++ b/src/Fixer/ClassNotation/SelfStaticAccessorFixer.php
@@ -117,7 +117,12 @@ enum Foo
     /**
      * {@inheritdoc}
      *
-     * Must run after FinalClassFixer, FinalInternalClassFixer, FunctionToConstantFixer, PhpUnitTestCaseStaticMethodCallsFixer.
+     * Must run after:
+     *
+     * - FinalClassFixer
+     * - FinalInternalClassFixer
+     * - FunctionToConstantFixer
+     * - PhpUnitTestCaseStaticMethodCallsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+++ b/src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
@@ -46,7 +46,9 @@ final class SingleClassElementPerStatementFixer extends AbstractFixer implements
     /**
      * {@inheritdoc}
      *
-     * Must run before ClassAttributesSeparationFixer.
+     * Must run before:
+     *
+     * - ClassAttributesSeparationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
+++ b/src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
@@ -45,7 +45,10 @@ final class Example
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesFixer, SpaceAfterSemicolonFixer.
+     * Must run before:
+     *
+     * - BracesFixer
+     * - SpaceAfterSemicolonFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+++ b/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
@@ -69,7 +69,9 @@ class Sample
     /**
      * {@inheritdoc}
      *
-     * Must run before ClassAttributesSeparationFixer.
+     * Must run before:
+     *
+     * - ClassAttributesSeparationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Comment/CommentToPhpdocFixer.php
+++ b/src/Fixer/Comment/CommentToPhpdocFixer.php
@@ -52,8 +52,46 @@ final class CommentToPhpdocFixer extends AbstractFixer implements ConfigurableFi
     /**
      * {@inheritdoc}
      *
-     * Must run before GeneralPhpdocAnnotationRemoveFixer, GeneralPhpdocTagRenameFixer, NoBlankLinesAfterPhpdocFixer, NoEmptyPhpdocFixer, NoSuperfluousPhpdocTagsFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocAlignFixer, PhpdocAnnotationWithoutDotFixer, PhpdocInlineTagNormalizerFixer, PhpdocLineSpanFixer, PhpdocNoAccessFixer, PhpdocNoAliasTagFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocNoUselessInheritdocFixer, PhpdocOrderByValueFixer, PhpdocOrderFixer, PhpdocParamOrderFixer, PhpdocReadonlyClassCommentToKeywordFixer, PhpdocReturnSelfReferenceFixer, PhpdocSeparationFixer, PhpdocSingleLineVarSpacingFixer, PhpdocSummaryFixer, PhpdocTagCasingFixer, PhpdocTagTypeFixer, PhpdocToCommentFixer, PhpdocToParamTypeFixer, PhpdocToPropertyTypeFixer, PhpdocToReturnTypeFixer, PhpdocTrimConsecutiveBlankLineSeparationFixer, PhpdocTrimFixer, PhpdocTypesOrderFixer, PhpdocVarAnnotationCorrectOrderFixer, PhpdocVarWithoutNameFixer.
-     * Must run after AlignMultilineCommentFixer.
+     * Must run before:
+     *
+     * - GeneralPhpdocAnnotationRemoveFixer
+     * - GeneralPhpdocTagRenameFixer
+     * - NoBlankLinesAfterPhpdocFixer
+     * - NoEmptyPhpdocFixer
+     * - NoSuperfluousPhpdocTagsFixer
+     * - PhpdocAddMissingParamAnnotationFixer
+     * - PhpdocAlignFixer
+     * - PhpdocAnnotationWithoutDotFixer
+     * - PhpdocInlineTagNormalizerFixer
+     * - PhpdocLineSpanFixer
+     * - PhpdocNoAccessFixer
+     * - PhpdocNoAliasTagFixer
+     * - PhpdocNoEmptyReturnFixer
+     * - PhpdocNoPackageFixer
+     * - PhpdocNoUselessInheritdocFixer
+     * - PhpdocOrderByValueFixer
+     * - PhpdocOrderFixer
+     * - PhpdocParamOrderFixer
+     * - PhpdocReadonlyClassCommentToKeywordFixer
+     * - PhpdocReturnSelfReferenceFixer
+     * - PhpdocSeparationFixer
+     * - PhpdocSingleLineVarSpacingFixer
+     * - PhpdocSummaryFixer
+     * - PhpdocTagCasingFixer
+     * - PhpdocTagTypeFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocToParamTypeFixer
+     * - PhpdocToPropertyTypeFixer
+     * - PhpdocToReturnTypeFixer
+     * - PhpdocTrimConsecutiveBlankLineSeparationFixer
+     * - PhpdocTrimFixer
+     * - PhpdocTypesOrderFixer
+     * - PhpdocVarAnnotationCorrectOrderFixer
+     * - PhpdocVarWithoutNameFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -118,8 +118,16 @@ echo 1;
     /**
      * {@inheritdoc}
      *
-     * Must run before BlankLinesBeforeNamespaceFixer, SingleBlankLineBeforeNamespaceFixer, SingleLineCommentStyleFixer.
-     * Must run after DeclareStrictTypesFixer, NoBlankLinesAfterPhpdocFixer.
+     * Must run before:
+     *
+     * - BlankLinesBeforeNamespaceFixer
+     * - SingleBlankLineBeforeNamespaceFixer
+     * - SingleLineCommentStyleFixer
+     *
+     * Must run after:
+     *
+     * - DeclareStrictTypesFixer
+     * - NoBlankLinesAfterPhpdocFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Comment/NoEmptyCommentFixer.php
+++ b/src/Fixer/Comment/NoEmptyCommentFixer.php
@@ -32,8 +32,15 @@ final class NoEmptyCommentFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before NoExtraBlankLinesFixer, NoTrailingWhitespaceFixer, NoWhitespaceInBlankLineFixer.
-     * Must run after PhpdocToCommentFixer.
+     * Must run before:
+     *
+     * - NoExtraBlankLinesFixer
+     * - NoTrailingWhitespaceFixer
+     * - NoWhitespaceInBlankLineFixer
+     *
+     * Must run after:
+     *
+     * - PhpdocToCommentFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php
+++ b/src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php
@@ -41,7 +41,9 @@ final class NoTrailingWhitespaceInCommentFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after PhpdocNoUselessInheritdocFixer.
+     * Must run after:
+     *
+     * - PhpdocNoUselessInheritdocFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Comment/SingleLineCommentSpacingFixer.php
+++ b/src/Fixer/Comment/SingleLineCommentSpacingFixer.php
@@ -43,7 +43,9 @@ final class SingleLineCommentSpacingFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after PhpdocToCommentFixer.
+     * Must run after:
+     *
+     * - PhpdocToCommentFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Comment/SingleLineCommentStyleFixer.php
+++ b/src/Fixer/Comment/SingleLineCommentStyleFixer.php
@@ -99,7 +99,11 @@ $c = 3;
     /**
      * {@inheritdoc}
      *
-     * Must run after HeaderCommentFixer, NoUselessReturnFixer, PhpdocToCommentFixer.
+     * Must run after:
+     *
+     * - HeaderCommentFixer
+     * - NoUselessReturnFixer
+     * - PhpdocToCommentFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
+++ b/src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
@@ -95,8 +95,13 @@ namespace {
     /**
      * {@inheritdoc}
      *
-     * Must run before GlobalNamespaceImportFixer.
-     * Must run after FunctionToConstantFixer.
+     * Must run before:
+     *
+     * - GlobalNamespaceImportFixer
+     *
+     * Must run after:
+     *
+     * - FunctionToConstantFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/ControlStructureBracesFixer.php
+++ b/src/Fixer/ControlStructure/ControlStructureBracesFixer.php
@@ -40,7 +40,12 @@ final class ControlStructureBracesFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesPositionFixer, ControlStructureContinuationPositionFixer, CurlyBracesPositionFixer, NoMultipleStatementsPerLineFixer.
+     * Must run before:
+     *
+     * - BracesPositionFixer
+     * - ControlStructureContinuationPositionFixer
+     * - CurlyBracesPositionFixer
+     * - NoMultipleStatementsPerLineFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/ControlStructureContinuationPositionFixer.php
+++ b/src/Fixer/ControlStructure/ControlStructureContinuationPositionFixer.php
@@ -83,7 +83,9 @@ if ($baz == true) {
     /**
      * {@inheritdoc}
      *
-     * Must run after ControlStructureBracesFixer.
+     * Must run after:
+     *
+     * - ControlStructureBracesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/ElseifFixer.php
+++ b/src/Fixer/ControlStructure/ElseifFixer.php
@@ -39,7 +39,9 @@ final class ElseifFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after NoAlternativeSyntaxFixer.
+     * Must run after:
+     *
+     * - NoAlternativeSyntaxFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/EmptyLoopBodyFixer.php
+++ b/src/Fixer/ControlStructure/EmptyLoopBodyFixer.php
@@ -53,8 +53,15 @@ final class EmptyLoopBodyFixer extends AbstractFixer implements ConfigurableFixe
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesFixer, NoExtraBlankLinesFixer, NoTrailingWhitespaceFixer.
-     * Must run after NoEmptyStatementFixer.
+     * Must run before:
+     *
+     * - BracesFixer
+     * - NoExtraBlankLinesFixer
+     * - NoTrailingWhitespaceFixer
+     *
+     * Must run after:
+     *
+     * - NoEmptyStatementFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/EmptyLoopConditionFixer.php
+++ b/src/Fixer/ControlStructure/EmptyLoopConditionFixer.php
@@ -47,7 +47,10 @@ final class EmptyLoopConditionFixer extends AbstractFixer implements Configurabl
     /**
      * {@inheritdoc}
      *
-     * Must run before NoExtraBlankLinesFixer, NoTrailingWhitespaceFixer.
+     * Must run before:
+     *
+     * - NoExtraBlankLinesFixer
+     * - NoTrailingWhitespaceFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+++ b/src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
@@ -54,7 +54,14 @@ final class NoAlternativeSyntaxFixer extends AbstractFixer implements Configurab
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesFixer, ElseifFixer, NoSuperfluousElseifFixer, NoUnneededControlParenthesesFixer, NoUselessElseFixer, SwitchContinueToBreakFixer.
+     * Must run before:
+     *
+     * - BracesFixer
+     * - ElseifFixer
+     * - NoSuperfluousElseifFixer
+     * - NoUnneededControlParenthesesFixer
+     * - NoUselessElseFixer
+     * - SwitchContinueToBreakFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/NoBreakCommentFixer.php
+++ b/src/Fixer/ControlStructure/NoBreakCommentFixer.php
@@ -78,7 +78,9 @@ switch ($foo) {
     /**
      * {@inheritdoc}
      *
-     * Must run after NoUselessElseFixer.
+     * Must run after:
+     *
+     * - NoUselessElseFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
+++ b/src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
@@ -42,8 +42,13 @@ final class NoSuperfluousElseifFixer extends AbstractNoUselessElseFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before SimplifiedIfReturnFixer.
-     * Must run after NoAlternativeSyntaxFixer.
+     * Must run before:
+     *
+     * - SimplifiedIfReturnFixer
+     *
+     * Must run after:
+     *
+     * - NoAlternativeSyntaxFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/NoUnneededBracesFixer.php
+++ b/src/Fixer/ControlStructure/NoUnneededBracesFixer.php
@@ -59,7 +59,12 @@ namespace Foo {
     /**
      * {@inheritdoc}
      *
-     * Must run before NoUselessElseFixer, NoUselessReturnFixer, ReturnAssignmentFixer, SimplifiedIfReturnFixer.
+     * Must run before:
+     *
+     * - NoUselessElseFixer
+     * - NoUselessReturnFixer
+     * - ReturnAssignmentFixer
+     * - SimplifiedIfReturnFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
+++ b/src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
@@ -172,8 +172,15 @@ while ($y) { continue (2); }
     /**
      * {@inheritdoc}
      *
-     * Must run before ConcatSpaceFixer, NoTrailingWhitespaceFixer.
-     * Must run after ModernizeTypesCastingFixer, NoAlternativeSyntaxFixer.
+     * Must run before:
+     *
+     * - ConcatSpaceFixer
+     * - NoTrailingWhitespaceFixer
+     *
+     * Must run after:
+     *
+     * - ModernizeTypesCastingFixer
+     * - NoAlternativeSyntaxFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+++ b/src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
@@ -59,7 +59,12 @@ final class NoUnneededCurlyBracesFixer extends AbstractProxyFixer implements Con
     /**
      * {@inheritdoc}
      *
-     * Must run before NoUselessElseFixer, NoUselessReturnFixer, ReturnAssignmentFixer, SimplifiedIfReturnFixer.
+     * Must run before:
+     *
+     * - NoUselessElseFixer
+     * - NoUselessReturnFixer
+     * - ReturnAssignmentFixer
+     * - SimplifiedIfReturnFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/NoUselessElseFixer.php
+++ b/src/Fixer/ControlStructure/NoUselessElseFixer.php
@@ -40,8 +40,25 @@ final class NoUselessElseFixer extends AbstractNoUselessElseFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before BlankLineBeforeStatementFixer, BracesFixer, CombineConsecutiveUnsetsFixer, NoBreakCommentFixer, NoExtraBlankLinesFixer, NoTrailingWhitespaceFixer, NoUselessReturnFixer, NoWhitespaceInBlankLineFixer, SimplifiedIfReturnFixer, StatementIndentationFixer.
-     * Must run after NoAlternativeSyntaxFixer, NoEmptyStatementFixer, NoUnneededBracesFixer, NoUnneededCurlyBracesFixer.
+     * Must run before:
+     *
+     * - BlankLineBeforeStatementFixer
+     * - BracesFixer
+     * - CombineConsecutiveUnsetsFixer
+     * - NoBreakCommentFixer
+     * - NoExtraBlankLinesFixer
+     * - NoTrailingWhitespaceFixer
+     * - NoUselessReturnFixer
+     * - NoWhitespaceInBlankLineFixer
+     * - SimplifiedIfReturnFixer
+     * - StatementIndentationFixer
+     *
+     * Must run after:
+     *
+     * - NoAlternativeSyntaxFixer
+     * - NoEmptyStatementFixer
+     * - NoUnneededBracesFixer
+     * - NoUnneededCurlyBracesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/SimplifiedIfReturnFixer.php
+++ b/src/Fixer/ControlStructure/SimplifiedIfReturnFixer.php
@@ -71,8 +71,18 @@ final class SimplifiedIfReturnFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before MultilineWhitespaceBeforeSemicolonsFixer, NoSinglelineWhitespaceBeforeSemicolonsFixer.
-     * Must run after NoSuperfluousElseifFixer, NoUnneededBracesFixer, NoUnneededCurlyBracesFixer, NoUselessElseFixer, SemicolonAfterInstructionFixer.
+     * Must run before:
+     *
+     * - MultilineWhitespaceBeforeSemicolonsFixer
+     * - NoSinglelineWhitespaceBeforeSemicolonsFixer
+     *
+     * Must run after:
+     *
+     * - NoSuperfluousElseifFixer
+     * - NoUnneededBracesFixer
+     * - NoUnneededCurlyBracesFixer
+     * - NoUselessElseFixer
+     * - SemicolonAfterInstructionFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
+++ b/src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
@@ -50,7 +50,9 @@ final class SwitchCaseSemicolonToColonFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after NoEmptyStatementFixer.
+     * Must run after:
+     *
+     * - NoEmptyStatementFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/SwitchContinueToBreakFixer.php
+++ b/src/Fixer/ControlStructure/SwitchContinueToBreakFixer.php
@@ -67,7 +67,9 @@ switch ($foo) {
     /**
      * {@inheritdoc}
      *
-     * Must run after NoAlternativeSyntaxFixer.
+     * Must run after:
+     *
+     * - NoAlternativeSyntaxFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ControlStructure/YodaStyleFixer.php
+++ b/src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -107,7 +107,9 @@ return $foo === count($bar);
     /**
      * {@inheritdoc}
      *
-     * Must run after IsNullFixer.
+     * Must run after:
+     *
+     * - IsNullFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixer.php
+++ b/src/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixer.php
@@ -48,7 +48,9 @@ final class DoctrineAnnotationArrayAssignmentFixer extends AbstractDoctrineAnnot
     /**
      * {@inheritdoc}
      *
-     * Must run before DoctrineAnnotationSpacesFixer.
+     * Must run before:
+     *
+     * - DoctrineAnnotationSpacesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+++ b/src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
@@ -51,7 +51,9 @@ final class DoctrineAnnotationSpacesFixer extends AbstractDoctrineAnnotationFixe
     /**
      * {@inheritdoc}
      *
-     * Must run after DoctrineAnnotationArrayAssignmentFixer.
+     * Must run after:
+     *
+     * - DoctrineAnnotationArrayAssignmentFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+++ b/src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
@@ -54,8 +54,15 @@ final class CombineNestedDirnameFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before MethodArgumentSpaceFixer, NoSpacesInsideParenthesisFixer, SpacesInsideParenthesesFixer.
-     * Must run after DirConstantFixer.
+     * Must run before:
+     *
+     * - MethodArgumentSpaceFixer
+     * - NoSpacesInsideParenthesisFixer
+     * - SpacesInsideParenthesesFixer
+     *
+     * Must run after:
+     *
+     * - DirConstantFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/DateTimeCreateFromFormatCallFixer.php
+++ b/src/Fixer/FunctionNotation/DateTimeCreateFromFormatCallFixer.php
@@ -44,7 +44,9 @@ final class DateTimeCreateFromFormatCallFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after NoUselessConcatOperatorFixer.
+     * Must run after:
+     *
+     * - NoUselessConcatOperatorFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+++ b/src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
@@ -93,8 +93,15 @@ $f = fn () => null;
     /**
      * {@inheritdoc}
      *
-     * Must run before MethodArgumentSpaceFixer.
-     * Must run after SingleSpaceAfterConstructFixer, SingleSpaceAroundConstructFixer, UseArrowFunctionsFixer.
+     * Must run before:
+     *
+     * - MethodArgumentSpaceFixer
+     *
+     * Must run after:
+     *
+     * - SingleSpaceAfterConstructFixer
+     * - SingleSpaceAroundConstructFixer
+     * - UseArrowFunctionsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/ImplodeCallFixer.php
+++ b/src/Fixer/FunctionNotation/ImplodeCallFixer.php
@@ -54,8 +54,13 @@ final class ImplodeCallFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before MethodArgumentSpaceFixer.
-     * Must run after NoAliasFunctionsFixer.
+     * Must run before:
+     *
+     * - MethodArgumentSpaceFixer
+     *
+     * Must run after:
+     *
+     * - NoAliasFunctionsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/LambdaNotUsedImportFixer.php
+++ b/src/Fixer/FunctionNotation/LambdaNotUsedImportFixer.php
@@ -52,7 +52,11 @@ final class LambdaNotUsedImportFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before MethodArgumentSpaceFixer, NoSpacesInsideParenthesisFixer, SpacesInsideParenthesesFixer.
+     * Must run before:
+     *
+     * - MethodArgumentSpaceFixer
+     * - NoSpacesInsideParenthesisFixer
+     * - SpacesInsideParenthesesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -121,8 +121,21 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurab
     /**
      * {@inheritdoc}
      *
-     * Must run before ArrayIndentationFixer, StatementIndentationFixer.
-     * Must run after CombineNestedDirnameFixer, FunctionDeclarationFixer, ImplodeCallFixer, LambdaNotUsedImportFixer, NoMultilineWhitespaceAroundDoubleArrowFixer, NoUselessSprintfFixer, PowToExponentiationFixer, StrictParamFixer.
+     * Must run before:
+     *
+     * - ArrayIndentationFixer
+     * - StatementIndentationFixer
+     *
+     * Must run after:
+     *
+     * - CombineNestedDirnameFixer
+     * - FunctionDeclarationFixer
+     * - ImplodeCallFixer
+     * - LambdaNotUsedImportFixer
+     * - NoMultilineWhitespaceAroundDoubleArrowFixer
+     * - NoUselessSprintfFixer
+     * - PowToExponentiationFixer
+     * - StrictParamFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -163,8 +163,15 @@ $c = get_class($d);
     /**
      * {@inheritdoc}
      *
-     * Must run before GlobalNamespaceImportFixer.
-     * Must run after BacktickToShellExecFixer, RegularCallableCallFixer, StrictParamFixer.
+     * Must run before:
+     *
+     * - GlobalNamespaceImportFixer
+     *
+     * Must run after:
+     *
+     * - BacktickToShellExecFixer
+     * - RegularCallableCallFixer
+     * - StrictParamFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -40,8 +40,14 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before FunctionToConstantFixer, GetClassToClassKeywordFixer.
-     * Must run after PowToExponentiationFixer.
+     * Must run before:
+     *
+     * - FunctionToConstantFixer
+     * - GetClassToClassKeywordFixer
+     *
+     * Must run after:
+     *
+     * - PowToExponentiationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/NoTrailingCommaInSinglelineFunctionCallFixer.php
+++ b/src/Fixer/FunctionNotation/NoTrailingCommaInSinglelineFunctionCallFixer.php
@@ -37,7 +37,9 @@ final class NoTrailingCommaInSinglelineFunctionCallFixer extends AbstractProxyFi
     /**
      * {@inheritdoc}
      *
-     * Must run before NoSpacesInsideParenthesisFixer.
+     * Must run before:
+     *
+     * - NoSpacesInsideParenthesisFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+++ b/src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
@@ -47,7 +47,9 @@ function example($foo = "two words", $bar) {}
     /**
      * {@inheritdoc}
      *
-     * Must run after NullableTypeDeclarationForDefaultNullValueFixer.
+     * Must run after:
+     *
+     * - NullableTypeDeclarationForDefaultNullValueFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/NoUselessSprintfFixer.php
+++ b/src/Fixer/FunctionNotation/NoUselessSprintfFixer.php
@@ -51,7 +51,14 @@ final class NoUselessSprintfFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before MethodArgumentSpaceFixer, NativeFunctionCasingFixer, NoEmptyStatementFixer, NoExtraBlankLinesFixer, NoSpacesInsideParenthesisFixer, SpacesInsideParenthesesFixer.
+     * Must run before:
+     *
+     * - MethodArgumentSpaceFixer
+     * - NativeFunctionCasingFixer
+     * - NoEmptyStatementFixer
+     * - NoExtraBlankLinesFixer
+     * - NoSpacesInsideParenthesisFixer
+     * - SpacesInsideParenthesesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php
+++ b/src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php
@@ -79,7 +79,11 @@ final class NullableTypeDeclarationForDefaultNullValueFixer extends AbstractFixe
     /**
      * {@inheritdoc}
      *
-     * Must run before NoUnreachableDefaultArgumentValueFixer, NullableTypeDeclarationFixer, OrderedTypesFixer.
+     * Must run before:
+     *
+     * - NoUnreachableDefaultArgumentValueFixer
+     * - NullableTypeDeclarationFixer
+     * - OrderedTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
@@ -85,8 +85,19 @@ function bar($foo) {}
     /**
      * {@inheritdoc}
      *
-     * Must run before NoSuperfluousPhpdocTagsFixer, PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - NoSuperfluousPhpdocTagsFixer
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/PhpdocToPropertyTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToPropertyTypeFixer.php
@@ -73,8 +73,19 @@ class Foo {
     /**
      * {@inheritdoc}
      *
-     * Must run before NoSuperfluousPhpdocTagsFixer, PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - NoSuperfluousPhpdocTagsFixer
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -105,8 +105,22 @@ final class Foo {
     /**
      * {@inheritdoc}
      *
-     * Must run before FullyQualifiedStrictTypesFixer, NoSuperfluousPhpdocTagsFixer, PhpdocAlignFixer, ReturnToYieldFromFixer, ReturnTypeDeclarationFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - FullyQualifiedStrictTypesFixer
+     * - NoSuperfluousPhpdocTagsFixer
+     * - PhpdocAlignFixer
+     * - ReturnToYieldFromFixer
+     * - ReturnTypeDeclarationFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/RegularCallableCallFixer.php
+++ b/src/Fixer/FunctionNotation/RegularCallableCallFixer.php
@@ -58,8 +58,14 @@ call_user_func(static function ($a, $b) { var_dump($a, $b); }, 1, 2);
     /**
      * {@inheritdoc}
      *
-     * Must run before NativeFunctionInvocationFixer.
-     * Must run after NoBinaryStringFixer, NoUselessConcatOperatorFixer.
+     * Must run before:
+     *
+     * - NativeFunctionInvocationFixer
+     *
+     * Must run after:
+     *
+     * - NoBinaryStringFixer
+     * - NoUselessConcatOperatorFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
+++ b/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
@@ -55,7 +55,11 @@ final class ReturnTypeDeclarationFixer extends AbstractFixer implements Configur
     /**
      * {@inheritdoc}
      *
-     * Must run after PhpUnitDataProviderReturnTypeFixer, PhpdocToReturnTypeFixer, VoidReturnFixer.
+     * Must run after:
+     *
+     * - PhpUnitDataProviderReturnTypeFixer
+     * - PhpdocToReturnTypeFixer
+     * - VoidReturnFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/SingleLineThrowFixer.php
+++ b/src/Fixer/FunctionNotation/SingleLineThrowFixer.php
@@ -49,7 +49,10 @@ final class SingleLineThrowFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesFixer, ConcatSpaceFixer.
+     * Must run before:
+     *
+     * - BracesFixer
+     * - ConcatSpaceFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/UseArrowFunctionsFixer.php
+++ b/src/Fixer/FunctionNotation/UseArrowFunctionsFixer.php
@@ -62,7 +62,9 @@ final class UseArrowFunctionsFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before FunctionDeclarationFixer.
+     * Must run before:
+     *
+     * - FunctionDeclarationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/VoidReturnFixer.php
+++ b/src/Fixer/FunctionNotation/VoidReturnFixer.php
@@ -47,8 +47,15 @@ final class VoidReturnFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocNoEmptyReturnFixer, ReturnTypeDeclarationFixer.
-     * Must run after NoSuperfluousPhpdocTagsFixer, SimplifiedNullReturnFixer.
+     * Must run before:
+     *
+     * - PhpdocNoEmptyReturnFixer
+     * - ReturnTypeDeclarationFixer
+     *
+     * Must run after:
+     *
+     * - NoSuperfluousPhpdocTagsFixer
+     * - SimplifiedNullReturnFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -76,8 +76,13 @@ class SomeClass
     /**
      * {@inheritdoc}
      *
-     * Must run before NoSuperfluousPhpdocTagsFixer.
-     * Must run after PhpdocToReturnTypeFixer.
+     * Must run before:
+     *
+     * - NoSuperfluousPhpdocTagsFixer
+     *
+     * Must run after:
+     *
+     * - PhpdocToReturnTypeFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Import/GlobalNamespaceImportFixer.php
+++ b/src/Fixer/Import/GlobalNamespaceImportFixer.php
@@ -90,8 +90,15 @@ if (count($x)) {
     /**
      * {@inheritdoc}
      *
-     * Must run before NoUnusedImportsFixer, OrderedImportsFixer.
-     * Must run after NativeConstantInvocationFixer, NativeFunctionInvocationFixer.
+     * Must run before:
+     *
+     * - NoUnusedImportsFixer
+     * - OrderedImportsFixer
+     *
+     * Must run after:
+     *
+     * - NativeConstantInvocationFixer
+     * - NativeFunctionInvocationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Import/NoLeadingImportSlashFixer.php
+++ b/src/Fixer/Import/NoLeadingImportSlashFixer.php
@@ -39,8 +39,14 @@ final class NoLeadingImportSlashFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before OrderedImportsFixer.
-     * Must run after NoUnusedImportsFixer, SingleImportPerStatementFixer.
+     * Must run before:
+     *
+     * - OrderedImportsFixer
+     *
+     * Must run after:
+     *
+     * - NoUnusedImportsFixer
+     * - SingleImportPerStatementFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Import/NoUnneededImportAliasFixer.php
+++ b/src/Fixer/Import/NoUnneededImportAliasFixer.php
@@ -39,7 +39,9 @@ final class NoUnneededImportAliasFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before NoSinglelineWhitespaceBeforeSemicolonsFixer.
+     * Must run before:
+     *
+     * - NoSinglelineWhitespaceBeforeSemicolonsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -44,8 +44,20 @@ final class NoUnusedImportsFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before BlankLineAfterNamespaceFixer, NoExtraBlankLinesFixer, NoLeadingImportSlashFixer, SingleLineAfterImportsFixer.
-     * Must run after ClassKeywordRemoveFixer, GlobalNamespaceImportFixer, PhpUnitDedicateAssertFixer, PhpUnitFqcnAnnotationFixer, SingleImportPerStatementFixer.
+     * Must run before:
+     *
+     * - BlankLineAfterNamespaceFixer
+     * - NoExtraBlankLinesFixer
+     * - NoLeadingImportSlashFixer
+     * - SingleLineAfterImportsFixer
+     *
+     * Must run after:
+     *
+     * - ClassKeywordRemoveFixer
+     * - GlobalNamespaceImportFixer
+     * - PhpUnitDedicateAssertFixer
+     * - PhpUnitFqcnAnnotationFixer
+     * - SingleImportPerStatementFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -174,8 +174,14 @@ use Bar;
     /**
      * {@inheritdoc}
      *
-     * Must run before BlankLineBetweenImportGroupsFixer.
-     * Must run after GlobalNamespaceImportFixer, NoLeadingImportSlashFixer.
+     * Must run before:
+     *
+     * - BlankLineBetweenImportGroupsFixer
+     *
+     * Must run after:
+     *
+     * - GlobalNamespaceImportFixer
+     * - NoLeadingImportSlashFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Import/SingleImportPerStatementFixer.php
+++ b/src/Fixer/Import/SingleImportPerStatementFixer.php
@@ -63,7 +63,13 @@ use Space\Models\ {
     /**
      * {@inheritdoc}
      *
-     * Must run before MultilineWhitespaceBeforeSemicolonsFixer, NoLeadingImportSlashFixer, NoSinglelineWhitespaceBeforeSemicolonsFixer, NoUnusedImportsFixer, SpaceAfterSemicolonFixer.
+     * Must run before:
+     *
+     * - MultilineWhitespaceBeforeSemicolonsFixer
+     * - NoLeadingImportSlashFixer
+     * - NoSinglelineWhitespaceBeforeSemicolonsFixer
+     * - NoUnusedImportsFixer
+     * - SpaceAfterSemicolonFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Import/SingleLineAfterImportsFixer.php
+++ b/src/Fixer/Import/SingleLineAfterImportsFixer.php
@@ -73,7 +73,9 @@ final class Example
     /**
      * {@inheritdoc}
      *
-     * Must run after NoUnusedImportsFixer.
+     * Must run after:
+     *
+     * - NoUnusedImportsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
@@ -61,7 +61,9 @@ $className = Baz::class;
     /**
      * {@inheritdoc}
      *
-     * Must run before NoUnusedImportsFixer.
+     * Must run before:
+     *
+     * - NoUnusedImportsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+++ b/src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
@@ -34,7 +34,14 @@ final class CombineConsecutiveIssetsFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before MultilineWhitespaceBeforeSemicolonsFixer, NoSinglelineWhitespaceBeforeSemicolonsFixer, NoSpacesInsideParenthesisFixer, NoTrailingWhitespaceFixer, NoWhitespaceInBlankLineFixer, SpacesInsideParenthesesFixer.
+     * Must run before:
+     *
+     * - MultilineWhitespaceBeforeSemicolonsFixer
+     * - NoSinglelineWhitespaceBeforeSemicolonsFixer
+     * - NoSpacesInsideParenthesisFixer
+     * - NoTrailingWhitespaceFixer
+     * - NoWhitespaceInBlankLineFixer
+     * - SpacesInsideParenthesesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+++ b/src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
@@ -34,8 +34,18 @@ final class CombineConsecutiveUnsetsFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before NoExtraBlankLinesFixer, NoTrailingWhitespaceFixer, NoWhitespaceInBlankLineFixer, SpaceAfterSemicolonFixer.
-     * Must run after NoEmptyStatementFixer, NoUnsetOnPropertyFixer, NoUselessElseFixer.
+     * Must run before:
+     *
+     * - NoExtraBlankLinesFixer
+     * - NoTrailingWhitespaceFixer
+     * - NoWhitespaceInBlankLineFixer
+     * - SpaceAfterSemicolonFixer
+     *
+     * Must run after:
+     *
+     * - NoEmptyStatementFixer
+     * - NoUnsetOnPropertyFixer
+     * - NoUselessElseFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
+++ b/src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
@@ -56,7 +56,9 @@ final class DeclareEqualNormalizeFixer extends AbstractFixer implements Configur
     /**
      * {@inheritdoc}
      *
-     * Must run after DeclareStrictTypesFixer.
+     * Must run after:
+     *
+     * - DeclareStrictTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/LanguageConstruct/DirConstantFixer.php
+++ b/src/Fixer/LanguageConstruct/DirConstantFixer.php
@@ -44,7 +44,9 @@ final class DirConstantFixer extends AbstractFunctionReferenceFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before CombineNestedDirnameFixer.
+     * Must run before:
+     *
+     * - CombineNestedDirnameFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+++ b/src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
@@ -96,8 +96,21 @@ final class FunctionToConstantFixer extends AbstractFixer implements Configurabl
     /**
      * {@inheritdoc}
      *
-     * Must run before NativeConstantInvocationFixer, NativeFunctionCasingFixer, NoExtraBlankLinesFixer, NoSinglelineWhitespaceBeforeSemicolonsFixer, NoTrailingWhitespaceFixer, NoWhitespaceInBlankLineFixer, SelfStaticAccessorFixer.
-     * Must run after NoSpacesAfterFunctionNameFixer, NoSpacesInsideParenthesisFixer, SpacesInsideParenthesesFixer.
+     * Must run before:
+     *
+     * - NativeConstantInvocationFixer
+     * - NativeFunctionCasingFixer
+     * - NoExtraBlankLinesFixer
+     * - NoSinglelineWhitespaceBeforeSemicolonsFixer
+     * - NoTrailingWhitespaceFixer
+     * - NoWhitespaceInBlankLineFixer
+     * - SelfStaticAccessorFixer
+     *
+     * Must run after:
+     *
+     * - NoSpacesAfterFunctionNameFixer
+     * - NoSpacesInsideParenthesisFixer
+     * - SpacesInsideParenthesesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/LanguageConstruct/GetClassToClassKeywordFixer.php
+++ b/src/Fixer/LanguageConstruct/GetClassToClassKeywordFixer.php
@@ -51,8 +51,15 @@ final class GetClassToClassKeywordFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before MultilineWhitespaceBeforeSemicolonsFixer.
-     * Must run after NoSpacesAfterFunctionNameFixer, NoSpacesInsideParenthesisFixer, SpacesInsideParenthesesFixer.
+     * Must run before:
+     *
+     * - MultilineWhitespaceBeforeSemicolonsFixer
+     *
+     * Must run after:
+     *
+     * - NoSpacesAfterFunctionNameFixer
+     * - NoSpacesInsideParenthesisFixer
+     * - SpacesInsideParenthesesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/LanguageConstruct/IsNullFixer.php
+++ b/src/Fixer/LanguageConstruct/IsNullFixer.php
@@ -42,7 +42,9 @@ final class IsNullFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before YodaStyleFixer.
+     * Must run before:
+     *
+     * - YodaStyleFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+++ b/src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
@@ -54,7 +54,9 @@ final class NoUnsetOnPropertyFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before CombineConsecutiveUnsetsFixer.
+     * Must run before:
+     *
+     * - CombineConsecutiveUnsetsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/LanguageConstruct/NullableTypeDeclarationFixer.php
+++ b/src/Fixer/LanguageConstruct/NullableTypeDeclarationFixer.php
@@ -80,8 +80,15 @@ class ValueObject
     /**
      * {@inheritdoc}
      *
-     * Must run before OrderedTypesFixer, TypesSpacesFixer.
-     * Must run after NullableTypeDeclarationForDefaultNullValueFixer, SingleSpaceAroundConstructFixer.
+     * Must run before:
+     *
+     * - OrderedTypesFixer
+     * - TypesSpacesFixer
+     *
+     * Must run after:
+     *
+     * - NullableTypeDeclarationForDefaultNullValueFixer
+     * - SingleSpaceAroundConstructFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
@@ -167,8 +167,15 @@ yield  from  baz();
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesFixer, FunctionDeclarationFixer.
-     * Must run after ArraySyntaxFixer, ModernizeStrposFixer.
+     * Must run before:
+     *
+     * - BracesFixer
+     * - FunctionDeclarationFixer
+     *
+     * Must run after:
+     *
+     * - ArraySyntaxFixer
+     * - ModernizeStrposFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixer.php
@@ -255,8 +255,16 @@ yield  from  baz();
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesFixer, FunctionDeclarationFixer, NullableTypeDeclarationFixer.
-     * Must run after ArraySyntaxFixer, ModernizeStrposFixer.
+     * Must run before:
+     *
+     * - BracesFixer
+     * - FunctionDeclarationFixer
+     * - NullableTypeDeclarationFixer
+     *
+     * Must run after:
+     *
+     * - ArraySyntaxFixer
+     * - ModernizeStrposFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ListNotation/ListSyntaxFixer.php
+++ b/src/Fixer/ListNotation/ListSyntaxFixer.php
@@ -65,7 +65,10 @@ final class ListSyntaxFixer extends AbstractFixer implements ConfigurableFixerIn
     /**
      * {@inheritdoc}
      *
-     * Must run before BinaryOperatorSpacesFixer, TernaryOperatorSpacesFixer.
+     * Must run before:
+     *
+     * - BinaryOperatorSpacesFixer
+     * - TernaryOperatorSpacesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
+++ b/src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
@@ -44,7 +44,9 @@ final class BlankLineAfterNamespaceFixer extends AbstractFixer implements Whites
     /**
      * {@inheritdoc}
      *
-     * Must run after NoUnusedImportsFixer.
+     * Must run after:
+     *
+     * - NoUnusedImportsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/NamespaceNotation/BlankLinesBeforeNamespaceFixer.php
+++ b/src/Fixer/NamespaceNotation/BlankLinesBeforeNamespaceFixer.php
@@ -56,7 +56,10 @@ final class BlankLinesBeforeNamespaceFixer extends AbstractFixer implements Whit
     /**
      * {@inheritdoc}
      *
-     * Must run after BlankLineAfterOpeningTagFixer, HeaderCommentFixer.
+     * Must run after:
+     *
+     * - BlankLineAfterOpeningTagFixer
+     * - HeaderCommentFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/NamespaceNotation/CleanNamespaceFixer.php
+++ b/src/Fixer/NamespaceNotation/CleanNamespaceFixer.php
@@ -48,7 +48,9 @@ final class CleanNamespaceFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpUnitDataProviderReturnTypeFixer.
+     * Must run before:
+     *
+     * - PhpUnitDataProviderReturnTypeFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixer.php
+++ b/src/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixer.php
@@ -54,7 +54,9 @@ final class NoBlankLinesBeforeNamespaceFixer extends AbstractProxyFixer implemen
     /**
      * {@inheritdoc}
      *
-     * Must run after BlankLineAfterOpeningTagFixer.
+     * Must run after:
+     *
+     * - BlankLineAfterOpeningTagFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixer.php
+++ b/src/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixer.php
@@ -53,7 +53,9 @@ final class SingleBlankLineBeforeNamespaceFixer extends AbstractProxyFixer imple
     /**
      * {@inheritdoc}
      *
-     * Must run after HeaderCommentFixer.
+     * Must run after:
+     *
+     * - HeaderCommentFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/AssignNullCoalescingToCoalesceEqualFixer.php
+++ b/src/Fixer/Operator/AssignNullCoalescingToCoalesceEqualFixer.php
@@ -38,8 +38,14 @@ final class AssignNullCoalescingToCoalesceEqualFixer extends AbstractShortOperat
     /**
      * {@inheritdoc}
      *
-     * Must run before BinaryOperatorSpacesFixer, NoWhitespaceInBlankLineFixer.
-     * Must run after TernaryToNullCoalescingFixer.
+     * Must run before:
+     *
+     * - BinaryOperatorSpacesFixer
+     * - NoWhitespaceInBlankLineFixer
+     *
+     * Must run after:
+     *
+     * - TernaryToNullCoalescingFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -308,7 +308,19 @@ $array = [
     /**
      * {@inheritdoc}
      *
-     * Must run after ArrayIndentationFixer, ArraySyntaxFixer, AssignNullCoalescingToCoalesceEqualFixer, ListSyntaxFixer, LongToShorthandOperatorFixer, ModernizeStrposFixer, NoMultilineWhitespaceAroundDoubleArrowFixer, NoUnsetCastFixer, PowToExponentiationFixer, StandardizeNotEqualsFixer, StrictComparisonFixer.
+     * Must run after:
+     *
+     * - ArrayIndentationFixer
+     * - ArraySyntaxFixer
+     * - AssignNullCoalescingToCoalesceEqualFixer
+     * - ListSyntaxFixer
+     * - LongToShorthandOperatorFixer
+     * - ModernizeStrposFixer
+     * - NoMultilineWhitespaceAroundDoubleArrowFixer
+     * - NoUnsetCastFixer
+     * - PowToExponentiationFixer
+     * - StandardizeNotEqualsFixer
+     * - StrictComparisonFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/ConcatSpaceFixer.php
+++ b/src/Fixer/Operator/ConcatSpaceFixer.php
@@ -69,7 +69,10 @@ final class ConcatSpaceFixer extends AbstractFixer implements ConfigurableFixerI
     /**
      * {@inheritdoc}
      *
-     * Must run after NoUnneededControlParenthesesFixer, SingleLineThrowFixer.
+     * Must run after:
+     *
+     * - NoUnneededControlParenthesesFixer
+     * - SingleLineThrowFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/IncrementStyleFixer.php
+++ b/src/Fixer/Operator/IncrementStyleFixer.php
@@ -59,8 +59,14 @@ final class IncrementStyleFixer extends AbstractIncrementOperatorFixer implement
     /**
      * {@inheritdoc}
      *
-     * Must run before NoSpacesInsideParenthesisFixer, SpacesInsideParenthesesFixer.
-     * Must run after StandardizeIncrementFixer.
+     * Must run before:
+     *
+     * - NoSpacesInsideParenthesisFixer
+     * - SpacesInsideParenthesesFixer
+     *
+     * Must run after:
+     *
+     * - StandardizeIncrementFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/LongToShorthandOperatorFixer.php
+++ b/src/Fixer/Operator/LongToShorthandOperatorFixer.php
@@ -59,7 +59,12 @@ final class LongToShorthandOperatorFixer extends AbstractShortOperatorFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before BinaryOperatorSpacesFixer, NoExtraBlankLinesFixer, NoSinglelineWhitespaceBeforeSemicolonsFixer, StandardizeIncrementFixer.
+     * Must run before:
+     *
+     * - BinaryOperatorSpacesFixer
+     * - NoExtraBlankLinesFixer
+     * - NoSinglelineWhitespaceBeforeSemicolonsFixer
+     * - StandardizeIncrementFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/NewWithBracesFixer.php
+++ b/src/Fixer/Operator/NewWithBracesFixer.php
@@ -52,7 +52,9 @@ final class NewWithBracesFixer extends AbstractProxyFixer implements Configurabl
     /**
      * {@inheritdoc}
      *
-     * Must run before ClassDefinitionFixer.
+     * Must run before:
+     *
+     * - ClassDefinitionFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/NewWithParenthesesFixer.php
+++ b/src/Fixer/Operator/NewWithParenthesesFixer.php
@@ -52,7 +52,9 @@ final class NewWithParenthesesFixer extends AbstractFixer implements Configurabl
     /**
      * {@inheritdoc}
      *
-     * Must run before ClassDefinitionFixer.
+     * Must run before:
+     *
+     * - ClassDefinitionFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/NoUselessConcatOperatorFixer.php
+++ b/src/Fixer/Operator/NoUselessConcatOperatorFixer.php
@@ -46,8 +46,18 @@ final class NoUselessConcatOperatorFixer extends AbstractFixer implements Config
     /**
      * {@inheritdoc}
      *
-     * Must run before DateTimeCreateFromFormatCallFixer, EregToPregFixer, PhpUnitDedicateAssertInternalTypeFixer, RegularCallableCallFixer, SetTypeToCastFixer.
-     * Must run after NoBinaryStringFixer, SingleQuoteFixer.
+     * Must run before:
+     *
+     * - DateTimeCreateFromFormatCallFixer
+     * - EregToPregFixer
+     * - PhpUnitDedicateAssertInternalTypeFixer
+     * - RegularCallableCallFixer
+     * - SetTypeToCastFixer
+     *
+     * Must run after:
+     *
+     * - NoBinaryStringFixer
+     * - SingleQuoteFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/NotOperatorWithSpaceFixer.php
+++ b/src/Fixer/Operator/NotOperatorWithSpaceFixer.php
@@ -44,7 +44,10 @@ if (!$bar) {
     /**
      * {@inheritdoc}
      *
-     * Must run after ModernizeStrposFixer, UnaryOperatorSpacesFixer.
+     * Must run after:
+     *
+     * - ModernizeStrposFixer
+     * - UnaryOperatorSpacesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/NotOperatorWithSuccessorSpaceFixer.php
+++ b/src/Fixer/Operator/NotOperatorWithSuccessorSpaceFixer.php
@@ -43,7 +43,10 @@ if (!$bar) {
     /**
      * {@inheritdoc}
      *
-     * Must run after ModernizeStrposFixer, UnaryOperatorSpacesFixer.
+     * Must run after:
+     *
+     * - ModernizeStrposFixer
+     * - UnaryOperatorSpacesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/StandardizeIncrementFixer.php
+++ b/src/Fixer/Operator/StandardizeIncrementFixer.php
@@ -52,8 +52,13 @@ final class StandardizeIncrementFixer extends AbstractIncrementOperatorFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before IncrementStyleFixer.
-     * Must run after LongToShorthandOperatorFixer.
+     * Must run before:
+     *
+     * - IncrementStyleFixer
+     *
+     * Must run after:
+     *
+     * - LongToShorthandOperatorFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/StandardizeNotEqualsFixer.php
+++ b/src/Fixer/Operator/StandardizeNotEqualsFixer.php
@@ -37,7 +37,9 @@ final class StandardizeNotEqualsFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before BinaryOperatorSpacesFixer.
+     * Must run before:
+     *
+     * - BinaryOperatorSpacesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/TernaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/TernaryOperatorSpacesFixer.php
@@ -41,7 +41,11 @@ final class TernaryOperatorSpacesFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after ArraySyntaxFixer, ListSyntaxFixer, TernaryToElvisOperatorFixer.
+     * Must run after:
+     *
+     * - ArraySyntaxFixer
+     * - ListSyntaxFixer
+     * - TernaryToElvisOperatorFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/TernaryToElvisOperatorFixer.php
+++ b/src/Fixer/Operator/TernaryToElvisOperatorFixer.php
@@ -76,7 +76,10 @@ final class TernaryToElvisOperatorFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before NoTrailingWhitespaceFixer, TernaryOperatorSpacesFixer.
+     * Must run before:
+     *
+     * - NoTrailingWhitespaceFixer
+     * - TernaryOperatorSpacesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+++ b/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
@@ -41,7 +41,9 @@ final class TernaryToNullCoalescingFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before AssignNullCoalescingToCoalesceEqualFixer.
+     * Must run before:
+     *
+     * - AssignNullCoalescingToCoalesceEqualFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Operator/UnaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/UnaryOperatorSpacesFixer.php
@@ -37,7 +37,10 @@ final class UnaryOperatorSpacesFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before NotOperatorWithSpaceFixer, NotOperatorWithSuccessorSpaceFixer.
+     * Must run before:
+     *
+     * - NotOperatorWithSpaceFixer
+     * - NotOperatorWithSuccessorSpaceFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php
+++ b/src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php
@@ -38,8 +38,14 @@ final class BlankLineAfterOpeningTagFixer extends AbstractFixer implements White
     /**
      * {@inheritdoc}
      *
-     * Must run before BlankLinesBeforeNamespaceFixer, NoBlankLinesBeforeNamespaceFixer.
-     * Must run after DeclareStrictTypesFixer.
+     * Must run before:
+     *
+     * - BlankLinesBeforeNamespaceFixer
+     * - NoBlankLinesBeforeNamespaceFixer
+     *
+     * Must run after:
+     *
+     * - DeclareStrictTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpTag/EchoTagSyntaxFixer.php
+++ b/src/Fixer/PhpTag/EchoTagSyntaxFixer.php
@@ -87,7 +87,9 @@ final class EchoTagSyntaxFixer extends AbstractFixer implements ConfigurableFixe
     /**
      * {@inheritdoc}
      *
-     * Must run before NoMixedEchoPrintFixer.
+     * Must run before:
+     *
+     * - NoMixedEchoPrintFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitConstructFixer.php
@@ -86,7 +86,9 @@ final class FooTest extends \PHPUnit_Framework_TestCase {
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpUnitDedicateAssertFixer.
+     * Must run before:
+     *
+     * - PhpUnitDedicateAssertFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixer.php
@@ -65,8 +65,14 @@ class FooTest extends TestCase {
     /**
      * {@inheritdoc}
      *
-     * Must run before ReturnToYieldFromFixer, ReturnTypeDeclarationFixer.
-     * Must run after CleanNamespaceFixer.
+     * Must run before:
+     *
+     * - ReturnToYieldFromFixer
+     * - ReturnTypeDeclarationFixer
+     *
+     * Must run after:
+     *
+     * - CleanNamespaceFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
@@ -216,8 +216,16 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      *
-     * Must run before NoUnusedImportsFixer, PhpUnitDedicateAssertInternalTypeFixer.
-     * Must run after ModernizeStrposFixer, NoAliasFunctionsFixer, PhpUnitConstructFixer.
+     * Must run before:
+     *
+     * - NoUnusedImportsFixer
+     * - PhpUnitDedicateAssertInternalTypeFixer
+     *
+     * Must run after:
+     *
+     * - ModernizeStrposFixer
+     * - NoAliasFunctionsFixer
+     * - PhpUnitConstructFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
@@ -97,7 +97,11 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     /**
      * {@inheritdoc}
      *
-     * Must run after NoBinaryStringFixer, NoUselessConcatOperatorFixer, PhpUnitDedicateAssertFixer.
+     * Must run after:
+     *
+     * - NoBinaryStringFixer
+     * - NoUselessConcatOperatorFixer
+     * - PhpUnitDedicateAssertFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
@@ -145,7 +145,9 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      *
-     * Must run after PhpUnitNoExpectationAnnotationFixer.
+     * Must run after:
+     *
+     * - PhpUnitNoExpectationAnnotationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
@@ -53,7 +53,10 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      *
-     * Must run before NoUnusedImportsFixer, PhpdocOrderByValueFixer.
+     * Must run before:
+     *
+     * - NoUnusedImportsFixer
+     * - PhpdocOrderByValueFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
@@ -49,7 +49,10 @@ final class PhpUnitInternalClassFixer extends AbstractPhpUnitFixer implements Wh
     /**
      * {@inheritdoc}
      *
-     * Must run before FinalInternalClassFixer, PhpdocSeparationFixer.
+     * Must run before:
+     *
+     * - FinalInternalClassFixer
+     * - PhpdocSeparationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
@@ -74,7 +74,9 @@ class MyTest extends \\PhpUnit\\FrameWork\\TestCase
     /**
      * {@inheritdoc}
      *
-     * Must run after PhpUnitTestAnnotationFixer.
+     * Must run after:
+     *
+     * - PhpUnitTestAnnotationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
@@ -103,7 +103,10 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      *
-     * Must run before NoEmptyPhpdocFixer, PhpUnitExpectationFixer.
+     * Must run before:
+     *
+     * - NoEmptyPhpdocFixer
+     * - PhpUnitExpectationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
@@ -47,7 +47,9 @@ final class PhpUnitSizeClassFixer extends AbstractPhpUnitFixer implements Whites
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocSeparationFixer.
+     * Must run before:
+     *
+     * - PhpdocSeparationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -67,7 +67,11 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
     /**
      * {@inheritdoc}
      *
-     * Must run before NoEmptyPhpdocFixer, PhpUnitMethodCasingFixer, PhpdocTrimFixer.
+     * Must run before:
+     *
+     * - NoEmptyPhpdocFixer
+     * - PhpUnitMethodCasingFixer
+     * - PhpdocTrimFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
@@ -340,7 +340,9 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      *
-     * Must run before SelfStaticAccessorFixer.
+     * Must run before:
+     *
+     * - SelfStaticAccessorFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -50,7 +50,9 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocSeparationFixer.
+     * Must run before:
+     *
+     * - PhpdocSeparationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
+++ b/src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
@@ -87,8 +87,46 @@ with a line not prefixed with asterisk
     /**
      * {@inheritdoc}
      *
-     * Must run before CommentToPhpdocFixer, GeneralPhpdocAnnotationRemoveFixer, GeneralPhpdocTagRenameFixer, NoBlankLinesAfterPhpdocFixer, NoEmptyPhpdocFixer, NoSuperfluousPhpdocTagsFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocAlignFixer, PhpdocAnnotationWithoutDotFixer, PhpdocInlineTagNormalizerFixer, PhpdocLineSpanFixer, PhpdocNoAccessFixer, PhpdocNoAliasTagFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocNoUselessInheritdocFixer, PhpdocOrderByValueFixer, PhpdocOrderFixer, PhpdocParamOrderFixer, PhpdocReadonlyClassCommentToKeywordFixer, PhpdocReturnSelfReferenceFixer, PhpdocSeparationFixer, PhpdocSingleLineVarSpacingFixer, PhpdocSummaryFixer, PhpdocTagCasingFixer, PhpdocTagTypeFixer, PhpdocToParamTypeFixer, PhpdocToPropertyTypeFixer, PhpdocToReturnTypeFixer, PhpdocTrimConsecutiveBlankLineSeparationFixer, PhpdocTrimFixer, PhpdocTypesOrderFixer, PhpdocVarAnnotationCorrectOrderFixer, PhpdocVarWithoutNameFixer.
-     * Must run after ArrayIndentationFixer.
+     * Must run before:
+     *
+     * - CommentToPhpdocFixer
+     * - GeneralPhpdocAnnotationRemoveFixer
+     * - GeneralPhpdocTagRenameFixer
+     * - NoBlankLinesAfterPhpdocFixer
+     * - NoEmptyPhpdocFixer
+     * - NoSuperfluousPhpdocTagsFixer
+     * - PhpdocAddMissingParamAnnotationFixer
+     * - PhpdocAlignFixer
+     * - PhpdocAnnotationWithoutDotFixer
+     * - PhpdocInlineTagNormalizerFixer
+     * - PhpdocLineSpanFixer
+     * - PhpdocNoAccessFixer
+     * - PhpdocNoAliasTagFixer
+     * - PhpdocNoEmptyReturnFixer
+     * - PhpdocNoPackageFixer
+     * - PhpdocNoUselessInheritdocFixer
+     * - PhpdocOrderByValueFixer
+     * - PhpdocOrderFixer
+     * - PhpdocParamOrderFixer
+     * - PhpdocReadonlyClassCommentToKeywordFixer
+     * - PhpdocReturnSelfReferenceFixer
+     * - PhpdocSeparationFixer
+     * - PhpdocSingleLineVarSpacingFixer
+     * - PhpdocSummaryFixer
+     * - PhpdocTagCasingFixer
+     * - PhpdocTagTypeFixer
+     * - PhpdocToParamTypeFixer
+     * - PhpdocToPropertyTypeFixer
+     * - PhpdocToReturnTypeFixer
+     * - PhpdocTrimConsecutiveBlankLineSeparationFixer
+     * - PhpdocTrimFixer
+     * - PhpdocTypesOrderFixer
+     * - PhpdocVarAnnotationCorrectOrderFixer
+     * - PhpdocVarWithoutNameFixer
+     *
+     * Must run after:
+     *
+     * - ArrayIndentationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
+++ b/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
@@ -79,8 +79,22 @@ function foo() {}
     /**
      * {@inheritdoc}
      *
-     * Must run before NoEmptyPhpdocFixer, PhpdocAlignFixer, PhpdocLineSpanFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - NoEmptyPhpdocFixer
+     * - PhpdocAlignFixer
+     * - PhpdocLineSpanFixer
+     * - PhpdocSeparationFixer
+     * - PhpdocTrimFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/GeneralPhpdocTagRenameFixer.php
+++ b/src/Fixer/Phpdoc/GeneralPhpdocTagRenameFixer.php
@@ -65,8 +65,19 @@ final class GeneralPhpdocTagRenameFixer extends AbstractFixer implements Configu
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAddMissingParamAnnotationFixer, PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAddMissingParamAnnotationFixer
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixer.php
+++ b/src/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixer.php
@@ -54,8 +54,19 @@ class Bar {}
     /**
      * {@inheritdoc}
      *
-     * Must run before HeaderCommentFixer, PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - HeaderCommentFixer
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/NoEmptyPhpdocFixer.php
+++ b/src/Fixer/Phpdoc/NoEmptyPhpdocFixer.php
@@ -34,8 +34,31 @@ final class NoEmptyPhpdocFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before NoExtraBlankLinesFixer, NoTrailingWhitespaceFixer, NoWhitespaceInBlankLineFixer, PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, GeneralPhpdocAnnotationRemoveFixer, NoSuperfluousPhpdocTagsFixer, PhpUnitNoExpectationAnnotationFixer, PhpUnitTestAnnotationFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocIndentFixer, PhpdocNoAccessFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocNoUselessInheritdocFixer, PhpdocReadonlyClassCommentToKeywordFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - NoExtraBlankLinesFixer
+     * - NoTrailingWhitespaceFixer
+     * - NoWhitespaceInBlankLineFixer
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - GeneralPhpdocAnnotationRemoveFixer
+     * - NoSuperfluousPhpdocTagsFixer
+     * - PhpUnitNoExpectationAnnotationFixer
+     * - PhpUnitTestAnnotationFixer
+     * - PhpdocAddMissingParamAnnotationFixer
+     * - PhpdocIndentFixer
+     * - PhpdocNoAccessFixer
+     * - PhpdocNoEmptyReturnFixer
+     * - PhpdocNoPackageFixer
+     * - PhpdocNoUselessInheritdocFixer
+     * - PhpdocReadonlyClassCommentToKeywordFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -91,8 +91,27 @@ class Foo {
     /**
      * {@inheritdoc}
      *
-     * Must run before NoEmptyPhpdocFixer, PhpdocAlignFixer, VoidReturnFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, FullyQualifiedStrictTypesFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocIndentFixer, PhpdocLineSpanFixer, PhpdocReturnSelfReferenceFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocToParamTypeFixer, PhpdocToPropertyTypeFixer, PhpdocToReturnTypeFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - NoEmptyPhpdocFixer
+     * - PhpdocAlignFixer
+     * - VoidReturnFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - FullyQualifiedStrictTypesFixer
+     * - PhpdocAddMissingParamAnnotationFixer
+     * - PhpdocIndentFixer
+     * - PhpdocLineSpanFixer
+     * - PhpdocReturnSelfReferenceFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocToParamTypeFixer
+     * - PhpdocToPropertyTypeFixer
+     * - PhpdocToReturnTypeFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -80,8 +80,23 @@ function f9(string $foo, $bar, $baz) {}
     /**
      * {@inheritdoc}
      *
-     * Must run before NoEmptyPhpdocFixer, NoSuperfluousPhpdocTagsFixer, PhpdocAlignFixer, PhpdocOrderFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, GeneralPhpdocTagRenameFixer, PhpdocIndentFixer, PhpdocNoAliasTagFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - NoEmptyPhpdocFixer
+     * - NoSuperfluousPhpdocTagsFixer
+     * - PhpdocAlignFixer
+     * - PhpdocOrderFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - GeneralPhpdocTagRenameFixer
+     * - PhpdocIndentFixer
+     * - PhpdocNoAliasTagFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -157,7 +157,46 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
     /**
      * {@inheritdoc}
      *
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, GeneralPhpdocAnnotationRemoveFixer, GeneralPhpdocTagRenameFixer, NoBlankLinesAfterPhpdocFixer, NoEmptyPhpdocFixer, NoSuperfluousPhpdocTagsFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocAnnotationWithoutDotFixer, PhpdocIndentFixer, PhpdocInlineTagNormalizerFixer, PhpdocLineSpanFixer, PhpdocNoAccessFixer, PhpdocNoAliasTagFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocNoUselessInheritdocFixer, PhpdocOrderByValueFixer, PhpdocOrderFixer, PhpdocParamOrderFixer, PhpdocReadonlyClassCommentToKeywordFixer, PhpdocReturnSelfReferenceFixer, PhpdocScalarFixer, PhpdocSeparationFixer, PhpdocSingleLineVarSpacingFixer, PhpdocSummaryFixer, PhpdocTagCasingFixer, PhpdocTagTypeFixer, PhpdocToCommentFixer, PhpdocToParamTypeFixer, PhpdocToPropertyTypeFixer, PhpdocToReturnTypeFixer, PhpdocTrimConsecutiveBlankLineSeparationFixer, PhpdocTrimFixer, PhpdocTypesFixer, PhpdocTypesOrderFixer, PhpdocVarAnnotationCorrectOrderFixer, PhpdocVarWithoutNameFixer.
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - GeneralPhpdocAnnotationRemoveFixer
+     * - GeneralPhpdocTagRenameFixer
+     * - NoBlankLinesAfterPhpdocFixer
+     * - NoEmptyPhpdocFixer
+     * - NoSuperfluousPhpdocTagsFixer
+     * - PhpdocAddMissingParamAnnotationFixer
+     * - PhpdocAnnotationWithoutDotFixer
+     * - PhpdocIndentFixer
+     * - PhpdocInlineTagNormalizerFixer
+     * - PhpdocLineSpanFixer
+     * - PhpdocNoAccessFixer
+     * - PhpdocNoAliasTagFixer
+     * - PhpdocNoEmptyReturnFixer
+     * - PhpdocNoPackageFixer
+     * - PhpdocNoUselessInheritdocFixer
+     * - PhpdocOrderByValueFixer
+     * - PhpdocOrderFixer
+     * - PhpdocParamOrderFixer
+     * - PhpdocReadonlyClassCommentToKeywordFixer
+     * - PhpdocReturnSelfReferenceFixer
+     * - PhpdocScalarFixer
+     * - PhpdocSeparationFixer
+     * - PhpdocSingleLineVarSpacingFixer
+     * - PhpdocSummaryFixer
+     * - PhpdocTagCasingFixer
+     * - PhpdocTagTypeFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocToParamTypeFixer
+     * - PhpdocToPropertyTypeFixer
+     * - PhpdocToReturnTypeFixer
+     * - PhpdocTrimConsecutiveBlankLineSeparationFixer
+     * - PhpdocTrimFixer
+     * - PhpdocTypesFixer
+     * - PhpdocTypesOrderFixer
+     * - PhpdocVarAnnotationCorrectOrderFixer
+     * - PhpdocVarWithoutNameFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
@@ -49,8 +49,16 @@ function foo ($bar) {}
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocToCommentFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocToCommentFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocIndentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocIndentFixer.php
@@ -48,8 +48,47 @@ class DocBlocks
     /**
      * {@inheritdoc}
      *
-     * Must run before GeneralPhpdocAnnotationRemoveFixer, GeneralPhpdocTagRenameFixer, NoBlankLinesAfterPhpdocFixer, NoEmptyPhpdocFixer, NoSuperfluousPhpdocTagsFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocAlignFixer, PhpdocAnnotationWithoutDotFixer, PhpdocInlineTagNormalizerFixer, PhpdocLineSpanFixer, PhpdocNoAccessFixer, PhpdocNoAliasTagFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocNoUselessInheritdocFixer, PhpdocOrderByValueFixer, PhpdocOrderFixer, PhpdocParamOrderFixer, PhpdocReadonlyClassCommentToKeywordFixer, PhpdocReturnSelfReferenceFixer, PhpdocSeparationFixer, PhpdocSingleLineVarSpacingFixer, PhpdocSummaryFixer, PhpdocTagCasingFixer, PhpdocTagTypeFixer, PhpdocToParamTypeFixer, PhpdocToPropertyTypeFixer, PhpdocToReturnTypeFixer, PhpdocTrimConsecutiveBlankLineSeparationFixer, PhpdocTrimFixer, PhpdocTypesFixer, PhpdocTypesOrderFixer, PhpdocVarAnnotationCorrectOrderFixer, PhpdocVarWithoutNameFixer.
-     * Must run after IndentationTypeFixer, PhpdocToCommentFixer.
+     * Must run before:
+     *
+     * - GeneralPhpdocAnnotationRemoveFixer
+     * - GeneralPhpdocTagRenameFixer
+     * - NoBlankLinesAfterPhpdocFixer
+     * - NoEmptyPhpdocFixer
+     * - NoSuperfluousPhpdocTagsFixer
+     * - PhpdocAddMissingParamAnnotationFixer
+     * - PhpdocAlignFixer
+     * - PhpdocAnnotationWithoutDotFixer
+     * - PhpdocInlineTagNormalizerFixer
+     * - PhpdocLineSpanFixer
+     * - PhpdocNoAccessFixer
+     * - PhpdocNoAliasTagFixer
+     * - PhpdocNoEmptyReturnFixer
+     * - PhpdocNoPackageFixer
+     * - PhpdocNoUselessInheritdocFixer
+     * - PhpdocOrderByValueFixer
+     * - PhpdocOrderFixer
+     * - PhpdocParamOrderFixer
+     * - PhpdocReadonlyClassCommentToKeywordFixer
+     * - PhpdocReturnSelfReferenceFixer
+     * - PhpdocSeparationFixer
+     * - PhpdocSingleLineVarSpacingFixer
+     * - PhpdocSummaryFixer
+     * - PhpdocTagCasingFixer
+     * - PhpdocTagTypeFixer
+     * - PhpdocToParamTypeFixer
+     * - PhpdocToPropertyTypeFixer
+     * - PhpdocToReturnTypeFixer
+     * - PhpdocTrimConsecutiveBlankLineSeparationFixer
+     * - PhpdocTrimFixer
+     * - PhpdocTypesFixer
+     * - PhpdocTypesOrderFixer
+     * - PhpdocVarAnnotationCorrectOrderFixer
+     * - PhpdocVarWithoutNameFixer
+     *
+     * Must run after:
+     *
+     * - IndentationTypeFixer
+     * - PhpdocToCommentFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocInlineTagNormalizerFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocInlineTagNormalizerFixer.php
@@ -52,8 +52,18 @@ final class PhpdocInlineTagNormalizerFixer extends AbstractFixer implements Conf
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php
@@ -52,8 +52,20 @@ final class PhpdocLineSpanFixer extends AbstractFixer implements WhitespacesAwar
     /**
      * {@inheritdoc}
      *
-     * Must run before NoSuperfluousPhpdocTagsFixer, PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, GeneralPhpdocAnnotationRemoveFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - NoSuperfluousPhpdocTagsFixer
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - GeneralPhpdocAnnotationRemoveFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocNoAccessFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoAccessFixer.php
@@ -49,8 +49,21 @@ class Foo
     /**
      * {@inheritdoc}
      *
-     * Must run before NoEmptyPhpdocFixer, PhpdocAlignFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - NoEmptyPhpdocFixer
+     * - PhpdocAlignFixer
+     * - PhpdocSeparationFixer
+     * - PhpdocTrimFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
@@ -73,8 +73,20 @@ final class Example
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAddMissingParamAnnotationFixer, PhpdocAlignFixer, PhpdocSingleLineVarSpacingFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAddMissingParamAnnotationFixer
+     * - PhpdocAlignFixer
+     * - PhpdocSingleLineVarSpacingFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
@@ -61,8 +61,23 @@ function foo() {}
     /**
      * {@inheritdoc}
      *
-     * Must run before NoEmptyPhpdocFixer, PhpdocAlignFixer, PhpdocOrderFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer, VoidReturnFixer.
+     * Must run before:
+     *
+     * - NoEmptyPhpdocFixer
+     * - PhpdocAlignFixer
+     * - PhpdocOrderFixer
+     * - PhpdocSeparationFixer
+     * - PhpdocTrimFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
+     * - VoidReturnFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocNoPackageFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoPackageFixer.php
@@ -49,8 +49,21 @@ class Baz
     /**
      * {@inheritdoc}
      *
-     * Must run before NoEmptyPhpdocFixer, PhpdocAlignFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - NoEmptyPhpdocFixer
+     * - PhpdocAlignFixer
+     * - PhpdocSeparationFixer
+     * - PhpdocTrimFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
@@ -42,8 +42,20 @@ final class PhpdocNoUselessInheritdocFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before NoEmptyPhpdocFixer, NoTrailingWhitespaceInCommentFixer, PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - NoEmptyPhpdocFixer
+     * - NoTrailingWhitespaceInCommentFixer
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocOrderByValueFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderByValueFixer.php
@@ -72,8 +72,19 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpUnitFqcnAnnotationFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpUnitFqcnAnnotationFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderFixer.php
@@ -75,8 +75,22 @@ final class PhpdocOrderFixer extends AbstractFixer implements ConfigurableFixerI
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocIndentFixer, PhpdocNoEmptyReturnFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     * - PhpdocSeparationFixer
+     * - PhpdocTrimFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocAddMissingParamAnnotationFixer
+     * - PhpdocIndentFixer
+     * - PhpdocNoEmptyReturnFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocParamOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocParamOrderFixer.php
@@ -40,8 +40,18 @@ final class PhpdocParamOrderFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
@@ -103,8 +103,19 @@ class Sample
     /**
      * {@inheritdoc}
      *
-     * Must run before NoSuperfluousPhpdocTagsFixer, PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - NoSuperfluousPhpdocTagsFixer
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocScalarFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocScalarFixer.php
@@ -82,8 +82,44 @@ function sample($a, $b, $c)
     /**
      * {@inheritdoc}
      *
-     * Must run before GeneralPhpdocAnnotationRemoveFixer, GeneralPhpdocTagRenameFixer, NoBlankLinesAfterPhpdocFixer, NoEmptyPhpdocFixer, NoSuperfluousPhpdocTagsFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocAlignFixer, PhpdocInlineTagNormalizerFixer, PhpdocLineSpanFixer, PhpdocNoAccessFixer, PhpdocNoAliasTagFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocNoUselessInheritdocFixer, PhpdocOrderByValueFixer, PhpdocOrderFixer, PhpdocParamOrderFixer, PhpdocReadonlyClassCommentToKeywordFixer, PhpdocReturnSelfReferenceFixer, PhpdocSeparationFixer, PhpdocSingleLineVarSpacingFixer, PhpdocSummaryFixer, PhpdocTagCasingFixer, PhpdocTagTypeFixer, PhpdocToParamTypeFixer, PhpdocToPropertyTypeFixer, PhpdocToReturnTypeFixer, PhpdocTrimConsecutiveBlankLineSeparationFixer, PhpdocTrimFixer, PhpdocTypesOrderFixer, PhpdocVarAnnotationCorrectOrderFixer, PhpdocVarWithoutNameFixer.
-     * Must run after PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - GeneralPhpdocAnnotationRemoveFixer
+     * - GeneralPhpdocTagRenameFixer
+     * - NoBlankLinesAfterPhpdocFixer
+     * - NoEmptyPhpdocFixer
+     * - NoSuperfluousPhpdocTagsFixer
+     * - PhpdocAddMissingParamAnnotationFixer
+     * - PhpdocAlignFixer
+     * - PhpdocInlineTagNormalizerFixer
+     * - PhpdocLineSpanFixer
+     * - PhpdocNoAccessFixer
+     * - PhpdocNoAliasTagFixer
+     * - PhpdocNoEmptyReturnFixer
+     * - PhpdocNoPackageFixer
+     * - PhpdocNoUselessInheritdocFixer
+     * - PhpdocOrderByValueFixer
+     * - PhpdocOrderFixer
+     * - PhpdocParamOrderFixer
+     * - PhpdocReadonlyClassCommentToKeywordFixer
+     * - PhpdocReturnSelfReferenceFixer
+     * - PhpdocSeparationFixer
+     * - PhpdocSingleLineVarSpacingFixer
+     * - PhpdocSummaryFixer
+     * - PhpdocTagCasingFixer
+     * - PhpdocTagTypeFixer
+     * - PhpdocToParamTypeFixer
+     * - PhpdocToPropertyTypeFixer
+     * - PhpdocToReturnTypeFixer
+     * - PhpdocTrimConsecutiveBlankLineSeparationFixer
+     * - PhpdocTrimFixer
+     * - PhpdocTypesOrderFixer
+     * - PhpdocVarAnnotationCorrectOrderFixer
+     * - PhpdocVarWithoutNameFixer
+     *
+     * Must run after:
+     *
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
@@ -104,8 +104,26 @@ final class PhpdocSeparationFixer extends AbstractFixer implements ConfigurableF
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, GeneralPhpdocAnnotationRemoveFixer, PhpUnitInternalClassFixer, PhpUnitSizeClassFixer, PhpUnitTestClassRequiresCoversFixer, PhpdocIndentFixer, PhpdocNoAccessFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocOrderFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - GeneralPhpdocAnnotationRemoveFixer
+     * - PhpUnitInternalClassFixer
+     * - PhpUnitSizeClassFixer
+     * - PhpUnitTestClassRequiresCoversFixer
+     * - PhpdocIndentFixer
+     * - PhpdocNoAccessFixer
+     * - PhpdocNoEmptyReturnFixer
+     * - PhpdocNoPackageFixer
+     * - PhpdocOrderFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
@@ -38,8 +38,19 @@ final class PhpdocSingleLineVarSpacingFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocNoAliasTagFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocNoAliasTagFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
@@ -45,8 +45,18 @@ function foo () {}
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocTagCasingFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTagCasingFixer.php
@@ -44,8 +44,18 @@ final class PhpdocTagCasingFixer extends AbstractProxyFixer implements Configura
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocTagTypeFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTagTypeFixer.php
@@ -64,8 +64,18 @@ final class PhpdocTagTypeFixer extends AbstractFixer implements ConfigurableFixe
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
@@ -46,8 +46,49 @@ final class PhpdocToCommentFixer extends AbstractFixer implements ConfigurableFi
     /**
      * {@inheritdoc}
      *
-     * Must run before GeneralPhpdocAnnotationRemoveFixer, GeneralPhpdocTagRenameFixer, NoBlankLinesAfterPhpdocFixer, NoEmptyCommentFixer, NoEmptyPhpdocFixer, NoSuperfluousPhpdocTagsFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocAlignFixer, PhpdocAnnotationWithoutDotFixer, PhpdocIndentFixer, PhpdocInlineTagNormalizerFixer, PhpdocLineSpanFixer, PhpdocNoAccessFixer, PhpdocNoAliasTagFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocNoUselessInheritdocFixer, PhpdocOrderByValueFixer, PhpdocOrderFixer, PhpdocParamOrderFixer, PhpdocReadonlyClassCommentToKeywordFixer, PhpdocReturnSelfReferenceFixer, PhpdocSeparationFixer, PhpdocSingleLineVarSpacingFixer, PhpdocSummaryFixer, PhpdocTagCasingFixer, PhpdocTagTypeFixer, PhpdocToParamTypeFixer, PhpdocToPropertyTypeFixer, PhpdocToReturnTypeFixer, PhpdocTrimConsecutiveBlankLineSeparationFixer, PhpdocTrimFixer, PhpdocTypesOrderFixer, PhpdocVarAnnotationCorrectOrderFixer, PhpdocVarWithoutNameFixer, SingleLineCommentSpacingFixer, SingleLineCommentStyleFixer.
-     * Must run after CommentToPhpdocFixer.
+     * Must run before:
+     *
+     * - GeneralPhpdocAnnotationRemoveFixer
+     * - GeneralPhpdocTagRenameFixer
+     * - NoBlankLinesAfterPhpdocFixer
+     * - NoEmptyCommentFixer
+     * - NoEmptyPhpdocFixer
+     * - NoSuperfluousPhpdocTagsFixer
+     * - PhpdocAddMissingParamAnnotationFixer
+     * - PhpdocAlignFixer
+     * - PhpdocAnnotationWithoutDotFixer
+     * - PhpdocIndentFixer
+     * - PhpdocInlineTagNormalizerFixer
+     * - PhpdocLineSpanFixer
+     * - PhpdocNoAccessFixer
+     * - PhpdocNoAliasTagFixer
+     * - PhpdocNoEmptyReturnFixer
+     * - PhpdocNoPackageFixer
+     * - PhpdocNoUselessInheritdocFixer
+     * - PhpdocOrderByValueFixer
+     * - PhpdocOrderFixer
+     * - PhpdocParamOrderFixer
+     * - PhpdocReadonlyClassCommentToKeywordFixer
+     * - PhpdocReturnSelfReferenceFixer
+     * - PhpdocSeparationFixer
+     * - PhpdocSingleLineVarSpacingFixer
+     * - PhpdocSummaryFixer
+     * - PhpdocTagCasingFixer
+     * - PhpdocTagTypeFixer
+     * - PhpdocToParamTypeFixer
+     * - PhpdocToPropertyTypeFixer
+     * - PhpdocToReturnTypeFixer
+     * - PhpdocTrimConsecutiveBlankLineSeparationFixer
+     * - PhpdocTrimFixer
+     * - PhpdocTypesOrderFixer
+     * - PhpdocVarAnnotationCorrectOrderFixer
+     * - PhpdocVarWithoutNameFixer
+     * - SingleLineCommentSpacingFixer
+     * - SingleLineCommentStyleFixer
+     *
+     * Must run after:
+     *
+     * - CommentToPhpdocFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocTrimConsecutiveBlankLineSeparationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTrimConsecutiveBlankLineSeparationFixer.php
@@ -62,8 +62,18 @@ function fnc($foo) {}
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocTrimFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTrimFixer.php
@@ -46,8 +46,24 @@ final class Foo {}
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, GeneralPhpdocAnnotationRemoveFixer, PhpUnitTestAnnotationFixer, PhpdocIndentFixer, PhpdocNoAccessFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocOrderFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - GeneralPhpdocAnnotationRemoveFixer
+     * - PhpUnitTestAnnotationFixer
+     * - PhpdocIndentFixer
+     * - PhpdocNoAccessFixer
+     * - PhpdocNoEmptyReturnFixer
+     * - PhpdocNoPackageFixer
+     * - PhpdocOrderFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocTypesFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesFixer.php
@@ -111,8 +111,45 @@ final class PhpdocTypesFixer extends AbstractPhpdocTypesFixer implements Configu
     /**
      * {@inheritdoc}
      *
-     * Must run before GeneralPhpdocAnnotationRemoveFixer, GeneralPhpdocTagRenameFixer, NoBlankLinesAfterPhpdocFixer, NoEmptyPhpdocFixer, NoSuperfluousPhpdocTagsFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocAlignFixer, PhpdocInlineTagNormalizerFixer, PhpdocLineSpanFixer, PhpdocNoAccessFixer, PhpdocNoAliasTagFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocNoUselessInheritdocFixer, PhpdocOrderByValueFixer, PhpdocOrderFixer, PhpdocParamOrderFixer, PhpdocReadonlyClassCommentToKeywordFixer, PhpdocReturnSelfReferenceFixer, PhpdocScalarFixer, PhpdocSeparationFixer, PhpdocSingleLineVarSpacingFixer, PhpdocSummaryFixer, PhpdocTagCasingFixer, PhpdocTagTypeFixer, PhpdocToParamTypeFixer, PhpdocToPropertyTypeFixer, PhpdocToReturnTypeFixer, PhpdocTrimConsecutiveBlankLineSeparationFixer, PhpdocTrimFixer, PhpdocTypesOrderFixer, PhpdocVarAnnotationCorrectOrderFixer, PhpdocVarWithoutNameFixer.
-     * Must run after PhpdocIndentFixer.
+     * Must run before:
+     *
+     * - GeneralPhpdocAnnotationRemoveFixer
+     * - GeneralPhpdocTagRenameFixer
+     * - NoBlankLinesAfterPhpdocFixer
+     * - NoEmptyPhpdocFixer
+     * - NoSuperfluousPhpdocTagsFixer
+     * - PhpdocAddMissingParamAnnotationFixer
+     * - PhpdocAlignFixer
+     * - PhpdocInlineTagNormalizerFixer
+     * - PhpdocLineSpanFixer
+     * - PhpdocNoAccessFixer
+     * - PhpdocNoAliasTagFixer
+     * - PhpdocNoEmptyReturnFixer
+     * - PhpdocNoPackageFixer
+     * - PhpdocNoUselessInheritdocFixer
+     * - PhpdocOrderByValueFixer
+     * - PhpdocOrderFixer
+     * - PhpdocParamOrderFixer
+     * - PhpdocReadonlyClassCommentToKeywordFixer
+     * - PhpdocReturnSelfReferenceFixer
+     * - PhpdocScalarFixer
+     * - PhpdocSeparationFixer
+     * - PhpdocSingleLineVarSpacingFixer
+     * - PhpdocSummaryFixer
+     * - PhpdocTagCasingFixer
+     * - PhpdocTagTypeFixer
+     * - PhpdocToParamTypeFixer
+     * - PhpdocToPropertyTypeFixer
+     * - PhpdocToReturnTypeFixer
+     * - PhpdocTrimConsecutiveBlankLineSeparationFixer
+     * - PhpdocTrimFixer
+     * - PhpdocTypesOrderFixer
+     * - PhpdocVarAnnotationCorrectOrderFixer
+     * - PhpdocVarWithoutNameFixer
+     *
+     * Must run after:
+     *
+     * - PhpdocIndentFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -96,8 +96,18 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements ConfigurableF
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocVarAnnotationCorrectOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocVarAnnotationCorrectOrderFixer.php
@@ -41,8 +41,18 @@ $foo = 2 + 2;
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
@@ -55,8 +55,18 @@ final class Foo
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run before:
+     *
+     * - PhpdocAlignFixer
+     *
+     * Must run after:
+     *
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocIndentFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ReturnNotation/NoUselessReturnFixer.php
+++ b/src/Fixer/ReturnNotation/NoUselessReturnFixer.php
@@ -49,8 +49,21 @@ function example($b) {
     /**
      * {@inheritdoc}
      *
-     * Must run before BlankLineBeforeStatementFixer, NoExtraBlankLinesFixer, NoWhitespaceInBlankLineFixer, SingleLineCommentStyleFixer, SingleLineEmptyBodyFixer.
-     * Must run after NoEmptyStatementFixer, NoUnneededBracesFixer, NoUnneededCurlyBracesFixer, NoUselessElseFixer, SimplifiedNullReturnFixer.
+     * Must run before:
+     *
+     * - BlankLineBeforeStatementFixer
+     * - NoExtraBlankLinesFixer
+     * - NoWhitespaceInBlankLineFixer
+     * - SingleLineCommentStyleFixer
+     * - SingleLineEmptyBodyFixer
+     *
+     * Must run after:
+     *
+     * - NoEmptyStatementFixer
+     * - NoUnneededBracesFixer
+     * - NoUnneededCurlyBracesFixer
+     * - NoUselessElseFixer
+     * - SimplifiedNullReturnFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+++ b/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -38,8 +38,15 @@ final class ReturnAssignmentFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before BlankLineBeforeStatementFixer.
-     * Must run after NoEmptyStatementFixer, NoUnneededBracesFixer, NoUnneededCurlyBracesFixer.
+     * Must run before:
+     *
+     * - BlankLineBeforeStatementFixer
+     *
+     * Must run after:
+     *
+     * - NoEmptyStatementFixer
+     * - NoUnneededBracesFixer
+     * - NoUnneededCurlyBracesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+++ b/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
@@ -49,7 +49,10 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before NoUselessReturnFixer, VoidReturnFixer.
+     * Must run before:
+     *
+     * - NoUselessReturnFixer
+     * - VoidReturnFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+++ b/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
@@ -71,8 +71,17 @@ $object->method1()
     /**
      * {@inheritdoc}
      *
-     * Must run before SpaceAfterSemicolonFixer.
-     * Must run after CombineConsecutiveIssetsFixer, GetClassToClassKeywordFixer, NoEmptyStatementFixer, SimplifiedIfReturnFixer, SingleImportPerStatementFixer.
+     * Must run before:
+     *
+     * - SpaceAfterSemicolonFixer
+     *
+     * Must run after:
+     *
+     * - CombineConsecutiveIssetsFixer
+     * - GetClassToClassKeywordFixer
+     * - NoEmptyStatementFixer
+     * - SimplifiedIfReturnFixer
+     * - SingleImportPerStatementFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Semicolon/NoEmptyStatementFixer.php
+++ b/src/Fixer/Semicolon/NoEmptyStatementFixer.php
@@ -41,8 +41,26 @@ final class NoEmptyStatementFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesFixer, CombineConsecutiveUnsetsFixer, EmptyLoopBodyFixer, MultilineWhitespaceBeforeSemicolonsFixer, NoExtraBlankLinesFixer, NoMultipleStatementsPerLineFixer, NoSinglelineWhitespaceBeforeSemicolonsFixer, NoTrailingWhitespaceFixer, NoUselessElseFixer, NoUselessReturnFixer, NoWhitespaceInBlankLineFixer, ReturnAssignmentFixer, SpaceAfterSemicolonFixer, SwitchCaseSemicolonToColonFixer.
-     * Must run after NoUselessSprintfFixer.
+     * Must run before:
+     *
+     * - BracesFixer
+     * - CombineConsecutiveUnsetsFixer
+     * - EmptyLoopBodyFixer
+     * - MultilineWhitespaceBeforeSemicolonsFixer
+     * - NoExtraBlankLinesFixer
+     * - NoMultipleStatementsPerLineFixer
+     * - NoSinglelineWhitespaceBeforeSemicolonsFixer
+     * - NoTrailingWhitespaceFixer
+     * - NoUselessElseFixer
+     * - NoUselessReturnFixer
+     * - NoWhitespaceInBlankLineFixer
+     * - ReturnAssignmentFixer
+     * - SpaceAfterSemicolonFixer
+     * - SwitchCaseSemicolonToColonFixer
+     *
+     * Must run after:
+     *
+     * - NoUselessSprintfFixer
      */
     public function getPriority(): int
     {
@@ -112,10 +130,17 @@ final class NoEmptyStatementFixer extends AbstractFixer
      *
      * Test for the following cases
      * - just '{' '}' block (following open tag or ';')
-     * - if, else, elseif
-     * - interface, trait, class (but not anonymous)
-     * - catch, finally (but not try)
-     * - for, foreach, while (but not 'do - while')
+     * - if
+     * - else
+     * - elseif
+     * - interface
+     * - trait
+     * - class (but not anonymous)
+     * - catch
+     * - finally (but not try)
+     * - for
+     * - foreach
+     * - while (but not 'do - while')
      * - switch
      * - function (declaration, but not lambda)
      * - declare (with '{' '}')

--- a/src/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixer.php
+++ b/src/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixer.php
@@ -36,7 +36,15 @@ final class NoSinglelineWhitespaceBeforeSemicolonsFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after CombineConsecutiveIssetsFixer, FunctionToConstantFixer, LongToShorthandOperatorFixer, NoEmptyStatementFixer, NoUnneededImportAliasFixer, SimplifiedIfReturnFixer, SingleImportPerStatementFixer.
+     * Must run after:
+     *
+     * - CombineConsecutiveIssetsFixer
+     * - FunctionToConstantFixer
+     * - LongToShorthandOperatorFixer
+     * - NoEmptyStatementFixer
+     * - NoUnneededImportAliasFixer
+     * - SimplifiedIfReturnFixer
+     * - SingleImportPerStatementFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Semicolon/SemicolonAfterInstructionFixer.php
+++ b/src/Fixer/Semicolon/SemicolonAfterInstructionFixer.php
@@ -34,7 +34,9 @@ final class SemicolonAfterInstructionFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before SimplifiedIfReturnFixer.
+     * Must run before:
+     *
+     * - SimplifiedIfReturnFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
+++ b/src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
@@ -50,7 +50,14 @@ final class SpaceAfterSemicolonFixer extends AbstractFixer implements Configurab
     /**
      * {@inheritdoc}
      *
-     * Must run after CombineConsecutiveUnsetsFixer, MultilineWhitespaceBeforeSemicolonsFixer, NoEmptyStatementFixer, OrderedClassElementsFixer, SingleImportPerStatementFixer, SingleTraitInsertPerStatementFixer.
+     * Must run after:
+     *
+     * - CombineConsecutiveUnsetsFixer
+     * - MultilineWhitespaceBeforeSemicolonsFixer
+     * - NoEmptyStatementFixer
+     * - OrderedClassElementsFixer
+     * - SingleImportPerStatementFixer
+     * - SingleTraitInsertPerStatementFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Strict/DeclareStrictTypesFixer.php
+++ b/src/Fixer/Strict/DeclareStrictTypesFixer.php
@@ -44,7 +44,11 @@ final class DeclareStrictTypesFixer extends AbstractFixer implements Whitespaces
     /**
      * {@inheritdoc}
      *
-     * Must run before BlankLineAfterOpeningTagFixer, DeclareEqualNormalizeFixer, HeaderCommentFixer.
+     * Must run before:
+     *
+     * - BlankLineAfterOpeningTagFixer
+     * - DeclareEqualNormalizeFixer
+     * - HeaderCommentFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Strict/StrictComparisonFixer.php
+++ b/src/Fixer/Strict/StrictComparisonFixer.php
@@ -39,7 +39,10 @@ final class StrictComparisonFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before BinaryOperatorSpacesFixer, ModernizeStrposFixer.
+     * Must run before:
+     *
+     * - BinaryOperatorSpacesFixer
+     * - ModernizeStrposFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Strict/StrictParamFixer.php
+++ b/src/Fixer/Strict/StrictParamFixer.php
@@ -51,7 +51,10 @@ final class StrictParamFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before MethodArgumentSpaceFixer, NativeFunctionInvocationFixer.
+     * Must run before:
+     *
+     * - MethodArgumentSpaceFixer
+     * - NativeFunctionInvocationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/StringNotation/EscapeImplicitBackslashesFixer.php
+++ b/src/Fixer/StringNotation/EscapeImplicitBackslashesFixer.php
@@ -81,8 +81,14 @@ final class EscapeImplicitBackslashesFixer extends AbstractFixer implements Conf
     /**
      * {@inheritdoc}
      *
-     * Must run before HeredocToNowdocFixer, SingleQuoteFixer.
-     * Must run after BacktickToShellExecFixer.
+     * Must run before:
+     *
+     * - HeredocToNowdocFixer
+     * - SingleQuoteFixer
+     *
+     * Must run after:
+     *
+     * - BacktickToShellExecFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -52,7 +52,9 @@ final class ExplicitStringVariableFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after BacktickToShellExecFixer.
+     * Must run after:
+     *
+     * - BacktickToShellExecFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/StringNotation/HeredocToNowdocFixer.php
+++ b/src/Fixer/StringNotation/HeredocToNowdocFixer.php
@@ -47,7 +47,9 @@ final class HeredocToNowdocFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after EscapeImplicitBackslashesFixer.
+     * Must run after:
+     *
+     * - EscapeImplicitBackslashesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/StringNotation/NoBinaryStringFixer.php
+++ b/src/Fixer/StringNotation/NoBinaryStringFixer.php
@@ -51,7 +51,12 @@ final class NoBinaryStringFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before NoUselessConcatOperatorFixer, PhpUnitDedicateAssertInternalTypeFixer, RegularCallableCallFixer, SetTypeToCastFixer.
+     * Must run before:
+     *
+     * - NoUselessConcatOperatorFixer
+     * - PhpUnitDedicateAssertInternalTypeFixer
+     * - RegularCallableCallFixer
+     * - SetTypeToCastFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
+++ b/src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
@@ -58,7 +58,9 @@ final class SimpleToComplexStringVariableFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after ExplicitStringVariableFixer.
+     * Must run after:
+     *
+     * - ExplicitStringVariableFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/StringNotation/SingleQuoteFixer.php
+++ b/src/Fixer/StringNotation/SingleQuoteFixer.php
@@ -56,8 +56,14 @@ final class SingleQuoteFixer extends AbstractFixer implements ConfigurableFixerI
     /**
      * {@inheritdoc}
      *
-     * Must run before NoUselessConcatOperatorFixer.
-     * Must run after BacktickToShellExecFixer, EscapeImplicitBackslashesFixer.
+     * Must run before:
+     *
+     * - NoUselessConcatOperatorFixer
+     *
+     * Must run after:
+     *
+     * - BacktickToShellExecFixer
+     * - EscapeImplicitBackslashesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/StringNotation/StringLengthToEmptyFixer.php
+++ b/src/Fixer/StringNotation/StringLengthToEmptyFixer.php
@@ -37,8 +37,15 @@ final class StringLengthToEmptyFixer extends AbstractFunctionReferenceFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before NoExtraBlankLinesFixer, NoTrailingWhitespaceFixer.
-     * Must run after NoSpacesInsideParenthesisFixer, SpacesInsideParenthesesFixer.
+     * Must run before:
+     *
+     * - NoExtraBlankLinesFixer
+     * - NoTrailingWhitespaceFixer
+     *
+     * Must run after:
+     *
+     * - NoSpacesInsideParenthesisFixer
+     * - SpacesInsideParenthesesFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Whitespace/ArrayIndentationFixer.php
+++ b/src/Fixer/Whitespace/ArrayIndentationFixer.php
@@ -47,8 +47,14 @@ final class ArrayIndentationFixer extends AbstractFixer implements WhitespacesAw
     /**
      * {@inheritdoc}
      *
-     * Must run before AlignMultilineCommentFixer, BinaryOperatorSpacesFixer.
-     * Must run after MethodArgumentSpaceFixer.
+     * Must run before:
+     *
+     * - AlignMultilineCommentFixer
+     * - BinaryOperatorSpacesFixer
+     *
+     * Must run after:
+     *
+     * - MethodArgumentSpaceFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -239,7 +239,13 @@ function getValues() {
     /**
      * {@inheritdoc}
      *
-     * Must run after NoExtraBlankLinesFixer, NoUselessElseFixer, NoUselessReturnFixer, ReturnAssignmentFixer, YieldFromArrayToYieldsFixer.
+     * Must run after:
+     *
+     * - NoExtraBlankLinesFixer
+     * - NoUselessElseFixer
+     * - NoUselessReturnFixer
+     * - ReturnAssignmentFixer
+     * - YieldFromArrayToYieldsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Whitespace/BlankLineBetweenImportGroupsFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBetweenImportGroupsFixer.php
@@ -88,7 +88,9 @@ use Bar;
     /**
      * {@inheritdoc}
      *
-     * Must run after OrderedImportsFixer.
+     * Must run after:
+     *
+     * - OrderedImportsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Whitespace/HeredocIndentationFixer.php
+++ b/src/Fixer/Whitespace/HeredocIndentationFixer.php
@@ -72,7 +72,10 @@ final class HeredocIndentationFixer extends AbstractFixer implements Configurabl
     /**
      * {@inheritdoc}
      *
-     * Must run after BracesFixer, StatementIndentationFixer.
+     * Must run after:
+     *
+     * - BracesFixer
+     * - StatementIndentationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Whitespace/IndentationTypeFixer.php
+++ b/src/Fixer/Whitespace/IndentationTypeFixer.php
@@ -48,8 +48,13 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
     /**
      * {@inheritdoc}
      *
-     * Must run before PhpdocIndentFixer.
-     * Must run after ClassAttributesSeparationFixer.
+     * Must run before:
+     *
+     * - PhpdocIndentFixer
+     *
+     * Must run after:
+     *
+     * - ClassAttributesSeparationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
@@ -254,8 +254,29 @@ switch($a) {
     /**
      * {@inheritdoc}
      *
-     * Must run before BlankLineBeforeStatementFixer.
-     * Must run after ClassAttributesSeparationFixer, CombineConsecutiveUnsetsFixer, EmptyLoopBodyFixer, EmptyLoopConditionFixer, FunctionToConstantFixer, LongToShorthandOperatorFixer, ModernizeStrposFixer, NoEmptyCommentFixer, NoEmptyPhpdocFixer, NoEmptyStatementFixer, NoUnusedImportsFixer, NoUselessElseFixer, NoUselessReturnFixer, NoUselessSprintfFixer, PhpdocReadonlyClassCommentToKeywordFixer, StringLengthToEmptyFixer, YieldFromArrayToYieldsFixer.
+     * Must run before:
+     *
+     * - BlankLineBeforeStatementFixer
+     *
+     * Must run after:
+     *
+     * - ClassAttributesSeparationFixer
+     * - CombineConsecutiveUnsetsFixer
+     * - EmptyLoopBodyFixer
+     * - EmptyLoopConditionFixer
+     * - FunctionToConstantFixer
+     * - LongToShorthandOperatorFixer
+     * - ModernizeStrposFixer
+     * - NoEmptyCommentFixer
+     * - NoEmptyPhpdocFixer
+     * - NoEmptyStatementFixer
+     * - NoUnusedImportsFixer
+     * - NoUselessElseFixer
+     * - NoUselessReturnFixer
+     * - NoUselessSprintfFixer
+     * - PhpdocReadonlyClassCommentToKeywordFixer
+     * - StringLengthToEmptyFixer
+     * - YieldFromArrayToYieldsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
+++ b/src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
@@ -50,8 +50,21 @@ function foo( \$bar, \$baz )
     /**
      * {@inheritdoc}
      *
-     * Must run before FunctionToConstantFixer, GetClassToClassKeywordFixer, StringLengthToEmptyFixer.
-     * Must run after CombineConsecutiveIssetsFixer, CombineNestedDirnameFixer, IncrementStyleFixer, LambdaNotUsedImportFixer, ModernizeStrposFixer, NoUselessSprintfFixer, PowToExponentiationFixer.
+     * Must run before:
+     *
+     * - FunctionToConstantFixer
+     * - GetClassToClassKeywordFixer
+     * - StringLengthToEmptyFixer
+     *
+     * Must run after:
+     *
+     * - CombineConsecutiveIssetsFixer
+     * - CombineNestedDirnameFixer
+     * - IncrementStyleFixer
+     * - LambdaNotUsedImportFixer
+     * - ModernizeStrposFixer
+     * - NoUselessSprintfFixer
+     * - PowToExponentiationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
+++ b/src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
@@ -43,7 +43,21 @@ final class NoTrailingWhitespaceFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after CombineConsecutiveIssetsFixer, CombineConsecutiveUnsetsFixer, EmptyLoopBodyFixer, EmptyLoopConditionFixer, FunctionToConstantFixer, ModernizeStrposFixer, NoEmptyCommentFixer, NoEmptyPhpdocFixer, NoEmptyStatementFixer, NoUnneededControlParenthesesFixer, NoUselessElseFixer, StringLengthToEmptyFixer, TernaryToElvisOperatorFixer.
+     * Must run after:
+     *
+     * - CombineConsecutiveIssetsFixer
+     * - CombineConsecutiveUnsetsFixer
+     * - EmptyLoopBodyFixer
+     * - EmptyLoopConditionFixer
+     * - FunctionToConstantFixer
+     * - ModernizeStrposFixer
+     * - NoEmptyCommentFixer
+     * - NoEmptyPhpdocFixer
+     * - NoEmptyStatementFixer
+     * - NoUnneededControlParenthesesFixer
+     * - NoUselessElseFixer
+     * - StringLengthToEmptyFixer
+     * - TernaryToElvisOperatorFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
+++ b/src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
@@ -38,7 +38,18 @@ final class NoWhitespaceInBlankLineFixer extends AbstractFixer implements Whites
     /**
      * {@inheritdoc}
      *
-     * Must run after AssignNullCoalescingToCoalesceEqualFixer, CombineConsecutiveIssetsFixer, CombineConsecutiveUnsetsFixer, FunctionToConstantFixer, NoEmptyCommentFixer, NoEmptyPhpdocFixer, NoEmptyStatementFixer, NoUselessElseFixer, NoUselessReturnFixer, YieldFromArrayToYieldsFixer.
+     * Must run after:
+     *
+     * - AssignNullCoalescingToCoalesceEqualFixer
+     * - CombineConsecutiveIssetsFixer
+     * - CombineConsecutiveUnsetsFixer
+     * - FunctionToConstantFixer
+     * - NoEmptyCommentFixer
+     * - NoEmptyPhpdocFixer
+     * - NoEmptyStatementFixer
+     * - NoUselessElseFixer
+     * - NoUselessReturnFixer
+     * - YieldFromArrayToYieldsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Whitespace/SpacesInsideParenthesesFixer.php
+++ b/src/Fixer/Whitespace/SpacesInsideParenthesesFixer.php
@@ -66,8 +66,21 @@ function foo(\$bar, \$baz)
     /**
      * {@inheritdoc}
      *
-     * Must run before FunctionToConstantFixer, GetClassToClassKeywordFixer, StringLengthToEmptyFixer.
-     * Must run after CombineConsecutiveIssetsFixer, CombineNestedDirnameFixer, IncrementStyleFixer, LambdaNotUsedImportFixer, ModernizeStrposFixer, NoUselessSprintfFixer, PowToExponentiationFixer.
+     * Must run before:
+     *
+     * - FunctionToConstantFixer
+     * - GetClassToClassKeywordFixer
+     * - StringLengthToEmptyFixer
+     *
+     * Must run after:
+     *
+     * - CombineConsecutiveIssetsFixer
+     * - CombineNestedDirnameFixer
+     * - IncrementStyleFixer
+     * - LambdaNotUsedImportFixer
+     * - ModernizeStrposFixer
+     * - NoUselessSprintfFixer
+     * - PowToExponentiationFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -63,8 +63,18 @@ else {
     /**
      * {@inheritdoc}
      *
-     * Must run before HeredocIndentationFixer.
-     * Must run after BracesPositionFixer, ClassAttributesSeparationFixer, CurlyBracesPositionFixer, MethodArgumentSpaceFixer, NoUselessElseFixer, YieldFromArrayToYieldsFixer.
+     * Must run before:
+     *
+     * - HeredocIndentationFixer
+     *
+     * Must run after:
+     *
+     * - BracesPositionFixer
+     * - ClassAttributesSeparationFixer
+     * - CurlyBracesPositionFixer
+     * - MethodArgumentSpaceFixer
+     * - NoUselessElseFixer
+     * - YieldFromArrayToYieldsFixer
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Whitespace/TypesSpacesFixer.php
+++ b/src/Fixer/Whitespace/TypesSpacesFixer.php
@@ -63,7 +63,10 @@ final class TypesSpacesFixer extends AbstractFixer implements ConfigurableFixerI
     /**
      * {@inheritdoc}
      *
-     * Must run after NullableTypeDeclarationFixer, OrderedTypesFixer.
+     * Must run after:
+     *
+     * - NullableTypeDeclarationFixer
+     * - OrderedTypesFixer
      */
     public function getPriority(): int
     {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -234,9 +234,10 @@ final class FixerFactoryTest extends TestCase
         }
 
         foreach ($graph as $fixerName => $edges) {
-            $expectedMessage = "/**\n     * {@inheritdoc}\n     *";
+            $expectedMessage = "/**\n     * {@inheritdoc}";
 
             foreach ($edges as $label => $others) {
+                $expectedMessage .= "\n     *";
                 if (\count($others) > 0) {
                     $shortClassNames = [];
 
@@ -245,7 +246,15 @@ final class FixerFactoryTest extends TestCase
                     }
 
                     sort($shortClassNames);
-                    $expectedMessage .= sprintf("\n     * Must run %s %s.", $label, implode(', ', $shortClassNames));
+
+                    $format = <<<'TXT'
+
+                             * Must run %s:
+                             *
+                             * - %s
+                        TXT;
+
+                    $expectedMessage .= sprintf($format, $label, implode("\n     * - ", $shortClassNames));
                 }
             }
 


### PR DESCRIPTION
This pull request

- [x] requires the lists of fixers in the DocBlock for fixers that need to run before or after specific fixers to be separated by a dash, space, and new line
- [x] adjusts DocBlocks

💁‍♂️ This could make managing the list a bit easier (you could now slide an item up and down)