### PR TITLE
fix: Mark `PhpdocReadonlyClassCommentToKeywordFixer` as risky

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2352,7 +2352,7 @@ List of Available Rules
    Converts readonly comment on classes to the readonly keyword.
 
    *warning risky* If classes marked with ``@readonly`` annotation were extended anyway,
-   applying this fixer may break the inheritance for these classes.
+   applying this fixer may break the inheritance for their child classes.
 
    `Source PhpCsFixer\\Fixer\\ClassNotation\\PhpdocReadonlyClassCommentToKeywordFixer <./../src/Fixer/ClassNotation/PhpdocReadonlyClassCommentToKeywordFixer.php>`_
 -  `phpdoc_return_self_reference <./rules/phpdoc/phpdoc_return_self_reference.rst>`_

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2351,6 +2351,9 @@ List of Available Rules
 
    Converts readonly comment on classes to the readonly keyword.
 
+   *warning risky* If classes marked with ``@readonly`` annotation were extended anyway,
+   applying this fixer may break the inheritance for these classes.
+
    `Source PhpCsFixer\\Fixer\\ClassNotation\\PhpdocReadonlyClassCommentToKeywordFixer <./../src/Fixer/ClassNotation/PhpdocReadonlyClassCommentToKeywordFixer.php>`_
 -  `phpdoc_return_self_reference <./rules/phpdoc/phpdoc_return_self_reference.rst>`_
 

--- a/doc/rules/class_notation/phpdoc_readonly_class_comment_to_keyword.rst
+++ b/doc/rules/class_notation/phpdoc_readonly_class_comment_to_keyword.rst
@@ -4,6 +4,15 @@ Rule ``phpdoc_readonly_class_comment_to_keyword``
 
 Converts readonly comment on classes to the readonly keyword.
 
+Warning
+-------
+
+Using this rule is risky
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+If classes marked with ``@readonly`` annotation were extended anyway, applying
+this fixer may break the inheritance for these classes.
+
 Examples
 --------
 

--- a/doc/rules/class_notation/phpdoc_readonly_class_comment_to_keyword.rst
+++ b/doc/rules/class_notation/phpdoc_readonly_class_comment_to_keyword.rst
@@ -11,7 +11,7 @@ Using this rule is risky
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 If classes marked with ``@readonly`` annotation were extended anyway, applying
-this fixer may break the inheritance for these classes.
+this fixer may break the inheritance for their child classes.
 
 Examples
 --------

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -209,7 +209,7 @@ Class Notation
 - `ordered_types <./class_notation/ordered_types.rst>`_
 
   Sort union types and intersection types using configured order.
-- `phpdoc_readonly_class_comment_to_keyword <./class_notation/phpdoc_readonly_class_comment_to_keyword.rst>`_
+- `phpdoc_readonly_class_comment_to_keyword <./class_notation/phpdoc_readonly_class_comment_to_keyword.rst>`_ *(risky)*
 
   Converts readonly comment on classes to the readonly keyword.
 - `protected_to_private <./class_notation/protected_to_private.rst>`_

--- a/src/Fixer/ClassNotation/PhpdocReadonlyClassCommentToKeywordFixer.php
+++ b/src/Fixer/ClassNotation/PhpdocReadonlyClassCommentToKeywordFixer.php
@@ -44,6 +44,11 @@ final class PhpdocReadonlyClassCommentToKeywordFixer extends AbstractFixer
         return \PHP_VERSION_ID >= 8_02_00 && $tokens->isTokenKindFound(T_DOC_COMMENT);
     }
 
+    public function isRisky(): bool
+    {
+        return true;
+    }
+
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
@@ -58,7 +63,9 @@ final class PhpdocReadonlyClassCommentToKeywordFixer extends AbstractFixer
                         EOT,
                     new VersionSpecification(8_02_00)
                 ),
-            ]
+            ],
+            null,
+            'If classes marked with `@readonly` annotation were extended anyway, applying this fixer may break the inheritance for these classes.'
         );
     }
 

--- a/src/Fixer/ClassNotation/PhpdocReadonlyClassCommentToKeywordFixer.php
+++ b/src/Fixer/ClassNotation/PhpdocReadonlyClassCommentToKeywordFixer.php
@@ -65,7 +65,7 @@ final class PhpdocReadonlyClassCommentToKeywordFixer extends AbstractFixer
                 ),
             ],
             null,
-            'If classes marked with `@readonly` annotation were extended anyway, applying this fixer may break the inheritance for these classes.'
+            'If classes marked with `@readonly` annotation were extended anyway, applying this fixer may break the inheritance for their child classes.'
         );
     }
 


### PR DESCRIPTION
Following #7353.