### PR TITLE
feat: extend `@Symfony` set to enable `no_superfluous_phpdoc_tags.allow_unused_params`

### DIFF
--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -109,6 +109,7 @@ final class SymfonySet extends AbstractRuleSetDescription
             'no_spaces_around_offset' => true,
             'no_superfluous_phpdoc_tags' => [
                 'remove_inheritdoc' => true,
+                'allow_unused_params' => true
             ],
             'no_trailing_comma_in_singleline' => true,
             'no_unneeded_braces' => [


### PR DESCRIPTION
ref https://github.com/symfony/symfony/pull/52102/files#r1361952724