### PR TITLE
fix: `return $this` to `static` return type

### DIFF
--- a/src/AbstractPhpdocToTypeDeclarationFixer.php
+++ b/src/AbstractPhpdocToTypeDeclarationFixer.php
@@ -185,6 +185,10 @@ abstract class AbstractPhpdocToTypeDeclarationFixer extends AbstractFixer implem
             return null;
         }
 
+        if ('$this' === $commonType) {
+            $commonType = 'static';
+        }
+
         if ('static' === $commonType && (!$isReturnType || \PHP_VERSION_ID < 8_00_00)) {
             $commonType = 'self';
         }

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -482,5 +482,18 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
                 }
             ',
         ];
+
+        yield '$this accessor' => [
+            '<?php
+                    class Foo {
+                        /** @return $this */ function my_foo(): static {}
+                    }
+                ',
+            '<?php
+                    class Foo {
+                        /** @return $this */ function my_foo() {}
+                    }
+                ',
+        ];
     }
 }

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -394,6 +394,20 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
             '<?php /** @return int */ fn(): int => 1;',
             '<?php /** @return int */ fn() => 1;',
         ];
+
+        yield '$this accessor' => [
+            '<?php
+                    class Foo {
+                        /** @return $this */ function my_foo(): static {}
+                    }
+                ',
+            '<?php
+                    class Foo {
+                        /** @return $this */ function my_foo() {}
+                    }
+                ',
+            8_00_00,
+        ];
     }
 
     /**
@@ -481,19 +495,6 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
                     public function something() {}
                 }
             ',
-        ];
-
-        yield '$this accessor' => [
-            '<?php
-                    class Foo {
-                        /** @return $this */ function my_foo(): static {}
-                    }
-                ',
-            '<?php
-                    class Foo {
-                        /** @return $this */ function my_foo() {}
-                    }
-                ',
         ];
     }
 }


### PR DESCRIPTION
Hello 👋 

First of all, thank you to all the creators and contributors for this amazing tool 🖖 I've been using it extensively for some legacy code refactoring and it helps a lot.
One of the things I noticed during my last work was the usage of `@return $this` doc-block instead of `@return self` or `@return static` I usually used before PHP8. Apparently, it's [quite common indeed](https://github.com/search?q=%22%40return+%24this%22+language%3APHP+repo%3Asymfony%2Fsymfony&type=code) :dancer: The current version of `PhpdocToReturnTypeFixer` does not support this case, so I've tried to fix this problem.

As it's my first contribution to this project, I would be grateful for any comments or guidelines 🫡
Cheers 🚀