### PR TITLE
feat: add rule that match only allow has one case on every arm

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1221,6 +1221,11 @@ List of Available Rules
    Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Casing\\MagicMethodCasingFixer <./../src/Fixer/Casing/MagicMethodCasingFixer.php>`_
+-  `match_has_one_case_on_every_arm <./rules/control_structure/match_has_one_case_on_every_arm.rst>`_
+
+   Match only allow has one case on every arm.
+
+   `Source PhpCsFixer\\Fixer\\ControlStructure\\MatchHasOneCaseOnEveryArmFixer <./../src/Fixer/ControlStructure/MatchHasOneCaseOnEveryArmFixer.php>`_
 -  `mb_str_functions <./rules/alias/mb_str_functions.rst>`_
 
    Replace non multibyte-safe functions with corresponding mb function.

--- a/doc/rules/control_structure/match_has_one_case_on_every_arm.rst
+++ b/doc/rules/control_structure/match_has_one_case_on_every_arm.rst
@@ -1,0 +1,25 @@
+========================================
+Rule ``match_has_one_case_on_every_arm``
+========================================
+
+Match only allow has one case on every arm.
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+                    return   match ($bar) {
+                        2 => "c",
+   -                    3,4,5 =>"e",
+   +                    3,
+   +                    4,
+   +                    5 =>"e",
+                        default => "d"
+                    };

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -291,6 +291,9 @@ Control Structure
 - `include <./control_structure/include.rst>`_
 
   Include/Require and file path should be divided with a single space. File path should not be placed within parentheses.
+- `match_has_one_case_on_every_arm <./control_structure/match_has_one_case_on_every_arm.rst>`_
+
+  Match only allow has one case on every arm.
 - `no_alternative_syntax <./control_structure/no_alternative_syntax.rst>`_
 
   Replace control structure alternative syntax to use braces.

--- a/src/Fixer/ControlStructure/MatchHasOneCaseOnEveryArmFixer.php
+++ b/src/Fixer/ControlStructure/MatchHasOneCaseOnEveryArmFixer.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\ControlStructure;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Analyzer\ControlCaseStructuresAnalyzer;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class MatchHasOneCaseOnEveryArmFixer extends AbstractFixer
+{
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return \PHP_VERSION_ID >= 80000 && $tokens->isTokenKindFound(T_MATCH);
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Match only allow has one case on every arm.',
+            [
+                new CodeSample(
+                    '<?php
+                return   match ($bar) {
+                    2 => "c",
+                    3,4,5 =>"e",
+                    default => "d"
+                };
+'
+                ),
+            ]
+        );
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        /** @var \PhpCsFixer\Tokenizer\Analyzer\Analysis\MatchAnalysis $analysis */
+        foreach (ControlCaseStructuresAnalyzer::findControlStructures($tokens, [T_MATCH]) as $analysis) {
+            for ($index = $analysis->getOpenIndex() + 1; $index <= $analysis->getCloseIndex(); ++$index) {
+                if (str_contains($tokens[$index]->getContent(), PHP_EOL)) {
+                    continue;
+                }
+
+                if (str_contains($tokens[$index]->getContent(), ',') && !str_contains($tokens[$index + 1]->getContent(), PHP_EOL)) {
+                    $tokens->insertSlices([$index + 1 => new Token([T_WHITESPACE, $tokens[$analysis->getOpenIndex() + 1]->getContent()])]);
+                }
+            }
+        }
+    }
+}

--- a/tests/Fixer/ControlStructure/MatchHasOneCaseOnEveryArmFixerTest.php
+++ b/tests/Fixer/ControlStructure/MatchHasOneCaseOnEveryArmFixerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\ControlStructure;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+final class MatchHasOneCaseOnEveryArmFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixCases(): iterable
+    {
+        yield [
+            '<?php
+                match($bar) {
+                    1 =>"1",
+                    2,
+                    3 => "2"
+                };
+            ',
+            '<?php
+                match($bar) {
+                    1 =>"1",
+                    2,3 => "2"
+                };
+            ',
+        ];
+
+        yield [
+            '<?php
+                match($bar) {
+                    1 =>"1",
+                    2,
+                    3,
+                    4 => "2"
+                };
+            ',
+            '<?php
+                match($bar) {
+                    1 =>"1",
+                    2,3,4 => "2"
+                };
+            ',
+        ];
+
+        yield [
+            '<?php
+                match($bar) {
+                    1 =>"1",
+                    2,
+                    3,
+                    4 => "2",
+                    5 => "3",
+                    6 => "4",
+                    7,
+                    8 => "5",
+                };
+            ',
+            '<?php
+                match($bar) {
+                    1 =>"1",
+                    2,3,4 => "2",
+                    5 => "3",
+                    6 => "4",
+                    7,8 => "5",
+                };
+            ',
+        ];
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a new coding standard rule for match expressions in PHP 8.0+. The rule enforces that each arm of a match expression can only have a single case. This improves readability of the code by avoiding multiple cases in a single line which might be harder to track.

Here's an example that illustrates this change:

```Diff
--- Original
+++ New
 <?php
                return   match ($bar) {
                      2 => "c",
-                    3,4,5 =>"e",
+                    3,
+                    4,
+                    5 =>"e",
                    default => "d"
                };
```

### Rationale

Although PHP allows multiple cases in a single match arm, having a single case per arm enforces a more linear reading of the code. This proposal simplifies how we treat each case equally and explicitly.

I kindly request a review of this PR. Happy to make the necessary adjustments based on the feedback.