### PR TITLE
CI: Run Symfony 6 compat check on PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,11 @@ jobs:
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.0'
-            job-description: 'with Symfony ^6'
-            execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.1'
+            job-description: 'with Symfony ^6'
+            execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.2'


### PR DESCRIPTION
Symfony 6 has dropped support for PHP 8.0, see https://symfony.com/blog/symfony-6-1-will-require-php-8-1

PHP CS Fixer's CI has a job that pins all Symfony dependencies to version 6. This job runs with outdated and unmaintained Symfony 6.0.x packages which I believe was not intended. I propose to run that job on PHP 8.1 instead.