### PR TITLE
feat: StatementIndentationFixer - support comment for continuous control statement

### DIFF
--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -365,7 +365,35 @@ else {
                             (null !== $firstNonWhitespaceTokenIndex && $firstNonWhitespaceTokenIndex < $endIndex)
                             || (null !== $nextNewlineIndex && $nextNewlineIndex < $endIndex)
                         ) {
-                            $indent = true;
+                            if (
+                                // do we touch whitespace directly before comment...
+                                $tokens[$firstNonWhitespaceTokenIndex]->isGivenKind(T_COMMENT)
+                                // ...and afterwards, there is only comment or `}`
+                                && $tokens[$tokens->getNextNonWhitespace($firstNonWhitespaceTokenIndex)]->equals('}')
+                            ) {
+                                if (
+                                    // ... and the comment was only content in docblock
+                                    $tokens[$tokens->getPrevNonWhitespace($firstNonWhitespaceTokenIndex)]->equals('{')
+                                ) {
+                                    $indent = true;
+                                } else {
+                                    // or it was dedicated comment for next control loop
+                                    // ^^ we need to check if there is a control group afterwards, in that case
+                                    // FRS TODO
+
+                                    $nextIndex = $tokens->getNextNonWhitespace($firstNonWhitespaceTokenIndex);
+                                    $nextNextIndex = $tokens->getNextNonWhitespace($nextIndex);
+                                    // if ($FRS) var_dump(["sss" => $tokens[$nextNextIndex]->toJson()]);
+
+                                    if (null !== $nextNextIndex && $tokens[$nextNextIndex]->isGivenKind([T_ELSE, T_ELSEIF])) {
+                                        $indent = false;
+                                    } else {
+                                        $indent = true;
+                                    }
+                                }
+                            } else {
+                                $indent = true;
+                            }
                         }
                     }
 

--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -378,12 +378,9 @@ else {
                                     $indent = true;
                                 } else {
                                     // or it was dedicated comment for next control loop
-                                    // ^^ we need to check if there is a control group afterwards, in that case
-                                    // FRS TODO
-
+                                    // ^^ we need to check if there is a control group afterwards, and in that case don't make extra indent level
                                     $nextIndex = $tokens->getNextNonWhitespace($firstNonWhitespaceTokenIndex);
                                     $nextNextIndex = $tokens->getNextNonWhitespace($nextIndex);
-                                    // if ($FRS) var_dump(["sss" => $tokens[$nextNextIndex]->toJson()]);
 
                                     if (null !== $nextNextIndex && $tokens[$nextNextIndex]->isGivenKind([T_ELSE, T_ELSEIF])) {
                                         $indent = false;

--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -369,18 +369,18 @@ else {
                                 // do we touch whitespace directly before comment...
                                 $tokens[$firstNonWhitespaceTokenIndex]->isGivenKind(T_COMMENT)
                                 // ...and afterwards, there is only comment or `}`
-                                && $tokens[$tokens->getNextNonWhitespace($firstNonWhitespaceTokenIndex)]->equals('}')
+                                && $tokens[$tokens->getNextMeaningfulToken($firstNonWhitespaceTokenIndex)]->equals('}')
                             ) {
                                 if (
                                     // ... and the comment was only content in docblock
-                                    $tokens[$tokens->getPrevNonWhitespace($firstNonWhitespaceTokenIndex)]->equals('{')
+                                    $tokens[$tokens->getPrevMeaningfulToken($firstNonWhitespaceTokenIndex)]->equals('{')
                                 ) {
                                     $indent = true;
                                 } else {
                                     // or it was dedicated comment for next control loop
                                     // ^^ we need to check if there is a control group afterwards, and in that case don't make extra indent level
-                                    $nextIndex = $tokens->getNextNonWhitespace($firstNonWhitespaceTokenIndex);
-                                    $nextNextIndex = $tokens->getNextNonWhitespace($nextIndex);
+                                    $nextIndex = $tokens->getNextMeaningfulToken($firstNonWhitespaceTokenIndex);
+                                    $nextNextIndex = $tokens->getNextMeaningfulToken($nextIndex);
 
                                     if (null !== $nextNextIndex && $tokens[$nextNextIndex]->isGivenKind([T_ELSE, T_ELSEIF])) {
                                         $indent = false;

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -1908,6 +1908,29 @@ if (1) {
             self::CONFIGURATION_OOP_POSITION_SAME_LINE,
         ];
 
+        yield 'multiline comment in block' => [
+            '<?php
+if (1) {
+    $b = "a";
+// multiline comment line 1
+// multiline comment line 2
+} elseif (2) {
+    // empty
+} else {
+    $c = "b";
+}',
+            '<?php
+if (1) {
+    $b = "a";
+        // multiline comment line 1
+        // multiline comment line 2
+} elseif (2) {
+// empty
+} else {
+    $c = "b";
+}',
+        ];
+
         yield [
             '<?php
 if (1) {
@@ -1915,10 +1938,10 @@ if (1) {
         $a = "a";
     } elseif (3) {
         $b = "b";
-        // comment line 1
-        // comment line 2
-        // comment line 3
-    // comment line 4 - @TODO: treat all 4 lines same way
+    // comment line 1
+    // comment line 2
+    // comment line 3
+    // comment line 4
     } else {
         $c = "c";
     }
@@ -1933,7 +1956,7 @@ if (1) {
         // comment line 1
         // comment line 2
 // comment line 3
-            // comment line 4 - @TODO: treat all 4 lines same way
+            // comment line 4
     } else {
         $c = "c";
     }

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -1136,7 +1136,7 @@ if (1) {
         $a = "a";
     } elseif (3) {
         $b = "b";
-        // comment
+    // comment
     } else {
         $c = "c";
     }
@@ -1898,7 +1898,7 @@ if (1) {
         $a = "a";
     } elseif (3) {
         $b = "b";
-        // comment
+    // comment
     } else {
         $c = "c";
     }
@@ -1918,7 +1918,7 @@ if (1) {
         // comment line 1
         // comment line 2
         // comment line 3
-        // comment line 4
+    // comment line 4 - @TODO: treat all 4 lines same way
     } else {
         $c = "c";
     }
@@ -1933,7 +1933,7 @@ if (1) {
         // comment line 1
         // comment line 2
 // comment line 3
-            // comment line 4
+            // comment line 4 - @TODO: treat all 4 lines same way
     } else {
         $c = "c";
     }
@@ -3222,10 +3222,10 @@ function foo()
     // 2.5+ API
     if (isNewApi()) {
         echo "new API";
-        // 2.4- API
+    // 2.4- API
     } elseif (isOldApi()) {
         echo "old API";
-        // 2.4- API
+    // other API
     } else {
         echo "unknown API";
         // sth

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -922,6 +922,12 @@ if (true) {
 } else {
     // bar
 }',
+            '<?php
+if (true) {
+// foo
+} else {
+        // bar
+}',
         ];
 
         yield 'comments at the end of if/elseif/else blocks' => [

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -930,7 +930,66 @@ if (true) {
 }',
         ];
 
+        yield 'comment before else blocks' => [
+            '<?php
+// foo
+if ($foo) {
+    echo "foo";
+// bar
+} else {
+    $aaa = 1;
+}',
+            '<?php
+    // foo
+if ($foo) {
+    echo "foo";
+    // bar
+} else {
+    $aaa = 1;
+}',
+        ];
+
+        yield 'comment before elseif blocks' => [
+            '<?php
+// foo
+if ($foo) {
+    echo "foo";
+// bar
+} elseif(1) {
+    echo "bar";
+} elseif(2) {
+    // do nothing
+} elseif(3) {
+    $aaa = 1;
+    // end comment in final block
+}',
+            '<?php
+    // foo
+if ($foo) {
+    echo "foo";
+    // bar
+} elseif(1) {
+    echo "bar";
+} elseif(2) {
+// do nothing
+} elseif(3) {
+    $aaa = 1;
+    // end comment in final block
+}',
+        ];
+
         yield 'comments at the end of if/elseif/else blocks' => [
+            '<?php
+if ($foo) {
+    echo "foo";
+// foo
+} elseif ($bar) {
+    echo "bar";
+// bar
+} else {
+    echo "baz";
+    // baz
+}',
             '<?php
 if ($foo) {
     echo "foo";

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -776,15 +776,6 @@ $foo
 ;',
         ];
 
-        yield 'if with only a comment and followed by else' => [
-            '<?php
-if (true) {
-    // foo
-} else {
-    // bar
-}',
-        ];
-
         yield 'multiple anonymous functions as function arguments' => [
             '<?php
 foo(function () {
@@ -922,6 +913,15 @@ $result3 = (new Argument())(
     new Bar3(),
     3
 );',
+        ];
+
+        yield 'if with only a comment and followed by else' => [
+            '<?php
+if (true) {
+    // foo
+} else {
+    // bar
+}',
         ];
 
         yield 'comments at the end of if/elseif/else blocks' => [

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -949,6 +949,46 @@ if ($foo) {
 }',
         ];
 
+        yield 'multiline comment in block - describing next block' => [
+            '<?php
+if (1) {
+    $b = "a";
+// multiline comment line 1
+// multiline comment line 2
+// multiline comment line 3
+} else {
+    $c = "b";
+}',
+            '<?php
+if (1) {
+    $b = "a";
+    // multiline comment line 1
+    // multiline comment line 2
+    // multiline comment line 3
+} else {
+    $c = "b";
+}',
+        ];
+
+        yield 'multiline comment in block - the only content in block' => [
+            '<?php
+if (1) {
+    // multiline comment line 1
+    // multiline comment line 2
+    // multiline comment line 3
+} else {
+    $c = "b";
+}',
+            '<?php
+if (1) {
+ // multiline comment line 1
+  // multiline comment line 2
+// multiline comment line 3
+} else {
+    $c = "b";
+}',
+        ];
+
         yield 'comment before elseif blocks' => [
             '<?php
 // foo


### PR DESCRIPTION
this PR will not support multi-line comments, but it's good enough imho - only 1 false positive on symfony/symfony repo , but that one is more related to multiline trailing comment (`$foo = 1; // multiline...`