### PR TITLE
feat: PhpdocSummaryFixer - support lists in description

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
@@ -72,7 +72,12 @@ function foo () {}
                 $line = $doc->getLine($end);
                 $content = rtrim($line->getContent());
 
-                if (!$this->isCorrectlyFormatted($content)) {
+                if (
+                    // final line of Description is NOT properly formatted
+                    !$this->isCorrectlyFormatted($content)
+                    // and first line  of Description, if different than final line, does NOT indicate a list
+                    && (1 === $end || substr(rtrim($doc->getLine(1)?->getContent() ?: ""), -1) !== ":")
+                ) {
                     $line->setContent($content.'.'.$this->whitespacesConfig->getLineEnding());
                     $tokens[$index] = new Token([T_DOC_COMMENT, $doc->getContent()]);
                 }
@@ -89,6 +94,6 @@ function foo () {}
             return true;
         }
 
-        return $content !== rtrim($content, '.。!?¡¿！？');
+        return $content !== rtrim($content, '.:。!?¡¿！？');
     }
 }

--- a/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
@@ -76,7 +76,7 @@ function foo () {}
                     // final line of Description is NOT properly formatted
                     !$this->isCorrectlyFormatted($content)
                     // and first line  of Description, if different than final line, does NOT indicate a list
-                    && (1 === $end || ':' !== substr(rtrim($doc->getLine(1)?->getContent() ?? ''), -1))
+                    && (1 === $end || ($doc->isMultiLine() && ':' !== substr(rtrim($doc->getLine(1)->getContent()), -1)))
                 ) {
                     $line->setContent($content.'.'.$this->whitespacesConfig->getLineEnding());
                     $tokens[$index] = new Token([T_DOC_COMMENT, $doc->getContent()]);

--- a/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
@@ -76,7 +76,7 @@ function foo () {}
                     // final line of Description is NOT properly formatted
                     !$this->isCorrectlyFormatted($content)
                     // and first line  of Description, if different than final line, does NOT indicate a list
-                    && (1 === $end || ':' !== substr(rtrim($doc->getLine(1)?->getContent() ?: ''), -1))
+                    && (1 === $end || ':' !== substr(rtrim($doc->getLine(1)?->getContent() ?? ''), -1))
                 ) {
                     $line->setContent($content.'.'.$this->whitespacesConfig->getLineEnding());
                     $tokens[$index] = new Token([T_DOC_COMMENT, $doc->getContent()]);

--- a/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
@@ -76,7 +76,7 @@ function foo () {}
                     // final line of Description is NOT properly formatted
                     !$this->isCorrectlyFormatted($content)
                     // and first line  of Description, if different than final line, does NOT indicate a list
-                    && (1 === $end || substr(rtrim($doc->getLine(1)?->getContent() ?: ""), -1) !== ":")
+                    && (1 === $end || ':' !== substr(rtrim($doc->getLine(1)?->getContent() ?: ''), -1))
                 ) {
                     $line->setContent($content.'.'.$this->whitespacesConfig->getLineEnding());
                     $tokens[$index] = new Token([T_DOC_COMMENT, $doc->getContent()]);

--- a/tests/Fixer/Phpdoc/PhpdocSummaryFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSummaryFixerTest.php
@@ -203,6 +203,30 @@ final class PhpdocSummaryFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
+
+    public function testWithList(): void
+    {
+        $expected = <<<'EOF'
+            <?php
+                /**
+                 * Options:
+                 *  * a: aaa
+                 *  * b: bbb
+                 *  * c: ccc
+                 */
+
+                /**
+                 * Options:
+                 *
+                 *  * a: aaa
+                 *  * b: bbb
+                 *  * c: ccc
+                 */
+            EOF;
+
+        $this->doTest($expected);
+    }
+
     public function testWithTags(): void
     {
         $expected = <<<'EOF'

--- a/tests/Fixer/Phpdoc/PhpdocSummaryFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSummaryFixerTest.php
@@ -203,7 +203,6 @@ final class PhpdocSummaryFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-
     public function testWithList(): void
     {
         $expected = <<<'EOF'


### PR DESCRIPTION
symfony/symfony was getting ugly outcome without this (`Possible options:.`)