### PR TITLE
feat: Introduce `reference_spaces` fixer

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2962,6 +2962,27 @@ List of Available Rules
    Part of rule sets `@PHP70Migration:risky <./ruleSets/PHP70MigrationRisky.rst>`_ `@PHP71Migration:risky <./ruleSets/PHP71MigrationRisky.rst>`_ `@PHP74Migration:risky <./ruleSets/PHP74MigrationRisky.rst>`_ `@PHP80Migration:risky <./ruleSets/PHP80MigrationRisky.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Alias\\RandomApiMigrationFixer <./../src/Fixer/Alias/RandomApiMigrationFixer.php>`_
+-  `reference_spaces <./rules/whitespace/reference_spaces.rst>`_
+
+   Reference operator should be surrounded by space as defined.
+
+   Configuration options:
+
+   - | ``anonymous_function_use_block``
+     | Default fix strategy for reference operator in anonymous function's use blocks.
+     | Allowed values: ``'by_reference'``, ``'single_space'`` and ``false``
+     | Default value: ``'by_reference'``
+   - | ``assignment``
+     | Default fix strategy for reference operator in assignments.
+     | Allowed values: ``'by_assign'``, ``'by_reference'``, ``'single_space'`` and ``false``
+     | Default value: ``'by_reference'``
+   - | ``function_signature``
+     | Default fix strategy for reference operator in function signatures.
+     | Allowed values: ``'by_reference'``, ``'single_space'`` and ``false``
+     | Default value: ``'by_reference'``
+
+
+   `Source PhpCsFixer\\Fixer\\Whitespace\\ReferenceSpacesFixer <./../src/Fixer/Whitespace/ReferenceSpacesFixer.php>`_
 -  `regular_callable_call <./rules/function_notation/regular_callable_call.rst>`_
 
    Callables must be called without using ``call_user_func*`` when possible.

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2974,7 +2974,7 @@ List of Available Rules
      | Default value: ``'by_reference'``
    - | ``assignment``
      | Default fix strategy for reference operator in assignments.
-     | Allowed values: ``'by_assign'``, ``'by_reference'``, ``'single_space'`` and ``false``
+     | Allowed values: ``'by_assign'``, ``'by_reference'``, ``'no_space'``, ``'single_space'`` and ``false``
      | Default value: ``'by_reference'``
    - | ``function_signature``
      | Default fix strategy for reference operator in function signatures.

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -919,6 +919,9 @@ Whitespace
 - `no_whitespace_in_blank_line <./whitespace/no_whitespace_in_blank_line.rst>`_
 
   Remove trailing whitespace at the end of blank lines.
+- `reference_spaces <./whitespace/reference_spaces.rst>`_
+
+  Reference operator should be surrounded by space as defined.
 - `single_blank_line_at_eof <./whitespace/single_blank_line_at_eof.rst>`_
 
   A PHP file without end tag must always end with a single empty line feed.

--- a/doc/rules/whitespace/reference_spaces.rst
+++ b/doc/rules/whitespace/reference_spaces.rst
@@ -1,0 +1,142 @@
+=========================
+Rule ``reference_spaces``
+=========================
+
+Reference operator should be surrounded by space as defined.
+
+Configuration
+-------------
+
+``anonymous_function_use_block``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default fix strategy for reference operator in anonymous function's use blocks.
+
+Allowed values: ``'by_reference'``, ``'single_space'`` and ``false``
+
+Default value: ``'by_reference'``
+
+``assignment``
+~~~~~~~~~~~~~~
+
+Default fix strategy for reference operator in assignments.
+
+Allowed values: ``'by_assign'``, ``'by_reference'``, ``'single_space'`` and ``false``
+
+Default value: ``'by_reference'``
+
+``function_signature``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Default fix strategy for reference operator in function signatures.
+
+Allowed values: ``'by_reference'``, ``'single_space'`` and ``false``
+
+Default value: ``'by_reference'``
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+*Default* configuration.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -$foo = & $bar;
+   +$foo = &$bar;
+
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['assignment' => 'by_assign']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -$foo = & $bar;
+   +$foo =& $bar;
+
+Example #3
+~~~~~~~~~~
+
+With configuration: ``['assignment' => 'by_reference']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -$foo = & $bar;
+   +$foo = &$bar;
+
+Example #4
+~~~~~~~~~~
+
+With configuration: ``['assignment' => 'single_space']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -$foo =&$bar;
+   +$foo = & $bar;
+
+Example #5
+~~~~~~~~~~
+
+With configuration: ``['function_signature' => 'by_reference']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -function foo(& $bar) {}
+   +function foo(&$bar) {}
+
+Example #6
+~~~~~~~~~~
+
+With configuration: ``['function_signature' => 'single_space']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -function foo(&$bar) {}
+   +function foo(& $bar) {}
+
+Example #7
+~~~~~~~~~~
+
+With configuration: ``['anonymous_function_use_block' => 'by_reference']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -$foo = function () use (& $bar) {};
+   +$foo = function () use (&$bar) {};
+
+Example #8
+~~~~~~~~~~
+
+With configuration: ``['anonymous_function_use_block' => 'single_space']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -$foo = function () use (&$bar) {};
+   +$foo = function () use (& $bar) {};

--- a/doc/rules/whitespace/reference_spaces.rst
+++ b/doc/rules/whitespace/reference_spaces.rst
@@ -21,7 +21,7 @@ Default value: ``'by_reference'``
 
 Default fix strategy for reference operator in assignments.
 
-Allowed values: ``'by_assign'``, ``'by_reference'``, ``'single_space'`` and ``false``
+Allowed values: ``'by_assign'``, ``'by_reference'``, ``'no_space'``, ``'single_space'`` and ``false``
 
 Default value: ``'by_reference'``
 
@@ -46,9 +46,8 @@ Example #1
 
    --- Original
    +++ New
-    <?php
-   -$foo = & $bar;
-   +$foo = &$bar;
+   -<?php $foo = & $bar;
+   +<?php $foo = &$bar;
 
 Example #2
 ~~~~~~~~~~
@@ -59,9 +58,8 @@ With configuration: ``['assignment' => 'by_assign']``.
 
    --- Original
    +++ New
-    <?php
-   -$foo = & $bar;
-   +$foo =& $bar;
+   -<?php $foo = & $bar;
+   +<?php $foo =& $bar;
 
 Example #3
 ~~~~~~~~~~
@@ -72,9 +70,8 @@ With configuration: ``['assignment' => 'by_reference']``.
 
    --- Original
    +++ New
-    <?php
-   -$foo = & $bar;
-   +$foo = &$bar;
+   -<?php $foo = & $bar;
+   +<?php $foo = &$bar;
 
 Example #4
 ~~~~~~~~~~
@@ -85,11 +82,22 @@ With configuration: ``['assignment' => 'single_space']``.
 
    --- Original
    +++ New
-    <?php
-   -$foo =&$bar;
-   +$foo = & $bar;
+   -<?php $foo =&$bar;
+   +<?php $foo = & $bar;
 
 Example #5
+~~~~~~~~~~
+
+With configuration: ``['assignment' => 'no_space']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+   -<?php $foo =& $bar;
+   +<?php $foo =&$bar;
+
+Example #6
 ~~~~~~~~~~
 
 With configuration: ``['function_signature' => 'by_reference']``.
@@ -98,11 +106,10 @@ With configuration: ``['function_signature' => 'by_reference']``.
 
    --- Original
    +++ New
-    <?php
-   -function foo(& $bar) {}
-   +function foo(&$bar) {}
+   -<?php function foo(& $bar) {}
+   +<?php function foo(&$bar) {}
 
-Example #6
+Example #7
 ~~~~~~~~~~
 
 With configuration: ``['function_signature' => 'single_space']``.
@@ -111,11 +118,10 @@ With configuration: ``['function_signature' => 'single_space']``.
 
    --- Original
    +++ New
-    <?php
-   -function foo(&$bar) {}
-   +function foo(& $bar) {}
+   -<?php function foo(&$bar) {}
+   +<?php function foo(& $bar) {}
 
-Example #7
+Example #8
 ~~~~~~~~~~
 
 With configuration: ``['anonymous_function_use_block' => 'by_reference']``.
@@ -124,11 +130,10 @@ With configuration: ``['anonymous_function_use_block' => 'by_reference']``.
 
    --- Original
    +++ New
-    <?php
-   -$foo = function () use (& $bar) {};
-   +$foo = function () use (&$bar) {};
+   -<?php $foo = function () use (& $bar) {};
+   +<?php $foo = function () use (&$bar) {};
 
-Example #8
+Example #9
 ~~~~~~~~~~
 
 With configuration: ``['anonymous_function_use_block' => 'single_space']``.
@@ -137,6 +142,5 @@ With configuration: ``['anonymous_function_use_block' => 'single_space']``.
 
    --- Original
    +++ New
-    <?php
-   -$foo = function () use (&$bar) {};
-   +$foo = function () use (& $bar) {};
+   -<?php $foo = function () use (&$bar) {};
+   +<?php $foo = function () use (& $bar) {};

--- a/src/Fixer/Whitespace/ReferenceSpacesFixer.php
+++ b/src/Fixer/Whitespace/ReferenceSpacesFixer.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Whitespace;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Jesper Skytte <jesper@skytte.it>
+ */
+final class ReferenceSpacesFixer extends AbstractFixer implements ConfigurableFixerInterface
+{
+    /**
+     * @internal
+     */
+    public const TYPE_ASSIGNMENT = 'assignment';
+
+    /**
+     * @internal
+     */
+    public const TYPE_FUNCTION_SIGNATURE = 'function_signature';
+
+    /**
+     * @internal
+     */
+    public const TYPE_ANONYMOUS_FUNCTION_USE_BLOCK = 'anonymous_function_use_block';
+
+    /**
+     * @internal
+     */
+    public const BY_ASSIGN = 'by_assign';
+
+    /**
+     * @internal
+     */
+    public const BY_REFERENCE = 'by_reference';
+
+    /**
+     * @internal
+     */
+    public const SINGLE_SPACE = 'single_space';
+
+    private array $relevantTokens = [];
+
+    public function configure(array $configuration): void
+    {
+        parent::configure($configuration);
+
+        $this->relevantTokens = \PHP_VERSION_ID >= 80100
+            ? [T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG, T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG, '&']
+            : ['&'];
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Reference operator should be surrounded by space as defined.',
+            [
+                new CodeSample(
+                    '<?php $foo = & $bar;
+'
+                ),
+                new CodeSample(
+                    '<?php $foo = & $bar;
+',
+                    ['assignment' => self::BY_ASSIGN]
+                ),
+                new CodeSample(
+                    '<?php $foo = & $bar;
+',
+                    ['assignment' => self::BY_REFERENCE]
+                ),
+                new CodeSample(
+                    '<?php $foo =&$bar;
+',
+                    ['assignment' => self::SINGLE_SPACE]
+                ),
+                new CodeSample(
+                    '<?php function foo(& $bar) {}
+',
+                    ['function_signature' => self::BY_REFERENCE]
+                ),
+                new CodeSample(
+                    '<?php function foo(&$bar) {}
+',
+                    ['function_signature' => self::SINGLE_SPACE]
+                ),
+                new CodeSample(
+                    '<?php $foo = function () use (& $bar) {};
+',
+                    ['anonymous_function_use_block' => self::BY_REFERENCE]
+                ),
+                new CodeSample(
+                    '<?php $foo = function () use (&$bar) {};
+',
+                    ['anonymous_function_use_block' => self::SINGLE_SPACE]
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Must run after BinaryOperatorSpacesFixer
+     */
+    public function getPriority(): int
+    {
+        return -33;
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound($this->relevantTokens);
+    }
+
+    protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('assignment', 'Default fix strategy for reference operator in assignments.'))
+                ->setDefault(self::BY_REFERENCE)
+                ->setAllowedValues([self::BY_REFERENCE, self::SINGLE_SPACE, self::BY_ASSIGN, false])
+                ->getOption(),
+            (new FixerOptionBuilder(
+                'function_signature',
+                'Default fix strategy for reference operator in function signatures.'
+            ))
+                ->setDefault(self::BY_REFERENCE)
+                ->setAllowedValues([self::BY_REFERENCE, self::SINGLE_SPACE, false])
+                ->getOption(),
+            (new FixerOptionBuilder(
+                'anonymous_function_use_block',
+                'Default fix strategy for reference operator in anonymous function\'s use blocks.'
+            ))
+                ->setDefault(self::BY_REFERENCE)
+                ->setAllowedValues([self::BY_REFERENCE, self::SINGLE_SPACE, false])
+                ->getOption(),
+        ]);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        for ($index = $tokens->count() - 1; $index > 0; --$index) {
+            if ('&' !== $tokens[$index]->getContent()) {
+                continue;
+            }
+
+            $this->fixWhiteSpaceAfterOperator($tokens, $index);
+            $this->fixWhiteSpaceBeforeOperator($tokens, $index);
+        }
+    }
+
+    /**
+     * Fix whitespace before the reference operator.
+     *
+     * @param Tokens $tokens
+     * @param int $index
+     * @return void
+     */
+    private function fixWhiteSpaceBeforeOperator(Tokens $tokens, int $index): void
+    {
+        // Only on assign by reference is it possible to fix space before
+        $prevToken = $tokens->getPrevMeaningfulToken($index);
+        if ('=' !== $tokens[$prevToken]->getContent()) {
+            return;
+        }
+
+        $strategy = $this->configuration[self::TYPE_ASSIGNMENT];
+        if (false === $strategy) {
+            return;
+        }
+
+        $isWhitespace = $tokens[$index - 1]->isWhitespace();
+
+        if (
+            !$isWhitespace
+            && \in_array($strategy, [self::BY_REFERENCE, self::SINGLE_SPACE], true)
+        ) {
+            $tokens->insertAt($index, new Token([T_WHITESPACE, ' ']));
+        } elseif ($isWhitespace) {
+            if (self::BY_ASSIGN === $strategy) {
+                $tokens->clearAt($index - 1);
+            } elseif (' ' !== $tokens[$index - 1]->getContent()) {
+                $tokens[$index - 1] = new Token([T_WHITESPACE, ' ']);
+            }
+        }
+    }
+
+    /**
+     * Fix whitespace after the reference operator.
+     *
+     * @param Tokens $tokens
+     * @param int $index
+     * @return void
+     */
+    private function fixWhiteSpaceAfterOperator(Tokens $tokens, int $index): void
+    {
+        $type = '';
+        // Only on assign by reference is it possible to fix space before
+        for ($search = $index - 1; $search > 0; --$search) {
+            if (
+                $tokens[$search]->isGivenKind([T_FUNCTION, T_USE, CT::T_USE_LAMBDA])
+                || '=' === $tokens[$search]->getContent()
+            ) {
+                $type = $this->getReferenceType($tokens[$search]);
+                break;
+            }
+        }
+
+        $strategy = $this->configuration[$type];
+        if (($strategy ?? false) === false) {
+            return;
+        }
+
+        $isWhitespace = $tokens[$index + 1]->isWhitespace();
+        if (
+            !$isWhitespace
+            && \in_array($strategy, [self::BY_ASSIGN, self::SINGLE_SPACE], true)
+        ) {
+            $tokens->insertAt($index + 1, new Token([T_WHITESPACE, ' ']));
+        } elseif ($isWhitespace) {
+            if (self::BY_REFERENCE === $strategy) {
+                $tokens->clearAt($index + 1);
+            } elseif (' ' !== $tokens[$index + 1]->getContent()) {
+                $tokens[$index + 1] = new Token([T_WHITESPACE, ' ']);
+            }
+        }
+    }
+
+    /**
+     * Determines the reference type based on the given token.
+     *
+     * @param Token $token The token to determine the reference type for.
+     *
+     * @return string The reference type.
+     */
+    private function getReferenceType(Token $token): string
+    {
+        if ($token->isGivenKind(T_FUNCTION)) {
+            return self::TYPE_FUNCTION_SIGNATURE;
+        }
+
+        if ($token->isGivenKind([T_USE, CT::T_USE_LAMBDA])) {
+            return self::TYPE_ANONYMOUS_FUNCTION_USE_BLOCK;
+        }
+
+        return self::TYPE_ASSIGNMENT;
+    }
+}

--- a/tests/Fixer/Whitespace/ReferenceSpacesFixerTest.php
+++ b/tests/Fixer/Whitespace/ReferenceSpacesFixerTest.php
@@ -24,6 +24,8 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class ReferenceSpacesFixerTest extends AbstractFixerTestCase
 {
     /**
+     * @param array<string, mixed> $configuration
+     *
      * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null, array $configuration = []): void
@@ -334,6 +336,86 @@ final class ReferenceSpacesFixerTest extends AbstractFixerTestCase
             '<?php $foo = function() use (&$bar) {};',
             '<?php $foo = function() use (&    $bar) {};',
             ['assignment' => 'single_space'],
+        ];
+
+        // Configuration: assignment: no_space --- //
+
+        yield 'configured: assignment: no_space - assign - reference char with a single space after' => [
+            '<?php $foo =&$var;',
+            '<?php $foo =& $var;',
+            ['assignment' => 'no_space'],
+        ];
+
+        yield 'configured: assignment: no_space - assign - reference char with a single space on both sides' => [
+            '<?php $foo =&$var;',
+            '<?php $foo = & $var;',
+            ['assignment' => 'no_space'],
+        ];
+
+        yield 'configured: assignment: no_space - assign - reference char with a single space before' => [
+            '<?php $foo =&$var;',
+            '<?php $foo = &$var;',
+            ['assignment' => 'no_space'],
+        ];
+
+        yield 'configured: assignment: no_space - assign - reference char with a no spaces around' => [
+            '<?php $foo =&$var;',
+            null,
+            ['assignment' => 'no_space'],
+        ];
+
+        yield 'configured: assignment: no_space - assign - reference char with multiple spaces after' => [
+            '<?php $foo =&$var;',
+            '<?php $foo = &    $var;',
+            ['assignment' => 'no_space'],
+        ];
+
+        yield 'configured: assignment: no_space - assign - reference char with multiple spaces on both sides' => [
+            '<?php $foo =&$var;',
+            '<?php $foo =    &    $var;',
+            ['assignment' => 'no_space'],
+        ];
+
+        yield 'configured: assignment: no_space - assign - reference char with multiple spaces before' => [
+            '<?php $foo =&$var;',
+            '<?php $foo =    &$var;',
+            ['assignment' => 'no_space'],
+        ];
+
+        yield 'configured: assignment: no_space - function_signature - reference char with no space after' => [
+            '<?php function bar(&$foo) {};',
+            null,
+            ['assignment' => 'no_space'],
+        ];
+
+        yield 'configured: assignment: no_space - function_signature - reference char with a single space after' => [
+            '<?php function bar(&$foo) {};',
+            '<?php function bar(& $foo) {};',
+            ['assignment' => 'no_space'],
+        ];
+
+        yield 'configured: assignment: no_space - function_signature - reference char with multiple spaces after' => [
+            '<?php function bar(&$foo) {};',
+            '<?php function bar(&     $foo) {};',
+            ['assignment' => 'no_space'],
+        ];
+
+        yield 'configured: assignment: no_space - anonymous_function_use_block - reference char with no space after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            null,
+            ['assignment' => 'no_space'],
+        ];
+
+        yield 'configured: assignment: no_space - anonymous_function_use_block - reference char a single multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (& $bar) {};',
+            ['assignment' => 'no_space'],
+        ];
+
+        yield 'configured: assignment: no_space - anonymous_function_use_block - reference char with multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (&    $bar) {};',
+            ['assignment' => 'no_space'],
         ];
 
         // Configuration: function_signature: by_reference --- //

--- a/tests/Fixer/Whitespace/ReferenceSpacesFixerTest.php
+++ b/tests/Fixer/Whitespace/ReferenceSpacesFixerTest.php
@@ -1,0 +1,659 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Whitespace;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Whitespace\ReferenceSpacesFixer
+ */
+final class ReferenceSpacesFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix(string $expected, ?string $input = null, array $configuration = []): void
+    {
+        $this->fixer->configure($configuration);
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixCases(): iterable
+    {
+        yield 'default configuration - assign - reference char with a single space after' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =& $var;',
+        ];
+
+        yield 'default configuration - assign - reference char with a single space on both sides' => [
+            '<?php $foo = &$var;',
+            '<?php $foo = & $var;',
+        ];
+
+        yield 'default configuration - assign - reference char with a single space before' => [
+            '<?php $foo = &$var;',
+        ];
+
+        yield 'default configuration - assign - reference char with a no spaces around' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =&$var;',
+        ];
+
+        yield 'default configuration - assign - reference char with multiple spaces after' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =&    $var;',
+        ];
+
+        yield 'default configuration - assign - reference char with multiple spaces on both sides' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =    &    $var;',
+        ];
+
+        yield 'default configuration - assign - reference char with multiple spaces before' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =    &$var;',
+        ];
+
+        yield 'default configuration - function_signature - reference char with no space after' => [
+            '<?php function bar(&$foo) {}',
+        ];
+
+        yield 'default configuration - function_signature - reference char with a single space after' => [
+            '<?php function bar(&$foo) {}',
+            '<?php function bar(& $foo) {}',
+        ];
+
+        yield 'default configuration - function_signature - reference char with multiple spaces after' => [
+            '<?php function bar(&$foo) {}',
+            '<?php function bar(&     $foo) {}',
+        ];
+
+        yield 'default configuration - anonymous_function_use_block - reference char with no space after' => [
+            '<?php $foo = function() use (&$bar) {};',
+        ];
+
+        yield 'default configuration - anonymous_function_use_block - reference char a single multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (& $bar) {};',
+        ];
+
+        yield 'default configuration - anonymous_function_use_block - reference char with multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (&    $bar) {};',
+        ];
+
+        // --- Configuration: assignment: by_assign --- //
+
+        yield 'configured: assignment: by_assign - assign - reference char with a single space after' => [
+            '<?php $foo =& $var;',
+            null,
+            ['assignment' => 'by_assign'],
+        ];
+
+        yield 'configured: assignment: by_assign - assign - reference char with a single space on both sides' => [
+            '<?php $foo =& $var;',
+            '<?php $foo = & $var;',
+            ['assignment' => 'by_assign'],
+        ];
+
+        yield 'configured: assignment: by_assign - assign - reference char with a single space before' => [
+            '<?php $foo =& $var;',
+            '<?php $foo = &$var;',
+            ['assignment' => 'by_assign'],
+        ];
+
+        yield 'configured: assignment: by_assign - assign - reference char with a no spaces around' => [
+            '<?php $foo =& $var;',
+            '<?php $foo =&$var;',
+            ['assignment' => 'by_assign'],
+        ];
+
+        yield 'configured: assignment: by_assign - assign - reference char with multiple spaces after' => [
+            '<?php $foo =& $var;',
+            '<?php $foo = &    $var;',
+            ['assignment' => 'by_assign'],
+        ];
+
+        yield 'configured: assignment: by_assign - assign - reference char with multiple spaces on both sides' => [
+            '<?php $foo =& $var;',
+            '<?php $foo =    &    $var;',
+            ['assignment' => 'by_assign'],
+        ];
+
+        yield 'configured: assignment: by_assign - assign - reference char with multiple spaces before' => [
+            '<?php $foo =& $var;',
+            '<?php $foo =    &$var;',
+            ['assignment' => 'by_assign'],
+        ];
+
+        yield 'configured: assignment: by_assign - function_signature - reference char with no space after' => [
+            '<?php function bar(&$foo) {};',
+            null,
+            ['assignment' => 'by_assign'],
+        ];
+
+        yield 'configured: assignment: by_assign - function_signature - reference char with a single space after' => [
+            '<?php function bar(&$foo) {};',
+            '<?php function bar(& $foo) {};',
+            ['assignment' => 'by_assign'],
+        ];
+
+        yield 'configured: assignment: by_assign - function_signature - reference char with multiple spaces after' => [
+            '<?php function bar(&$foo) {};',
+            '<?php function bar(&     $foo) {};',
+            ['assignment' => 'by_assign'],
+        ];
+
+        yield 'configured: assignment: by_assign - anonymous_function_use_block - reference char with no space after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            null,
+            ['assignment' => 'by_assign'],
+        ];
+
+        yield 'configured: assignment: by_assign - anonymous_function_use_block - reference char a single multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (& $bar) {};',
+            ['assignment' => 'by_assign'],
+        ];
+
+        yield 'configured: assignment: by_assign - anonymous_function_use_block - reference char with multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (&    $bar) {};',
+            ['assignment' => 'by_assign'],
+        ];
+
+        // Configuration: assignment: by_reference --- //
+
+        yield 'configured: assignment: by_reference - assign - reference char with a single space after' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =& $var;',
+            ['assignment' => 'by_reference'],
+        ];
+
+        yield 'configured: assignment: by_reference - assign - reference char with a single space on both sides' => [
+            '<?php $foo = &$var;',
+            '<?php $foo = & $var;',
+            ['assignment' => 'by_reference'],
+        ];
+
+        yield 'configured: assignment: by_reference - assign - reference char with a single space before' => [
+            '<?php $foo = &$var;',
+            null,
+            ['assignment' => 'by_reference'],
+        ];
+
+        yield 'configured: assignment: by_reference - assign - reference char with a no spaces around' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =&$var;',
+            ['assignment' => 'by_reference'],
+        ];
+
+        yield 'configured: assignment: by_reference - assign - reference char with multiple spaces after' => [
+            '<?php $foo = &$var;',
+            '<?php $foo = &    $var;',
+            ['assignment' => 'by_reference'],
+        ];
+
+        yield 'configured: assignment: by_reference - assign - reference char with multiple spaces on both sides' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =    &    $var;',
+            ['assignment' => 'by_reference'],
+        ];
+
+        yield 'configured: assignment: by_reference - assign - reference char with multiple spaces before' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =    &$var;',
+            ['assignment' => 'by_reference'],
+        ];
+
+        yield 'configured: assignment: by_reference - function_signature - reference char with no space after' => [
+            '<?php function bar(&$foo) {};',
+            null,
+            ['assignment' => 'by_reference'],
+        ];
+
+        yield 'configured: assignment: by_reference - function_signature - reference char with a single space after' => [
+            '<?php function bar(&$foo) {};',
+            '<?php function bar(& $foo) {};',
+            ['assignment' => 'by_reference'],
+        ];
+
+        yield 'configured: assignment: by_reference - function_signature - reference char with multiple spaces after' => [
+            '<?php function bar(&$foo) {};',
+            '<?php function bar(&     $foo) {};',
+            ['assignment' => 'by_reference'],
+        ];
+
+        yield 'configured: assignment: by_reference - anonymous_function_use_block - reference char with no space after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            null,
+            ['assignment' => 'by_reference'],
+        ];
+
+        yield 'configured: assignment: by_reference - anonymous_function_use_block - reference char a single multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (& $bar) {};',
+            ['assignment' => 'by_reference'],
+        ];
+
+        yield 'configured: assignment: by_reference - anonymous_function_use_block - reference char with multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (&    $bar) {};',
+            ['assignment' => 'by_reference'],
+        ];
+
+        // Configuration: assignment: single_space --- //
+
+        yield 'configured: assignment: single_space - assign - reference char with a single space after' => [
+            '<?php $foo = & $var;',
+            '<?php $foo =& $var;',
+            ['assignment' => 'single_space'],
+        ];
+
+        yield 'configured: assignment: single_space - assign - reference char with a single space on both sides' => [
+            '<?php $foo = & $var;',
+            null,
+            ['assignment' => 'single_space'],
+        ];
+
+        yield 'configured: assignment: single_space - assign - reference char with a single space before' => [
+            '<?php $foo = & $var;',
+            '<?php $foo = &$var;',
+            ['assignment' => 'single_space'],
+        ];
+
+        yield 'configured: assignment: single_space - assign - reference char with a no spaces around' => [
+            '<?php $foo = & $var;',
+            '<?php $foo =&$var;',
+            ['assignment' => 'single_space'],
+        ];
+
+        yield 'configured: assignment: single_space - assign - reference char with multiple spaces after' => [
+            '<?php $foo = & $var;',
+            '<?php $foo = &    $var;',
+            ['assignment' => 'single_space'],
+        ];
+
+        yield 'configured: assignment: single_space - assign - reference char with multiple spaces on both sides' => [
+            '<?php $foo = & $var;',
+            '<?php $foo =    &    $var;',
+            ['assignment' => 'single_space'],
+        ];
+
+        yield 'configured: assignment: single_space - assign - reference char with multiple spaces before' => [
+            '<?php $foo = & $var;',
+            '<?php $foo =    &$var;',
+            ['assignment' => 'single_space'],
+        ];
+
+        yield 'configured: assignment: single_space - function_signature - reference char with no space after' => [
+            '<?php function bar(&$foo) {};',
+            null,
+            ['assignment' => 'single_space'],
+        ];
+
+        yield 'configured: assignment: single_space - function_signature - reference char with a single space after' => [
+            '<?php function bar(&$foo) {};',
+            '<?php function bar(& $foo) {};',
+            ['assignment' => 'single_space'],
+        ];
+
+        yield 'configured: assignment: single_space - function_signature - reference char with multiple spaces after' => [
+            '<?php function bar(&$foo) {};',
+            '<?php function bar(&     $foo) {};',
+            ['assignment' => 'single_space'],
+        ];
+
+        yield 'configured: assignment: single_space - anonymous_function_use_block - reference char with no space after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            null,
+            ['assignment' => 'single_space'],
+        ];
+
+        yield 'configured: assignment: single_space - anonymous_function_use_block - reference char a single multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (& $bar) {};',
+            ['assignment' => 'single_space'],
+        ];
+
+        yield 'configured: assignment: single_space - anonymous_function_use_block - reference char with multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (&    $bar) {};',
+            ['assignment' => 'single_space'],
+        ];
+
+        // Configuration: function_signature: by_reference --- //
+
+        yield 'configured: function_signature: by_reference - assign - reference char with a single space after' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =& $var;',
+            ['function_signature' => 'by_reference'],
+        ];
+
+        yield 'configured: function_signature: by_reference - assign - reference char with a single space on both sides' => [
+            '<?php $foo = &$var;',
+            '<?php $foo = & $var;',
+            ['function_signature' => 'by_reference'],
+        ];
+
+        yield 'configured: function_signature: by_reference - assign - reference char with a single space before' => [
+            '<?php $foo = &$var;',
+            null,
+            ['function_signature' => 'by_reference'],
+        ];
+
+        yield 'configured: function_signature: by_reference - assign - reference char with a no spaces around' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =&$var;',
+            ['function_signature' => 'by_reference'],
+        ];
+
+        yield 'configured: function_signature: by_reference - assign - reference char with multiple spaces after' => [
+            '<?php $foo = &$var;',
+            '<?php $foo = &    $var;',
+            ['function_signature' => 'by_reference'],
+        ];
+
+        yield 'configured: function_signature: by_reference - assign - reference char with multiple spaces on both sides' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =    &    $var;',
+            ['function_signature' => 'by_reference'],
+        ];
+
+        yield 'configured: function_signature: by_reference - assign - reference char with multiple spaces before' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =    &$var;',
+            ['function_signature' => 'by_reference'],
+        ];
+
+        yield 'configured: function_signature: by_reference - function_signature - reference char with no space after' => [
+            '<?php function bar(&$foo) {};',
+            null,
+            ['function_signature' => 'by_reference'],
+        ];
+
+        yield 'configured: function_signature: by_reference - function_signature - reference char with a single space after' => [
+            '<?php function bar(&$foo) {};',
+            '<?php function bar(& $foo) {};',
+            ['function_signature' => 'by_reference'],
+        ];
+
+        yield 'configured: function_signature: by_reference - function_signature - reference char with multiple spaces after' => [
+            '<?php function bar(&$foo) {};',
+            '<?php function bar(&     $foo) {};',
+            ['function_signature' => 'by_reference'],
+        ];
+
+        yield 'configured: function_signature: by_reference - anonymous_function_use_block - reference char with no space after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            null,
+            ['function_signature' => 'by_reference'],
+        ];
+
+        yield 'configured: function_signature: by_reference - anonymous_function_use_block - reference char a single multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (& $bar) {};',
+            ['function_signature' => 'by_reference'],
+        ];
+
+        yield 'configured: function_signature: by_reference - anonymous_function_use_block - reference char with multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (&    $bar) {};',
+            ['function_signature' => 'by_reference'],
+        ];
+
+        // Configuration: function_signature: single_space --- //
+
+        yield 'configured: function_signature: single_space - assign - reference char with a single space after' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =& $var;',
+            ['function_signature' => 'single_space'],
+        ];
+
+        yield 'configured: function_signature: single_space - assign - reference char with a single space on both sides' => [
+            '<?php $foo = &$var;',
+            '<?php $foo = & $var;',
+            ['function_signature' => 'single_space'],
+        ];
+
+        yield 'configured: function_signature: single_space - assign - reference char with a single space before' => [
+            '<?php $foo = &$var;',
+            null,
+            ['function_signature' => 'single_space'],
+        ];
+
+        yield 'configured: function_signature: single_space - assign - reference char with a no spaces around' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =&$var;',
+            ['function_signature' => 'single_space'],
+        ];
+
+        yield 'configured: function_signature: single_space - assign - reference char with multiple spaces after' => [
+            '<?php $foo = &$var;',
+            '<?php $foo = &    $var;',
+            ['function_signature' => 'single_space'],
+        ];
+
+        yield 'configured: function_signature: single_space - assign - reference char with multiple spaces on both sides' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =    &    $var;',
+            ['function_signature' => 'single_space'],
+        ];
+
+        yield 'configured: function_signature: single_space - assign - reference char with multiple spaces before' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =    &$var;',
+            ['function_signature' => 'single_space'],
+        ];
+
+        yield 'configured: function_signature: single_space - function_signature - reference char with no space after' => [
+            '<?php function bar(& $foo) {};',
+            '<?php function bar(&$foo) {};',
+            ['function_signature' => 'single_space'],
+        ];
+
+        yield 'configured: function_signature: single_space - function_signature - reference char with a single space after' => [
+            '<?php function bar(& $foo) {};',
+            null,
+            ['function_signature' => 'single_space'],
+        ];
+
+        yield 'configured: function_signature: single_space - function_signature - reference char with multiple spaces after' => [
+            '<?php function bar(& $foo) {};',
+            '<?php function bar(&     $foo) {};',
+            ['function_signature' => 'single_space'],
+        ];
+
+        yield 'configured: function_signature: single_space - anonymous_function_use_block - reference char with no space after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            null,
+            ['function_signature' => 'single_space'],
+        ];
+
+        yield 'configured: function_signature: single_space - anonymous_function_use_block - reference char a single multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (& $bar) {};',
+            ['function_signature' => 'single_space'],
+        ];
+
+        yield 'configured: function_signature: single_space - anonymous_function_use_block - reference char with multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (&    $bar) {};',
+            ['function_signature' => 'single_space'],
+        ];
+
+        // Configuration: anonymous_function_use_block: by_reference --- //
+
+        yield 'configured: anonymous_function_use_block: by_reference - assign - reference char with a single space after' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =& $var;',
+            ['anonymous_function_use_block' => 'by_reference'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: by_reference - assign - reference char with a single space on both sides' => [
+            '<?php $foo = &$var;',
+            '<?php $foo = & $var;',
+            ['anonymous_function_use_block' => 'by_reference'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: by_reference - assign - reference char with a single space before' => [
+            '<?php $foo = &$var;',
+            null,
+            ['anonymous_function_use_block' => 'by_reference'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: by_reference - assign - reference char with a no spaces around' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =&$var;',
+            ['anonymous_function_use_block' => 'by_reference'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: by_reference - assign - reference char with multiple spaces after' => [
+            '<?php $foo = &$var;',
+            '<?php $foo = &    $var;',
+            ['anonymous_function_use_block' => 'by_reference'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: by_reference - assign - reference char with multiple spaces on both sides' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =    &    $var;',
+            ['anonymous_function_use_block' => 'by_reference'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: by_reference - assign - reference char with multiple spaces before' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =    &$var;',
+            ['anonymous_function_use_block' => 'by_reference'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: by_reference - function_signature - reference char with no space after' => [
+            '<?php function bar(&$foo) {};',
+            null,
+            ['anonymous_function_use_block' => 'by_reference'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: by_reference - function_signature - reference char with a single space after' => [
+            '<?php function bar(&$foo) {};',
+            '<?php function bar(& $foo) {};',
+            ['anonymous_function_use_block' => 'by_reference'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: by_reference - function_signature - reference char with multiple spaces after' => [
+            '<?php function bar(&$foo) {};',
+            '<?php function bar(&     $foo) {};',
+            ['anonymous_function_use_block' => 'by_reference'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: by_reference - anonymous_function_use_block - reference char with no space after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            null,
+            ['anonymous_function_use_block' => 'by_reference'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: by_reference - anonymous_function_use_block - reference char a single multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (& $bar) {};',
+            ['anonymous_function_use_block' => 'by_reference'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: by_reference - anonymous_function_use_block - reference char with multiple spaces after' => [
+            '<?php $foo = function() use (&$bar) {};',
+            '<?php $foo = function() use (&    $bar) {};',
+            ['anonymous_function_use_block' => 'by_reference'],
+        ];
+
+        // Configuration: anonymous_function_use_block: single_space --- //
+
+        yield 'configured: anonymous_function_use_block: single_space - assign - reference char with a single space after' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =& $var;',
+            ['anonymous_function_use_block' => 'single_space'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: single_space - assign - reference char with a single space on both sides' => [
+            '<?php $foo = &$var;',
+            '<?php $foo = & $var;',
+            ['anonymous_function_use_block' => 'single_space'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: single_space - assign - reference char with a single space before' => [
+            '<?php $foo = &$var;',
+            null,
+            ['anonymous_function_use_block' => 'single_space'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: single_space - assign - reference char with a no spaces around' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =&$var;',
+            ['anonymous_function_use_block' => 'single_space'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: single_space - assign - reference char with multiple spaces after' => [
+            '<?php $foo = &$var;',
+            '<?php $foo = &    $var;',
+            ['anonymous_function_use_block' => 'single_space'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: single_space - assign - reference char with multiple spaces on both sides' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =    &    $var;',
+            ['anonymous_function_use_block' => 'single_space'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: single_space - assign - reference char with multiple spaces before' => [
+            '<?php $foo = &$var;',
+            '<?php $foo =    &$var;',
+            ['anonymous_function_use_block' => 'single_space'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: single_space - function_signature - reference char with no space after' => [
+            '<?php function bar(&$foo) {};',
+            null,
+            ['anonymous_function_use_block' => 'single_space'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: single_space - function_signature - reference char with a single space after' => [
+            '<?php function bar(&$foo) {};',
+            '<?php function bar(& $foo) {};',
+            ['anonymous_function_use_block' => 'single_space'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: single_space - function_signature - reference char with multiple spaces after' => [
+            '<?php function bar(&$foo) {};',
+            '<?php function bar(&     $foo) {};',
+            ['anonymous_function_use_block' => 'single_space'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: single_space - anonymous_function_use_block - reference char with no space after' => [
+            '<?php $foo = function() use (& $bar) {};',
+            '<?php $foo = function() use (&$bar) {};',
+            ['anonymous_function_use_block' => 'single_space'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: single_space - anonymous_function_use_block - reference char a single multiple spaces after' => [
+            '<?php $foo = function() use (& $bar) {};',
+            null,
+            ['anonymous_function_use_block' => 'single_space'],
+        ];
+
+        yield 'configured: anonymous_function_use_block: single_space - anonymous_function_use_block - reference char with multiple spaces after' => [
+            '<?php $foo = function() use (& $bar) {};',
+            '<?php $foo = function() use (&    $bar) {};',
+            ['anonymous_function_use_block' => 'single_space'],
+        ];
+    }
+}


### PR DESCRIPTION
This pull request adds a new `PhpCsFixer\Fixer\Whitespace\ReferenceSpacesFixer`.

Based on #7303, this code

```php
<?php
$bar = 'a';
$foo =& $bar;
```

will be changed to 

```php
<?php
$bar = 'a';
$foo = & $bar;
```

with a space between `=` and `&`.

This PR adds to possibility to handle the reference operator individually in the following cases:

- assignments
  - `by_reference`: `$foo = &$bar`
  - `by_assign`: `$foo =& $bar`
  - `single_space`: `$foo = & $bar`
  - `no_space`: `$foo =&$bar`
- function signatures
  - `by_reference`: `function foo(&$bar) {...`
  - `single_space`: `function foo(& $bar) {...`
- use arguments
  - `by_reference`: `$foo = function () use (&bar) {...`
  - `single_space`: `$foo = function () use (& bar) {...`


