### PR TITLE
CI: use fast-linter when calculating code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,8 @@ jobs:
 
       - name: Collect code coverage
         if: matrix.calculate-code-coverage == 'yes'
+        env:
+          FAST_LINT_TEST_CASES: 1
         run: vendor/bin/paraunit coverage --testsuite coverage --exclude-group covers-nothing --clover build/logs/clover.xml
 
       - name: Upload coverage results to Coveralls


### PR DESCRIPTION
extracted from https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7366