### PR TITLE
fix: Avoid `php_unit_data_provider_name` rule to change names if the test or the data provider are declared as abstract

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2605,7 +2605,8 @@ List of Available Rules
 
    Data provider names must match the name of the test.
 
-   *warning risky* Fixer could be risky if one is calling data provider by name as function.
+   *warning risky* Fixer could be risky if one is calling data provider by name as function or
+   if any of the test or the provider are overwritten in an inherited class.
 
    Configuration options:
 

--- a/doc/rules/php_unit/php_unit_data_provider_name.rst
+++ b/doc/rules/php_unit/php_unit_data_provider_name.rst
@@ -10,7 +10,8 @@ Warning
 Using this rule is risky
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Fixer could be risky if one is calling data provider by name as function.
+Fixer could be risky if one is calling data provider by name as function or if
+any of the test or the provider are overwritten in an inherited class.
 
 Configuration
 -------------

--- a/tests/Fixer/PhpUnit/PhpUnitDataProviderNameFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDataProviderNameFixerTest.php
@@ -291,24 +291,24 @@ class FooTest extends TestCase {
 }',
         ];
 
-        foreach (['abstract', 'final', 'private', 'protected', 'static', '/* private */'] as $modifier) {
+        foreach (['final', 'private', 'protected', 'static', '/* private */'] as $modifier) {
             yield sprintf('test function with %s modifier', $modifier) => [
                 sprintf('<?php
                 abstract class FooTest extends TestCase {
                     /**
                      * @dataProvider provideFooCases
                      */
-                    %s function testFoo() %s
+                    %s function testFoo() {}
                     public function provideFooCases() {}
-                }', $modifier, 'abstract' === $modifier ? ';' : '{}'),
+                }', $modifier),
                 sprintf('<?php
                 abstract class FooTest extends TestCase {
                     /**
                      * @dataProvider fooDataProvider
                      */
-                    %s function testFoo() %s
+                    %s function testFoo() {}
                     public function fooDataProvider() {}
-                }', $modifier, 'abstract' === $modifier ? ';' : '{}'),
+                }', $modifier),
             ];
         }
 
@@ -396,5 +396,27 @@ class FooTest extends TestCase {
                 $config,
             ];
         }
+
+        yield 'abstract data provider' => [
+            '<?php
+abstract class FooTest extends TestCase {
+    /**
+     * @dataProvider provideCustomCases
+     */
+    public function testFoo() {}
+    abstract public function provideCustomCases();
+}',
+        ];
+
+        yield 'abstract test' => [
+            '<?php
+abstract class FooTest extends TestCase {
+    /**
+     * @dataProvider provideCustomCases
+     */
+    abstract public function testFoo();
+    public function provideCustomCases() {}
+}',
+        ];
     }
 }


### PR DESCRIPTION
If the test or the data provider are overridden by a child class, the inherited methods are not updated by this rule.