### PR TITLE
feat: Introduce `OrderedAttributesFixer`

### DIFF
--- a/doc/rules/attribute_notation/ordered_attributes.rst
+++ b/doc/rules/attribute_notation/ordered_attributes.rst
@@ -1,0 +1,89 @@
+===========================
+Rule ``ordered_attributes``
+===========================
+
+Sorts attributes using the configured sort algorithm.
+
+Configuration
+-------------
+
+``order``
+~~~~~~~~~
+
+A list of FQCNs of attributes defining the desired order used when no sorting
+algorithm is configured.
+
+Allowed types: ``string[]``
+
+Default value: ``[]``
+
+``sort_algorithm``
+~~~~~~~~~~~~~~~~~~
+
+How the attributes should be sorted.
+
+Allowed values: ``'alpha'`` and ``'none'``
+
+Default value: ``'alpha'``
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+*Default* configuration.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+
+   +#[Bar(3)]
+   +#[Corge(a: 'test')]
+    #[Foo]
+   -#[Bar(3)]
+    #[Qux(new Bar(5))]
+   -#[Corge(a: 'test')]
+    class Sample1 {}
+
+    #[
+   +    Bar(3),
+   +    Corge(a: 'test'),
+        Foo,
+   -    Bar(3),
+        Qux(new Bar(5)),
+   -    Corge(a: 'test'),
+    ]
+    class Sample2 {}
+
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['sort_algorithm' => 'none', 'order' => ['A\\B\\Qux', 'A\\B\\Bar', 'A\\B\\Corge']]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+
+    use A\B\Foo;
+    use A\B\Bar as BarAlias;
+    use A\B as AB;
+
+   -#[Foo]
+   +#[AB\Qux(new Bar(5))]
+    #[BarAlias(3)]
+   -#[AB\Qux(new Bar(5))]
+    #[\A\B\Corge(a: 'test')]
+   +#[Foo]
+    class Sample1 {}
+References
+----------
+
+- Fixer class: `PhpCsFixer\\Fixer\\AttributeNotation\\OrderedAttributesFixer <./../../../src/Fixer/AttributeNotation/OrderedAttributesFixer.php>`_
+- Test class: `PhpCsFixer\\Tests\\Fixer\\AttributeNotation\\OrderedAttributesFixerTest <./../../../tests/Fixer/AttributeNotation/OrderedAttributesFixerTest.php>`_
+
+The test class defines officially supported behaviour. Each test case is a part of our backward compatibility promise.

--- a/doc/rules/attribute_notation/ordered_attributes.rst
+++ b/doc/rules/attribute_notation/ordered_attributes.rst
@@ -10,8 +10,8 @@ Configuration
 ``order``
 ~~~~~~~~~
 
-A list of FQCNs of attributes defining the desired order used when no sorting
-algorithm is configured.
+A list of FQCNs of attributes defining the desired order used when custom
+sorting algorithm is configured.
 
 Allowed types: ``string[]``
 
@@ -22,7 +22,7 @@ Default value: ``[]``
 
 How the attributes should be sorted.
 
-Allowed values: ``'alpha'`` and ``'none'``
+Allowed values: ``'alpha'`` and ``'custom'``
 
 Default value: ``'alpha'``
 
@@ -61,7 +61,7 @@ Example #1
 Example #2
 ~~~~~~~~~~
 
-With configuration: ``['sort_algorithm' => 'none', 'order' => ['A\\B\\Qux', 'A\\B\\Bar', 'A\\B\\Corge']]``.
+With configuration: ``['sort_algorithm' => 'custom', 'order' => ['A\\B\\Qux', 'A\\B\\Bar', 'A\\B\\Corge']]``.
 
 .. code-block:: diff
 

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -76,6 +76,9 @@ Attribute Notation
 - `attribute_empty_parentheses <./attribute_notation/attribute_empty_parentheses.rst>`_
 
   PHP attributes declared without arguments must (not) be followed by empty parentheses.
+- `ordered_attributes <./attribute_notation/ordered_attributes.rst>`_
+
+  Sorts attributes using the configured sort algorithm.
 
 Basic
 -----

--- a/src/Fixer/AttributeNotation/OrderedAttributesFixer.php
+++ b/src/Fixer/AttributeNotation/OrderedAttributesFixer.php
@@ -156,7 +156,7 @@ final class OrderedAttributesFixer extends AbstractFixer implements Configurable
                     'start' => $attributeAnalysis->getStartIndex(),
                     'end' => $attributeAnalysis->getEndIndex(),
                 ];
-            }, AttributeAnalyzer::collectFor($tokens, $index));
+            }, AttributeAnalyzer::collect($tokens, $index));
 
             $endIndex = end($elements)['end'];
 

--- a/src/Fixer/AttributeNotation/OrderedAttributesFixer.php
+++ b/src/Fixer/AttributeNotation/OrderedAttributesFixer.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\AttributeNotation;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\AttributeAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceUseAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\AttributeAnalyzer;
+use PhpCsFixer\Tokenizer\Analyzer\NamespacesAnalyzer;
+use PhpCsFixer\Tokenizer\Analyzer\NamespaceUsesAnalyzer;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use Symfony\Component\OptionsResolver\Options;
+
+/**
+ * @author HypeMC <hypemc@gmail.com>
+ *
+ * @phpstan-import-type _AttributeItems from AttributeAnalysis
+ */
+final class OrderedAttributesFixer extends AbstractFixer implements ConfigurableFixerInterface
+{
+    public const ORDER_ALPHA = 'alpha';
+    public const ORDER_NONE = 'none';
+
+    private const SUPPORTED_SORT_ALGORITHMS = [
+        self::ORDER_ALPHA,
+        self::ORDER_NONE,
+    ];
+
+    private ?NamespaceAnalysis $namespaceAnalysis = null;
+
+    /**
+     * @var null|array<string, NamespaceUseAnalysis>
+     */
+    private ?array $namespaceUseAnalyses = null;
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Sorts attributes using the configured sort algorithm.',
+            [
+                new VersionSpecificCodeSample(
+                    <<<'EOL'
+                        <?php
+
+                        #[Foo]
+                        #[Bar(3)]
+                        #[Qux(new Bar(5))]
+                        #[Corge(a: 'test')]
+                        class Sample1 {}
+
+                        #[
+                            Foo,
+                            Bar(3),
+                            Qux(new Bar(5)),
+                            Corge(a: 'test'),
+                        ]
+                        class Sample2 {}
+
+                        EOL,
+                    new VersionSpecification(8_00_00),
+                ),
+                new VersionSpecificCodeSample(
+                    <<<'EOL'
+                        <?php
+
+                        use A\B\Foo;
+                        use A\B\Bar as BarAlias;
+                        use A\B as AB;
+
+                        #[Foo]
+                        #[BarAlias(3)]
+                        #[AB\Qux(new Bar(5))]
+                        #[\A\B\Corge(a: 'test')]
+                        class Sample1 {}
+
+                        EOL,
+                    new VersionSpecification(8_00_00),
+                    ['sort_algorithm' => self::ORDER_NONE, 'order' => ['A\\B\\Qux', 'A\\B\\Bar', 'A\\B\\Corge']],
+                ),
+            ],
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Must run after FullyQualifiedStrictTypesFixer.
+     */
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return \defined('T_ATTRIBUTE') && $tokens->isTokenKindFound(T_ATTRIBUTE);
+    }
+
+    protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
+    {
+        $fixerName = $this->getName();
+
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('sort_algorithm', 'How the attributes should be sorted.'))
+                ->setAllowedValues(self::SUPPORTED_SORT_ALGORITHMS)
+                ->setDefault(self::ORDER_ALPHA)
+                ->getOption(),
+            (new FixerOptionBuilder('order', 'A list of FQCNs of attributes defining the desired order used when no sorting algorithm is configured.'))
+                ->setAllowedTypes(['string[]'])
+                ->setDefault([])
+                ->setNormalizer(static function (Options $options, array $value) use ($fixerName): array {
+                    if ($value !== array_unique($value)) {
+                        throw new InvalidFixerConfigurationException($fixerName, 'The list includes attributes that are not unique.');
+                    }
+
+                    return array_flip(array_values(
+                        array_map(static fn (string $attribute): string => ltrim($attribute, '\\'), $value),
+                    ));
+                })
+                ->getOption(),
+        ]);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        $index = 0;
+
+        while (null !== $index = $tokens->getNextTokenOfKind($index, [[T_ATTRIBUTE]])) {
+            /** @var list<array{name: string, start: int, end: int}> $elements */
+            $elements = array_map(function (AttributeAnalysis $attributeAnalysis) use ($tokens): array {
+                return [
+                    'name' => $this->sortAttributes($tokens, $attributeAnalysis->getStartIndex(), $attributeAnalysis->getAttributes()),
+                    'start' => $attributeAnalysis->getStartIndex(),
+                    'end' => $attributeAnalysis->getEndIndex(),
+                ];
+            }, AttributeAnalyzer::collectFor($tokens, $index));
+
+            $endIndex = end($elements)['end'];
+
+            try {
+                if (1 === \count($elements)) {
+                    continue;
+                }
+
+                $sortedElements = $this->sortElements($elements);
+
+                if ($elements === $sortedElements) {
+                    continue;
+                }
+
+                $this->sortTokens($tokens, $index, $endIndex, $sortedElements);
+            } finally {
+                $index = $endIndex;
+                $this->clearNamespaceAnalysis();
+            }
+        }
+    }
+
+    /**
+     * @param _AttributeItems $attributes
+     */
+    private function sortAttributes(Tokens $tokens, int $index, array $attributes): string
+    {
+        if (1 === \count($attributes)) {
+            return $this->getAttributeName($tokens, $attributes[0]['name'], $attributes[0]['start']);
+        }
+
+        foreach ($attributes as &$attribute) {
+            $attribute['name'] = $this->getAttributeName($tokens, $attribute['name'], $attribute['start']);
+        }
+
+        $sortedElements = $this->sortElements($attributes);
+
+        if ($attributes === $sortedElements) {
+            return $attributes[0]['name'];
+        }
+
+        $this->sortTokens($tokens, $index + 1, end($attributes)['end'], $sortedElements, new Token(','));
+
+        return $sortedElements[0]['name'];
+    }
+
+    private function getAttributeName(Tokens $tokens, string $name, int $index): string
+    {
+        if (self::ORDER_NONE === $this->configuration['sort_algorithm']) {
+            $name = $this->determineAttributeFQCN($tokens, $name, $index);
+        }
+
+        return ltrim($name, '\\');
+    }
+
+    private function determineAttributeFQCN(Tokens $tokens, string $name, int $index): string
+    {
+        if ('\\' === $name[0]) {
+            return $name;
+        }
+
+        if (!$tokens[$index]->isGivenKind([T_STRING, T_NS_SEPARATOR])) {
+            $index = $tokens->getNextTokenOfKind($index, [[T_STRING], [T_NS_SEPARATOR]]);
+        }
+
+        $this->initializeNamespaceAnalysis($tokens, $index);
+
+        $namespace = $this->namespaceAnalysis->getFullName();
+
+        $firstTokenOfName = $tokens[$index]->getContent();
+        $namespaceUseAnalysis = $this->namespaceUseAnalyses[$firstTokenOfName] ?? false;
+        if ($namespaceUseAnalysis) {
+            $namespace = $namespaceUseAnalysis->getFullName();
+
+            if ($name === $firstTokenOfName) {
+                return $namespace;
+            }
+
+            $name = substr(strstr($name, '\\'), 1);
+        }
+
+        return $namespace.'\\'.$name;
+    }
+
+    /**
+     * @param list<array{name: string, start: int, end: int}> $elements
+     *
+     * @return list<array{name: string, start: int, end: int}>
+     */
+    private function sortElements(array $elements): array
+    {
+        usort($elements, function (array $a, array $b): int {
+            $sortAlgorithm = $this->configuration['sort_algorithm'];
+
+            if (self::ORDER_ALPHA === $sortAlgorithm) {
+                return $a['name'] <=> $b['name'];
+            }
+
+            if (self::ORDER_NONE === $sortAlgorithm) {
+                return
+                    ($this->configuration['order'][$a['name']] ?? PHP_INT_MAX)
+                    <=>
+                    ($this->configuration['order'][$b['name']] ?? PHP_INT_MAX);
+            }
+
+            throw new \InvalidArgumentException(sprintf('Invalid sort algorithm "%s" provided.', $sortAlgorithm));
+        });
+
+        return $elements;
+    }
+
+    /**
+     * @param list<array{name: string, start: int, end: int}> $elements
+     */
+    private function sortTokens(Tokens $tokens, int $startIndex, int $endIndex, array $elements, ?Token $delimiter = null): void
+    {
+        $replaceTokens = [];
+
+        foreach ($elements as $pos => $element) {
+            for ($i = $element['start']; $i <= $element['end']; ++$i) {
+                $replaceTokens[] = clone $tokens[$i];
+            }
+            if (null !== $delimiter && $pos !== \count($elements) - 1) {
+                $replaceTokens[] = clone $delimiter;
+            }
+        }
+
+        $tokens->overrideRange($startIndex, $endIndex, $replaceTokens);
+    }
+
+    private function initializeNamespaceAnalysis(Tokens $tokens, int $startIndex): void
+    {
+        if (isset($this->namespaceAnalysis, $this->namespaceUseAnalyses)) {
+            return;
+        }
+
+        $this->namespaceAnalysis = (new NamespacesAnalyzer())->getNamespaceAt($tokens, $startIndex);
+
+        $this->namespaceUseAnalyses = [];
+        foreach ((new NamespaceUsesAnalyzer())->getDeclarationsInNamespace($tokens, $this->namespaceAnalysis) as $namespaceUseAnalysis) {
+            if (!$namespaceUseAnalysis->isClass()) {
+                continue;
+            }
+            $this->namespaceUseAnalyses[$namespaceUseAnalysis->getShortName()] = $namespaceUseAnalysis;
+        }
+    }
+
+    private function clearNamespaceAnalysis(): void
+    {
+        $this->namespaceAnalysis = $this->namespaceUseAnalyses = null;
+    }
+}

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -695,16 +695,14 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
      */
     private function fixAttribute(Tokens $tokens, int $index, array $uses, string $namespaceName): void
     {
-        $attributeAnalyses = AttributeAnalyzer::collectFor($tokens, $index);
+        $attributeAnalysis = AttributeAnalyzer::collectFor($tokens, $index)[0];
 
-        foreach ($attributeAnalyses as $attributeAnalysis) {
-            foreach ($attributeAnalysis->getAttributes() as $attribute) {
-                $index = $attribute['start'];
-                while ($tokens[$index]->equalsAny([[T_STRING], [T_NS_SEPARATOR]])) {
-                    $index = $tokens->getPrevMeaningfulToken($index);
-                }
-                $this->fixNextName($tokens, $index, $uses, $namespaceName);
+        foreach ($attributeAnalysis->getAttributes() as $attribute) {
+            $index = $attribute['start'];
+            while ($tokens[$index]->equalsAny([[T_STRING], [T_NS_SEPARATOR]])) {
+                $index = $tokens->getPrevMeaningfulToken($index);
             }
+            $this->fixNextName($tokens, $index, $uses, $namespaceName);
         }
     }
 

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -695,7 +695,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
      */
     private function fixAttribute(Tokens $tokens, int $index, array $uses, string $namespaceName): void
     {
-        $attributeAnalysis = AttributeAnalyzer::collectFor($tokens, $index)[0];
+        $attributeAnalysis = AttributeAnalyzer::collectOne($tokens, $index);
 
         foreach ($attributeAnalysis->getAttributes() as $attribute) {
             $index = $attribute['start'];

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -26,6 +26,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Analyzer\Analysis\TypeAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\AttributeAnalyzer;
 use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
 use PhpCsFixer\Tokenizer\Analyzer\NamespaceUsesAnalyzer;
 use PhpCsFixer\Tokenizer\CT;
@@ -179,7 +180,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
     /**
      * {@inheritdoc}
      *
-     * Must run before NoSuperfluousPhpdocTagsFixer, OrderedImportsFixer, OrderedInterfacesFixer, StatementIndentationFixer.
+     * Must run before NoSuperfluousPhpdocTagsFixer, OrderedAttributesFixer, OrderedImportsFixer, OrderedInterfacesFixer, StatementIndentationFixer.
      * Must run after ClassKeywordFixer, PhpUnitAttributesFixer, PhpdocToReturnTypeFixer.
      */
     public function getPriority(): int
@@ -312,7 +313,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
                             $this->fixPrevName($tokens, $index, $uses, $namespaceName);
                         }
                     } elseif (\defined('T_ATTRIBUTE') && $tokens[$index]->isGivenKind(T_ATTRIBUTE)) { // @TODO: drop const check when PHP 8.0+ is required
-                        $this->fixNextName($tokens, $index, $uses, $namespaceName);
+                        $this->fixAttribute($tokens, $index, $uses, $namespaceName);
                     } elseif ($discoverSymbolsPhase && !\defined('T_ATTRIBUTE') && $tokens[$index]->isComment() && Preg::match('/#\[\s*('.self::REGEX_CLASS.')/', $tokens[$index]->getContent(), $matches)) { // @TODO: drop when PHP 8.0+ is required
                         $this->determineShortType($matches[1], $uses, $namespaceName);
                     } elseif ($tokens[$index]->isGivenKind(T_DOC_COMMENT)) {
@@ -686,6 +687,24 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
             }
 
             $index = $tokens->getNextMeaningfulToken($index);
+        }
+    }
+
+    /**
+     * @param array<string, string> $uses
+     */
+    private function fixAttribute(Tokens $tokens, int $index, array $uses, string $namespaceName): void
+    {
+        $attributeAnalyses = AttributeAnalyzer::collectFor($tokens, $index);
+
+        foreach ($attributeAnalyses as $attributeAnalysis) {
+            foreach ($attributeAnalysis->getAttributes() as $attribute) {
+                $index = $attribute['start'];
+                while ($tokens[$index]->equalsAny([[T_STRING], [T_NS_SEPARATOR]])) {
+                    $index = $tokens->getPrevMeaningfulToken($index);
+                }
+                $this->fixNextName($tokens, $index, $uses, $namespaceName);
+            }
         }
     }
 

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -455,6 +455,7 @@ final class FixerFactoryTest extends TestCase
             ],
             'fully_qualified_strict_types' => [
                 'no_superfluous_phpdoc_tags',
+                'ordered_attributes',
                 'ordered_imports',
                 'ordered_interfaces',
                 'statement_indentation',

--- a/tests/Fixer/AttributeNotation/OrderedAttributesFixerTest.php
+++ b/tests/Fixer/AttributeNotation/OrderedAttributesFixerTest.php
@@ -1,0 +1,888 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\AttributeNotation;
+
+use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
+use PhpCsFixer\Fixer\AttributeNotation\OrderedAttributesFixer;
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author HypeMC <hypemc@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\AttributeNotation\OrderedAttributesFixer
+ *
+ * @requires PHP 8.0
+ */
+final class OrderedAttributesFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideInvalidConfigurationCases
+     *
+     * @param array{sort_algorithm: OrderedAttributesFixer::ORDER_*, order: list<string>} $configuration
+     */
+    public function testInvalidConfiguration(array $configuration, string $expectedExceptionMessage): void
+    {
+        self::expectException(InvalidFixerConfigurationException::class);
+        self::expectExceptionMessage($expectedExceptionMessage);
+
+        $this->fixer->configure($configuration);
+    }
+
+    /**
+     * @return iterable<array{0: array{sort_algorithm: OrderedAttributesFixer::ORDER_*, order: list<string>}, 1: string}>
+     */
+    public static function provideInvalidConfigurationCases(): iterable
+    {
+        yield 'Non unique attributes throw an exception' => [
+            [
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'order' => ['A\B\Bar', 'Test\Corge', 'A\B\Bar'],
+            ],
+            'The list includes attributes that are not unique.',
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix(string $expected, ?string $input = null, array $configuration = []): void
+    {
+        $this->fixer->configure($configuration);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<array{0: string, 1?: string, 2?: array<string, mixed>}>
+     */
+    public static function provideFixCases(): iterable
+    {
+        yield 'Alpha on various declarations' => [
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[AB\Baz(prop: \'baz\')]
+            #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            #[\A\B\Qux()]
+            #[BarAlias(3)]
+            #[Corge]
+            #[Foo(4, \'baz qux\')]
+            class X
+            {
+                #[AB\Baz(prop: \'baz\')]
+                #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+                #[\A\B\Qux()]
+                #[BarAlias(3)]
+                #[Corge]
+                #[Foo(4, \'baz qux\')]
+                const Y = 1;
+
+                #[AB\Baz(prop: \'baz\')]
+                #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+                #[\A\B\Qux()]
+                #[BarAlias(3)]
+                #[Corge]
+                #[Foo(4, \'baz qux\')]
+                public $y;
+
+                #[AB\Baz(prop: \'baz\')]
+                #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+                #[\A\B\Qux()]
+                #[BarAlias(3)]
+                #[Corge]
+                #[Foo(4, \'baz qux\')]
+                public function y() {}
+            }
+
+            #[AB\Baz(prop: \'baz\')]
+            #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            #[\A\B\Qux()]
+            #[BarAlias(3)]
+            #[Corge]
+            #[Foo(4, \'baz qux\')]
+            function f(
+                #[AB\Baz(prop: \'baz\')]
+                #[BarAlias(3)]
+                #[Foo(4, \'baz qux\')]
+                string $param1,
+                #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+                #[\A\B\Qux()]
+                #[Corge]
+                string $param2
+            ) {}
+
+            function f2(#[BarAlias(3)] #[Foo(4, \'baz qux\')] string $param1, #[\A\B\Qux()] #[Corge] string $param2) {}
+
+            $anon = #[AB\Baz(prop: \'baz\')] #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')] #[\A\B\Qux()] #[BarAlias(3)] #[Corge] #[Foo(4, \'baz qux\')] function () {};
+            $short = #[AB\Baz(prop: \'baz\')] #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')] #[\A\B\Qux()] #[BarAlias(3)] #[Corge] #[Foo(4, \'baz qux\')] fn () => null;
+            ',
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[Foo(4, \'baz qux\')]
+            #[BarAlias(3)]
+            #[AB\Baz(prop: \'baz\')]
+            #[\A\B\Qux()]
+            #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            #[Corge]
+            class X
+            {
+                #[Foo(4, \'baz qux\')]
+                #[BarAlias(3)]
+                #[AB\Baz(prop: \'baz\')]
+                #[\A\B\Qux()]
+                #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+                #[Corge]
+                const Y = 1;
+
+                #[Foo(4, \'baz qux\')]
+                #[BarAlias(3)]
+                #[AB\Baz(prop: \'baz\')]
+                #[\A\B\Qux()]
+                #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+                #[Corge]
+                public $y;
+
+                #[Foo(4, \'baz qux\')]
+                #[BarAlias(3)]
+                #[AB\Baz(prop: \'baz\')]
+                #[\A\B\Qux()]
+                #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+                #[Corge]
+                public function y() {}
+            }
+
+            #[Foo(4, \'baz qux\')]
+            #[BarAlias(3)]
+            #[AB\Baz(prop: \'baz\')]
+            #[\A\B\Qux()]
+            #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            #[Corge]
+            function f(
+                #[Foo(4, \'baz qux\')]
+                #[BarAlias(3)]
+                #[AB\Baz(prop: \'baz\')]
+                string $param1,
+                #[\A\B\Qux()]
+                #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+                #[Corge]
+                string $param2
+            ) {}
+
+            function f2(#[Foo(4, \'baz qux\')] #[BarAlias(3)] string $param1, #[\A\B\Qux()] #[Corge] string $param2) {}
+
+            $anon = #[Foo(4, \'baz qux\')] #[BarAlias(3)] #[AB\Baz(prop: \'baz\')] #[\A\B\Qux()] #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')] #[Corge] function () {};
+            $short = #[Foo(4, \'baz qux\')] #[BarAlias(3)] #[AB\Baz(prop: \'baz\')] #[\A\B\Qux()] #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')] #[Corge] fn () => null;
+            ',
+        ];
+
+        yield 'Explicit in namespace' => [
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            #[BarAlias(3)]
+            #[Corge]
+            #[AB\Baz(prop: \'baz\')]
+            #[Foo(4, \'baz qux\')]
+            #[\A\B\Qux()]
+            function f() {}
+            ',
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[Foo(4, \'baz qux\')]
+            #[BarAlias(3)]
+            #[AB\Baz(prop: \'baz\')]
+            #[\A\B\Qux()]
+            #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            #[Corge]
+            function f() {}
+            ',
+            [
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'order' => ['Test\A\B\Quux', 'A\B\Bar', 'Test\Corge', 'A\B\Baz', 'A\B\Foo', 'A\B\Qux'],
+            ],
+        ];
+
+        yield 'Explicit in global namespace' => [
+            '<?php
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            #[BarAlias(3)]
+            #[Corge]
+            #[AB\Baz(prop: \'baz\')]
+            #[Foo(4, \'baz qux\')]
+            #[\A\B\Qux()]
+            function f() {}
+            ',
+            '<?php
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[Foo(4, \'baz qux\')]
+            #[BarAlias(3)]
+            #[AB\Baz(prop: \'baz\')]
+            #[\A\B\Qux()]
+            #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            #[Corge]
+            function f() {}
+            ',
+            [
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'order' => ['A\B\Quux', 'A\B\Bar', 'Corge', 'A\B\Baz', 'A\B\Foo', 'A\B\Qux'],
+            ],
+        ];
+
+        yield 'Explicit with unconfigured attributes' => [
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            #[AB\Baz(prop: \'baz\')]
+            #[\A\B\Qux()]
+            #[Foo(4, \'baz qux\')]
+            #[BarAlias(3)]
+            #[Corge]
+            function f() {}
+            ',
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[Foo(4, \'baz qux\')]
+            #[BarAlias(3)]
+            #[AB\Baz(prop: \'baz\')]
+            #[\A\B\Qux()]
+            #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            #[Corge]
+            function f() {}
+            ',
+            [
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'order' => ['Test\A\B\Quux', 'A\B\Baz', 'A\B\Qux'],
+            ],
+        ];
+
+        yield 'Multiple namespaces' => [
+            '<?php
+            namespace Test
+            {
+                use A\B\Foo;
+                use A\B\Bar as BarAlias;
+
+                #[BarAlias(3)]
+                #[AB\Baz(prop: \'baz\')]
+                #[Foo(4, \'baz qux\')]
+                function f() {}
+            }
+
+            namespace Test2
+            {
+                use A\B\Bar as BarAlias;
+                use A\B as AB;
+
+                #[BarAlias(3)]
+                #[\A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+                #[AB\Baz(prop: \'baz\')]
+                function f() {}
+            }
+
+            namespace Test
+            {
+                use A\B\Foo;
+                use A\B\Bar as BarAlias2;
+
+                #[BarAlias2(3)]
+                #[AB\Baz(prop: \'baz\')]
+                #[Foo(4, \'baz qux\')]
+                function f2() {}
+            }
+
+            namespace
+            {
+                use A\B\Foo;
+                use A\B\Bar as BarAlias3;
+
+                #[BarAlias3(3)]
+                #[Foo(4, \'baz qux\')]
+                #[AB\Baz(prop: \'baz\')]
+                function f() {}
+            }
+            ',
+            '<?php
+            namespace Test
+            {
+                use A\B\Foo;
+                use A\B\Bar as BarAlias;
+
+                #[AB\Baz(prop: \'baz\')]
+                #[Foo(4, \'baz qux\')]
+                #[BarAlias(3)]
+                function f() {}
+            }
+
+            namespace Test2
+            {
+                use A\B\Bar as BarAlias;
+                use A\B as AB;
+
+                #[BarAlias(3)]
+                #[AB\Baz(prop: \'baz\')]
+                #[\A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+                function f() {}
+            }
+
+            namespace Test
+            {
+                use A\B\Foo;
+                use A\B\Bar as BarAlias2;
+
+                #[AB\Baz(prop: \'baz\')]
+                #[Foo(4, \'baz qux\')]
+                #[BarAlias2(3)]
+                function f2() {}
+            }
+
+            namespace
+            {
+                use A\B\Foo;
+                use A\B\Bar as BarAlias3;
+
+                #[AB\Baz(prop: \'baz\')]
+                #[Foo(4, \'baz qux\')]
+                #[BarAlias3(3)]
+                function f() {}
+            }
+            ',
+            [
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'order' => ['A\B\Bar', 'Test\AB\Baz', 'A\B\Quux', 'A\B\Baz', 'A\B\Foo', 'AB\Baz'],
+            ],
+        ];
+
+        yield 'With whitespaces' => [
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[   AB\Baz   (prop: \'baz\')   ]
+            #[   A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')   ]
+            #[   \A\B\Qux()   ]
+            #[   BarAlias   (3)   ]
+            #[   Corge   ]
+            #[   Foo   (4, \'baz qux\')   ]
+            function f() {}
+            ',
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[   Foo   (4, \'baz qux\')   ]
+            #[   BarAlias   (3)   ]
+            #[   AB\Baz   (prop: \'baz\')   ]
+            #[   \A\B\Qux()   ]
+            #[   A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')   ]
+            #[   Corge   ]
+            function f() {}
+            ',
+        ];
+
+        yield 'With docblock' => [
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            /**
+             * Start docblock
+             */
+            /**
+             * AB\Baz docblock
+             */
+            #[AB\Baz(prop: \'baz\')]
+            #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            #[\A\B\Qux()]
+            #[BarAlias(3)]
+            /**
+             * Corge docblock
+             */
+            #[Corge]
+            #[Foo(4, \'baz qux\')]
+            /**
+             * End docblock
+             */
+            class X
+            {}
+
+            function f2(/** Start docblock */#[\A\B\Qux()] #[BarAlias(3)] /** Corge docblock */#[Corge] #[Foo(4, \'baz qux\')] /** End docblock */string $param) {}
+            ',
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            /**
+             * Start docblock
+             */
+            #[Foo(4, \'baz qux\')]
+            #[BarAlias(3)]
+            /**
+             * AB\Baz docblock
+             */
+            #[AB\Baz(prop: \'baz\')]
+            #[\A\B\Qux()]
+            #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            /**
+             * Corge docblock
+             */
+            #[Corge]
+            /**
+             * End docblock
+             */
+            class X
+            {}
+
+            function f2(/** Start docblock */#[Foo(4, \'baz qux\')] #[BarAlias(3)] #[\A\B\Qux()] /** Corge docblock */#[Corge] /** End docblock */string $param) {}
+            ',
+        ];
+
+        yield 'With comments' => [
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[/* comment */A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\') /* comment */]
+            #[ /* comment */ BarAlias/* comment */(3)/* comment */]
+            #[/* comment */ Corge/* comment */]
+            #[/* comment */AB\Baz /* comment */ (prop: \'baz\') /* comment */ ]
+            #[/* comment */Foo/* comment */(4, \'baz qux\') /* comment */ ]
+            #[   /* comment */   \A\B\Qux()/* comment */]
+            function f() {}
+            ',
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[/* comment */Foo/* comment */(4, \'baz qux\') /* comment */ ]
+            #[ /* comment */ BarAlias/* comment */(3)/* comment */]
+            #[/* comment */AB\Baz /* comment */ (prop: \'baz\') /* comment */ ]
+            #[   /* comment */   \A\B\Qux()/* comment */]
+            #[/* comment */A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\') /* comment */]
+            #[/* comment */ Corge/* comment */]
+            function f() {}
+            ',
+            [
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'order' => ['Test\A\B\Quux', 'A\B\Bar', 'Test\Corge', 'A\B\Baz', 'A\B\Foo', 'A\B\Qux'],
+            ],
+        ];
+
+        yield 'Alpha with multiple attributes' => [
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[
+                AB\Baz(prop: \'baz\'),
+                A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'),
+                \A\B\Qux(),
+                BarAlias(3),
+                Corge,
+                Foo(4, \'baz qux\'),
+            ]
+            class X
+            {
+                #[ AB\Baz(prop: \'baz\'), A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'), \A\B\Qux(), BarAlias(3), Corge,Foo(4, \'baz qux\')]
+                public function y() {}
+            }
+            ',
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[
+                Foo(4, \'baz qux\'),
+                BarAlias(3),
+                AB\Baz(prop: \'baz\'),
+                \A\B\Qux(),
+                A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'),
+                Corge,
+            ]
+            class X
+            {
+                #[Foo(4, \'baz qux\'), BarAlias(3), AB\Baz(prop: \'baz\'), \A\B\Qux(), A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'), Corge]
+                public function y() {}
+            }
+            ',
+        ];
+
+        yield 'Explicit with multiple attributes' => [
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[
+                A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'),
+                BarAlias(3),
+                Corge,
+                AB\Baz(prop: \'baz\'),
+                \A\B\Qux(),
+                Foo(4, \'baz qux\'),
+            ]
+            class X
+            {
+                #[ A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'), BarAlias(3), Corge, AB\Baz(prop: \'baz\'), \A\B\Qux(),Foo(4, \'baz qux\')]
+                public function y() {}
+            }
+            ',
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[
+                Foo(4, \'baz qux\'),
+                BarAlias(3),
+                AB\Baz(prop: \'baz\'),
+                \A\B\Qux(),
+                A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'),
+                Corge,
+            ]
+            class X
+            {
+                #[Foo(4, \'baz qux\'), BarAlias(3), AB\Baz(prop: \'baz\'), \A\B\Qux(), A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'), Corge]
+                public function y() {}
+            }
+            ',
+            [
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'order' => ['Test\A\B\Quux', 'A\B\Bar', 'Test\Corge', 'A\B\Baz', 'A\B\Qux'],
+            ],
+        ];
+
+        yield 'Multiline with no trailing comma' => [
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[
+                AB\Baz(prop: \'baz\'),
+                A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'),
+                \A\B\Qux(),
+                BarAlias(3),
+                Corge,
+                Foo(4, \'baz qux\')
+            ]
+            class X
+            {}
+            ',
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[
+                Foo(4, \'baz qux\'),
+                BarAlias(3),
+                AB\Baz(prop: \'baz\'),
+                \A\B\Qux(),
+                A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'),
+                Corge
+            ]
+            class X
+            {}
+            ',
+        ];
+
+        yield 'Multiple with comments' => [
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[
+                /*
+                 * AB\Baz comment
+                 */
+                AB\Baz(prop: \'baz\'),
+                A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'),
+                \A\B\Qux(),
+                BarAlias(3),
+                /*
+                 * Corge comment
+                 */
+                Corge,
+                /**
+                 * Foo docblock
+                 */
+                Foo(4, \'baz qux\'),
+            ]
+            class X
+            {
+                #[ /* AB\Baz comment */AB\Baz(prop: \'baz\'), A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'), \A\B\Qux(), BarAlias(3), /* Corge comment */Corge,/** Foo docblock */Foo(4, \'baz qux\')]
+                public function y() {}
+            }
+            ',
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[
+                /**
+                 * Foo docblock
+                 */
+                Foo(4, \'baz qux\'),
+                BarAlias(3),
+                /*
+                 * AB\Baz comment
+                 */
+                AB\Baz(prop: \'baz\'),
+                \A\B\Qux(),
+                A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'),
+                /*
+                 * Corge comment
+                 */
+                Corge,
+            ]
+            class X
+            {
+                #[/** Foo docblock */Foo(4, \'baz qux\'), BarAlias(3), /* AB\Baz comment */AB\Baz(prop: \'baz\'), \A\B\Qux(), A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'), /* Corge comment */Corge]
+                public function y() {}
+            }
+            ',
+        ];
+
+        yield 'Alpha with mixed multiple attribute declarations and attributes' => [
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[AB\Baz(prop: \'baz\')]
+            #[ A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'),Corge]
+            #[ \A\B\Qux(), BarAlias(3),Foo(4, \'baz qux\')]
+            function f() {}
+            ',
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[Foo(4, \'baz qux\'), \A\B\Qux(), BarAlias(3)]
+            #[AB\Baz(prop: \'baz\')]
+            #[Corge, A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            function f() {}
+            ',
+        ];
+
+        yield 'Explicit with mixed multiple attribute declarations and attributes' => [
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[ A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'),Corge]
+            #[ BarAlias(3), \A\B\Qux(),Foo(4, \'baz qux\')]
+            #[AB\Baz(prop: \'baz\')]
+            function f() {}
+            ',
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[Foo(4, \'baz qux\'), \A\B\Qux(), BarAlias(3)]
+            #[AB\Baz(prop: \'baz\')]
+            #[Corge, A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            function f() {}
+            ',
+            [
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'order' => ['Test\A\B\Quux', 'A\B\Bar', 'Test\Corge', 'A\B\Baz', 'A\B\Qux'],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     *
+     * @dataProvider provideFix81Cases
+     *
+     * @requires PHP 8.1
+     */
+    public function testFix81(string $expected, ?string $input = null, array $configuration = []): void
+    {
+        $this->fixer->configure($configuration);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<array{0: string, 1?: string, 2?: array<string, mixed>}>
+     */
+    public static function provideFix81Cases(): iterable
+    {
+        yield 'Alpha with nested attribute' => [
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[AB\Baz(prop: new P\R())]
+            #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            #[\A\B\Qux()]
+            #[BarAlias(3)]
+            #[Corge]
+            #[Foo(4, \'baz qux\')]
+            function f() {}
+            ',
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[Foo(4, \'baz qux\')]
+            #[BarAlias(3)]
+            #[AB\Baz(prop: new P\R())]
+            #[\A\B\Qux()]
+            #[A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
+            #[Corge]
+            function f() {}
+            ',
+        ];
+
+        yield 'Explicit multiple with nested attribute' => [
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[
+                A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'),
+                BarAlias(3),
+                Corge,
+                AB\Baz(prop: new P\R()),
+                Foo(4, \'baz qux\'),
+                \A\B\Qux(),
+            ]
+            function f() {}
+            ',
+            '<?php
+            namespace Test;
+
+            use A\B\Foo;
+            use A\B\Bar as BarAlias;
+            use A\B as AB;
+
+            #[
+                Foo(4, \'baz qux\'),
+                BarAlias(3),
+                AB\Baz(prop: new P\R()),
+                \A\B\Qux(),
+                A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\'),
+                Corge,
+            ]
+            function f() {}
+            ',
+            [
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'order' => ['Test\A\B\Quux', 'A\B\Bar', 'Test\Corge', 'A\B\Baz', 'A\B\Foo', 'A\B\Qux'],
+            ],
+        ];
+    }
+}

--- a/tests/Fixer/AttributeNotation/OrderedAttributesFixerTest.php
+++ b/tests/Fixer/AttributeNotation/OrderedAttributesFixerTest.php
@@ -43,13 +43,26 @@ final class OrderedAttributesFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @return iterable<array{0: array{sort_algorithm: OrderedAttributesFixer::ORDER_*, order: list<string>}, 1: string}>
+     * @return iterable<array{0: array{sort_algorithm: OrderedAttributesFixer::ORDER_*, order?: list<string>}, 1: string}>
      */
     public static function provideInvalidConfigurationCases(): iterable
     {
+        yield 'Custom order strategy without `order` option' => [
+            ['sort_algorithm' => OrderedAttributesFixer::ORDER_CUSTOM],
+            'The custom order strategy requires providing `order` option with a list of attributes\'s FQNs.',
+        ];
+
+        yield 'Custom order strategy with empty `order` option' => [
+            [
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_CUSTOM,
+                'order' => [],
+            ],
+            'The custom order strategy requires providing `order` option with a list of attributes\'s FQNs.',
+        ];
+
         yield 'Non unique attributes throw an exception' => [
             [
-                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_CUSTOM,
                 'order' => ['A\B\Bar', 'Test\Corge', 'A\B\Bar'],
             ],
             'The list includes attributes that are not unique.',
@@ -232,7 +245,7 @@ final class OrderedAttributesFixerTest extends AbstractFixerTestCase
             function f() {}
             ',
             [
-                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_CUSTOM,
                 'order' => ['Test\A\B\Quux', 'A\B\Bar', 'Test\Corge', 'A\B\Baz', 'A\B\Foo', 'A\B\Qux'],
             ],
         ];
@@ -265,7 +278,7 @@ final class OrderedAttributesFixerTest extends AbstractFixerTestCase
             function f() {}
             ',
             [
-                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_CUSTOM,
                 'order' => ['A\B\Quux', 'A\B\Bar', 'Corge', 'A\B\Baz', 'A\B\Foo', 'A\B\Qux'],
             ],
         ];
@@ -302,7 +315,7 @@ final class OrderedAttributesFixerTest extends AbstractFixerTestCase
             function f() {}
             ',
             [
-                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_CUSTOM,
                 'order' => ['Test\A\B\Quux', 'A\B\Baz', 'A\B\Qux'],
             ],
         ];
@@ -399,7 +412,7 @@ final class OrderedAttributesFixerTest extends AbstractFixerTestCase
             }
             ',
             [
-                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_CUSTOM,
                 'order' => ['A\B\Bar', 'Test\AB\Baz', 'A\B\Quux', 'A\B\Baz', 'A\B\Foo', 'AB\Baz'],
             ],
         ];
@@ -532,7 +545,7 @@ final class OrderedAttributesFixerTest extends AbstractFixerTestCase
             function f() {}
             ',
             [
-                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_CUSTOM,
                 'order' => ['Test\A\B\Quux', 'A\B\Bar', 'Test\Corge', 'A\B\Baz', 'A\B\Foo', 'A\B\Qux'],
             ],
         ];
@@ -626,7 +639,7 @@ final class OrderedAttributesFixerTest extends AbstractFixerTestCase
             }
             ',
             [
-                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_CUSTOM,
                 'order' => ['Test\A\B\Quux', 'A\B\Bar', 'Test\Corge', 'A\B\Baz', 'A\B\Qux'],
             ],
         ];
@@ -786,7 +799,7 @@ final class OrderedAttributesFixerTest extends AbstractFixerTestCase
             function f() {}
             ',
             [
-                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_CUSTOM,
                 'order' => ['Test\A\B\Quux', 'A\B\Bar', 'Test\Corge', 'A\B\Baz', 'A\B\Qux'],
             ],
         ];
@@ -880,7 +893,7 @@ final class OrderedAttributesFixerTest extends AbstractFixerTestCase
             function f() {}
             ',
             [
-                'sort_algorithm' => OrderedAttributesFixer::ORDER_NONE,
+                'sort_algorithm' => OrderedAttributesFixer::ORDER_CUSTOM,
                 'order' => ['Test\A\B\Quux', 'A\B\Bar', 'Test\Corge', 'A\B\Baz', 'A\B\Foo', 'A\B\Qux'],
             ],
         ];

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -2683,23 +2683,31 @@ function foo($a) {}',
 
 namespace Foo\Test;
 use Other\ClassAttr;
+use Other\ClassAttr2;
 use Other\MethodAttr;
+use Other\MethodAttr2;
 use Other\PromotedAttr;
+use Other\PromotedAttr2;
 use Other\PropertyAttr;
+use Other\PropertyAttr2;
 
 #[ClassAttr]
+#[ClassAttr, ClassAttr2]
 #[\AllowDynamicProperties]
 class Foo
 {
     #[PropertyAttr]
+    #[PropertyAttr, PropertyAttr2]
     public int $prop;
 
     public function __construct(
         #[PromotedAttr]
+        #[PromotedAttr, PromotedAttr2]
         public int $arg
     ) {}
 
     #[MethodAttr]
+    #[MethodAttr, MethodAttr2]
     public function foo(): void {}
 }
             ',
@@ -2708,18 +2716,22 @@ class Foo
 namespace Foo\Test;
 
 #[\Other\ClassAttr]
+#[\Other\ClassAttr, \Other\ClassAttr2]
 #[\AllowDynamicProperties]
 class Foo
 {
     #[\Other\PropertyAttr]
+    #[\Other\PropertyAttr, \Other\PropertyAttr2]
     public int $prop;
 
     public function __construct(
         #[\Other\PromotedAttr]
+        #[\Other\PromotedAttr, \Other\PromotedAttr2]
         public int $arg
     ) {}
 
     #[\Other\MethodAttr]
+    #[\Other\MethodAttr, \Other\MethodAttr2]
     public function foo(): void {}
 }
             ',

--- a/tests/Fixtures/Integration/priority/fully_qualified_strict_types,ordered_attributes.test
+++ b/tests/Fixtures/Integration/priority/fully_qualified_strict_types,ordered_attributes.test
@@ -1,0 +1,42 @@
+--TEST--
+Integration of fixers: fully_qualified_strict_types,ordered_attributes.
+--RULESET--
+{"fully_qualified_strict_types": {"import_symbols": true}, "ordered_attributes": true}
+--REQUIREMENTS--
+{"php": 80000}
+--EXPECT--
+<?php
+
+namespace Test;
+use A\Bar;
+use B\Foo;
+use C\Baz;
+
+#[Bar]
+#[Baz]
+#[Foo]
+function foo() {}
+
+#[
+    Bar,
+    Baz,
+    Foo,
+]
+function bar() {}
+
+--INPUT--
+<?php
+
+namespace Test;
+
+#[\C\Baz]
+#[\A\Bar]
+#[\B\Foo]
+function foo() {}
+
+#[
+    \C\Baz,
+    \A\Bar,
+    \B\Foo,
+]
+function bar() {}


### PR DESCRIPTION
Sorts attributes:

```diff
<?php

+#[Bar(3)]
+#[Corge(a: 'test')]
 #[Foo]
-#[Bar(3)]
 #[Qux(new Bar(5))]
-#[Corge(a: 'test')]
 class Sample1 {}

#[
+    Bar(3),
+    Corge(a: 'test'),
     Foo,
-    Bar(3),
     Qux(new Bar(5)),
-    Corge(a: 'test'),
]
class Sample2 {}
```

Inspired by https://github.com/rectorphp/rector-src/pull/3838