### PR TITLE
fix: OrderedImportsFixer - handle non-grouped list of const/function imports

### DIFF
--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -569,16 +569,16 @@ use Bar;
                 $use['namespace']
             );
 
-            $numberOfInitial0TokensToClear = 3; // clear `<?php use `
+            $numberOfInitialTokensToClear = 3; // clear `<?php use `
             if (self::IMPORT_TYPE_CLASS !== $use['importType']) {
                 $prevIndex = $tokens->getPrevMeaningfulToken($index);
                 if ($tokens[$prevIndex]->equals(',')) {
-                    $numberOfInitial0TokensToClear = 5; // clear `<?php use const ` or `<?php use function `
+                    $numberOfInitialTokensToClear = 5; // clear `<?php use const ` or `<?php use function `
                 }
             }
 
             $declarationTokens = Tokens::fromCode($code);
-            $declarationTokens->clearRange(0, $numberOfInitial0TokensToClear - 1);
+            $declarationTokens->clearRange(0, $numberOfInitialTokensToClear - 1);
             $declarationTokens->clearAt(\count($declarationTokens) - 1); // clear `;`
             $declarationTokens->clearEmptyTokens();
 

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -569,8 +569,16 @@ use Bar;
                 $use['namespace']
             );
 
+            $numberOfInitial0TokensToClear = 3; // clear `<?php use `
+            if (self::IMPORT_TYPE_CLASS !== $use['importType']) {
+                $prevIndex = $tokens->getPrevMeaningfulToken($index);
+                if ($tokens[$prevIndex]->equals(',')) {
+                    $numberOfInitial0TokensToClear = 5; // clear `<?php use const ` or `<?php use function `
+                }
+            }
+
             $declarationTokens = Tokens::fromCode($code);
-            $declarationTokens->clearRange(0, 2); // clear `<?php use `
+            $declarationTokens->clearRange(0, $numberOfInitial0TokensToClear - 1);
             $declarationTokens->clearAt(\count($declarationTokens) - 1); // clear `;`
             $declarationTokens->clearEmptyTokens();
 

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -1137,6 +1137,16 @@ use function some\a\{fn_a, fn_b, fn_c,};
                 'imports_order' => [OrderedImportsFixer::IMPORT_TYPE_CLASS, OrderedImportsFixer::IMPORT_TYPE_CONST, OrderedImportsFixer::IMPORT_TYPE_FUNCTION],
             ],
         ];
+
+        yield [
+            '<?php use const CONST_A, CONST_B, CONST_C;',
+            '<?php use const CONST_C, CONST_B, CONST_A;',
+        ];
+
+        yield [
+            '<?php use function Foo\A, Foo\B, Foo\C;',
+            '<?php use function Foo\B, Foo\C, Foo\A;',
+        ];
     }
 
     public function testUnknownOrderTypes(): void


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7375