### PR TITLE
feat: `@Symfony` - keep Annotation,NamedArgumentConstructor,Target annotations as single group

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2394,7 +2394,7 @@ List of Available Rules
    - | ``groups``
      | Sets of annotation types to be grouped together. Use ``*`` to match any tag character.
      | Allowed types: ``string[][]``
-     | Default value: ``[['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write']]``
+     | Default value: ``[['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['deprecated', 'link', 'see', 'since']]``
    - | ``skip_unlisted_annotations``
      | Whether to skip annotations that are not listed in any group.
      | Allowed types: ``bool``

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -129,7 +129,10 @@ Rules
 
 - `phpdoc_return_self_reference <./../rules/phpdoc/phpdoc_return_self_reference.rst>`_
 - `phpdoc_scalar <./../rules/phpdoc/phpdoc_scalar.rst>`_
-- `phpdoc_separation <./../rules/phpdoc/phpdoc_separation.rst>`_
+- `phpdoc_separation <./../rules/phpdoc/phpdoc_separation.rst>`_ with config:
+
+  ``['groups' => [['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['Annotation', 'NamedArgumentConstructor', 'Target']]]``
+
 - `phpdoc_single_line_var_spacing <./../rules/phpdoc/phpdoc_single_line_var_spacing.rst>`_
 - `phpdoc_summary <./../rules/phpdoc/phpdoc_summary.rst>`_
 - `phpdoc_tag_type <./../rules/phpdoc/phpdoc_tag_type.rst>`_ with config:

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -131,7 +131,7 @@ Rules
 - `phpdoc_scalar <./../rules/phpdoc/phpdoc_scalar.rst>`_
 - `phpdoc_separation <./../rules/phpdoc/phpdoc_separation.rst>`_ with config:
 
-  ``['groups' => [['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['Annotation', 'NamedArgumentConstructor', 'Target']]]``
+  ``['groups' => [['Annotation', 'NamedArgumentConstructor', 'Target'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['deprecated', 'link', 'see', 'since']]]``
 
 - `phpdoc_single_line_var_spacing <./../rules/phpdoc/phpdoc_single_line_var_spacing.rst>`_
 - `phpdoc_summary <./../rules/phpdoc/phpdoc_summary.rst>`_

--- a/doc/rules/phpdoc/phpdoc_separation.rst
+++ b/doc/rules/phpdoc/phpdoc_separation.rst
@@ -17,7 +17,7 @@ character.
 
 Allowed types: ``string[][]``
 
-Default value: ``[['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write']]``
+Default value: ``[['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['deprecated', 'link', 'see', 'since']]``
 
 ``skip_unlisted_annotations``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -157,10 +157,10 @@ The rule is part of the following rule sets:
 
 - `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ with config:
 
-  ``['groups' => [['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['Annotation', 'NamedArgumentConstructor', 'Target']]]``
+  ``['groups' => [['Annotation', 'NamedArgumentConstructor', 'Target'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['deprecated', 'link', 'see', 'since']]]``
 
 - `@Symfony <./../../ruleSets/Symfony.rst>`_ with config:
 
-  ``['groups' => [['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['Annotation', 'NamedArgumentConstructor', 'Target']]]``
+  ``['groups' => [['Annotation', 'NamedArgumentConstructor', 'Target'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['deprecated', 'link', 'see', 'since']]]``
 
 

--- a/doc/rules/phpdoc/phpdoc_separation.rst
+++ b/doc/rules/phpdoc/phpdoc_separation.rst
@@ -155,6 +155,12 @@ Rule sets
 
 The rule is part of the following rule sets:
 
-- `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
-- `@Symfony <./../../ruleSets/Symfony.rst>`_
+- `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ with config:
+
+  ``['groups' => [['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['Annotation', 'NamedArgumentConstructor', 'Target']]]``
+
+- `@Symfony <./../../ruleSets/Symfony.rst>`_ with config:
+
+  ``['groups' => [['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['Annotation', 'NamedArgumentConstructor', 'Target']]]``
+
 

--- a/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
@@ -41,10 +41,10 @@ final class PhpdocSeparationFixer extends AbstractFixer implements ConfigurableF
      * @var string[][]
      */
     public const OPTION_GROUPS_DEFAULT = [
-        ['deprecated', 'link', 'see', 'since'],
         ['author', 'copyright', 'license'],
         ['category', 'package', 'subpackage'],
         ['property', 'property-read', 'property-write'],
+        ['deprecated', 'link', 'see', 'since'],
     ];
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
@@ -36,6 +36,18 @@ use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 final class PhpdocSeparationFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
     /**
+     * @internal
+     *
+     * @var string[][]
+     */
+    public const OPTION_GROUPS_DEFAULT = [
+        ['deprecated', 'link', 'see', 'since'],
+        ['author', 'copyright', 'license'],
+        ['category', 'package', 'subpackage'],
+        ['property', 'property-read', 'property-write'],
+    ];
+
+    /**
      * @var string[][]
      */
     private array $groups;
@@ -161,12 +173,7 @@ final class PhpdocSeparationFixer extends AbstractFixer implements ConfigurableF
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('groups', 'Sets of annotation types to be grouped together. Use `*` to match any tag character.'))
                 ->setAllowedTypes(['string[][]'])
-                ->setDefault([
-                    ['deprecated', 'link', 'see', 'since'],
-                    ['author', 'copyright', 'license'],
-                    ['category', 'package', 'subpackage'],
-                    ['property', 'property-read', 'property-write'],
-                ])
+                ->setDefault(self::OPTION_GROUPS_DEFAULT)
                 ->setAllowedValues([$allowTagToBelongToOnlyOneGroup])
                 ->getOption(),
             (new FixerOptionBuilder('skip_unlisted_annotations', 'Whether to skip annotations that are not listed in any group.'))

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\RuleSet\Sets;
 
+use PhpCsFixer\Fixer\Phpdoc\PhpdocSeparationFixer;
 use PhpCsFixer\RuleSet\AbstractRuleSetDescription;
 
 /**
@@ -166,7 +167,12 @@ final class SymfonySet extends AbstractRuleSetDescription
             ],
             'phpdoc_return_self_reference' => true,
             'phpdoc_scalar' => true,
-            'phpdoc_separation' => true,
+            'phpdoc_separation' => [
+                'groups' => [
+                    ...PhpdocSeparationFixer::OPTION_GROUPS_DEFAULT,
+                    ['Annotation', 'NamedArgumentConstructor', 'Target'],
+                ],
+            ],
             'phpdoc_single_line_var_spacing' => true,
             'phpdoc_summary' => true,
             'phpdoc_tag_type' => [

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -169,8 +169,8 @@ final class SymfonySet extends AbstractRuleSetDescription
             'phpdoc_scalar' => true,
             'phpdoc_separation' => [
                 'groups' => [
-                    ...PhpdocSeparationFixer::OPTION_GROUPS_DEFAULT,
                     ['Annotation', 'NamedArgumentConstructor', 'Target'],
+                    ...PhpdocSeparationFixer::OPTION_GROUPS_DEFAULT,
                 ],
             ],
             'phpdoc_single_line_var_spacing' => true,


### PR DESCRIPTION
ref https://github.com/symfony/symfony/pull/52389