### PR TITLE
CI: Do not run post-autoload-dump on Composer install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           max_attempts: 5
           retry_wait_seconds: 30
           command: |
-            composer update --optimize-autoloader --no-interaction --no-progress --no-scripts ${{ matrix.composer-flags }}
+            composer update --optimize-autoloader --no-interaction --no-progress --no-scripts ${{ matrix.composer-flags }} # --no-scripts to avoid installing dev-tools for all jobs on CI level
             composer info -D
 
       # execute migration rules before running tests and self-fixing,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           max_attempts: 5
           retry_wait_seconds: 30
           command: |
-            composer update --optimize-autoloader --no-interaction --no-progress ${{ matrix.composer-flags }}
+            composer update --optimize-autoloader --no-interaction --no-progress --no-scripts ${{ matrix.composer-flags }}
             composer info -D
 
       # execute migration rules before running tests and self-fixing,


### PR DESCRIPTION
externalised from https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7366/commits/246ecd77f08a524d5dd0ae0ce13edf27ae9c602f