### PR TITLE
CI: add curl and mbstring to build php

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: none, dom, json, opcache, simplexml, tokenizer, xml, xmlwriter, zip
+          extensions: none, curl, dom, json, mbstring, opcache, simplexml, tokenizer, xml, xmlwriter, zip
           coverage: ${{ steps.code-coverage-driver.outputs.result }}
           tools: flex
 

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -35,7 +35,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: none, dom, mbstring, opcache, simplexml, tokenizer, xml, xmlwriter
+          extensions: none, curl, dom, json, mbstring, opcache, simplexml, tokenizer, xml, xmlwriter, zip
           coverage: none # without this Xdebug will be enabled
           tools: cs2pr
 


### PR DESCRIPTION
to solve warnings like (not affecting if we have the cache, yet if not...)

> Composer is operating significantly slower than normal because you do not have the PHP curl extension enabled.