### PR TITLE
CI: prevent Infection plugins during build time, as we do not use it

### DIFF
--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -15,7 +15,8 @@
     "config": {
         "allow-plugins": {
             "ergebnis/composer-normalize": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "infection/extension-installer": false
         },
         "optimize-autoloader": true,
         "platform": {


### PR DESCRIPTION
to prevent this error on CD:
```
  infection/extension-installer contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.                           
  You can run "composer config --no-plugins allow-plugins.infection/extension-installer [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)  
  See https://getcomposer.org/allow-plugins  
```