### PR TITLE
fix: Satisfy `composer normalize`

### DIFF
--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -15,8 +15,8 @@
     "config": {
         "allow-plugins": {
             "ergebnis/composer-normalize": true,
-            "phpstan/extension-installer": true,
-            "infection/extension-installer": false
+            "infection/extension-installer": false,
+            "phpstan/extension-installer": true
         },
         "optimize-autoloader": true,
         "platform": {


### PR DESCRIPTION
While working on #7423 I noticed, that the StaticAnalysis build was failing due to a not normalized composer.json in `/dev-tools`


https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/actions/runs/6782571716/job/18435059330?pr=7423