### PR TITLE
fix: Remove all variable names in `@var` callable signature

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
@@ -114,12 +114,12 @@ final class Foo
 
     private function fixLine(Line $line): void
     {
-        $content = $line->getContent();
+        Preg::matchAll('/ \$'.TypeExpression::REGEX_IDENTIFIER.'(?<!\$this)/', $line->getContent(), $matches);
 
-        Preg::matchAll('/ \$'.TypeExpression::REGEX_IDENTIFIER.'(?<!\$this)/', $content, $matches);
-
-        if (isset($matches[0][0])) {
-            $line->setContent(str_replace($matches[0][0], '', $content));
+        if (isset($matches[0])) {
+            foreach ($matches[0] as $match) {
+                $line->setContent(str_replace($match, '', $line->getContent()));
+            }
         }
     }
 

--- a/tests/Fixer/Phpdoc/PhpdocVarWithoutNameFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocVarWithoutNameFixerTest.php
@@ -595,6 +595,29 @@ class A
                 EOF
             ,
         ];
+
+        yield '@var with callable syntax' => [
+            <<<'EOF'
+                <?php
+
+                class Foo
+                {
+                    /** @var array<callable(string, Buzz): void> */
+                    protected $bar;
+                }
+                EOF
+            ,
+            <<<'EOF'
+                <?php
+
+                class Foo
+                {
+                    /** @var array<callable(string $baz, Buzz $buzz): void> */
+                    protected $bar;
+                }
+                EOF
+            ,
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes #5402.