### PR TITLE
fix: `NoSpacesAfterFunctionNameFixer` - do not remove space if the opening parenthesis part of an expression

### DIFF
--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -82,6 +82,10 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
             // check if it is a function call
             if ($tokens[$lastTokenIndex]->isGivenKind($functionyTokens)) {
                 $this->fixFunctionCall($tokens, $index);
+            } elseif ($tokens[$lastTokenIndex]->isGivenKind(T_ECHO)) {
+                if ($tokens[$nextNonWhiteSpace]->equals(';')) {
+                    $this->fixFunctionCall($tokens, $index);
+                }
             } elseif ($tokens[$lastTokenIndex]->isGivenKind(T_STRING)) { // for real function calls or definitions
                 $possibleDefinitionIndex = $tokens->getPrevMeaningfulToken($lastTokenIndex);
                 if (!$tokens[$possibleDefinitionIndex]->isGivenKind(T_FUNCTION)) {
@@ -139,7 +143,6 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
     {
         static $tokens = [
             T_ARRAY,
-            T_ECHO,
             T_EMPTY,
             T_EVAL,
             T_EXIT,
@@ -165,7 +168,6 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
     private function getLanguageConstructionTokenKinds(): array
     {
         static $languageConstructionTokens = [
-            T_ECHO,
             T_PRINT,
             T_INCLUDE,
             T_INCLUDE_ONCE,

--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -50,7 +50,7 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isAnyTokenKindsFound(array_merge($this->getFunctionyTokenKinds(), [T_STRING]));
+        return $tokens->isAnyTokenKindsFound([T_STRING, ...$this->getFunctionyTokenKinds()]);
     }
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
@@ -73,7 +73,7 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
             $nextNonWhiteSpace = $tokens->getNextMeaningfulToken($endParenthesisIndex);
             if (
                 null !== $nextNonWhiteSpace
-                && $tokens[$nextNonWhiteSpace]->equals('?')
+                && !$tokens[$nextNonWhiteSpace]->equals(';')
                 && $tokens[$lastTokenIndex]->isGivenKind($languageConstructionTokens)
             ) {
                 continue;
@@ -82,10 +82,6 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
             // check if it is a function call
             if ($tokens[$lastTokenIndex]->isGivenKind($functionyTokens)) {
                 $this->fixFunctionCall($tokens, $index);
-            } elseif ($tokens[$lastTokenIndex]->isGivenKind(T_ECHO)) {
-                if ($tokens[$nextNonWhiteSpace]->equals(';')) {
-                    $this->fixFunctionCall($tokens, $index);
-                }
             } elseif ($tokens[$lastTokenIndex]->isGivenKind(T_STRING)) { // for real function calls or definitions
                 $possibleDefinitionIndex = $tokens->getPrevMeaningfulToken($lastTokenIndex);
                 if (!$tokens[$possibleDefinitionIndex]->isGivenKind(T_FUNCTION)) {
@@ -143,6 +139,7 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
     {
         static $tokens = [
             T_ARRAY,
+            T_ECHO,
             T_EMPTY,
             T_EVAL,
             T_EXIT,
@@ -168,6 +165,7 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
     private function getLanguageConstructionTokenKinds(): array
     {
         static $languageConstructionTokens = [
+            T_ECHO,
             T_PRINT,
             T_INCLUDE,
             T_INCLUDE_ONCE,

--- a/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
@@ -167,6 +167,21 @@ $$e(2);
             '<?php $a()(1);',
             '<?php $a () (1);',
         ];
+
+        yield [
+            '<?php
+                echo (function () {})();
+                echo ($propertyValue ? "TRUE" : "FALSE") . EOL;
+                echo(FUNCTION_1);
+                echo (EXPRESSION + CONST_1), CONST_2;
+            ',
+            '<?php
+                echo (function () {})();
+                echo ($propertyValue ? "TRUE" : "FALSE") . EOL;
+                echo (FUNCTION_1);
+                echo (EXPRESSION + CONST_1), CONST_2;
+            ',
+        ];
     }
 
     /**

--- a/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
@@ -182,6 +182,40 @@ $$e(2);
                 echo (EXPRESSION + CONST_1), CONST_2;
             ',
         ];
+
+        yield [
+            '<?php
+                include(SOME_PATH_1);
+                include_once(SOME_PATH_2);
+                require(SOME_PATH_3);
+                require_once(SOME_PATH_4);
+                print(SOME_VALUE);
+                print(FIRST_HALF_OF_STRING_1 . SECOND_HALF_OF_STRING_1);
+                print((FIRST_HALF_OF_STRING_2) . (SECOND_HALF_OF_STRING_2));
+            ',
+            '<?php
+                include         (SOME_PATH_1);
+                include_once    (SOME_PATH_2);
+                require         (SOME_PATH_3);
+                require_once    (SOME_PATH_4);
+                print           (SOME_VALUE);
+                print           (FIRST_HALF_OF_STRING_1 . SECOND_HALF_OF_STRING_1);
+                print           ((FIRST_HALF_OF_STRING_2) . (SECOND_HALF_OF_STRING_2));
+            ',
+        ];
+
+        yield [
+            '<?php
+                include         (DIR) . FILENAME_1;
+                include_once    (DIR) . (FILENAME_2);
+                require         (DIR) . FILENAME_3;
+                require_once    (DIR) . (FILENAME_4);
+                print           (FIRST_HALF_OF_STRING_1) . SECOND_HALF_OF_STRING_1;
+                print           (FIRST_HALF_OF_STRING_2) . ((((SECOND_HALF_OF_STRING_2))));
+                print           ((FIRST_HALF_OF_STRING_3)) . ((SECOND_HALF_OF_STRING_3));
+                print           ((((FIRST_HALF_OF_STRING_4)))) . ((((SECOND_HALF_OF_STRING_4))));
+            ',
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/5950