### PR TITLE
docs: fix 'Could not lex literal_block as "php". Highlighting skipped.'

### DIFF
--- a/doc/cookbook_fixers.rst
+++ b/doc/cookbook_fixers.rst
@@ -149,6 +149,7 @@ Keeping things as they are:
 
 .. code-block:: php
 
+   <?php
    // tests/Fixer/Comment/RemoveCommentsFixerTest.php
 
        // ...
@@ -164,6 +165,7 @@ Ensuring things change:
 
 .. code-block:: php
 
+   <?php
    // tests/Fixer/Comment/RemoveCommentsFixerTest.php
 
        // ...
@@ -238,6 +240,7 @@ First, we need to create one method to describe what this fixer does:
 
 .. code-block:: php
 
+   <?php
    // src/Fixer/Comment/RemoveCommentsFixer.php
 
    final class RemoveCommentsFixer extends AbstractFixer
@@ -267,6 +270,7 @@ Next, we must filter what type of tokens we want to fix. Here, we are interested
 
 .. code-block:: php
 
+   <?php
    // src/Fixer/Comment/RemoveCommentsFixer.php
 
    final class RemoveCommentsFixer extends AbstractFixer
@@ -283,6 +287,7 @@ For now, let us just make a fixer that applies no modification:
 
 .. code-block:: php
 
+   <?php
    // src/Fixer/Comment/RemoveCommentsFixer.php
 
    final class RemoveCommentsFixer extends AbstractFixer
@@ -334,6 +339,7 @@ iterate the token(s) we are interested in.
 
 .. code-block:: php
 
+   <?php
    // src/Fixer/Comment/RemoveCommentsFixer.php
 
    final class RemoveCommentsFixer extends AbstractFixer
@@ -357,6 +363,7 @@ token is a semicolon.
 
 .. code-block:: php
 
+   <?php
    // src/Fixer/Comment/RemoveCommentsFixer.php
 
    final class RemoveCommentsFixer extends AbstractFixer


### PR DESCRIPTION
Without this PR, not all samples are highlighted

https://cs.symfony.com/doc/cookbook_fixers.html#step-2-using-tests-to-define-fixers-behavior

<img width="952" alt="Screenshot 2023-11-13 at 23 32 16" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/2716794/d1e3a685-a551-4341-98ce-795692e137b8">
