### PR TITLE
test: Improve `ExplicitIndirectVariableFixerTest`

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -21,7 +21,7 @@ parameters:
         -
             message: '#^Method PhpCsFixer\\Tests\\.+::provide.+Cases\(\) return type has no value type specified in iterable type (array|iterable)\.$#'
             path: tests
-            count: 1131
+            count: 1129
 
         -
             message: '#Call to static method .+ with .+ will always evaluate to true.$#'

--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -33,6 +33,9 @@ final class ExplicitIndirectVariableFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @return iterable<string, array{0: string, 1?: string|null}>
+     */
     public static function provideFixCases(): iterable
     {
         yield 'variable variable function call' => [
@@ -91,6 +94,9 @@ $foo
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @return iterable<string, array{0: string, 1?: string|null}>
+     */
     public static function provideFix80Cases(): iterable
     {
         yield 'dynamic property fetch with nullsafe operator' => [
@@ -114,6 +120,9 @@ $foo
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @return iterable<string, array{0: string, 1?: string|null}>
+     */
     public static function provideFix83Cases(): iterable
     {
         yield 'dynamic class const fetch with variable variable' => [

--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -34,7 +34,7 @@ final class ExplicitIndirectVariableFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @return iterable<string, array{0: string, 1?: string|null}>
+     * @return iterable<string, array{0: string, 1?: null|string}>
      */
     public static function provideFixCases(): iterable
     {
@@ -95,7 +95,7 @@ $foo
     }
 
     /**
-     * @return iterable<string, array{0: string, 1?: string|null}>
+     * @return iterable<string, array{0: string, 1?: null|string}>
      */
     public static function provideFix80Cases(): iterable
     {
@@ -121,7 +121,7 @@ $foo
     }
 
     /**
-     * @return iterable<string, array{0: string, 1?: string|null}>
+     * @return iterable<string, array{0: string, 1?: null|string}>
      */
     public static function provideFix83Cases(): iterable
     {

--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -103,4 +103,22 @@ $foo
             '<?php echo $foo?->$bar["baz"]();',
         ];
     }
+
+    /**
+     * @dataProvider provideFix83Cases
+     *
+     * @requires PHP 8.3
+     */
+    public function testFix83(string $expected, ?string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFix83Cases(): iterable
+    {
+        yield 'dynamic class const fetch with variable variable' => [
+            '<?php echo Foo::{${$bar}};',
+            '<?php echo Foo::{$$bar};',
+        ];
+    }
 }

--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -69,6 +69,16 @@ $foo
 // C3
 ;',
         ];
+
+        yield 'dynamic static property access using variable variable' => [
+            '<?php echo Foo::${$bar};',
+            '<?php echo Foo::$$bar;',
+        ];
+
+        yield 'dynamic static property access using variable variable with method call' => [
+            '<?php echo Foo::${$bar}->baz();',
+            '<?php echo Foo::$$bar->baz();',
+        ];
     }
 
     /**

--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -72,14 +72,11 @@ $foo
     }
 
     /**
-     * @param mixed $expected
-     * @param mixed $input
-     *
      * @dataProvider provideFix80Cases
      *
      * @requires PHP 8.0
      */
-    public function testFix80($expected, $input): void
+    public function testFix80(string $expected, ?string $input): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -35,27 +35,27 @@ final class ExplicitIndirectVariableFixerTest extends AbstractFixerTestCase
 
     public static function provideFixCases(): iterable
     {
-        yield [
+        yield 'variable variable function call' => [
             '<?php echo ${$foo}($bar);',
             '<?php echo $$foo($bar);',
         ];
 
-        yield [
+        yield 'variable variable array fetch' => [
             '<?php echo ${$foo}[\'bar\'][\'baz\'];',
             '<?php echo $$foo[\'bar\'][\'baz\'];',
         ];
 
-        yield [
+        yield 'dynamic property access' => [
             '<?php echo $foo->{$bar}[\'baz\'];',
             '<?php echo $foo->$bar[\'baz\'];',
         ];
 
-        yield [
+        yield 'dynamic property access with method call' => [
             '<?php echo $foo->{$bar}[\'baz\']();',
             '<?php echo $foo->$bar[\'baz\']();',
         ];
 
-        yield [
+        yield 'variable variable with comments between dollar signs' => [
             '<?php echo $
 /* C1 */
 // C2
@@ -86,12 +86,12 @@ $foo
 
     public static function provideFix80Cases(): iterable
     {
-        yield [
+        yield 'dynamic property fetch with nullsafe operator' => [
             '<?php echo $foo?->{$bar}["baz"];',
             '<?php echo $foo?->$bar["baz"];',
         ];
 
-        yield [
+        yield 'dynamic property fetch with nullsafe operator and method call' => [
             '<?php echo $foo?->{$bar}["baz"]();',
             '<?php echo $foo?->$bar["baz"]();',
         ];


### PR DESCRIPTION
- add more test cases
- add yield keys (better `--testdox` output)
- add missing `iterable` type for PHPStan

Related to #7442.