### PR TITLE
fix: NoExtraBlankLinesFixer - do not remove blank line after `? : throw`

### DIFF
--- a/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
@@ -25,6 +25,7 @@ use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Preg;
+use PhpCsFixer\Tokenizer\Analyzer\SwitchAnalyzer;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -374,9 +375,17 @@ switch($a) {
 
     private function fixAfterThrowToken(int $index): void
     {
-        if ($this->tokens[$this->tokens->getPrevMeaningfulToken($index)]->equalsAny([';', '{', '}', ':', [T_OPEN_TAG]])) {
-            $this->fixAfterToken($index);
+        $prevIndex = $this->tokens->getPrevMeaningfulToken($index);
+
+        if (!$this->tokens[$prevIndex]->equalsAny([';', '{', '}', ':', [T_OPEN_TAG]])) {
+            return;
         }
+
+        if ($this->tokens[$prevIndex]->equals(':') && !SwitchAnalyzer::belongsToSwitch($this->tokens, $prevIndex)) {
+            return;
+        }
+
+        $this->fixAfterToken($index);
     }
 
     /**

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -1130,11 +1130,23 @@ class Foo {}'
         yield [
             ['tokens' => ['throw']],
             '<?php
-                $a = $bar ?? throw new \Exception();
+                $nullCoalescingOperator1 = $bar ?? throw new \Exception();
 
-                $a = $bar ?? throw new \Exception();
+                $nullCoalescingOperator2 = $bar ?? throw new \Exception();
 
-                $a = $bar ?? throw new \Exception();
+                $nullCoalescingOperator3 = $bar ?? throw new \Exception();
+
+                $ternaryOperator1 = $bar ? 42 : throw new \Exception();
+
+                $ternaryOperator2 = $bar ? 42 : throw new \Exception();
+
+                $ternaryOperator3 = $bar ? 42 : throw new \Exception();
+
+                $orOperator1 = $bar || throw new \Exception();
+
+                $orOperator2 = $bar || throw new \Exception();
+
+                $orOperator3 = $bar || throw new \Exception();
             ',
         ];
 


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6499