### PR TITLE
DX: introduce MethodAnalysis

### DIFF
--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -537,9 +537,9 @@ class Sample
     {
         // find last token of the element
         if ('method' === $element['type'] && !$tokens[$class['index']]->isGivenKind(T_INTERFACE)) {
-            $attributes = $tokensAnalyzer->getMethodAttributes($element['index']);
+            $methodAnalysis = $tokensAnalyzer->getMethodAnalysis($element['index']);
 
-            if (true === $attributes['abstract']) {
+            if ($methodAnalysis->isAbstract()) {
                 $elementEndIndex = $tokens->getNextTokenOfKind($element['index'], [';']);
             } else {
                 $elementEndIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $tokens->getNextTokenOfKind($element['index'], ['{']));

--- a/src/Fixer/PhpUnit/PhpUnitDataProviderStaticFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDataProviderStaticFixer.php
@@ -119,8 +119,8 @@ class FooTest extends TestCase {
             }
             $functionIndex = $tokens->getPrevTokenOfKind($dataProviderDefinitionIndex->getNameIndex(), [[T_FUNCTION]]);
 
-            $methodAttributes = $tokensAnalyzer->getMethodAttributes($functionIndex);
-            if (false !== $methodAttributes['static']) {
+            $methodAnalysis = $tokensAnalyzer->getMethodAnalysis($functionIndex);
+            if ($methodAnalysis->isStatic()) {
                 continue;
             }
 

--- a/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
@@ -78,14 +78,14 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             ++$counter;
             $methodAnalysis = $tokensAnalyzer->getMethodAnalysis($i);
 
-            if ($methodAnalysis->isPublic()) {
+            if ($methodAnalysis->isPublicVisibilityDeclared()) {
                 $index = $tokens->getPrevTokenOfKind($i, [[T_PUBLIC]]);
                 $tokens[$index] = new Token([T_PROTECTED, 'protected']);
 
                 continue;
             }
 
-            if (!$methodAnalysis->hasVisibility()) {
+            if (!$methodAnalysis->hasVisibilityDeclared()) {
                 $tokens->insertAt($i, [new Token([T_PROTECTED, 'protected']), new Token([T_WHITESPACE, ' '])]);
             }
         }

--- a/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
@@ -76,16 +76,16 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             }
 
             ++$counter;
-            $visibility = $tokensAnalyzer->getMethodAttributes($i)['visibility'];
+            $methodAnalysis = $tokensAnalyzer->getMethodAnalysis($i);
 
-            if (T_PUBLIC === $visibility) {
+            if ($methodAnalysis->isPublic()) {
                 $index = $tokens->getPrevTokenOfKind($i, [[T_PUBLIC]]);
                 $tokens[$index] = new Token([T_PROTECTED, 'protected']);
 
                 continue;
             }
 
-            if (null === $visibility) {
+            if (!$methodAnalysis->hasVisibility()) {
                 $tokens->insertAt($i, [new Token([T_PROTECTED, 'protected']), new Token([T_WHITESPACE, ' '])]);
             }
         }

--- a/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
@@ -419,9 +419,9 @@ final class MyTest extends \PHPUnit_Framework_TestCase
 
                 // do not change `self` to `this` in static methods
                 if ('this' === $callType) {
-                    $attributes = $analyzer->getMethodAttributes($index);
+                    $methodAnalysis = $analyzer->getMethodAnalysis($index);
 
-                    if (false !== $attributes['static']) {
+                    if ($methodAnalysis->isStatic()) {
                         $index = $this->findEndOfNextBlock($tokens, $index);
 
                         continue;

--- a/src/Tokenizer/Analyzer/Analysis/MethodAnalysis.php
+++ b/src/Tokenizer/Analyzer/Analysis/MethodAnalysis.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer\Analyzer\Analysis;
+
+/**
+ * @internal
+ */
+final class MethodAnalysis
+{
+    private ?int $visibility;
+    private bool $isStatic;
+    private bool $isAbstract;
+    private bool $isFinal;
+
+    public function __construct(?int $visibility, bool $isStatic, bool $isAbstract, bool $isFinal)
+    {
+        $this->visibility = $visibility;
+        $this->isStatic = $isStatic;
+        $this->isAbstract = $isAbstract;
+        $this->isFinal = $isFinal;
+    }
+
+    public function hasVisibility(): bool
+    {
+        return null !== $this->visibility;
+    }
+
+    public function isPublic(): bool
+    {
+        return T_PUBLIC === $this->visibility;
+    }
+
+    public function isProtected(): bool
+    {
+        return T_PROTECTED === $this->visibility;
+    }
+
+    public function isPrivate(): bool
+    {
+        return T_PRINT === $this->visibility;
+    }
+
+    public function isAbstract(): bool
+    {
+        return $this->isAbstract;
+    }
+
+    public function isStatic(): bool
+    {
+        return $this->isStatic;
+    }
+
+    public function isFinal(): bool
+    {
+        return $this->isFinal;
+    }
+}

--- a/src/Tokenizer/Analyzer/Analysis/MethodAnalysis.php
+++ b/src/Tokenizer/Analyzer/Analysis/MethodAnalysis.php
@@ -32,22 +32,22 @@ final class MethodAnalysis
         $this->isFinal = $isFinal;
     }
 
-    public function hasVisibility(): bool
+    public function hasVisibilityDeclared(): bool
     {
         return null !== $this->visibility;
     }
 
-    public function isPublic(): bool
+    public function isPublicVisibilityDeclared(): bool
     {
         return T_PUBLIC === $this->visibility;
     }
 
-    public function isProtected(): bool
+    public function isProtectedVisibilityDeclared(): bool
     {
         return T_PROTECTED === $this->visibility;
     }
 
-    public function isPrivate(): bool
+    public function isPrivateVisibilityDeclared(): bool
     {
         return T_PRINT === $this->visibility;
     }

--- a/tests/Tokenizer/Analyzer/Analysis/MethodAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/MethodAnalysisTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Tokenizer\Analyzer\Analysis;
+
+use PhpCsFixer\Tests\TestCase;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\MethodAnalysis;
+
+/**
+ * @covers \PhpCsFixer\Tokenizer\Analyzer\Analysis\MethodAnalysis
+ *
+ * @internal
+ */
+final class MethodAnalysisTest extends TestCase
+{
+    public function testDataProviderAnalysis(): void
+    {
+        $analysis = new MethodAnalysis(T_PROTECTED, false, true, false);
+
+        self::assertTrue($analysis->hasVisibility());
+        self::assertFalse($analysis->isPublic());
+        self::assertTrue($analysis->isProtected());
+        self::assertFalse($analysis->isPrivate());
+        self::assertFalse($analysis->isStatic());
+        self::assertTrue($analysis->isAbstract());
+        self::assertFalse($analysis->isFinal());
+    }
+}

--- a/tests/Tokenizer/Analyzer/Analysis/MethodAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/MethodAnalysisTest.php
@@ -24,7 +24,7 @@ use PhpCsFixer\Tokenizer\Analyzer\Analysis\MethodAnalysis;
  */
 final class MethodAnalysisTest extends TestCase
 {
-    public function testDataProviderAnalysis(): void
+    public function testMethodAnalysis(): void
     {
         $analysis = new MethodAnalysis(T_PROTECTED, false, true, false);
 

--- a/tests/Tokenizer/Analyzer/Analysis/MethodAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/MethodAnalysisTest.php
@@ -28,10 +28,10 @@ final class MethodAnalysisTest extends TestCase
     {
         $analysis = new MethodAnalysis(T_PROTECTED, false, true, false);
 
-        self::assertTrue($analysis->hasVisibility());
-        self::assertFalse($analysis->isPublic());
-        self::assertTrue($analysis->isProtected());
-        self::assertFalse($analysis->isPrivate());
+        self::assertTrue($analysis->hasVisibilityDeclared());
+        self::assertFalse($analysis->isPublicVisibilityDeclared());
+        self::assertTrue($analysis->isProtectedVisibilityDeclared());
+        self::assertFalse($analysis->isPrivateVisibilityDeclared());
         self::assertFalse($analysis->isStatic());
         self::assertTrue($analysis->isAbstract());
         self::assertFalse($analysis->isFinal());


### PR DESCRIPTION
Plus renaming method `TokensAnalyzer::getMethodAttributes`  as it had nothing to do with attributes.