### PR TITLE
chore: officially support PHP 8.3

### DIFF
--- a/.github/composite-actions/install-composer-deps/action.yml
+++ b/.github/composite-actions/install-composer-deps/action.yml
@@ -45,7 +45,7 @@ runs:
           Composer-${{ runner.os }}-
 
     - name: Auto-add ignore-platform-req
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       id: resolve-ignore-platform-req
       with:
         script: 'return ${{ env.PHP_VERSION_ID }} >= 80300 ? "--ignore-platform-req=php+" : ""'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
       matrix:
         include:
           - operating-system: 'ubuntu-20.04'
-            php-version: '8.3'
+            php-version: '8.2'
 
     name: Deployment checks
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PHP_MAX: '8.2'
+  PHP_MAX: '8.3'
   PHP_MIN: '7.4'
 
 jobs:
@@ -68,67 +68,77 @@ jobs:
             run-tests: 'yes'
 
           - operating-system: 'ubuntu-20.04'
-            php-version: '8.2'
+            php-version: '8.3'
+            job-description: 'Fixer'
+            run-fixer: 'yes'
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.3'
+            job-description: 'tests'
+            run-tests: 'yes'
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.3'
             job-description: 'Fixer with migration rules'
             run-fixer: 'yes'
             run-migration-rules: 'yes' # should be checked on the highest supported PHP version
 
           - operating-system: 'ubuntu-20.04'
-            php-version: '8.2'
+            php-version: '8.3'
             job-description: 'tests with migration rules'
             run-tests: 'yes'
             run-migration-rules: 'yes' # should be checked on the highest supported PHP version
 
           - operating-system: 'ubuntu-20.04'
-            php-version: '8.2'
+            php-version: '8.3'
             job-description: 'Fixer with Symfony ^7'
             run-fixer: 'yes'
             execute-flex-with-symfony-version: '^7' # explicit check for Symfony 7.x compatibility
 
           - operating-system: 'ubuntu-20.04'
-            php-version: '8.2'
+            php-version: '8.3'
             job-description: 'tests with Symfony ^7'
             run-tests: 'yes'
             execute-flex-with-symfony-version: '^7' # explicit check for Symfony 7.x compatibility
 
           - operating-system: 'ubuntu-20.04'
-            php-version: '8.2'
+            php-version: '8.3'
             job-description: 'code coverage'
             run-tests: 'yes'
             collect-code-coverage: 'yes'
 
           - operating-system: 'windows-latest'
-            php-version: '8.2'
+            php-version: '8.3'
             job-description: 'Fixer on Windows'
             run-fixer: 'yes'
             FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional
 
           - operating-system: 'windows-latest'
-            php-version: '8.2'
+            php-version: '8.3'
             job-description: 'tests on Windows'
             run-tests: 'yes'
             FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional systems
 
           - operating-system: 'macos-latest'
-            php-version: '8.2'
+            php-version: '8.3'
             job-description: 'Fixer on macOS'
             run-fixer: 'yes'
             FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional systems
 
           - operating-system: 'macos-latest'
-            php-version: '8.2'
+            php-version: '8.3'
             job-description: 'tests on macOS'
             run-tests: 'yes'
             FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional
 
           - operating-system: 'ubuntu-22.04'
-            php-version: '8.3'
+            php-version: '8.4'
             job-description: 'Fixer'
             run-fixer: 'yes'
             PHP_CS_FIXER_IGNORE_ENV: 1
 
           - operating-system: 'ubuntu-22.04'
-            php-version: '8.3'
+            php-version: '8.4'
             job-description: 'tests'
             run-tests: 'yes'
             PHP_CS_FIXER_IGNORE_ENV: 1
@@ -204,7 +214,7 @@ jobs:
       matrix:
         include:
           - operating-system: 'ubuntu-20.04'
-            php-version: '8.2'
+            php-version: '8.3'
 
     name: Deployment checks
 

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -19,7 +19,7 @@ jobs:
         operating-system:
           - ubuntu-20.04
         php-version:
-          - 8.2
+          - 8.3
 
     name: Static Code Analysis
 

--- a/.php-cs-fixer.php-highest.php
+++ b/.php-cs-fixer.php-highest.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-if (PHP_VERSION_ID < 8_02_00 || PHP_VERSION_ID >= 8_03_00) {
-    fwrite(STDERR, "PHP CS Fixer's config for PHP-HIGHEST can be executed only on highest supported PHP version - 8.2.*.\n");
+if (PHP_VERSION_ID < 8_03_00 || PHP_VERSION_ID >= 8_04_00) {
+    fwrite(STDERR, "PHP CS Fixer's config for PHP-HIGHEST can be executed only on highest supported PHP version - 8.3.*.\n");
     fwrite(STDERR, "Running it on lower PHP version would prevent calling migration rules.\n");
 
     exit(1);
@@ -22,7 +22,7 @@ if (PHP_VERSION_ID < 8_02_00 || PHP_VERSION_ID >= 8_03_00) {
 $config = require __DIR__.'/.php-cs-fixer.dist.php';
 
 $config->setRules(array_merge($config->getRules(), [
-    '@PHP82Migration' => true,
+    '@PHP83Migration' => true,
     '@PHP80Migration:risky' => true,
 ]));
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ projects. This tool does not only detect them, but also fixes them for you.
 * PHP 8.0 (except PHP 8.0.0 due to [bug in PHP tokenizer](https://bugs.php.net/bug.php?id=80462))
 * PHP 8.1
 * PHP 8.2
+* PHP 8.3
 
 > **Note**
 > Each new PHP version requires a huge effort to support the new syntax.

--- a/compose.yaml
+++ b/compose.yaml
@@ -40,5 +40,5 @@ services:
     <<: *php
     build:
       args:
-        PHP_VERSION: "8.3.0RC6"
+        PHP_VERSION: "8.3"
         PHP_XDEBUG_VERSION: "3.3.0alpha3"

--- a/dev-tools/build.sh
+++ b/dev-tools/build.sh
@@ -22,4 +22,5 @@ dev-tools/bin/box compile
 
 # revert changes to composer
 git checkout composer.json
-composer update --optimize-autoloader --no-interaction --no-progress --no-scripts -q
+PHP83HACK=--ignore-platform-req=PHP+ # for building on local machine
+composer update --optimize-autoloader --no-interaction --no-progress --no-scripts -q $PHP83HACK

--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ergebnis/composer-normalize": "^2.39.0",
         "jangregor/phpstan-prophecy": "^1.0.0",
         "maglnet/composer-require-checker": "^4.7.1",
@@ -19,7 +19,7 @@
         },
         "optimize-autoloader": true,
         "platform": {
-            "php": "8.2"
+            "php": "8.3"
         },
         "prefer-stable": true,
         "sort-packages": true

--- a/dev-tools/composer.lock
+++ b/dev-tools/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e7a2e85e8dc3ab139db15bff04f9d4b2",
+    "content-hash": "e21766d70502779b715c1ca58f9fdfa0",
     "packages": [
         {
             "name": "composer/pcre",
@@ -1133,16 +1133,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.41",
+            "version": "1.10.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "c6174523c2a69231df55bdc65b61655e72876d76"
+                "reference": "bf84367c53a23f759513985c54ffe0d0c249825b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c6174523c2a69231df55bdc65b61655e72876d76",
-                "reference": "c6174523c2a69231df55bdc65b61655e72876d76",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/bf84367c53a23f759513985c54ffe0d0c249825b",
+                "reference": "bf84367c53a23f759513985c54ffe0d0c249825b",
                 "shasum": ""
             },
             "require": {
@@ -1191,7 +1191,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-05T12:57:57+00:00"
+            "time": "2023-11-21T16:30:46+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -1349,30 +1349,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1393,22 +1393,22 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v6.3.2",
+            "version": "v6.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "b47ca238b03e7b0d7880ffd1cf06e8d637ca1467"
+                "reference": "b7a63887960359e5b59b15826fa9f9be10acbe88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/b47ca238b03e7b0d7880ffd1cf06e8d637ca1467",
-                "reference": "b47ca238b03e7b0d7880ffd1cf06e8d637ca1467",
+                "url": "https://api.github.com/repos/symfony/config/zipball/b7a63887960359e5b59b15826fa9f9be10acbe88",
+                "reference": "b7a63887960359e5b59b15826fa9f9be10acbe88",
                 "shasum": ""
             },
             "require": {
@@ -1454,7 +1454,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v6.3.2"
+                "source": "https://github.com/symfony/config/tree/v6.3.8"
             },
             "funding": [
                 {
@@ -1470,20 +1470,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-19T20:22:16+00:00"
+            "time": "2023-11-09T08:28:21+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.3.4",
+            "version": "v6.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "eca495f2ee845130855ddf1cf18460c38966c8b6"
+                "reference": "0d14a9f6d04d4ac38a8cea1171f4554e325dae92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/eca495f2ee845130855ddf1cf18460c38966c8b6",
-                "reference": "eca495f2ee845130855ddf1cf18460c38966c8b6",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0d14a9f6d04d4ac38a8cea1171f4554e325dae92",
+                "reference": "0d14a9f6d04d4ac38a8cea1171f4554e325dae92",
                 "shasum": ""
             },
             "require": {
@@ -1544,7 +1544,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.3.4"
+                "source": "https://github.com/symfony/console/tree/v6.3.8"
             },
             "funding": [
                 {
@@ -1560,20 +1560,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-16T10:10:12+00:00"
+            "time": "2023-10-31T08:09:35+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.3.5",
+            "version": "v6.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "2ed62b3bf98346e1f45529a7b6be2196739bb993"
+                "reference": "1f30f545c4151f611148fc19e28d54d39e0a00bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/2ed62b3bf98346e1f45529a7b6be2196739bb993",
-                "reference": "2ed62b3bf98346e1f45529a7b6be2196739bb993",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/1f30f545c4151f611148fc19e28d54d39e0a00bc",
+                "reference": "1f30f545c4151f611148fc19e28d54d39e0a00bc",
                 "shasum": ""
             },
             "require": {
@@ -1625,7 +1625,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.3.5"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.3.8"
             },
             "funding": [
                 {
@@ -1641,11 +1641,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-25T16:46:40+00:00"
+            "time": "2023-10-31T08:07:48+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.3.0",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
@@ -1692,7 +1692,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -2105,16 +2105,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.3.0",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "40da9cc13ec349d9e4966ce18b5fbcd724ab10a4"
+                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/40da9cc13ec349d9e4966ce18b5fbcd724ab10a4",
-                "reference": "40da9cc13ec349d9e4966ce18b5fbcd724ab10a4",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
+                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
                 "shasum": ""
             },
             "require": {
@@ -2167,7 +2167,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -2183,20 +2183,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-23T14:45:45+00:00"
+            "time": "2023-07-30T20:28:31+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.3.5",
+            "version": "v6.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "13d76d0fb049051ed12a04bef4f9de8715bea339"
+                "reference": "13880a87790c76ef994c91e87efb96134522577a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/13d76d0fb049051ed12a04bef4f9de8715bea339",
-                "reference": "13d76d0fb049051ed12a04bef4f9de8715bea339",
+                "url": "https://api.github.com/repos/symfony/string/zipball/13880a87790c76ef994c91e87efb96134522577a",
+                "reference": "13880a87790c76ef994c91e87efb96134522577a",
                 "shasum": ""
             },
             "require": {
@@ -2253,7 +2253,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.3.5"
+                "source": "https://github.com/symfony/string/tree/v6.3.8"
             },
             "funding": [
                 {
@@ -2269,7 +2269,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-18T10:38:32+00:00"
+            "time": "2023-11-09T08:28:21+00:00"
         },
         {
             "name": "symfony/var-exporter",
@@ -2460,11 +2460,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.3"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.2"
+        "php": "8.3"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -28,8 +28,8 @@ set_error_handler(static function ($severity, $message, $file, $line) {
         exit(1);
     }
 
-    if (\PHP_VERSION_ID < 70400 || \PHP_VERSION_ID >= 80300) {
-        fwrite(STDERR, "PHP needs to be a minimum version of PHP 7.4.0 and maximum version of PHP 8.2.*.\n");
+    if (\PHP_VERSION_ID < 70400 || \PHP_VERSION_ID >= 80400) {
+        fwrite(STDERR, "PHP needs to be a minimum version of PHP 7.4.0 and maximum version of PHP 8.3.*.\n");
         fwrite(STDERR, 'Current PHP version: '.PHP_VERSION.".\n");
 
         if (getenv('PHP_CS_FIXER_IGNORE_ENV')) {

--- a/tests/AutoReview/CiConfigurationTest.php
+++ b/tests/AutoReview/CiConfigurationTest.php
@@ -77,7 +77,7 @@ final class CiConfigurationTest extends TestCase
     {
         $ciVersionsForDeployments = $this->getAllPhpVersionsUsedByCiForDeployments();
         $ciVersions = $this->getAllPhpVersionsUsedByCiForTests();
-        $expectedPhp = $this->getMaxPhpVersionFromEntryFile();
+        $expectedPhp = '8.2'; // @TODO not everything compatible with 8.3 yet, replace with `$this->getMaxPhpVersionFromEntryFile();` afterwards
 
         if (\in_array($expectedPhp.'snapshot', $ciVersions, true)) {
             // last version of used PHP is snapshot. we should test against previous one, that is stable

--- a/tests/AutoReview/ReadmeTest.php
+++ b/tests/AutoReview/ReadmeTest.php
@@ -44,7 +44,7 @@ final class ReadmeTest extends TestCase
 
         self::assertEqualsCanonicalizing([
             '    if (\PHP_VERSION_ID === 80000) {'."\n",
-            '    if (\PHP_VERSION_ID < 70400 || \PHP_VERSION_ID >= 80300) {'."\n",
+            '    if (\PHP_VERSION_ID < 70400 || \PHP_VERSION_ID >= 80400) {'."\n",
         ], $phpVersionIdLines, 'Seems supported PHP versions changed in "./php-cs-fixer" - edit the README.md (and this test file) to match them!');
     }
 }

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -156,7 +156,7 @@ abstract class AbstractFixerTestCase extends TestCase
             }
 
             if ($sample instanceof VersionSpecificCodeSampleInterface) {
-                $supportedPhpVersions = [7_04_00, 8_00_00, 8_01_00, 8_02_00, 8_03_00];
+                $supportedPhpVersions = [7_04_00, 8_00_00, 8_01_00, 8_02_00, 8_03_00, 8_04_00];
 
                 $hasSuitableSupportedVersion = false;
                 foreach ($supportedPhpVersions as $version) {


### PR DESCRIPTION
- custom tokenization for the only syntax change was added in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7004 , kudos @SpacePossum 
- overall integration tests for 8.3 were added in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7439 , kudos @Wirone 
- I believe those issues could be closed now as well due to already existing integration tests
  - https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6998
  - https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/6999 

Merge of this PR does mean that we are understanding and not crashing on syntax introduced by PHP 8.3

Merge of this PR does not mean we are able to fix every new syntax to look good, we may have open feature requests for this - [ref](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues?q=is%3Aopen+label%3Atopic%2FPHP8.3+label%3A%22kind%2Ffeature+request%22)

