### PR TITLE
CI: add --no-update while dropping non-compat `facile-it/paraunit`

### DIFF
--- a/.github/composite-actions/setup-php-with-composer-deps/action.yml
+++ b/.github/composite-actions/setup-php-with-composer-deps/action.yml
@@ -56,7 +56,7 @@ runs:
       shell: bash
       run: |
         composer config minimum-stability RC
-        composer remove facile-it/paraunit --dev
+        composer remove facile-it/paraunit --dev --no-update
 
     - name: Install Composer deps
       uses: ./.github/composite-actions/install-composer-deps


### PR DESCRIPTION
extracted from #7466