### PR TITLE
CI: Use PHPStan's native Github error formatter

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           os: ${{ runner.os }}
           php: ${{ matrix.php-version }}
-          tools: cs2pr
 
       ## We want to have a lock-file used on PR level, so contributors are not bothered by SCA complains unrelated to their changes,
       ## and same time we want to be aware that we are complying with bleeding edge of SCA tools as maintainers observing the push hook.
@@ -66,7 +65,7 @@ jobs:
         run: ./dev-tools/check_trailing_spaces.sh
 
       - name: Check - phpstan
-        run: ./dev-tools/vendor/bin/phpstan analyse --error-format=checkstyle | cs2pr
+        run: ./dev-tools/vendor/bin/phpstan analyse --error-format=github
 
       - name: Check - composer-require-checker
         run: ./dev-tools/vendor/bin/composer-require-checker check composer.json --config-file .composer-require-checker.json


### PR DESCRIPTION
Using `cs2pr` is not required anymore in terms of PHPStan 🙂.

There's no violations in CI currently, but the output looks like this (modified file locally to achieve this):
<img width="1177" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/3f5a4056-b97f-45de-8154-c797ad9c9e5d">
