### PR TITLE
DX: Utilise auto-discovery for PHPStan formatter

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -65,7 +65,7 @@ jobs:
         run: ./dev-tools/check_trailing_spaces.sh
 
       - name: Check - phpstan
-        run: ./dev-tools/vendor/bin/phpstan analyse
+        run: ./dev-tools/vendor/bin/phpstan analyse --ansi
 
       - name: Check - composer-require-checker
         run: ./dev-tools/vendor/bin/composer-require-checker check composer.json --config-file .composer-require-checker.json

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -65,7 +65,7 @@ jobs:
         run: ./dev-tools/check_trailing_spaces.sh
 
       - name: Check - phpstan
-        run: ./dev-tools/vendor/bin/phpstan analyse --error-format=github
+        run: ./dev-tools/vendor/bin/phpstan analyse
 
       - name: Check - composer-require-checker
         run: ./dev-tools/vendor/bin/composer-require-checker check composer.json --config-file .composer-require-checker.json

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -25,6 +25,9 @@ final class Cache implements CacheInterface
 {
     private SignatureInterface $signature;
 
+    /**
+     * @var array<string, string>
+     */
     private array $hashes = [];
 
     public function __construct(SignatureInterface $signature)

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -25,9 +25,6 @@ final class Cache implements CacheInterface
 {
     private SignatureInterface $signature;
 
-    /**
-     * @var array<string, string>
-     */
     private array $hashes = [];
 
     public function __construct(SignatureInterface $signature)


### PR DESCRIPTION
I've been told that instead of using `--error-format=github` it's better to let PHPStan auto-detect it. After this change [it prints both user-friendly output _and_ Github format too](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/actions/runs/7065835855/job/19236607268?pr=7490).