### PR TITLE
DX: restore contract of AbstractFixerTestCase::getTestFile()->getRealPath() to return false on non-existing file

### DIFF
--- a/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
+++ b/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
@@ -34,7 +34,7 @@ final class PsrAutoloadingFixerTest extends AbstractFixerTestCase
         if (null === $filepath) {
             $filepath = __FILE__;
         }
-        $file = self::getTestFile($filepath);
+        $file = self::getMockedTestFile($filepath);
 
         if (null !== $dir) {
             $this->fixer->configure(['dir' => $dir]);
@@ -460,5 +460,22 @@ class extends stdClass {};
             '<?php enum PsrAutoloadingFixerTest {}',
             '<?php enum psrautoloadingfixertest {}',
         ];
+    }
+
+    /**
+     * Mocked test file will return _some_ value for `getRealPath()`, even if file does not exist.
+     */
+    protected static function getMockedTestFile(string $filename = __FILE__): \SplFileInfo
+    {
+        static $files = [];
+
+        return $files[$filename] ?? $files[$filename] = new class($filename) extends \SplFileInfo {
+            public function getRealPath(): string
+            {
+                return false !== parent::getRealPath()
+                    ? parent::getRealPath()
+                    : $this->getPathname();
+            }
+        };
     }
 }

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -382,14 +382,7 @@ abstract class AbstractFixerTestCase extends TestCase
     {
         static $files = [];
 
-        return $files[$filename] ?? $files[$filename] = new class($filename) extends \SplFileInfo {
-            public function getRealPath(): string
-            {
-                return false !== parent::getRealPath()
-                    ? parent::getRealPath()
-                    : $this->getPathname();
-            }
-        };
+        return $files[$filename] ?? $files[$filename] = new \SplFileInfo($filename);
     }
 
     /**


### PR DESCRIPTION


https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7491/files#r1413160086