### PR TITLE
feat: Support `mb_str_pad` function in `mb_str_functions` rule

### DIFF
--- a/src/Fixer/Alias/MbStrFunctionsFixer.php
+++ b/src/Fixer/Alias/MbStrFunctionsFixer.php
@@ -69,6 +69,10 @@ final class MbStrFunctionsFixer extends AbstractFunctionReferenceFixer
     {
         parent::__construct();
 
+        if (\PHP_VERSION_ID >= 8_03_00) {
+            self::$functionsMap['str_pad'] = ['alternativeName' => 'mb_str_pad', 'argumentCount' => [1, 2, 3, 4]];
+        }
+
         $this->functions = array_filter(
             self::$functionsMap,
             static fn (array $mapping): bool => (new \ReflectionFunction($mapping['alternativeName']))->isInternal()

--- a/tests/Fixer/Alias/MbStrFunctionsFixerTest.php
+++ b/tests/Fixer/Alias/MbStrFunctionsFixerTest.php
@@ -79,5 +79,9 @@ final class MbStrFunctionsFixerTest extends AbstractFixerTestCase
             '<?php $a = mb_str_split($a);',
             '<?php $a = str_split($a);',
         ];
+
+        if (\PHP_VERSION_ID >= 8_03_00) {
+            yield ['<?php $x = mb_str_pad("bar", 2, "0", STR_PAD_LEFT);', '<?php $x = str_pad("bar", 2, "0", STR_PAD_LEFT);'];
+        }
     }
 }


### PR DESCRIPTION
The [`mb_str_pad`](https://www.php.net/manual/en/function.mb-str-pad.php) function has been added in PHP 8.3.0.  
I think it would be useful to also replace non multibyte-safe function `str_pad` to `mb_str_pad` in the `mb_str_functions`.