### PR TITLE
DX: Proof of Concept - Utilise PHPStan for auto-review

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -4,6 +4,12 @@ includes:
     # Baseline, should only shrink! To regenerate it, just execute `composer phpstan:baseline`.
     - dev-tools/phpstan/baseline.php
 
+services:
+    -
+        class: PhpCsFixer\Tests\AutoReview\PhpStan\FixerTestNamingConventionRule
+        tags:
+            - phpstan.rules.rule
+
 parameters:
     level: 6
     paths:

--- a/tests/AutoReview/PhpStan/FixerTestNamingConventionRule.php
+++ b/tests/AutoReview/PhpStan/FixerTestNamingConventionRule.php
@@ -60,6 +60,7 @@ final readonly class FixerTestNamingConventionRule implements Rule
                 self::METHOD_TEST_APPLY_FIX
             ))
                 ->identifier('php_cs_fixer.tests_convention.base_test_missing')
+                ->line($node->getLine())
                 ->build()
             ;
         }
@@ -109,6 +110,7 @@ final readonly class FixerTestNamingConventionRule implements Rule
                             (string) $method->name
                         ))
                             ->identifier('php_cs_fixer.tests_convention.invalid_version_specific_method_name')
+                            ->line($method->getLine())
                             ->build()
                         ;
                     }

--- a/tests/AutoReview/PhpStan/FixerTestNamingConventionRule.php
+++ b/tests/AutoReview/PhpStan/FixerTestNamingConventionRule.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\AutoReview\PhpStan;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Class_>
+ */
+final readonly class FixerTestNamingConventionRule implements Rule
+{
+    private const METHOD_TEST_APPLY_FIX = 'testApplyFix';
+
+    public function __construct(private Lexer $phpDocLexer, private PhpDocParser $phpDocParser) {}
+
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // Ignore every class that does not extend our base test case for fixers
+        if (null === $node->extends
+            || $node->isAnonymous()
+            || AbstractFixerTestCase::class !== (string) $node->extends
+        ) {
+            return [];
+        }
+
+        $errors = [];
+        $methods = $node->getMethods() ?? [];
+        $methodNames = array_map(static fn (ClassMethod $method) => (string) $method->name, $methods);
+
+        // Every fixers' test must have `testApplyFix` method
+        if ([] === $methodNames || !\in_array(self::METHOD_TEST_APPLY_FIX, $methodNames, true)) {
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                'Base test `%s` is missing',
+                self::METHOD_TEST_APPLY_FIX
+            ))
+                ->identifier('php_cs_fixer.tests_convention.base_test_missing')
+                ->build()
+            ;
+        }
+
+        foreach ($methods as $method) {
+            // Ensure basic naming convention
+            if ($method->isPublic() && !preg_match('/^(test|provide)+.*/', (string) $method->name)) {
+                $errors[] = RuleErrorBuilder::message(sprintf(
+                    'Method name `%s` is invalid',
+                    (string) $method->name
+                ))
+                    ->identifier('php_cs_fixer.tests_convention.invalid_method_name')
+                    ->line($method->getLine())
+                    ->addTip('Only `test*` and `provide*` methods are allowed')
+                    ->build()
+                ;
+            }
+
+            $methodDoc = $method->getDocComment();
+            if (null !== $methodDoc) {
+                $phpDocString = $methodDoc->getText();
+                $tokens = new TokenIterator($this->phpDocLexer->tokenize($phpDocString));
+                $phpDocNode = $this->phpDocParser->parse($tokens);
+
+                foreach ($phpDocNode->getTagsByName('@requires') as $tag) {
+                    if (!str_starts_with(strtolower((string) $tag->value), 'php ')) {
+                        continue;
+                    }
+
+                    preg_match(
+                        '/PHP\s+(?<operator>[\<\>=\!]{1,2})?\s?(?<version>[0-9\.]+)/',
+                        (string) $tag->value,
+                        $matches
+                    );
+                    $expectedMethodName = sprintf(
+                        '%sOnPhp%s%s',
+                        self::METHOD_TEST_APPLY_FIX,
+                        $this->descriptionForVersionOperator($matches['operator'] ?? '>='),
+                        // TODO use X_Y_Z format instead of XYZ (make versions more clear)
+                        str_replace('.', '', $matches['version'])
+                    );
+
+                    if ((string) $method->name !== $expectedMethodName) {
+                        $errors[] = RuleErrorBuilder::message(sprintf(
+                            'Version-specific test should be named `%s`, but is named `%s`',
+                            $expectedMethodName,
+                            (string) $method->name
+                        ))
+                            ->identifier('php_cs_fixer.tests_convention.invalid_version_specific_method_name')
+                            ->build()
+                        ;
+                    }
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    private function descriptionForVersionOperator(string $operator): string
+    {
+        switch ($operator) {
+            case '<': return 'LowerThan';
+
+            case '<=': return 'LowerOrEqualTo';
+
+            case '>': return 'HigherThan';
+
+            case '=':
+            case '==':
+                return 'EqualTo';
+
+            case '!=':
+            case '<>':
+                return 'OtherThan';
+
+            case '>=':
+            case '':
+            default:
+                return 'HigherOrEqualTo';
+        }
+    }
+}

--- a/tests/AutoReview/PhpStan/FixerTestNamingConventionRule.php
+++ b/tests/AutoReview/PhpStan/FixerTestNamingConventionRule.php
@@ -28,11 +28,18 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements Rule<Class_>
  */
-final readonly class FixerTestNamingConventionRule implements Rule
+final class FixerTestNamingConventionRule implements Rule
 {
     private const METHOD_TEST_APPLY_FIX = 'testApplyFix';
 
-    public function __construct(private Lexer $phpDocLexer, private PhpDocParser $phpDocParser) {}
+    private Lexer $phpDocLexer;
+    private PhpDocParser $phpDocParser;
+
+    public function __construct(Lexer $phpDocLexer, PhpDocParser $phpDocParser)
+    {
+        $this->phpDocLexer = $phpDocLexer;
+        $this->phpDocParser = $phpDocParser;
+    }
 
     public function getNodeType(): string
     {

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -28,15 +28,15 @@ final class FullyQualifiedStrictTypesFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, bool> $config
      *
-     * @dataProvider provideNewLogicCases
+     * @dataProvider provideApplyFixCases
      */
-    public function testNewLogic(string $expected, ?string $input = null, array $config = []): void
+    public function testApplyFix(string $expected, ?string $input = null, array $config = []): void
     {
         $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
 
-    public static function provideNewLogicCases(): iterable
+    public static function provideApplyFixCases(): iterable
     {
         yield 'namespace === type name' => [
             '<?php
@@ -690,14 +690,14 @@ class Two
     /**
      * @requires PHP 8.0
      *
-     * @dataProvider provideFix80Cases
+     * @dataProvider provideApplyFixOnPhpHigherOrEqualTo80Cases
      */
-    public function testFix80(string $expected, ?string $input = null): void
+    public function testApplyFixOnPhpHigherOrEqualTo80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFix80Cases(): iterable
+    public static function provideApplyFixOnPhpHigherOrEqualTo80Cases(): iterable
     {
         yield [
             '<?php function foo(int|float $x) {}',
@@ -733,15 +733,15 @@ class Two
      *
      * @requires PHP 8.1
      *
-     * @dataProvider provideFix81Cases
+     * @dataProvider provideApplyFixOnPhpHigherOrEqualTo81Cases
      */
-    public function testFix81(string $expected, ?string $input = null, array $config = []): void
+    public function testApplyFixOnPhpHigherOrEqualTo81(string $expected, ?string $input = null, array $config = []): void
     {
         $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
 
-    public static function provideFix81Cases(): iterable
+    public static function provideApplyFixOnPhpHigherOrEqualTo81Cases(): iterable
     {
         yield [
             '<?php function f(): Foo&Bar & A\B\C {}',
@@ -787,15 +787,15 @@ class SomeClass
      *
      * @requires PHP 8.2
      *
-     * @dataProvider provideFix82Cases
+     * @dataProvider provideApplyFixOnPhpHigherOrEqualTo82Cases
      */
-    public function testFix82(string $expected, ?string $input = null, array $config = []): void
+    public function testApplyFixOnPhpHigherOrEqualTo82(string $expected, ?string $input = null, array $config = []): void
     {
         $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
 
-    public static function provideFix82Cases(): iterable
+    public static function provideApplyFixOnPhpHigherOrEqualTo82Cases(): iterable
     {
         yield 'simple param in global namespace without use' => [
             '<?php

--- a/tests/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixerTest.php
@@ -193,7 +193,7 @@ class FooTest extends TestCase {
     }
 
     /**
-     * @requires PHP ^7.4
+     * @requires PHP 7.4
      *
      * @dataProvider provideFix7Cases
      */

--- a/tests/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixerTest.php
@@ -193,7 +193,7 @@ class FooTest extends TestCase {
     }
 
     /**
-     * @requires PHP 7.4
+     * @requires PHP <8.0
      *
      * @dataProvider provideFix7Cases
      */


### PR DESCRIPTION
This PR is an 2-in-1 RFC / PoC.

## Standardise test classes

I propose standardised naming convention for test methods for fixers:

- `testApplyFix()` as a base (and required) method that handles all common cases, applicable on any PHP version.
- `testApplyFixOnPhp*()` that would be directly related to `@requires PHP *` and would contain only test cases for specific PHP version(s). You can see in rule how expected method name is built and how it looks like in the example fixer.

If we agree on that, we can enforce this for new tests and slowly(?) migrate old ones.

## Utilise PHPStan for auto-review

I propose using PHPStan as an engine for running auto-review checks. I am not sure if all existing auto-review PHPUnit tests could be represented with PHPStan, but static analysis can help us anyway. Regular rules or [collector-based](https://phpstan.org/developing-extensions/collectors) approach - only our own imagination can stop us 😉.

What should be taken into consideration:
- PHPStan rules will only find violations, but won't fix them. For me it's not a problem, most often it would be easy fix.
- I am not sure how we can test these rules, probably we should move them to separate package (maybe inside this repo, and define [local repository](https://getcomposer.org/doc/05-repositories.md#path) in `composer.json`, to speed up development)
- Writing PHPStan rules is pretty fun, there is working DI with a lot of services, object-oriented AST, rules' identifiers that soon can be used for fine-tuned ignoring (like per line or per file). Could be good alternative to token-based rules in Fixer, just for fun.

In practice, when you have real-time PHPStan analysis enabled in IDE, you get instant feedback:

![image](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/d736934b-160c-481b-95a2-faf35ef54081)

Let me know what you think about both ideas 🙂.