### PR TITLE
DX: Add progress output for `cs:check` script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
             "Composer\\Config::disableProcessTimeout",
             "paraunit run --testsuite auto-review"
         ],
-        "cs:check": "@php php-cs-fixer check --diff",
+        "cs:check": "@php php-cs-fixer check --verbose --diff",
         "cs:fix": "@php php-cs-fixer fix",
         "cs:fix:parallel": "echo '🔍 Will run in batches of 50 files.'; if [[ -f .php-cs-fixer.php ]]; then FIXER_CONFIG=.php-cs-fixer.php; else FIXER_CONFIG=.php-cs-fixer.dist.php; fi; php php-cs-fixer list-files --config=$FIXER_CONFIG | xargs -n 50 -P 8 php php-cs-fixer fix --config=$FIXER_CONFIG --path-mode intersection 2> /dev/null",
         "docs": "@php dev-tools/doc.php",


### PR DESCRIPTION
Other checks in `composer qa` display progress (ParaUnit, PHPStan), so let's make it consistent. Also, it's frustrating to wait without knowing how much is already done.