### PR TITLE
fix: NoSpacesAfterFunctionNameFixer should not fix parentheses that are not part of a language construct

### DIFF
--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -56,7 +56,6 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
         $functionyTokens = $this->getFunctionyTokenKinds();
-        $languageConstructionTokens = $this->getLanguageConstructionTokenKinds();
         $braceTypes = $this->getBraceAfterVariableKinds();
 
         foreach ($tokens as $index => $token) {
@@ -67,17 +66,6 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
 
             // last non-whitespace token, can never be `null` always at least PHP open tag before it
             $lastTokenIndex = $tokens->getPrevNonWhitespace($index);
-
-            // check for ternary operator
-            $endParenthesisIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
-            $nextNonWhiteSpace = $tokens->getNextMeaningfulToken($endParenthesisIndex);
-            if (
-                null !== $nextNonWhiteSpace
-                && !$tokens[$nextNonWhiteSpace]->equals(';')
-                && $tokens[$lastTokenIndex]->isGivenKind($languageConstructionTokens)
-            ) {
-                continue;
-            }
 
             // check if it is a function call
             if ($tokens[$lastTokenIndex]->isGivenKind($functionyTokens)) {
@@ -139,40 +127,15 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
     {
         static $tokens = [
             T_ARRAY,
-            T_ECHO,
             T_EMPTY,
             T_EVAL,
             T_EXIT,
-            T_INCLUDE,
-            T_INCLUDE_ONCE,
             T_ISSET,
             T_LIST,
-            T_PRINT,
-            T_REQUIRE,
-            T_REQUIRE_ONCE,
             T_UNSET,
             T_VARIABLE,
         ];
 
         return $tokens;
-    }
-
-    /**
-     * Gets the token kinds of actually language construction.
-     *
-     * @return int[]
-     */
-    private function getLanguageConstructionTokenKinds(): array
-    {
-        static $languageConstructionTokens = [
-            T_ECHO,
-            T_PRINT,
-            T_INCLUDE,
-            T_INCLUDE_ONCE,
-            T_REQUIRE,
-            T_REQUIRE_ONCE,
-        ];
-
-        return $languageConstructionTokens;
     }
 }

--- a/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
@@ -47,16 +47,16 @@ final class NoSpacesAfterFunctionNameFixerTest extends AbstractFixerTestCase
 
         yield 'test function-like constructs' => [
             '<?php
-    include("something.php");
-    include_once("something.php");
-    require("something.php");
-    require_once("something.php");
-    print("hello");
+    include ("something.php");
+    include_once ("something.php");
+    require ("something.php");
+    require_once ("something.php");
+    print ("hello");
     unset($hello);
     isset($hello);
     empty($hello);
     die($hello);
-    echo("hello");
+    echo ("hello");
     array("hello");
     list($a, $b) = $c;
     eval("a");
@@ -104,6 +104,11 @@ final class NoSpacesAfterFunctionNameFixerTest extends AbstractFixerTestCase
 
         yield [
             '<?php echo ($a == $b) ? "foo" : "bar";',
+        ];
+
+        yield [
+            '<?php strlen($a . $b) ? "foo" : "bar";',
+            '<?php strlen ($a . $b) ? "foo" : "bar";',
         ];
 
         yield [
@@ -172,27 +177,17 @@ $$e(2);
             '<?php
                 echo (function () {})();
                 echo ($propertyValue ? "TRUE" : "FALSE") . EOL;
-                echo(FUNCTION_1);
-                echo (EXPRESSION + CONST_1), CONST_2;
-            ',
-            '<?php
-                echo (function () {})();
-                echo ($propertyValue ? "TRUE" : "FALSE") . EOL;
                 echo (FUNCTION_1);
                 echo (EXPRESSION + CONST_1), CONST_2;
             ',
         ];
 
         yield [
-            '<?php
-                include(SOME_PATH_1);
-                include_once(SOME_PATH_2);
-                require(SOME_PATH_3);
-                require_once(SOME_PATH_4);
-                print(SOME_VALUE);
-                print(FIRST_HALF_OF_STRING_1 . SECOND_HALF_OF_STRING_1);
-                print((FIRST_HALF_OF_STRING_2) . (SECOND_HALF_OF_STRING_2));
-            ',
+            '<?php echo foo(EXPRESSION + CONST_1), CONST_2;',
+            '<?php echo foo (EXPRESSION + CONST_1), CONST_2;',
+        ];
+
+        yield [
             '<?php
                 include         (SOME_PATH_1);
                 include_once    (SOME_PATH_2);


### PR DESCRIPTION
Ref. #7516

This removes the "feature" that removed spaces between certain language constructs and unrelated parentheses that followed after it. The fixer still removes spaces between language constructs that use parentheses as part of their syntax, e.g. `empty()` or `isset()`.