### PR TITLE
DX: remove jangregor/phpstan-prophecy

### DIFF
--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -2,7 +2,6 @@
     "require": {
         "php": "^8.3",
         "ergebnis/composer-normalize": "^2.39.0",
-        "jangregor/phpstan-prophecy": "^1.0.0",
         "maglnet/composer-require-checker": "^4.7.1",
         "mi-schi/phpmd-extension": "^4.3.0",
         "pdepend/pdepend": "~2.15.0",

--- a/dev-tools/composer.lock
+++ b/dev-tools/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a421637c5f547bec60fd18c7ab1eaa07",
+    "content-hash": "36ed9f7514224b2342b41a7b2f237906",
     "packages": [
         {
             "name": "composer/pcre",
@@ -554,71 +554,6 @@
                 "source": "https://github.com/ergebnis/json-schema-validator"
             },
             "time": "2023-10-10T14:16:57+00:00"
-        },
-        {
-            "name": "jangregor/phpstan-prophecy",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Jan0707/phpstan-prophecy.git",
-                "reference": "2bc7ca9460395690c6bf7332bdfb2f25d5cae8e0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Jan0707/phpstan-prophecy/zipball/2bc7ca9460395690c6bf7332bdfb2f25d5cae8e0",
-                "reference": "2bc7ca9460395690c6bf7332bdfb2f25d5cae8e0",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0",
-                "phpstan/phpstan": "^1.0.0"
-            },
-            "conflict": {
-                "phpspec/prophecy": "<1.7.0,>=2.0.0",
-                "phpunit/phpunit": "<6.0.0,>=10.0.0"
-            },
-            "require-dev": {
-                "ergebnis/composer-normalize": "^2.1.1",
-                "ergebnis/license": "^1.0.0",
-                "ergebnis/php-cs-fixer-config": "~2.2.0",
-                "phpspec/prophecy": "^1.7.0",
-                "phpunit/phpunit": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
-            },
-            "type": "phpstan-extension",
-            "extra": {
-                "phpstan": {
-                    "includes": [
-                        "extension.neon"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "JanGregor\\Prophecy\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jan Gregor Emge-Triebel",
-                    "email": "jan@jangregor.me"
-                }
-            ],
-            "description": "Provides a phpstan/phpstan extension for phpspec/prophecy",
-            "support": {
-                "issues": "https://github.com/Jan0707/phpstan-prophecy/issues",
-                "source": "https://github.com/Jan0707/phpstan-prophecy/tree/1.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/localheinz",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-11-08T16:37:47+00:00"
         },
         {
             "name": "justinrainbow/json-schema",


### PR DESCRIPTION
We don't need it since https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7509