### PR TITLE
DX: Change `@testWith` to `@dataProvider`

### DIFF
--- a/tests/Linter/ProcessLinterProcessBuilderTest.php
+++ b/tests/Linter/ProcessLinterProcessBuilderTest.php
@@ -27,8 +27,7 @@ use PhpCsFixer\Tests\TestCase;
 final class ProcessLinterProcessBuilderTest extends TestCase
 {
     /**
-     * @testWith ["php", "foo.php", "'php' '-l' 'foo.php'"]
-     *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "'C:\\Program Files\\php\\php.exe' '-l' 'foo bar\\baz.php'"]
+     * @dataProvider providePrepareCommandOnPhpOnLinuxOrMacCases
      *
      * @requires OS Linux|Darwin
      */
@@ -43,8 +42,17 @@ final class ProcessLinterProcessBuilderTest extends TestCase
     }
 
     /**
-     * @testWith ["php", "foo.php", "php -l foo.php"]
-     *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "\"C:\\Program Files\\php\\php.exe\" -l \"foo bar\\baz.php\""]
+     * @return iterable<array{string, string, string}>
+     */
+    public static function providePrepareCommandOnPhpOnLinuxOrMacCases(): iterable
+    {
+        yield 'Linux-like' => ['php', 'foo.php', "'php' '-l' 'foo.php'"];
+
+        yield 'Windows-like' => ['C:\\Program Files\\php\\php.exe', 'foo bar\\baz.php', "'C:\\Program Files\\php\\php.exe' '-l' 'foo bar\\baz.php'"];
+    }
+
+    /**
+     * @dataProvider providePrepareCommandOnPhpOnWindowsCases
      *
      * @requires OS ^Win
      */
@@ -56,5 +64,15 @@ final class ProcessLinterProcessBuilderTest extends TestCase
             $expected,
             $builder->build($file)->getCommandLine()
         );
+    }
+
+    /**
+     * @return iterable<array{string, string, string}>
+     */
+    public static function providePrepareCommandOnPhpOnWindowsCases(): iterable
+    {
+        yield 'Linux-like' => ['php', 'foo.php', 'php -l foo.php'];
+
+        yield 'Windows-like' => ['C:\\Program Files\\php\\php.exe', 'foo bar\\baz.php', '"C:\\Program Files\\php\\php.exe" -l "foo bar\\baz.php"'];
     }
 }

--- a/tests/Runner/FileFilterIteratorTest.php
+++ b/tests/Runner/FileFilterIteratorTest.php
@@ -28,9 +28,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 final class FileFilterIteratorTest extends TestCase
 {
     /**
-     * @testWith [1]
-     *           [2]
-     *           [3]
+     * @dataProvider provideAcceptCases
      */
     public function testAccept(int $repeat): void
     {
@@ -60,6 +58,18 @@ final class FileFilterIteratorTest extends TestCase
 
         self::assertCount(1, $files);
         self::assertSame($fileInfo, reset($files));
+    }
+
+    /**
+     * @return iterable<array<int>>
+     */
+    public static function provideAcceptCases(): iterable
+    {
+        yield [1];
+
+        yield [2];
+
+        yield [3];
     }
 
     public function testEmitSkipEventWhenCacheNeedFixingFalse(): void


### PR DESCRIPTION
I know there is `PhpUnitTestAnnotationFixerTest` that has test cases with `@testWith`, but I believe we don't need this kind of approach for providing test cases in our actual codebase?