### PR TITLE
fix: NativeTypeDeclarationCasingFixer - do not crash on `var` keyword

### DIFF
--- a/src/Fixer/Casing/NativeTypeDeclarationCasingFixer.php
+++ b/src/Fixer/Casing/NativeTypeDeclarationCasingFixer.php
@@ -127,7 +127,7 @@ final class NativeTypeDeclarationCasingFixer extends AbstractFixer
     {
         parent::__construct();
 
-        $this->propertyTypeModifiers = [[T_PRIVATE], [T_PROTECTED], [T_PUBLIC]];
+        $this->propertyTypeModifiers = [[T_PRIVATE], [T_PROTECTED], [T_PUBLIC], [T_VAR]];
 
         $this->functionTypeHints = [
             'array' => true,

--- a/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
@@ -562,6 +562,12 @@ function Foo(INTEGER $a) {}
             ',
         ];
 
+        yield 'var keyword' => [
+            '<?php class Foo {
+                var $bar;
+            }',
+        ];
+
         if (\PHP_VERSION_ID >= 8_00_00) {
             yield 'union Types' => [
                 '<?php $a = new class {


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7537