### PR TITLE
fix: Better OS detection in integration tests

### DIFF
--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -216,7 +216,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
             self::markTestSkipped(sprintf('PHP lower than %d is required for "%s", current "%d".', $phpUpperLimit, $case->getFileName(), \PHP_VERSION_ID));
         }
 
-        if (!\in_array(PHP_OS, $case->getRequirement('os'), true)) {
+        if (!\in_array(PHP_OS_FAMILY, $case->getRequirement('os'), true)) {
             self::markTestSkipped(
                 sprintf(
                     'Unsupported OS (%s) for "%s", allowed are: %s.',


### PR DESCRIPTION
skipped message before this fix:
```
Unsupported OS (WINNT) for "xxx.test", allowed are: Linux, Darwin, Windows.
```