### PR TITLE
feat: Add support for official Docker images of Fixer

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,14 +61,17 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
+          flavor: |
+            latest=false
+            suffix=${{ matrix.php-suffix }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}
           # "edge" will only build from master, "semver" only from tags
           tags: |
-            type=edge,branch=master,suffix=${{ matrix.php-suffix }}
-            type=semver,pattern={{version}},suffix=${{ matrix.php-suffix }}
-            type=semver,pattern={{major}}.{{minor}},suffix=${{ matrix.php-suffix }}
-            type=semver,pattern={{major}},suffix=${{ matrix.php-suffix }}
-            type=semver,pattern=latest,suffix=${{ matrix.php-suffix }}
+            type=edge,branch=master
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=semver,pattern=latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-and-push-image:
-    name: PHP ${{ matrix.php-version }}, Fixer ${{ github.ref == 'refs/heads/master' && 'nightly' || ${{ github.ref_name }} }}
+    name: PHP ${{ matrix.php-version }}, Fixer ${{ github.ref == 'refs/heads/master' && 'edge' || ${{ github.ref_name }} }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -33,7 +33,8 @@ jobs:
           - php-version: '8.3'
             php-suffix: '-php8.3'
             alpine-version: '3.18'
-          - php-version: 'latest'
+          # This is the latest supported PHP Version and will be provided without -phpX.X suffix
+          - php-version: '8.3'
             php-suffix: ''
             alpine-version: '3.18'
 
@@ -61,6 +62,7 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}
+          # "edge" will only build from master, "semver" only from tags
           tags: |
             type=edge,branch=master,suffix=${{ matrix.php-suffix }}
             type=semver,pattern={{version}},suffix=${{ matrix.php-suffix }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   build-and-push-image:
+    name: PHP ${{ matrix.php-version }}, Fixer ${{ github.ref == 'refs/heads/master' && 'nightly' || ${{ github.ref_name }} }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,81 @@
+name: Create and publish a Docker images
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+    branches:
+      - "main"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - php-version: '7.4'
+            php-suffix: '-php7.4'
+            alpine-version: '3.16'
+          - php-version: '8.0'
+            php-suffix: '-php8.0'
+            alpine-version: '3.16'
+          - php-version: '8.1'
+            php-suffix: '-php8.1'
+            alpine-version: '3.18'
+          - php-version: '8.2'
+            php-suffix: '-php8.2'
+            alpine-version: '3.18'
+          - php-version: '8.3'
+            php-suffix: '-php8.3'
+            alpine-version: '3.18'
+          - php-version: 'latest'
+            php-suffix: ''
+            alpine-version: '3.18'
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Make image lowercase
+        run: |
+          echo IMAGE_NAME_LOWER=$(echo ${{ env.IMAGE_NAME }} | tr '[:upper:]' '[:lower:]') >> ${GITHUB_ENV}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}
+          tags: |
+            type=edge,branch=main,suffix=${{ matrix.php-suffix }}
+            type=semver,pattern={{version}},suffix=${{ matrix.php-suffix }}
+            type=semver,pattern={{major}}.{{minor}},suffix=${{ matrix.php-suffix }}
+            type=semver,pattern={{major}},suffix=${{ matrix.php-suffix }}
+            type=semver,pattern=latest,suffix=${{ matrix.php-suffix }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
+        with:
+          context: .
+          file: Dockerfile
+          target: dist
+          build-args: |
+            PHP_VERSION=${{ matrix.php-version }}
+            ALPINE_VERSION=${{ matrix.alpine-version }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-and-push-image:
-    name: PHP ${{ matrix.php-version }}, Fixer ${{ github.ref == 'refs/heads/master' && 'edge' || ${{ github.ref_name }} }}
+    name: PHP ${{ matrix.php-version }}, Fixer ${{ github.ref == 'refs/heads/master' && 'edge' || github.ref_name }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v*.*.*"
     branches:
-      - "main"
+      - "master"
 
 env:
   REGISTRY: ghcr.io
@@ -61,7 +61,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}
           tags: |
-            type=edge,branch=main,suffix=${{ matrix.php-suffix }}
+            type=edge,branch=master,suffix=${{ matrix.php-suffix }}
             type=semver,pattern={{version}},suffix=${{ matrix.php-suffix }}
             type=semver,pattern={{major}}.{{minor}},suffix=${{ matrix.php-suffix }}
             type=semver,pattern={{major}},suffix=${{ matrix.php-suffix }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,23 +19,14 @@ jobs:
       matrix:
         include:
           - php-version: '7.4'
-            php-suffix: '-php7.4'
             alpine-version: '3.16'
           - php-version: '8.0'
-            php-suffix: '-php8.0'
             alpine-version: '3.16'
           - php-version: '8.1'
-            php-suffix: '-php8.1'
             alpine-version: '3.18'
           - php-version: '8.2'
-            php-suffix: '-php8.2'
             alpine-version: '3.18'
           - php-version: '8.3'
-            php-suffix: '-php8.3'
-            alpine-version: '3.18'
-          # This is the latest supported PHP Version and will be provided without -phpX.X suffix
-          - php-version: '8.3'
-            php-suffix: ''
             alpine-version: '3.18'
 
     permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   build-and-push-image:
     name: PHP ${{ matrix.php-version }}, Fixer ${{ github.ref == 'refs/heads/master' && 'edge' || github.ref_name }}
+    if: github.repository == 'PHP-CS-Fixer/PHP-CS-Fixer'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Create and publish a Docker images
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           flavor: |
             latest=false
-            suffix=${{ matrix.php-suffix }}
+            suffix=-${{ matrix.php-version }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}
           # "edge" will only build from master, "semver" only from tags
           tags: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "v*.*.*"
-    branches:
-      - "master"
 
 env:
   REGISTRY: ghcr.io
@@ -13,7 +11,7 @@ env:
 
 jobs:
   build-and-push-image:
-    name: PHP ${{ matrix.php-version }}, Fixer ${{ github.ref == 'refs/heads/master' && 'edge' || github.ref_name }}
+    name: PHP ${{ matrix.php-version }}, Fixer ${{ github.ref_name }}
     if: github.repository == 'PHP-CS-Fixer/PHP-CS-Fixer'
     runs-on: ubuntu-latest
     strategy:
@@ -39,7 +37,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -51,22 +49,19 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           flavor: |
             latest=false
             suffix=-${{ matrix.php-version }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}
-          # "edge" will only build from master, "semver" only from tags
           tags: |
-            type=edge,branch=master
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=semver,pattern=latest
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,29 @@ RUN apk add python3 py3-pip git \
 CMD git ls-files --cached -z -- '*.rst' \
     | xargs -0 -- python3 -m sphinxlint --enable all --disable trailing-whitespace --max-line-length 2000
 
-FROM php:${PHP_VERSION}-cli-alpine${ALPINE_VERSION} as php
-
-ARG DOCKER_USER_ID
-ARG DOCKER_GROUP_ID
-ARG PHP_XDEBUG_VERSION
-
+FROM php:${PHP_VERSION}-cli-alpine${ALPINE_VERSION} as base
 # https://blog.codito.dev/2022/11/composer-binary-only-docker-images/
 # https://github.com/composer/docker/pull/250
 COPY --from=composer/composer:2-bin /composer /usr/local/bin/composer
+
+FROM base as vendor
+WORKDIR /var/www
+COPY composer.json /var/www/composer.json
+RUN composer install --prefer-dist --no-dev --optimize-autoloader --no-scripts
+
+FROM php:${PHP_VERSION}-cli-alpine${ALPINE_VERSION} as dist
+WORKDIR /var/www
+RUN rmdir /var/www/html
+COPY src /usr/local/bin/src
+COPY php-cs-fixer /usr/local/bin/php-cs-fixer
+# Only take the dependencies (not composer itself) into the container
+COPY --from=vendor /var/www/vendor /usr/local/bin/vendor
+ENTRYPOINT ["/usr/local/bin/php-cs-fixer"]
+
+FROM php:${PHP_VERSION}-cli-alpine${ALPINE_VERSION} as dev
+ARG DOCKER_USER_ID
+ARG DOCKER_GROUP_ID
+ARG PHP_XDEBUG_VERSION
 
 RUN if [ ! -z "$DOCKER_GROUP_ID" ] && [ ! getent group "${DOCKER_GROUP_ID}" > /dev/null ]; \
         then addgroup -S -g "${DOCKER_GROUP_ID}" devs; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=vendor /fixer/vendor /fixer/vendor
 RUN ln -s /fixer/php-cs-fixer /usr/local/bin/php-cs-fixer
 ENTRYPOINT ["/usr/local/bin/php-cs-fixer"]
 
-FROM base as dev
+FROM base as php
 ARG DOCKER_USER_ID
 ARG DOCKER_GROUP_ID
 ARG PHP_XDEBUG_VERSION

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can take a ready built docker image to run ``php-cs-fixer``.
 docker run -v $(pwd):/var/www ghcr.io/php-cs-fixer/php-cs-fixer:latest fix src
 ```
 
-or integrate as check into gitlab-ci like this
+or integrate as check into Gitlab CI like this:
 
 ```yaml
 php-cs-fixer:

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ There are different tags for each stability and php version with syntax `<php-cs
 
 * `3.41.1-php8.1`
 * `3.41-php8.2`
-* `3` (uses the latest php version)
-* `latest` (latest stable cs-fixer and latest stable php version)
-* `edge-php7.4` (current build from main with old php version)
+* `3` (uses the highest supported PHP version)
+* `latest` (latest stable Fixer on highest supported PHP version)
+* `edge-php7.4` (current build from main branch with specific PHP version)
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,31 @@ projects. This tool does not only detect them, but also fixes them for you.
 
 ## Documentation
 
+### Run with docker
+
+You can take a ready built docker image to run ``php-cs-fixer``.
+
+```console
+docker run -v $(pwd):/var/www ghcr.io/php-cs-fixer/php-cs-fixer:latest fix src
+```
+
+or integrate as check into gitlab-ci like this
+
+```yaml
+php-cs-fixer:
+  image: ghcr.io/php-cs-fixer/php-cs-fixer:3.41-php8.2
+  script:
+    php-cs-fixer fix --diff --dry-run --format=txt src
+```
+
+There are different tags for each stability and php version with syntax `<php-cs-fixer-version>-php<php-version>`. For example:
+
+* `3.41.1-php8.1`
+* `3.41-php8.2`
+* `3` (uses the latest php version)
+* `latest` (latest stable cs-fixer and latest stable php version)
+* `edge-php7.4` (current build from main with old php version)
+
 ### Installation
 
 The recommended way to install PHP CS Fixer is to use [Composer](https://getcomposer.org/download/)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ projects. This tool does not only detect them, but also fixes them for you.
 You can take a ready built docker image to run ``php-cs-fixer``.
 
 ```console
-docker run -v $(pwd):/var/www ghcr.io/php-cs-fixer/php-cs-fixer:latest fix src
+docker run -v $(pwd):/code ghcr.io/php-cs-fixer/php-cs-fixer:latest fix src
 ```
 
 or integrate as check into Gitlab CI like this:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Or integrate as check into Gitlab CI like this:
 
 ```yaml
 php-cs-fixer:
-  image: ghcr.io/php-cs-fixer/php-cs-fixer:3.41-php8.2
+  image: ghcr.io/php-cs-fixer/php-cs-fixer:$FIXER_VERSION
   script:
     php-cs-fixer fix --diff --dry-run --format=txt src
 ```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For more details and other installation methods, see
 You can take a ready built docker image to run ``php-cs-fixer``.
 
 ```console
-docker run -v $(pwd):/code ghcr.io/php-cs-fixer/php-cs-fixer:latest fix src
+docker run -v $(pwd):/code ghcr.io/php-cs-fixer/php-cs-fixer:$FIXER_VERSION fix src
 ```
 
 Or integrate as check into Gitlab CI like this:

--- a/README.md
+++ b/README.md
@@ -36,31 +36,6 @@ projects. This tool does not only detect them, but also fixes them for you.
 
 ## Documentation
 
-### Run with docker
-
-You can take a ready built docker image to run ``php-cs-fixer``.
-
-```console
-docker run -v $(pwd):/code ghcr.io/php-cs-fixer/php-cs-fixer:latest fix src
-```
-
-or integrate as check into Gitlab CI like this:
-
-```yaml
-php-cs-fixer:
-  image: ghcr.io/php-cs-fixer/php-cs-fixer:3.41-php8.2
-  script:
-    php-cs-fixer fix --diff --dry-run --format=txt src
-```
-
-There are different tags for each stability and php version with syntax `<php-cs-fixer-version>-php<php-version>`. For example:
-
-* `3.41.1-php8.1`
-* `3.41-php8.2`
-* `3-php7.4`
-* `latest-php8.3` (latest stable Fixer release)
-* `edge-php8.0` (current build from main branch)
-
 ### Installation
 
 The recommended way to install PHP CS Fixer is to use [Composer](https://getcomposer.org/download/)
@@ -80,6 +55,29 @@ composer require --dev friendsofphp/php-cs-fixer
 
 For more details and other installation methods, see
 [installation instructions](./doc/installation.rst).
+
+### Run with Docker
+
+You can take a ready built docker image to run ``php-cs-fixer``.
+
+```console
+docker run -v $(pwd):/code ghcr.io/php-cs-fixer/php-cs-fixer:latest fix src
+```
+
+Or integrate as check into Gitlab CI like this:
+
+```yaml
+php-cs-fixer:
+  image: ghcr.io/php-cs-fixer/php-cs-fixer:3.41-php8.2
+  script:
+    php-cs-fixer fix --diff --dry-run --format=txt src
+```
+
+There are different tags for each stability and php version with syntax `<php-cs-fixer-version>-php<php-version>`. For example:
+
+* `3.41.1-php8.1`
+* `3.41-php8.2`
+* `3-php7.4`
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For more details and other installation methods, see
 
 ### Run with Docker
 
-You can take a ready built docker image to run ``php-cs-fixer``.
+You can use pre-built Docker images to run ``php-cs-fixer``.
 
 ```console
 docker run -v $(pwd):/code ghcr.io/php-cs-fixer/php-cs-fixer:$FIXER_VERSION fix src

--- a/README.md
+++ b/README.md
@@ -73,11 +73,12 @@ php-cs-fixer:
     php-cs-fixer fix --diff --dry-run --format=txt src
 ```
 
-There are different tags for each stability and php version with syntax `<php-cs-fixer-version>-php<php-version>`. For example:
 
-* `3.41.1-php8.1`
-* `3.41-php8.2`
-* `3-php7.4`
+`$FIXER_VERSION` used in example above is an identifier of a release you want to use, which is based on Fixer and PHP versions combined. There are different tags for each Fixer's SemVer level and PHP version with syntax `<php-cs-fixer-version>-php<php-version>`. For example:
+
+* `3.47.0-php7.4`
+* `3.47-php8.0`
+* `3-php8.3`
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -61,16 +61,7 @@ For more details and other installation methods, see
 You can use pre-built Docker images to run ``php-cs-fixer``.
 
 ```console
-docker run -v $(pwd):/code ghcr.io/php-cs-fixer/php-cs-fixer:$FIXER_VERSION fix src
-```
-
-Or integrate as check into Gitlab CI like this:
-
-```yaml
-php-cs-fixer:
-  image: ghcr.io/php-cs-fixer/php-cs-fixer:$FIXER_VERSION
-  script:
-    php-cs-fixer fix --diff --dry-run --format=txt src
+docker run -v $(pwd):/code ghcr.io/php-cs-fixer/php-cs-fixer:${FIXER_VERSION:-3-php8.3} fix src
 ```
 
 `$FIXER_VERSION` used in example above is an identifier of a release you want to use, which is based on Fixer and PHP versions combined. There are different tags for each Fixer's SemVer level and PHP version with syntax `<php-cs-fixer-version>-php<php-version>`. For example:

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ There are different tags for each stability and php version with syntax `<php-cs
 
 * `3.41.1-php8.1`
 * `3.41-php8.2`
-* `3` (uses the highest supported PHP version)
-* `latest` (latest stable Fixer on highest supported PHP version)
-* `edge-php7.4` (current build from main branch with specific PHP version)
+* `3-php7.4`
+* `latest-php8.3` (latest stable Fixer release)
+* `edge-php8.0` (current build from main branch)
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ php-cs-fixer:
     php-cs-fixer fix --diff --dry-run --format=txt src
 ```
 
-
 `$FIXER_VERSION` used in example above is an identifier of a release you want to use, which is based on Fixer and PHP versions combined. There are different tags for each Fixer's SemVer level and PHP version with syntax `<php-cs-fixer-version>-php<php-version>`. For example:
 
 * `3.47.0-php7.4`

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -77,6 +77,18 @@ Install `PHIVE <https://phar.io>`_ and issue the following command:
 
     phive install php-cs-fixer # use `--global` for global install
 
+Gitlab-CI (Docker)
+~~~~~~~~~~~~~~~~~~
+
+To integrate php-cs-fixer as check into Gitlab-CI, you can use a configuration like this:
+
+.. code-block:: yaml
+
+    php-cs-fixer:
+      image: ghcr.io/php-cs-fixer/php-cs-fixer:$FIXER_VERSION
+      script:
+        php-cs-fixer fix --diff --dry-run --format=txt src
+
 Update
 ------
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -85,7 +85,7 @@ To integrate php-cs-fixer as check into Gitlab-CI, you can use a configuration l
 .. code-block:: yaml
 
     php-cs-fixer:
-      image: ghcr.io/php-cs-fixer/php-cs-fixer:$FIXER_VERSION
+      image: ghcr.io/php-cs-fixer/php-cs-fixer:${FIXER_VERSION:-3-php8.3}
       script:
         php-cs-fixer fix --diff --dry-run --format=txt src
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -87,7 +87,7 @@ To integrate php-cs-fixer as check into Gitlab-CI, you can use a configuration l
     php-cs-fixer:
       image: ghcr.io/php-cs-fixer/php-cs-fixer:${FIXER_VERSION:-3-php8.3}
       script:
-        php-cs-fixer fix --diff --dry-run --format=txt src
+        php-cs-fixer check --diff --format=txt src
 
 Update
 ------

--- a/tests/AutoReview/CiConfigurationTest.php
+++ b/tests/AutoReview/CiConfigurationTest.php
@@ -267,7 +267,7 @@ final class CiConfigurationTest extends TestCase
         $yaml = Yaml::parse(file_get_contents(__DIR__.'/../../.github/workflows/docker.yml'));
 
         return array_map(
-            static fn($item) => $item['php-version'],
+            static fn ($item) => $item['php-version'],
             $yaml['jobs']['build-and-push-image']['strategy']['matrix']['include']
         );
     }

--- a/tests/AutoReview/CiConfigurationTest.php
+++ b/tests/AutoReview/CiConfigurationTest.php
@@ -71,6 +71,7 @@ final class CiConfigurationTest extends TestCase
 
         self::assertSupportedPhpVersionsAreCoveredByCiJobs($supportedVersions, $ciVersions);
         self::assertUpcomingPhpVersionIsCoveredByCiJob(end($supportedVersions), $ciVersions);
+        self::assertSupportedPhpVersionsAreCoveredByCiJobs($supportedVersions, $this->getPhpVersionsUsedByGitHubDocker());
     }
 
     public function testDeploymentJobsRunOnLatestStablePhpThatIsSupportedByTool(): void
@@ -252,6 +253,22 @@ final class CiConfigurationTest extends TestCase
         $phpVersions = $yaml['jobs']['tests']['strategy']['matrix']['php-version'] ?? [];
 
         foreach ($yaml['jobs']['tests']['strategy']['matrix']['include'] as $job) {
+            $phpVersions[] = $job['php-version'];
+        }
+
+        return $phpVersions;
+    }
+
+    /**
+     * @return list<numeric-string>
+     */
+    private function getPhpVersionsUsedByGitHubDocker(): array
+    {
+        $yaml = Yaml::parse(file_get_contents(__DIR__.'/../../.github/workflows/docker.yml'));
+
+        $phpVersions = [];
+
+        foreach ($yaml['jobs']['build-and-push-image']['strategy']['matrix']['include'] as $job) {
             $phpVersions[] = $job['php-version'];
         }
 

--- a/tests/AutoReview/CiConfigurationTest.php
+++ b/tests/AutoReview/CiConfigurationTest.php
@@ -266,12 +266,9 @@ final class CiConfigurationTest extends TestCase
     {
         $yaml = Yaml::parse(file_get_contents(__DIR__.'/../../.github/workflows/docker.yml'));
 
-        $phpVersions = [];
-
-        foreach ($yaml['jobs']['build-and-push-image']['strategy']['matrix']['include'] as $job) {
-            $phpVersions[] = $job['php-version'];
-        }
-
-        return $phpVersions;
+        return array_map(
+            static fn($item) => $item['php-version'],
+            $yaml['jobs']['build-and-push-image']['strategy']['matrix']['include']
+        );
     }
 }


### PR DESCRIPTION
Here is a suggestion, how to automatically build and publish a docker image for php-cs-fixer. 
For end-users this should make the use much easier, as no installation is needed. Also it may be useful inside CI Pipelines like gitlab-ci, which can run the docker image directly.