### PR TITLE
DX: do not allow overriding constructor of `PHPUnit\Framework\TestCase`

### DIFF
--- a/tests/Smoke/InstallViaComposerTest.php
+++ b/tests/Smoke/InstallViaComposerTest.php
@@ -32,7 +32,7 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class InstallViaComposerTest extends AbstractSmokeTestCase
 {
-    private Filesystem $fs;
+    private ?Filesystem $fs;
 
     /** @var array<string, mixed> */
     private array $currentCodeAsComposerDependency = [
@@ -64,13 +64,6 @@ final class InstallViaComposerTest extends AbstractSmokeTestCase
         'vendor/bin/php-cs-fixer fix --help',
     ];
 
-    public function __construct()
-    {
-        $this->fs = new Filesystem();
-
-        parent::__construct();
-    }
-
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
@@ -96,6 +89,16 @@ final class InstallViaComposerTest extends AbstractSmokeTestCase
         } catch (\RuntimeException $e) {
             self::fail('Composer check failed. Details:'."\n".$e->getMessage());
         }
+    }
+
+    protected function setUp(): void
+    {
+        $this->fs = new Filesystem();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fs = null;
     }
 
     public function testInstallationViaPathIsPossible(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,4 +25,14 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 abstract class TestCase extends BaseTestCase
 {
     use ExpectDeprecationTrait;
+
+    final public function testNotDefiningConstructor(): void
+    {
+        $reflection = new \ReflectionObject($this);
+
+        self::assertNotSame(
+            $reflection->getConstructor()->getDeclaringClass()->getName(),
+            $reflection->getName(),
+        );
+    }
 }


### PR DESCRIPTION
In PHPUnit 9 it would work as all parameters are optional: https://github.com/sebastianbergmann/phpunit/blob/9.6.15/src/Framework/TestCase.php#L489

However, in PHPUnit is not the same: https://github.com/sebastianbergmann/phpunit/blob/10.5.3/src/Framework/TestCase.php#L322C46-L322C46