### PR TITLE
DX: remove `PhpUnitNamespacedFixerTest::testClassIsFixed`

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -21,7 +21,7 @@ parameters:
         -
             message: '#^Method PhpCsFixer\\Tests\\.+::provide.+Cases\(\) return type has no value type specified in iterable type iterable\.$#'
             path: tests
-            count: 1096
+            count: 1095
 
         -
             message: '#Call to static method .+ with .+ will always evaluate to true.$#'

--- a/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
@@ -308,6 +308,15 @@ final class PhpUnitNamespacedFixerTest extends AbstractFixerTestCase
         }
     }
 
+    public function testDataProviderIsEmpty(): void
+    {
+        // check that data provider above is always empty
+        self::assertSame(
+            [],
+            iterator_to_array(self::provideClassIsFixedCases())
+        );
+    }
+
     /**
      * @dataProvider provideFix81Cases
      *

--- a/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
@@ -16,7 +16,6 @@ namespace PhpCsFixer\Tests\Fixer\PhpUnit;
 
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTargetVersion;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
-use PhpCsFixer\Tokenizer\Tokens;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -279,42 +278,6 @@ final class PhpUnitNamespacedFixerTest extends AbstractFixerTestCase
                 define(\'PHPUNIT_COMPOSER_INSTALL\', dirname(__DIR__).\'/vendor/autoload.php\');
                 require PHPUNIT_COMPOSER_INSTALL;',
         ];
-    }
-
-    /**
-     * @dataProvider provideClassIsFixedCases
-     */
-    public function testClassIsFixed(string $class): void
-    {
-        $this->fixer->configure(['target' => PhpUnitTargetVersion::VERSION_NEWEST]);
-
-        Tokens::clearCache();
-        $tokens = Tokens::fromCode(sprintf('<?php new %s();', $class));
-
-        $this->fixer->fix(new \SplFileInfo(__FILE__), $tokens);
-
-        self::assertTrue($tokens->isChanged());
-        self::assertStringNotContainsString('_', $tokens->generateCode());
-    }
-
-    public static function provideClassIsFixedCases(): iterable
-    {
-        $classmap = require __DIR__.'/../../../vendor/composer/autoload_classmap.php';
-
-        foreach ($classmap as $class => $file) {
-            if (str_starts_with($class, 'PHPUnit_')) {
-                yield $file => [$class];
-            }
-        }
-    }
-
-    public function testDataProviderIsEmpty(): void
-    {
-        // check that data provider above is always empty
-        self::assertSame(
-            [],
-            iterator_to_array(self::provideClassIsFixedCases())
-        );
     }
 
     /**


### PR DESCRIPTION
As it always operates on an empty data provider.