### PR TITLE
feat: [PoC] Support disabling PHP-CS-Fixer for single lines and rules

### DIFF
--- a/src/AbstractFixer.php
+++ b/src/AbstractFixer.php
@@ -72,6 +72,8 @@ abstract class AbstractFixer implements FixerInterface
             throw new RequiredFixerConfigurationException($this->getName(), 'Configuration is required.');
         }
 
+        $changed = $tokens->isChanged();
+
         $isIgnored = false;
         $tokenMapping = [];
         foreach ($tokens as $index => $token) {
@@ -92,7 +94,10 @@ abstract class AbstractFixer implements FixerInterface
             }
         }
 
-        $tokens->clearChanged();
+        if (!$changed) {
+
+            $tokens->clearChanged();
+        }
 
         if (0 < $tokens->count() && $this->isCandidate($tokens) && $this->supports($file)) {
             $this->applyFix($file, $tokens);
@@ -117,7 +122,7 @@ abstract class AbstractFixer implements FixerInterface
             return false;
         }
         $comment = $token->getContent();
-        if ($comment[1] !== '/') {
+        if (!str_starts_with('//', $comment)) {
             return false;
         }
         $comment = trim(substr($comment, 2));

--- a/src/AbstractFixer.php
+++ b/src/AbstractFixer.php
@@ -108,7 +108,7 @@ abstract class AbstractFixer implements FixerInterface
 
         foreach ($tokens as $index => $token) {
             $originalToken = $tokenMapping[spl_object_hash($token)] ?? null;
-            if ($originalToken) {
+            if ($originalToken !== null) {
                 $tokens->offsetSet($index, $originalToken);
             }
         }
@@ -229,7 +229,7 @@ abstract class AbstractFixer implements FixerInterface
             return false;
         }
         $comment = $token->getContent();
-        if (!str_starts_with('//', $comment)) {
+        if (!str_starts_with($comment, '//')) {
             return false;
         }
         $comment = trim(substr($comment, 2));
@@ -237,8 +237,8 @@ abstract class AbstractFixer implements FixerInterface
         if (!str_starts_with($comment, 'phpcsfixer:disable')) {
             return false;
         }
-        $rules = substr($comment, 18);
-        if (empty($rules)) {
+        $rules = trim(substr($comment, 18));
+        if ($rules === '') {
             return true;
         }
         $rules = array_map('trim', explode(',', $rules));

--- a/src/AbstractFixer.php
+++ b/src/AbstractFixer.php
@@ -108,7 +108,7 @@ abstract class AbstractFixer implements FixerInterface
 
         foreach ($tokens as $index => $token) {
             $originalToken = $tokenMapping[spl_object_hash($token)] ?? null;
-            if ($originalToken !== null) {
+            if (null !== $originalToken) {
                 $tokens->offsetSet($index, $originalToken);
             }
         }
@@ -238,7 +238,7 @@ abstract class AbstractFixer implements FixerInterface
             return false;
         }
         $rules = trim(substr($comment, 18));
-        if ($rules === '') {
+        if ('' === $rules) {
             return true;
         }
         $rules = array_map('trim', explode(',', $rules));

--- a/src/AbstractFixer.php
+++ b/src/AbstractFixer.php
@@ -26,7 +26,6 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
 use PhpCsFixer\FixerConfiguration\InvalidOptionsForEnvException;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
-use ReflectionClass;
 use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 
@@ -130,7 +129,7 @@ abstract class AbstractFixer implements FixerInterface
         if (empty($rules)) {
             return true;
         }
-        $rules = array_map(trim(...), explode(',', $rules));
+        $rules = array_map('trim', explode(',', $rules));
 
         return in_array($this->getName(), $rules, true);
     }

--- a/src/AbstractFixer.php
+++ b/src/AbstractFixer.php
@@ -79,11 +79,13 @@ abstract class AbstractFixer implements FixerInterface
         foreach ($tokens as $index => $token) {
             if (!$isIgnored && $this->tokenDisablesFixer($token)) {
                 $isIgnored = true;
+
                 continue;
             }
 
-            if ($isIgnored && $token->isGivenKind(T_COMMENT) && $token->getContent() === '// phpcsfixer:enable') {
+            if ($isIgnored && $token->isGivenKind(T_COMMENT) && '// phpcsfixer:enable' === $token->getContent()) {
                 $isIgnored = false;
+
                 continue;
             }
 
@@ -95,7 +97,6 @@ abstract class AbstractFixer implements FixerInterface
         }
 
         if (!$changed) {
-
             $tokens->clearChanged();
         }
 
@@ -115,28 +116,6 @@ abstract class AbstractFixer implements FixerInterface
         if (!$changed) {
             $tokens->clearChanged();
         }
-    }
-
-    private function tokenDisablesFixer(Token $token): bool {
-        if (!$token->isGivenKind(T_COMMENT)) {
-            return false;
-        }
-        $comment = $token->getContent();
-        if (!str_starts_with('//', $comment)) {
-            return false;
-        }
-        $comment = trim(substr($comment, 2));
-
-        if (!str_starts_with($comment, 'phpcsfixer:disable')) {
-            return false;
-        }
-        $rules = substr($comment, 18);
-        if (empty($rules)) {
-            return true;
-        }
-        $rules = array_map('trim', explode(',', $rules));
-
-        return in_array($this->getName(), $rules, true);
     }
 
     public function isRisky(): bool
@@ -242,6 +221,29 @@ abstract class AbstractFixer implements FixerInterface
         }
 
         throw new \LogicException('Not implemented.');
+    }
+
+    private function tokenDisablesFixer(Token $token): bool
+    {
+        if (!$token->isGivenKind(T_COMMENT)) {
+            return false;
+        }
+        $comment = $token->getContent();
+        if (!str_starts_with('//', $comment)) {
+            return false;
+        }
+        $comment = trim(substr($comment, 2));
+
+        if (!str_starts_with($comment, 'phpcsfixer:disable')) {
+            return false;
+        }
+        $rules = substr($comment, 18);
+        if (empty($rules)) {
+            return true;
+        }
+        $rules = array_map('trim', explode(',', $rules));
+
+        return \in_array($this->getName(), $rules, true);
     }
 
     private function getDefaultWhitespacesFixerConfig(): WhitespacesFixerConfig

--- a/tests/Fixtures/Integration/disable/disable-all-rules.test
+++ b/tests/Fixtures/Integration/disable/disable-all-rules.test
@@ -1,0 +1,21 @@
+--TEST--
+Integration of fixers: array_indentation,braces.
+--RULESET--
+{"strict_comparison": true, "single_quote": true}
+--EXPECT--
+<?php
+
+// phpcsfixer:disable
+$a = "test" == 'test';
+// phpcsfixer:enable
+
+$b = 'test' === 'test';
+
+--INPUT--
+<?php
+
+// phpcsfixer:disable
+$a = "test" == 'test';
+// phpcsfixer:enable
+
+$b = "test" == 'test';

--- a/tests/Fixtures/Integration/disable/disable-in-different-blocks-2.test
+++ b/tests/Fixtures/Integration/disable/disable-in-different-blocks-2.test
@@ -1,0 +1,16 @@
+--TEST--
+undefined behavior 2
+--RULESET--
+{"array_syntax": true}
+--EXPECT--
+<?php
+???
+
+--INPUT--
+<?php
+$array = array(
+    1,
+    // phpcsfixer:disable
+    2,
+);
+// phpcsfixer:enable

--- a/tests/Fixtures/Integration/disable/disable-in-different-blocks.test
+++ b/tests/Fixtures/Integration/disable/disable-in-different-blocks.test
@@ -1,0 +1,25 @@
+--TEST--
+undefined behavior
+--RULESET--
+{"statement_indentation": true}
+--EXPECT--
+<?php
+$goodIntentation = 7;
+// phpcsfixer:disable
+        $toMuchIndentation = foo(
+                     $x,
+                     $y,
+                     // phpcsfixer:enable
+                     $z,
+);
+
+--INPUT--
+<?php
+$goodIntentation = 7;
+// phpcsfixer:disable
+        $toMuchIndentation = foo(
+                     $x,
+                     $y,
+                     // phpcsfixer:enable
+                     $z,
+        );

--- a/tests/Fixtures/Integration/disable/disable-in-use-statements.test
+++ b/tests/Fixtures/Integration/disable/disable-in-use-statements.test
@@ -1,0 +1,26 @@
+--TEST--
+Todo: modify fixer? The disabled part is interpreted as logic between use statements. 
+The groups are sorted for themselves
+--RULESET--
+{"ordered_imports": true}
+--EXPECT--
+<?php
+use D;
+use E;
+// phpcsfixer:disable
+use C;
+use B;
+// phpcsfixer:enable
+use A;
+use F;
+
+--INPUT--
+<?php
+use E;
+use D;
+// phpcsfixer:disable
+use C;
+use B;
+// phpcsfixer:enable
+use F;
+use A;

--- a/tests/Fixtures/Integration/disable/disable-one-rule.test
+++ b/tests/Fixtures/Integration/disable/disable-one-rule.test
@@ -1,0 +1,21 @@
+--TEST--
+Integration of fixers: array_indentation,braces.
+--RULESET--
+{"strict_comparison": true, "single_quote": true}
+--EXPECT--
+<?php
+
+// phpcsfixer:disable strict_comparison
+$a = 'test' == 'test';
+// phpcsfixer:enable
+
+$b = 'test' === 'test';
+
+--INPUT--
+<?php
+
+// phpcsfixer:disable strict_comparison
+$a = "test" == 'test';
+// phpcsfixer:enable
+
+$b = "test" == 'test';

--- a/tests/Fixtures/Integration/disable/disable-two-rules.test
+++ b/tests/Fixtures/Integration/disable/disable-two-rules.test
@@ -1,0 +1,21 @@
+--TEST--
+Integration of fixers: array_indentation,braces.
+--RULESET--
+{"strict_comparison": true, "single_quote": true}
+--EXPECT--
+<?php
+
+// phpcsfixer:disable strict_comparison,single_quote
+$a = "test" == 'test';
+// phpcsfixer:enable
+
+$b = 'test' === 'test';
+
+--INPUT--
+<?php
+
+// phpcsfixer:disable strict_comparison,single_quote
+$a = "test" == 'test';
+// phpcsfixer:enable
+
+$b = "test" == 'test';


### PR DESCRIPTION
This PR is a proof of concept on wether it is possible to disable PHP-CS-Fixer for single lines in the code and for single rules.

Please note that this PR is only a proof of concept and therefore no attention has been paid to details yet.

The idea behind this is to modify all tokes between to marker tokens, so that they won't be changed by fixer. The marker-tokens are simple comments. The modification is currently only by done setting a special ID to a token so the fixer will hopefully leave them alone. After a fixer has applied changes to the remaining tokes, the tokens will be changed back to their original state. Now the next fixer can work with the tokens again.

## Syntax:

* Disable all rules: `// phpcsfixer:disable`
* Disable some rules: `// phpcsfixer:disable rule1,rule2`
* Enable rules again: `// phpcsfixer:enable`

## Example

```php
public function containsElementEqualTo(mixed $search): bool
{
    // phpcsfixer:disable strict_comparison
    return $this->first(fn($element) => $element == $search) !== null;
    // phpcsfixer:enable
}
```

Related to: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/4512