### PR TITLE
DX: cleanup deprecation message

### DIFF
--- a/tests/DocBlock/TagComparatorTest.php
+++ b/tests/DocBlock/TagComparatorTest.php
@@ -39,7 +39,7 @@ final class TagComparatorTest extends TestCase
         $tag1 = new Tag(new Line('* @'.$first));
         $tag2 = new Tag(new Line('* @'.$second));
 
-        $this->expectDeprecation('%AMethod PhpCsFixer\DocBlock\TagComparator::shouldBeTogether is deprecated and will be removed in version 4.0.');
+        $this->expectDeprecation('Method PhpCsFixer\DocBlock\TagComparator::shouldBeTogether is deprecated and will be removed in version 4.0.');
 
         self::assertSame($expected, TagComparator::shouldBeTogether($tag1, $tag2));
     }
@@ -77,7 +77,7 @@ final class TagComparatorTest extends TestCase
         $tag1 = new Tag(new Line('* @'.$first));
         $tag2 = new Tag(new Line('* @'.$second));
 
-        $this->expectDeprecation('%AMethod PhpCsFixer\DocBlock\TagComparator::shouldBeTogether is deprecated and will be removed in version 4.0.');
+        $this->expectDeprecation('Method PhpCsFixer\DocBlock\TagComparator::shouldBeTogether is deprecated and will be removed in version 4.0.');
 
         self::assertSame(
             $expected,

--- a/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
+++ b/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
@@ -40,7 +40,7 @@ final class LowercaseCastFixerTest extends AbstractFixerTestCase
      */
     public function testFix74Deprecated(string $expected, ?string $input = null): void
     {
-        $this->expectDeprecation('%AThe (real) cast is deprecated, use (float) instead');
+        $this->expectDeprecation('The (real) cast is deprecated, use (float) instead');
 
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
+++ b/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
@@ -40,7 +40,7 @@ final class ShortScalarCastFixerTest extends AbstractFixerTestCase
      */
     public function testFix74Deprecated(string $expected, ?string $input = null): void
     {
-        $this->expectDeprecation('%AThe (real) cast is deprecated, use (float) instead');
+        $this->expectDeprecation('The (real) cast is deprecated, use (float) instead');
 
         $this->doTest($expected, $input);
     }


### PR DESCRIPTION
This was working because of https://github.com/symfony/phpunit-bridge/blob/v7.0.1/Legacy/SymfonyTestsListenerTrait.php#L306