### PR TITLE
test: weird stuff here

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage == 'yes'
         env:
           FAST_LINT_TEST_CASES: 1
-        run: vendor/bin/paraunit coverage --testsuite unit --exclude-group covers-nothing --clover build/logs/clover.xml
+        run: vendor/bin/paraunit coverage --testsuite hello --exclude-group covers-nothing --clover build/logs/clover.xml
 
       - name: Upload coverage results to Coveralls
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/paraunit run --testsuite hello
 
       - name: Run tests and collect code coverage
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage == 'yes'

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -56,7 +56,7 @@ jobs:
           command: ./dev-tools/install.sh
 
       - name: Run AutoReview
-        run: vendor/bin/paraunit run --testsuite auto-review
+        run: vendor/bin/paraunit run --testsuite hello
 
       - name: Check - file permissions
         run: ./dev-tools/check_file_permissions.sh

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -33,6 +33,10 @@
         <testsuite name="auto-review">
             <directory>./tests/AutoReview/</directory>
         </testsuite>
+        <testsuite name="hello">
+            <file>./tests/Console/Command/ListFilesCommandTest.php</file>
+            <file>./tests/FileRemovalTest.php</file>
+        </testsuite>
     </testsuites>
 
     <coverage>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -46,7 +46,7 @@
     </coverage>
 
     <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+<!--        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>-->
     </listeners>
 
     <php>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -34,8 +34,8 @@
             <directory>./tests/AutoReview/</directory>
         </testsuite>
         <testsuite name="hello">
-            <file>./tests/Console/Command/ListFilesCommandTest.php</file>
             <file>./tests/FileRemovalTest.php</file>
+            <file>./tests/Console/Command/ListFilesCommandTest.php</file>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
So, if we test 2 files, `tests/Console/Command/ListFilesCommandTest.php` and `tests/FileRemovalTest.php`, in that order, with `Symfony\Bridge\PhpUnit\SymfonyTestsListener` enabled - all tests are passing (1st commit).

When we disable `Symfony\Bridge\PhpUnit\SymfonyTestsListener` then there is a test fail for Symfony 7 only (2nd commit).

When we swap the test order, then all tests are passing again (3rd commit).

@stof is this regression in Symfony (Filesystem component)? 