### PR TITLE
DX: unify fixer's test method names - quick wins

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -21,7 +21,7 @@ parameters:
         -
             message: '#^Method PhpCsFixer\\Tests\\.+::provide.+Cases\(\) return type has no value type specified in iterable type iterable\.$#'
             path: tests
-            count: 1042
+            count: 1041
 
         -
             message: '#Call to static method .+ with .+ will always evaluate to true.$#'

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -21,7 +21,7 @@ parameters:
         -
             message: '#^Method PhpCsFixer\\Tests\\.+::provide.+Cases\(\) return type has no value type specified in iterable type iterable\.$#'
             path: tests
-            count: 1044
+            count: 1042
 
         -
             message: '#Call to static method .+ with .+ will always evaluate to true.$#'

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -21,7 +21,7 @@ parameters:
         -
             message: '#^Method PhpCsFixer\\Tests\\.+::provide.+Cases\(\) return type has no value type specified in iterable type iterable\.$#'
             path: tests
-            count: 1046
+            count: 1044
 
         -
             message: '#Call to static method .+ with .+ will always evaluate to true.$#'

--- a/tests/Fixer/ControlStructure/ControlStructureContinuationPositionFixerTest.php
+++ b/tests/Fixer/ControlStructure/ControlStructureContinuationPositionFixerTest.php
@@ -271,9 +271,9 @@ final class ControlStructureContinuationPositionFixerTest extends AbstractFixerT
     /**
      * @param null|array<string, mixed> $configuration
      *
-     * @dataProvider provideFixWithWindowsLineEndingsCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testFixWithWindowsLineEndings(string $expected, ?string $input = null, array $configuration = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null, array $configuration = null): void
     {
         if (null !== $configuration) {
             $this->fixer->configure($configuration);
@@ -286,7 +286,7 @@ final class ControlStructureContinuationPositionFixerTest extends AbstractFixerT
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixWithWindowsLineEndingsCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         foreach (self::provideFixCases() as $label => $case) {
             yield $label => [

--- a/tests/Fixer/ControlStructure/EmptyLoopBodyFixerTest.php
+++ b/tests/Fixer/ControlStructure/EmptyLoopBodyFixerTest.php
@@ -26,9 +26,9 @@ final class EmptyLoopBodyFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideFixConfigCases
+     * @dataProvider provideFixCases
      */
-    public function testFixConfig(string $expected, ?string $input = null, array $config = []): void
+    public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
         if ([] === $config) {
             $this->doTest($expected, $input);
@@ -46,7 +46,7 @@ final class EmptyLoopBodyFixerTest extends AbstractFixerTestCase
         }
     }
 
-    public static function provideFixConfigCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'simple "while"' => [
             '<?php while(foo());',

--- a/tests/Fixer/ControlStructure/EmptyLoopConditionFixerTest.php
+++ b/tests/Fixer/ControlStructure/EmptyLoopConditionFixerTest.php
@@ -26,16 +26,16 @@ final class EmptyLoopConditionFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideFixConfigCases
+     * @dataProvider provideFixCases
      */
-    public function testFixConfig(string $expected, ?string $input = null, array $config = []): void
+    public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
         $this->fixer->configure($config);
 
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixConfigCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'from `for` to `while`' => [
             '<?php

--- a/tests/Fixer/FunctionNotation/LambdaNotUsedImportFixerTest.php
+++ b/tests/Fixer/FunctionNotation/LambdaNotUsedImportFixerTest.php
@@ -26,7 +26,7 @@ final class LambdaNotUsedImportFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, string $input): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -125,18 +125,7 @@ $a = function() use ($b) { new class(){ public function foo($b){echo $b;}}; }; /
                     new class("bar") {};
                 };',
         ];
-    }
 
-    /**
-     * @dataProvider provideDoNotFixCases
-     */
-    public function testDoNotFix(string $expected): void
-    {
-        $this->doTest($expected);
-    }
-
-    public static function provideDoNotFixCases(): iterable
-    {
         yield 'reference' => [
             '<?php $fn = function() use(&$b) {} ?>',
         ];

--- a/tests/Fixer/Import/NoLeadingImportSlashFixerTest.php
+++ b/tests/Fixer/Import/NoLeadingImportSlashFixerTest.php
@@ -213,16 +213,16 @@ use const \some\Z\{ConstX,ConstY,ConstZ,};
     }
 
     /**
-     * @dataProvider provideFixPrePHP80Cases
+     * @dataProvider provideFixPre80Cases
      *
      * @requires PHP <8.0
      */
-    public function testFixPrePHP80(string $expected, ?string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixPrePHP80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php use /*1*/A\D;',

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -1430,7 +1430,7 @@ use Z;
     /**
      * @requires PHP <8.0
      */
-    public function testFixPrePHP80(): void
+    public function testFixPre80(): void
     {
         $this->doTest(
             '<?php
@@ -1605,20 +1605,7 @@ function test2($param = (new Foo6)) {}
 const D = new Foo7(1,2);
 ',
         ];
-    }
 
-    /**
-     * @requires PHP 8.1
-     *
-     * @dataProvider provideFixPhp81Cases
-     */
-    public function testFixPhp81(string $expected): void
-    {
-        $this->doTest($expected);
-    }
-
-    public static function provideFixPhp81Cases(): iterable
-    {
         yield [
             '<?php
                 enum Foo: string

--- a/tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
+++ b/tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
@@ -505,16 +505,16 @@ use some\a\ClassA; use function some\a\fn_a; use const some\c;
     }
 
     /**
-     * @dataProvider provideMessyWhitespacesCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testMessyWhitespaces(string $expected, ?string $input = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
 
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         yield [
             "<?php namespace A\\B;\r\n    use D;\r\n\r\n    class C {}",

--- a/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
@@ -112,9 +112,9 @@ final class DeclareEqualNormalizeFixerTest extends AbstractFixerTestCase
     /**
      * @param array<mixed> $config
      *
-     * @dataProvider provideInvalidConfigCases
+     * @dataProvider provideInvalidConfigurationCases
      */
-    public function testInvalidConfig(array $config, string $expectedMessage): void
+    public function testInvalidConfiguration(array $config, string $expectedMessage): void
     {
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage(sprintf('[declare_equal_normalize] Invalid configuration: %s', $expectedMessage));
@@ -122,7 +122,7 @@ final class DeclareEqualNormalizeFixerTest extends AbstractFixerTestCase
         $this->fixer->configure($config);
     }
 
-    public static function provideInvalidConfigCases(): iterable
+    public static function provideInvalidConfigurationCases(): iterable
     {
         yield [
             [1, 2],

--- a/tests/Fixer/LanguageConstruct/DirConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/DirConstantFixerTest.php
@@ -185,7 +185,7 @@ final class DirConstantFixerTest extends AbstractFixerTestCase
     /**
      * @requires PHP <8.0
      */
-    public function testFixPrePHP80(): void
+    public function testFixPre80(): void
     {
         $this->doTest(
             '<?php $x =# A

--- a/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
@@ -26,11 +26,11 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class NullableTypeDeclarationFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideDefaultFixCases
+     * @dataProvider provideFixCases
      *
      * @requires PHP 8.0
      */
-    public function testDefaultFix(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -38,7 +38,7 @@ final class NullableTypeDeclarationFixerTest extends AbstractFixerTestCase
     /**
      * @return iterable<string, array{string, 1?: ?string}>
      */
-    public static function provideDefaultFixCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'scalar with null' => [
             "<?php\nfunction foo(?int \$bar): void {}\n",
@@ -101,11 +101,11 @@ class Dto
     }
 
     /**
-     * @dataProvider provideFixWithUnionSyntaxCases
+     * @dataProvider provideFix80Cases
      *
      * @requires PHP 8.0
      */
-    public function testFixWithUnionSyntax(string $expected, ?string $input = null): void
+    public function testFix80(string $expected, ?string $input = null): void
     {
         $this->fixer->configure(['syntax' => 'union']);
 
@@ -115,7 +115,7 @@ class Dto
     /**
      * @return iterable<string, array{string, 1?: ?string}>
      */
-    public static function provideFixWithUnionSyntaxCases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield 'scalar with null' => [
             "<?php\nfunction foo(null|int \$bar): void {}\n",
@@ -195,11 +195,11 @@ class Foo
     /**
      * @param null|array<string, string> $config
      *
-     * @dataProvider provideFixPhp81Cases
+     * @dataProvider provideFix81Cases
      *
      * @requires PHP 8.1
      */
-    public function testFixPhp81(string $expected, ?string $input = null, ?array $config = null): void
+    public function testFix81(string $expected, ?string $input = null, ?array $config = null): void
     {
         if (null !== $config) {
             $this->fixer->configure($config);
@@ -211,7 +211,7 @@ class Foo
     /**
      * @return iterable<string, array{string, 1?: ?string, 2?: array<string, mixed>}>
      */
-    public static function provideFixPhp81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield 'readonly property' => [
             '<?php
@@ -248,11 +248,11 @@ class Qux
     /**
      * @param null|array<string, string> $config
      *
-     * @dataProvider provideFixPhp82Cases
+     * @dataProvider provideFix82Cases
      *
      * @requires PHP 8.2
      */
-    public function testFixPhp82(string $expected, ?string $input = null, ?array $config = null): void
+    public function testFix82(string $expected, ?string $input = null, ?array $config = null): void
     {
         if (null !== $config) {
             $this->fixer->configure($config);
@@ -264,7 +264,7 @@ class Qux
     /**
      * @return iterable<string, array{string, 1?: ?string, 2?: array<string, mixed>}>
      */
-    public static function provideFixPhp82Cases(): iterable
+    public static function provideFix82Cases(): iterable
     {
         yield 'skips DNF types' => [
             '<?php

--- a/tests/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixerTest.php
@@ -234,16 +234,16 @@ class X extends Y {}',
     }
 
     /**
-     * @dataProvider provideMessyWhitespacesCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testMessyWhitespaces(string $expected, ?string $input = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
 
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         yield [
             "<?php namespace A\\B;\r\n\r\nclass C {}",

--- a/tests/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixerTest.php
@@ -155,16 +155,16 @@ namespace TestComment;',
     }
 
     /**
-     * @dataProvider provideMessyWhitespacesCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testMessyWhitespaces(string $expected, ?string $input = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
 
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         yield [
             "<?php\r\nnamespace TestW1a{}\r\nnamespace TestW1b{}",

--- a/tests/Fixer/Operator/LongToShorthandOperatorFixerTest.php
+++ b/tests/Fixer/Operator/LongToShorthandOperatorFixerTest.php
@@ -452,14 +452,14 @@ class Foo
     /**
      * @requires PHP <8.0
      *
-     * @dataProvider provideFixPrePHP80Cases
+     * @dataProvider provideFixPre80Cases
      */
-    public function testFixPrePHP80(string $expected, ?string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixPrePHP80Cases(): iterable
+    public static function provideFixPre80Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Operator/TernaryToElvisOperatorFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToElvisOperatorFixerTest.php
@@ -493,16 +493,16 @@ EOT
     }
 
     /**
-     * @dataProvider provideDoNotFix80Cases
+     * @dataProvider provideFix80Cases
      *
      * @requires PHP 8.0
      */
-    public function testDoNotFix80(string $input): void
+    public function testFix80(string $input): void
     {
         $this->doTest($input);
     }
 
-    public static function provideDoNotFix80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield ['<?php
 

--- a/tests/Fixer/PhpTag/BlankLineAfterOpeningTagFixerTest.php
+++ b/tests/Fixer/PhpTag/BlankLineAfterOpeningTagFixerTest.php
@@ -141,16 +141,16 @@ $foo = $bar;
     }
 
     /**
-     * @dataProvider provideMessyWhitespacesCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testMessyWhitespaces(string $expected, ?string $input = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
 
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         yield [
             "<?php\r\n\r\n\$foo = true;\r\n",

--- a/tests/Fixer/PhpTag/LinebreakAfterOpeningTagFixerTest.php
+++ b/tests/Fixer/PhpTag/LinebreakAfterOpeningTagFixerTest.php
@@ -94,16 +94,16 @@ $foo = $bar;
     }
 
     /**
-     * @dataProvider provideMessyWhitespacesCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testMessyWhitespaces(string $expected, ?string $input = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
 
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         yield [
             "<?php\r\n\$foo = true;\n",

--- a/tests/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixerTest.php
@@ -190,23 +190,7 @@ class FooTest extends TestCase {
                 ', $modifier, 'abstract' === $modifier ? ';' : '{}'),
             ];
         }
-    }
 
-    /**
-     * @requires PHP ^7.4
-     *
-     * @dataProvider provideFix7Cases
-     */
-    public function testFix7(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    /**
-     * @return iterable<array{string, string}>
-     */
-    public static function provideFix7Cases(): iterable
-    {
         yield 'data provider with return type namespaced class starting with iterable' => self::mapToTemplate(
             ': iterable \ Foo',
         );

--- a/tests/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixerTest.php
@@ -190,7 +190,23 @@ class FooTest extends TestCase {
                 ', $modifier, 'abstract' === $modifier ? ';' : '{}'),
             ];
         }
+    }
 
+    /**
+     * @requires PHP <8.0>
+     *
+     * @dataProvider provideFixPre80Cases
+     */
+    public function testFixPre80(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<array{string, string}>
+     */
+    public static function provideFixPre80Cases(): iterable
+    {
         yield 'data provider with return type namespaced class starting with iterable' => self::mapToTemplate(
             ': iterable \ Foo',
         );

--- a/tests/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixerTest.php
@@ -193,7 +193,7 @@ class FooTest extends TestCase {
     }
 
     /**
-     * @requires PHP <8.0>
+     * @requires PHP <8.0
      *
      * @dataProvider provideFixPre80Cases
      */

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixerTest.php
@@ -26,14 +26,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class PhpUnitDedicateAssertInternalTypeFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideFixInternalTypeCases
+     * @dataProvider provideFixCases
      */
-    public function testFixInternalType(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixInternalTypeCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield 'skip cases' => [
             '<?php

--- a/tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
@@ -407,9 +407,9 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider provideMessyWhitespacesCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testMessyWhitespaces(string $expected, ?string $input = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null): void
     {
         $expected = str_replace(['    ', "\n"], ["\t", "\r\n"], $expected);
         if (null !== $input) {
@@ -421,7 +421,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         $expectedTemplate =
 '

--- a/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
@@ -695,9 +695,9 @@ final class PhpUnitNoExpectationAnnotationFixerTest extends AbstractFixerTestCas
     }
 
     /**
-     * @dataProvider provideMessyWhitespacesCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testMessyWhitespaces(string $expected, ?string $input = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null): void
     {
         $expected = str_replace(['    ', "\n"], ["\t", "\r\n"], $expected);
         if (null !== $input) {
@@ -709,7 +709,7 @@ final class PhpUnitNoExpectationAnnotationFixerTest extends AbstractFixerTestCas
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
@@ -1032,16 +1032,16 @@ class Test extends \PhpUnit\FrameWork\TestCase
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideMessyWhitespacesCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testMessyWhitespaces(string $expected, ?string $input = null, array $config = []): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null, array $config = []): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
         $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
@@ -252,9 +252,9 @@ class FooTest extends \PHPUnit_Framework_TestCase {}
     }
 
     /**
-     * @dataProvider provideMessyWhitespacesCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testMessyWhitespaces(string $expected, ?string $input = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null): void
     {
         $expected = str_replace(['    ', "\n"], ["\t", "\r\n"], $expected);
         if (null !== $input) {
@@ -266,7 +266,7 @@ class FooTest extends \PHPUnit_Framework_TestCase {}
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -2461,17 +2461,17 @@ class Foo {
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideFixPhp80Cases
+     * @dataProvider provideFix80Cases
      *
      * @requires PHP 8.0
      */
-    public function testFixPhp80(string $expected, ?string $input = null, array $config = []): void
+    public function testFix80(string $expected, ?string $input = null, array $config = []): void
     {
         $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixPhp80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield 'static return' => [
             '<?php

--- a/tests/Fixer/Phpdoc/PhpdocIndentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocIndentFixerTest.php
@@ -26,14 +26,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class PhpdocIndentFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideFixIndentCases
+     * @dataProvider provideFixCases
      */
-    public function testFixIndent(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixIndentCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield ['<?php /** @var Foo $foo */ ?>'];
 

--- a/tests/Fixer/Phpdoc/PhpdocTagTypeFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTagTypeFixerTest.php
@@ -403,7 +403,7 @@ final class PhpdocTagTypeFixerTest extends AbstractFixerTestCase
         ];
     }
 
-    public function testConfigureWithInvalidTagType(): void
+    public function testInvalidConfiguration(): void
     {
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches('#^\[phpdoc_tag_type\] Invalid configuration: Unknown tag type "foo"\.#');

--- a/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
@@ -28,8 +28,6 @@ final class PhpdocToCommentFixerTest extends AbstractFixerTestCase
     /**
      * @param array<string, mixed> $config
      *
-     * @dataProvider provideDocblocksCases
-     * @dataProvider provideTraitsCases
      * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null, array $config = []): void
@@ -39,7 +37,7 @@ final class PhpdocToCommentFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public static function provideDocblocksCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php
@@ -715,10 +713,7 @@ function doSomething()
             null,
             ['allow_before_return_statement' => true],
         ];
-    }
 
-    public static function provideTraitsCases(): iterable
-    {
         yield [
             '<?php
 $first = true;// needed because by default first docblock is never fixed.
@@ -731,10 +726,7 @@ trait DocBlocks
     public function test() {}
 }',
         ];
-    }
 
-    public static function provideFixCases(): iterable
-    {
         yield [
             '<?php
 /** header */

--- a/tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
@@ -326,7 +326,7 @@ final class PhpdocTypesFixerTest extends AbstractFixerTestCase
         ];
     }
 
-    public function testWrongConfig(): void
+    public function testInvalidConfiguration(): void
     {
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches('/^\[phpdoc_types\] Invalid configuration: The option "groups" .*\.$/');

--- a/tests/Fixer/Strict/DeclareStrictTypesFixerTest.php
+++ b/tests/Fixer/Strict/DeclareStrictTypesFixerTest.php
@@ -129,34 +129,23 @@ $a = 456;
             '<?php declare(strict_types=1);',
             '<?php declare(strict_types=0);',
         ];
-    }
 
-    /**
-     * @dataProvider provideDoNotFixCases
-     */
-    public function testDoNotFix(string $input): void
-    {
-        $this->doTest($input);
-    }
-
-    public static function provideDoNotFixCases(): iterable
-    {
         yield ['  <?php echo 123;']; // first statement must be an open tag
 
         yield ['<?= 123;']; // first token open with echo is not fixed
     }
 
     /**
-     * @dataProvider provideMessyWhitespacesCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testMessyWhitespaces(string $expected, ?string $input = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
 
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         yield [
             "<?php declare(strict_types=1);\r\nphpinfo();",

--- a/tests/Fixer/StringNotation/StringLineEndingFixerTest.php
+++ b/tests/Fixer/StringNotation/StringLineEndingFixerTest.php
@@ -113,7 +113,7 @@ final class StringLineEndingFixerTest extends AbstractFixerTestCase
         ];
     }
 
-    public function testWithDifferentLineEndingConfiguration(): void
+    public function testWithWhitespacesConfig(): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
 

--- a/tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
@@ -897,15 +897,15 @@ $foo = [
     }
 
     /**
-     * @dataProvider provideFixWithTabsCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testFixWithTabs(string $expected, ?string $input = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t"));
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixWithTabsCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         yield from self::withLongArraySyntaxCases([
             [
@@ -990,16 +990,16 @@ $foo = [
     }
 
     /**
-     * @dataProvider provideFixPhp80Cases
+     * @dataProvider provideFix80Cases
      *
      * @requires PHP 8.0
      */
-    public function testFixPhp80(string $expected, ?string $input = null): void
+    public function testFix80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixPhp80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield 'attribute' => [
             '<?php

--- a/tests/Fixer/Whitespace/BlankLineBetweenImportGroupsFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBetweenImportGroupsFixerTest.php
@@ -24,14 +24,14 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class BlankLineBetweenImportGroupsFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideFixTypesOrderAndNewlinesCases
+     * @dataProvider provideFixCases
      */
-    public function testFixTypesOrderAndNewlines(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixTypesOrderAndNewlinesCases(): iterable
+    public static function provideFixCases(): iterable
     {
         yield [
             '<?php
@@ -528,16 +528,16 @@ use const C\D; // bar
     }
 
     /**
-     * @dataProvider provideFixPre80Cases
+     * @dataProvider provideFix80Cases
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFix80(string $expected, string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
-    public static function provideFixPre80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php

--- a/tests/Fixer/Whitespace/HeredocIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/HeredocIndentationFixerTest.php
@@ -300,7 +300,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
         ];
     }
 
-    public function testFixWithTabIndentation(): void
+    public function testWithWhitespacesConfig(): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t"));
 

--- a/tests/Fixer/Whitespace/LineEndingFixerTest.php
+++ b/tests/Fixer/Whitespace/LineEndingFixerTest.php
@@ -73,16 +73,16 @@ final class LineEndingFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideMessyWhitespacesCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testMessyWhitespaces(string $expected, ?string $input = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
 
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         yield from array_map(static fn (array $case): array => array_reverse($case), self::provideCommonCases());
 

--- a/tests/Fixer/Whitespace/MethodChainingIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/MethodChainingIndentationFixerTest.php
@@ -461,15 +461,15 @@ abc(),
     }
 
     /**
-     * @dataProvider provideWindowsWhitespacesCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testWindowsWhitespaces(string $expected, ?string $input = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
         $this->doTest($expected, $input);
     }
 
-    public static function provideWindowsWhitespacesCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         yield [
             "<?php\r\n\$user->setEmail('voff.web@gmail.com')\r\n\t->setPassword('233434')\r\n\t->setEmailConfirmed(false)\r\n\t->setEmailConfirmationCode('123456')\r\n\t->setHashsalt('1234')\r\n\t->setTncAccepted(true);",

--- a/tests/Fixer/Whitespace/NoWhitespaceInBlankLineFixerTest.php
+++ b/tests/Fixer/Whitespace/NoWhitespaceInBlankLineFixerTest.php
@@ -157,16 +157,16 @@ $t = true> 9;       '.'
     }
 
     /**
-     * @dataProvider provideMessyWhitespacesCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testMessyWhitespaces(string $expected, ?string $input = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
 
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         yield [
             "<?php\r\n\r\n    \$a = 1;\r\n\r\n    \$b = 2;",

--- a/tests/Fixer/Whitespace/SingleBlankLineAtEofFixerTest.php
+++ b/tests/Fixer/Whitespace/SingleBlankLineAtEofFixerTest.php
@@ -163,16 +163,16 @@ inline 1
     }
 
     /**
-     * @dataProvider provideMessyWhitespacesCases
+     * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testMessyWhitespaces(string $expected, ?string $input = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
 
         $this->doTest($expected, $input);
     }
 
-    public static function provideMessyWhitespacesCases(): iterable
+    public static function provideWithWhitespacesConfigCases(): iterable
     {
         yield [
             "<?php\r\n\$a = 4;\r\n",

--- a/tests/Fixer/Whitespace/TypeDeclarationSpacesFixerTest.php
+++ b/tests/Fixer/Whitespace/TypeDeclarationSpacesFixerTest.php
@@ -353,11 +353,11 @@ class Point
     }
 
     /**
-     * @dataProvider provideFixPhp80Cases
+     * @dataProvider provideFix80Cases
      *
      * @requires PHP 8.0
      */
-    public function testFixPhp80(string $expected, string $input): void
+    public function testFix80(string $expected, string $input): void
     {
         $this->doTest($expected, $input);
     }
@@ -365,7 +365,7 @@ class Point
     /**
      * @return iterable<array{string, 1?: ?string}>
      */
-    public static function provideFixPhp80Cases(): iterable
+    public static function provideFix80Cases(): iterable
     {
         yield [
             '<?php function foo(mixed $a) {}',
@@ -402,11 +402,11 @@ class Foo
     }
 
     /**
-     * @dataProvider provideFixPhp81Cases
+     * @dataProvider provideFix81Cases
      *
      * @requires PHP 8.1
      */
-    public function testFixPhp81(string $expected, ?string $input = null): void
+    public function testFix81(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -414,7 +414,7 @@ class Foo
     /**
      * @return iterable<array{string, 1?: ?string}>
      */
-    public static function provideFixPhp81Cases(): iterable
+    public static function provideFix81Cases(): iterable
     {
         yield [
             '<?php class Foo { private readonly int $bar; }',
@@ -428,11 +428,11 @@ class Foo
     }
 
     /**
-     * @dataProvider provideFixPhp82Cases
+     * @dataProvider provideFix82Cases
      *
      * @requires PHP 8.2
      */
-    public function testFixPhp82(string $expected, ?string $input = null): void
+    public function testFix82(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -440,7 +440,7 @@ class Foo
     /**
      * @return iterable<array{string, 1?: ?string}>
      */
-    public static function provideFixPhp82Cases(): iterable
+    public static function provideFix82Cases(): iterable
     {
         yield [
             '<?php class Foo { public (A&B)|C $bar; }',

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -404,10 +404,12 @@ abstract class AbstractFixerTestCase extends TestCase
             \PhpCsFixer\Tests\Fixer\Import\GlobalNamespaceImportFixerTest::class,
             \PhpCsFixer\Tests\Fixer\Import\OrderedImportsFixerTest::class,
             \PhpCsFixer\Tests\Fixer\Import\SingleImportPerStatementFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\LanguageConstruct\CombineConsecutiveIssetsFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\LanguageConstruct\FunctionToConstantFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\LanguageConstruct\SingleSpaceAroundConstructFixerTest::class,
         ];
 
         $exceptionGroup = [
-            'LanguageConstruct', // @TODO: remove it before others
             'ListNotation',
             'NamespaceNotation',
             'Naming',

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -400,17 +400,21 @@ abstract class AbstractFixerTestCase extends TestCase
             'StringNotation',
             'Whitespace', // @TODO: remove it before others
         ];
-
-        $exceptions = [
-            \PhpCsFixer\Tests\Fixer\ClassNotation\ClassAttributesSeparationFixerTest::class => ['testCommentBlockStartDetection', 'provideCommentBlockStartDetectionCases'],
-            \PhpCsFixer\Tests\Fixer\ClassNotation\ClassDefinitionFixerTest::class => ['testClassyDefinitionInfo', 'provideClassyDefinitionInfoCases', 'testClassyInheritanceInfo', 'provideClassyInheritanceInfoCases'],
-        ];
-
         $fixerGroup = explode('\\', static::class)[3];
-
         if (\in_array($fixerGroup, $exceptionGroup, true)) {
             self::markTestSkipped('Not covered yet.');
         }
+
+        // should only shrink, baseline of classes violating method naming
+        $exceptionClasses = [
+            \PhpCsFixer\Tests\Fixer\ClassNotation\ClassAttributesSeparationFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\ClassNotation\ClassDefinitionFixerTest::class,
+        ];
+
+        if (in_array(static::class, $exceptionClasses)) {
+            self::markTestSkipped('Not covered yet.');
+        }
+
 
         self::assertTrue(method_exists($this, 'testFix'), 'Method testFix does not exist.');
         self::assertTrue(method_exists($this, 'provideFixCases'), 'Method provideFixCases does not exist.');
@@ -422,18 +426,18 @@ abstract class AbstractFixerTestCase extends TestCase
             $methodNames[] = 'provide'.$name.'Cases';
         }
 
-        $class = new \ReflectionObject($this);
+        $reflectionClass = new \ReflectionObject($this);
 
         $extraMethods = array_map(
             static fn (\ReflectionMethod $method): string => $method->getName(),
             array_filter(
-                $class->getMethods(\ReflectionMethod::IS_PUBLIC),
-                static fn (\ReflectionMethod $method): bool => $method->getDeclaringClass()->getName() === $class->getName()
+                $reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC),
+                static fn (\ReflectionMethod $method): bool => $method->getDeclaringClass()->getName() === $reflectionClass->getName()
                     && !\in_array($method->getName(), $methodNames, true)
             )
         );
 
-        $extraMethods = array_diff($extraMethods, $exceptions[$class->getName()] ?? []);
+        $extraMethods = array_diff($extraMethods, $exceptions[$reflectionClass->getName()] ?? []);
 
         self::assertSame(
             [],

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -407,14 +407,18 @@ abstract class AbstractFixerTestCase extends TestCase
             \PhpCsFixer\Tests\Fixer\LanguageConstruct\CombineConsecutiveIssetsFixerTest::class,
             \PhpCsFixer\Tests\Fixer\LanguageConstruct\FunctionToConstantFixerTest::class,
             \PhpCsFixer\Tests\Fixer\LanguageConstruct\SingleSpaceAroundConstructFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\ListNotation\ListSyntaxFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\NamespaceNotation\BlankLinesBeforeNamespaceFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Operator\BinaryOperatorSpacesFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Operator\ConcatSpaceFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Operator\IncrementStyleFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Operator\NewWithParenthesesFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Operator\NoUselessConcatOperatorFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\PhpTag\EchoTagSyntaxFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\PhpTag\NoClosingTagFixerTest::class,
         ];
 
         $exceptionGroup = [
-            'ListNotation',
-            'NamespaceNotation',
-            'Naming',
-            'Operator', // @TODO: remove it before others
-            'PhpTag',
             'PhpUnit',
             'Phpdoc',
             'ReturnNotation',

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -422,16 +422,32 @@ abstract class AbstractFixerTestCase extends TestCase
             \PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitMethodCasingFixerTest::class,
             \PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitStrictFixerTest::class,
             \PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitTestCaseStaticMethodCallsFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\AlignMultilineCommentFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\GeneralPhpdocTagRenameFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\NoBlankLinesAfterPhpdocFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocAddMissingParamAnnotationFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocNoAccessFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocNoAliasTagFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocNoEmptyReturnFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocNoPackageFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocOrderByValueFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocOrderFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocParamOrderFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocReturnSelfReferenceFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocSeparationFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocSummaryFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocTrimFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocTypesOrderFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocVarWithoutNameFixerTest::class,
         ];
 
         self::assertSame(array_unique($exceptionClasses), $exceptionClasses);
         $sorted = $exceptionClasses;
         sort($sorted);
+        // @phpstan-ignore-next-line
         self::assertSame($sorted, $exceptionClasses);
 
-/** @phpstan-ignore-line */
         $exceptionGroup = [
-            'Phpdoc',
             'ReturnNotation',
             'Semicolon',
             'Strict',

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -378,11 +378,22 @@ abstract class AbstractFixerTestCase extends TestCase
             self::markTestSkipped('Not worth refactoring tests for deprecated fixers.');
         }
 
+        // should only shrink, baseline of classes violating method naming
+        $exceptionClasses = [
+            \PhpCsFixer\Tests\Fixer\ClassNotation\ClassAttributesSeparationFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\ClassNotation\ClassDefinitionFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Comment\NoEmptyCommentFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Comment\HeaderCommentFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Comment\SingleLineCommentStyleFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\ConstantNotation\NativeConstantInvocationFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\ControlStructure\NoBreakCommentFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\ControlStructure\NoUselessElseFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\ControlStructure\NoUnneededBracesFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\ControlStructure\NoUnneededControlParenthesesFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\ControlStructure\YodaStyleFixerTest::class,
+        ];
+
         $exceptionGroup = [
-            'ClassUsage',
-            'Comment',
-            'ConstantNotation',
-            'ControlStructure',
             'DoctrineAnnotation',
             'FunctionNotation', // @TODO: remove it before others
             'Import',
@@ -405,19 +416,12 @@ abstract class AbstractFixerTestCase extends TestCase
             self::markTestSkipped('Not covered yet.');
         }
 
-        // should only shrink, baseline of classes violating method naming
-        $exceptionClasses = [
-            \PhpCsFixer\Tests\Fixer\ClassNotation\ClassAttributesSeparationFixerTest::class,
-            \PhpCsFixer\Tests\Fixer\ClassNotation\ClassDefinitionFixerTest::class,
-        ];
-
-        if (in_array(static::class, $exceptionClasses)) {
+        if (\in_array(static::class, $exceptionClasses, true)) {
             self::markTestSkipped('Not covered yet.');
         }
 
-
-        self::assertTrue(method_exists($this, 'testFix'), 'Method testFix does not exist.');
-        self::assertTrue(method_exists($this, 'provideFixCases'), 'Method provideFixCases does not exist.');
+        self::assertTrue(method_exists($this, 'testFix'), sprintf('Method testFix does not exist in %s.', static::class));
+        self::assertTrue(method_exists($this, 'provideFixCases'), sprintf('Method provideFixCases does not exist in %s.', static::class));
 
         $names = ['Fix', 'Fix74Deprecated', 'FixPre80', 'Fix80', 'FixPre81', 'Fix81', 'Fix82', 'Fix83', 'WithWhitespacesConfig', 'InvalidConfiguration'];
         $methodNames = ['testConfigure'];
@@ -437,12 +441,10 @@ abstract class AbstractFixerTestCase extends TestCase
             )
         );
 
-        $extraMethods = array_diff($extraMethods, $exceptions[$reflectionClass->getName()] ?? []);
-
         self::assertSame(
             [],
             $extraMethods,
-            sprintf('Methods "%s" should not be present.', implode('". "', $extraMethods)),
+            sprintf('Methods "%s" should not be present in %s.', implode('". "', $extraMethods), static::class),
         );
     }
 

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -445,21 +445,13 @@ abstract class AbstractFixerTestCase extends TestCase
             \PhpCsFixer\Tests\Fixer\Semicolon\SemicolonAfterInstructionFixerTest::class,
             \PhpCsFixer\Tests\Fixer\Semicolon\SpaceAfterSemicolonFixerTest::class,
             \PhpCsFixer\Tests\Fixer\StringNotation\SingleQuoteFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Whitespace\BlankLineBeforeStatementFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Whitespace\IndentationTypeFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Whitespace\NoExtraBlankLinesFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Whitespace\NoSpacesAroundOffsetFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Whitespace\SpacesInsideParenthesesFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Whitespace\StatementIndentationFixerTest::class,
         ];
-
-        self::assertSame(array_unique($exceptionClasses), $exceptionClasses);
-        $sorted = $exceptionClasses;
-        sort($sorted);
-        // @phpstan-ignore-next-line
-        self::assertSame($sorted, $exceptionClasses);
-
-        $exceptionGroup = [
-            'Whitespace', // @TODO: remove it before others
-        ];
-        $fixerGroup = explode('\\', static::class)[3];
-        if (\in_array($fixerGroup, $exceptionGroup, true)) {
-            self::markTestSkipped('Not covered yet.');
-        }
 
         if (\in_array(static::class, $exceptionClasses, true)) {
             self::markTestSkipped('Not covered yet.');

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -439,6 +439,12 @@ abstract class AbstractFixerTestCase extends TestCase
             \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocTrimFixerTest::class,
             \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocTypesOrderFixerTest::class,
             \PhpCsFixer\Tests\Fixer\Phpdoc\PhpdocVarWithoutNameFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\ReturnNotation\ReturnAssignmentFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Semicolon\MultilineWhitespaceBeforeSemicolonsFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Semicolon\NoEmptyStatementFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Semicolon\SemicolonAfterInstructionFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Semicolon\SpaceAfterSemicolonFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\StringNotation\SingleQuoteFixerTest::class,
         ];
 
         self::assertSame(array_unique($exceptionClasses), $exceptionClasses);
@@ -448,10 +454,6 @@ abstract class AbstractFixerTestCase extends TestCase
         self::assertSame($sorted, $exceptionClasses);
 
         $exceptionGroup = [
-            'ReturnNotation',
-            'Semicolon',
-            'Strict',
-            'StringNotation',
             'Whitespace', // @TODO: remove it before others
         ];
         $fixerGroup = explode('\\', static::class)[3];

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -382,14 +382,14 @@ abstract class AbstractFixerTestCase extends TestCase
         $exceptionClasses = [
             \PhpCsFixer\Tests\Fixer\ClassNotation\ClassAttributesSeparationFixerTest::class,
             \PhpCsFixer\Tests\Fixer\ClassNotation\ClassDefinitionFixerTest::class,
-            \PhpCsFixer\Tests\Fixer\Comment\NoEmptyCommentFixerTest::class,
             \PhpCsFixer\Tests\Fixer\Comment\HeaderCommentFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Comment\NoEmptyCommentFixerTest::class,
             \PhpCsFixer\Tests\Fixer\Comment\SingleLineCommentStyleFixerTest::class,
             \PhpCsFixer\Tests\Fixer\ConstantNotation\NativeConstantInvocationFixerTest::class,
             \PhpCsFixer\Tests\Fixer\ControlStructure\NoBreakCommentFixerTest::class,
-            \PhpCsFixer\Tests\Fixer\ControlStructure\NoUselessElseFixerTest::class,
             \PhpCsFixer\Tests\Fixer\ControlStructure\NoUnneededBracesFixerTest::class,
             \PhpCsFixer\Tests\Fixer\ControlStructure\NoUnneededControlParenthesesFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\ControlStructure\NoUselessElseFixerTest::class,
             \PhpCsFixer\Tests\Fixer\ControlStructure\YodaStyleFixerTest::class,
             \PhpCsFixer\Tests\Fixer\DoctrineAnnotation\DoctrineAnnotationArrayAssignmentFixerTest::class,
             \PhpCsFixer\Tests\Fixer\DoctrineAnnotation\DoctrineAnnotationBracesFixerTest::class,
@@ -416,10 +416,21 @@ abstract class AbstractFixerTestCase extends TestCase
             \PhpCsFixer\Tests\Fixer\Operator\NoUselessConcatOperatorFixerTest::class,
             \PhpCsFixer\Tests\Fixer\PhpTag\EchoTagSyntaxFixerTest::class,
             \PhpCsFixer\Tests\Fixer\PhpTag\NoClosingTagFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitConstructFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitDedicateAssertFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitFqcnAnnotationFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitMethodCasingFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitStrictFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitTestCaseStaticMethodCallsFixerTest::class,
         ];
 
+        self::assertSame(array_unique($exceptionClasses), $exceptionClasses);
+        $sorted = $exceptionClasses;
+        sort($sorted);
+        self::assertSame($sorted, $exceptionClasses);
+
+/** @phpstan-ignore-line */
         $exceptionGroup = [
-            'PhpUnit',
             'Phpdoc',
             'ReturnNotation',
             'Semicolon',

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -391,12 +391,22 @@ abstract class AbstractFixerTestCase extends TestCase
             \PhpCsFixer\Tests\Fixer\ControlStructure\NoUnneededBracesFixerTest::class,
             \PhpCsFixer\Tests\Fixer\ControlStructure\NoUnneededControlParenthesesFixerTest::class,
             \PhpCsFixer\Tests\Fixer\ControlStructure\YodaStyleFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\DoctrineAnnotation\DoctrineAnnotationArrayAssignmentFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\DoctrineAnnotation\DoctrineAnnotationBracesFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\DoctrineAnnotation\DoctrineAnnotationIndentationFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\DoctrineAnnotation\DoctrineAnnotationSpacesFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\FunctionNotation\FopenFlagsFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\FunctionNotation\FunctionDeclarationFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\FunctionNotation\MethodArgumentSpaceFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\FunctionNotation\NativeFunctionInvocationFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\FunctionNotation\ReturnTypeDeclarationFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Import\FullyQualifiedStrictTypesFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Import\GlobalNamespaceImportFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Import\OrderedImportsFixerTest::class,
+            \PhpCsFixer\Tests\Fixer\Import\SingleImportPerStatementFixerTest::class,
         ];
 
         $exceptionGroup = [
-            'DoctrineAnnotation',
-            'FunctionNotation', // @TODO: remove it before others
-            'Import',
             'LanguageConstruct', // @TODO: remove it before others
             'ListNotation',
             'NamespaceNotation',


### PR DESCRIPTION
This one will swap exceptions from per-group to per-class and fix the ones requiring only name changes.