### PR TITLE
feat: Add rule to convert single line PhpDoc to compact notation

### DIFF
--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -724,7 +724,7 @@ PHPDoc
   All items of the given PHPDoc tags must be either left-aligned or (by default) aligned vertically.
 - `phpdoc_annotation_without_dot <./phpdoc/phpdoc_annotation_without_dot.rst>`_
 
-  PHPDoc that only contain a single line should be in compact notation
+  PHPDoc that only contains a single line should be in compact notation
 - `phpdoc_compact_single_line <./phpdoc/phpdoc_compact_single_line.rst>`_
 
   PHPDoc annotation descriptions should not be a sentence.

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -724,6 +724,9 @@ PHPDoc
   All items of the given PHPDoc tags must be either left-aligned or (by default) aligned vertically.
 - `phpdoc_annotation_without_dot <./phpdoc/phpdoc_annotation_without_dot.rst>`_
 
+  PHPDoc that only contain a single line should be in compact notation
+- `phpdoc_compact_single_line <./phpdoc/phpdoc_compact_single_line.rst>`_
+
   PHPDoc annotation descriptions should not be a sentence.
 - `phpdoc_indent <./phpdoc/phpdoc_indent.rst>`_
 

--- a/doc/rules/phpdoc/phpdoc_compact_single_line.rst
+++ b/doc/rules/phpdoc/phpdoc_compact_single_line.rst
@@ -21,7 +21,7 @@ Example #1
    -     * foo
    -     */
    +    /** foo */
-        const INDENT = 1;
+        const COMPACT = 1;
     }
 
 Source class

--- a/doc/rules/phpdoc/phpdoc_compact_single_line.rst
+++ b/doc/rules/phpdoc/phpdoc_compact_single_line.rst
@@ -1,0 +1,30 @@
+======================
+Rule ``phpdoc_compact_single_line``
+======================
+
+Docblocks that only have a single line of content should be in compact notation
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    class DocBlocks
+    {
+   -    /**
+   -     * foo
+   -     */
+   +    /** foo */
+        const INDENT = 1;
+    }
+
+Source class
+------------
+
+`PhpCsFixer\\Fixer\\Phpdoc\\PhpdocCompactSingleLineFixer <./../../../src/Fixer/Phpdoc/PhpdocCompactSingleLineFixer.php>`_

--- a/src/Fixer/Phpdoc/PhpdocCompactSingleLineFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocCompactSingleLineFixer.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Phpdoc;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Preg;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Frank Prins
+ */
+final class PhpdocCompactSingleLineFixer extends AbstractFixer
+{
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'PHPDoc blocks should be single line when only one line of content is present',
+            [new CodeSample("<?php /**\n * This is only one line of content\n  */\n")]
+        );
+    }
+
+    public function getPriority(): int
+    {
+        return 4;
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
+            if (Preg::match('#^/\*\*\n*\s*\*.*\n\*/$#', $token->getContent())) {
+                $tokens[$index] = new Token([T_DOC_COMMENT, Preg::replace('#^/\*\*\n*\s*\*(.*)\n\*/$#', '/** $1 */', $token->getContent())]);
+            }
+        }
+    }
+}

--- a/src/Fixer/Phpdoc/PhpdocCompactSingleLineFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocCompactSingleLineFixer.php
@@ -52,8 +52,8 @@ final class PhpdocCompactSingleLineFixer extends AbstractFixer
                 continue;
             }
 
-            if (Preg::match('#^/\*\*\n*\s*\*.*\n\*/$#', $token->getContent())) {
-                $tokens[$index] = new Token([T_DOC_COMMENT, Preg::replace('#^/\*\*\n*\s*\*(.*)\n\*/$#', '/** $1 */', $token->getContent())]);
+            if (Preg::match('#^/\*\*\n*\s*\*.*\n\s*\*/$#', $token->getContent())) {
+                $tokens[$index] = new Token([T_DOC_COMMENT, Preg::replace('#^/\*\*\n*\s*\*\s*(.*)\n\s*\*/$#', '/** $1 */', $token->getContent())]);
             }
         }
     }

--- a/tests/Fixer/Phpdoc/PhpdocCompactSingleLineFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocCompactSingleLineFixerTest.php
@@ -65,7 +65,7 @@ final class PhpdocCompactSingleLineFixerTest extends AbstractFixerTestCase
  * @var Foo $foo
  * @var Bar $bar
  */
-            '
+            ',
         ];
     }
 }

--- a/tests/Fixer/Phpdoc/PhpdocCompactSingleLineFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocCompactSingleLineFixerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Phpdoc;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Frank Prins
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Phpdoc\PhpdocCompactSingleLineFixer
+ */
+final class PhpdocCompactSingleLineFixerTest extends AbstractFixerTestCase
+{
+    /** @dataProvider provideFixCases */
+    public function testFix(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFixCases(): iterable
+    {
+        yield ['<?php /** @var Foo $foo */'];
+
+        yield ['<?php /** bar */'];
+
+        yield [
+            '<?php
+/**
+ * @var Foo $foo
+ */
+            ',
+            '<?php
+/** @var Foo @foo */
+            '
+        ];
+
+        yield [
+            '<?php
+/**
+ * bar
+ */
+            ',
+            '<?php
+/** bar */
+            '
+        ];
+
+        yield [
+            '<?php
+/**
+ * @var Foo $foo
+ * @var Bar $bar
+ */
+            '
+        ];
+    }
+}

--- a/tests/Fixer/Phpdoc/PhpdocCompactSingleLineFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocCompactSingleLineFixerTest.php
@@ -45,7 +45,7 @@ final class PhpdocCompactSingleLineFixerTest extends AbstractFixerTestCase
             ',
             '<?php
 /** @var Foo @foo */
-            '
+            ',
         ];
 
         yield [
@@ -56,7 +56,7 @@ final class PhpdocCompactSingleLineFixerTest extends AbstractFixerTestCase
             ',
             '<?php
 /** bar */
-            '
+            ',
         ];
 
         yield [

--- a/tests/Fixer/Phpdoc/PhpdocCompactSingleLineFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocCompactSingleLineFixerTest.php
@@ -39,23 +39,23 @@ final class PhpdocCompactSingleLineFixerTest extends AbstractFixerTestCase
 
         yield [
             '<?php
+/** @var Foo $foo */
+            ',
+            '<?php
 /**
  * @var Foo $foo
  */
-            ',
-            '<?php
-/** @var Foo @foo */
             ',
         ];
 
         yield [
             '<?php
+/** bar */
+            ',
+            '<?php
 /**
  * bar
  */
-            ',
-            '<?php
-/** bar */
             ',
         ];
 


### PR DESCRIPTION
This PR adds a rule to convert single line PHPDoc to compact notation:
```diff
- /**
-  * foo
-  */
+ /** foo */
```

Converting from long to compact notation makes more lines of code fit onto a screen