### PR TITLE
DX: remove `@group` annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage == 'yes'
         env:
           FAST_LINT_TEST_CASES: 1
-        run: vendor/bin/paraunit coverage --testsuite unit --exclude-group covers-nothing --clover build/logs/clover.xml
+        run: vendor/bin/paraunit coverage --testsuite unit --clover build/logs/clover.xml
 
       - name: Upload coverage results to Coveralls
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage == 'yes'

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -37,7 +37,10 @@ return (new PhpCsFixer\Config())
         '@PHPUnit100Migration:risky' => true,
         '@PhpCsFixer' => true,
         '@PhpCsFixer:risky' => true,
-        'general_phpdoc_annotation_remove' => ['annotations' => ['expectedDeprecation']], // one should use PHPUnit built-in method instead
+        'general_phpdoc_annotation_remove' => ['annotations' => [
+            'expectedDeprecation', // one should use PHPUnit built-in method instead
+            'group',
+        ]],
         'header_comment' => ['header' => $header],
         'modernize_strpos' => true, // needs PHP 8+ or polyfill
         'no_useless_concat_operator' => false, // TODO switch back on when the `src/Console/Application.php` no longer needs the concat

--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
         ],
         "test:coverage": [
             "Composer\\Config::disableProcessTimeout",
-            "paraunit coverage --testsuite unit --exclude-group covers-nothing"
+            "paraunit coverage --testsuite unit"
         ],
         "test:integration": [
             "Composer\\Config::disableProcessTimeout",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,11 +22,13 @@
         <testsuite name="unit">
             <directory>./tests/</directory>
             <exclude>./tests/IntegrationTest.php</exclude>
+            <exclude>./tests/TextDiffTest.php</exclude>
             <exclude>./tests/AutoReview/</exclude>
             <exclude>./tests/Smoke/</exclude>
         </testsuite>
         <testsuite name="integration">
             <file>./tests/IntegrationTest.php</file>
+            <file>./tests/TextDiffTest.php</file>
         </testsuite>
         <testsuite name="smoke">
             <directory>./tests/Smoke/</directory>

--- a/tests/AutoReview/CiConfigurationTest.php
+++ b/tests/AutoReview/CiConfigurationTest.php
@@ -26,9 +26,6 @@ use Symfony\Component\Yaml\Yaml;
  * @internal
  *
  * @coversNothing
- *
- * @group auto-review
- * @group covers-nothing
  */
 final class CiConfigurationTest extends TestCase
 {

--- a/tests/AutoReview/CommandTest.php
+++ b/tests/AutoReview/CommandTest.php
@@ -24,9 +24,6 @@ use Symfony\Component\Console\Command\Command;
  * @internal
  *
  * @coversNothing
- *
- * @group auto-review
- * @group covers-nothing
  */
 final class CommandTest extends TestCase
 {

--- a/tests/AutoReview/ComposerFileTest.php
+++ b/tests/AutoReview/ComposerFileTest.php
@@ -20,9 +20,6 @@ use PhpCsFixer\Tests\TestCase;
  * @internal
  *
  * @coversNothing
- *
- * @group covers-nothing
- * @group auto-review
  */
 final class ComposerFileTest extends TestCase
 {

--- a/tests/AutoReview/DescribeCommandTest.php
+++ b/tests/AutoReview/DescribeCommandTest.php
@@ -24,10 +24,6 @@ use Symfony\Component\Console\Tester\CommandTester;
  * @internal
  *
  * @coversNothing
- *
- * @group legacy
- * @group auto-review
- * @group covers-nothing
  */
 final class DescribeCommandTest extends TestCase
 {

--- a/tests/AutoReview/DocumentationTest.php
+++ b/tests/AutoReview/DocumentationTest.php
@@ -28,9 +28,6 @@ use Symfony\Component\Finder\Finder;
  * @internal
  *
  * @coversNothing
- *
- * @group legacy
- * @group auto-review
  */
 final class DocumentationTest extends TestCase
 {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -26,9 +26,6 @@ use Symfony\Component\Finder\SplFileInfo;
  * @internal
  *
  * @coversNothing
- *
- * @group auto-review
- * @group covers-nothing
  */
 final class FixerFactoryTest extends TestCase
 {

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -35,9 +35,6 @@ use Symfony\Component\Finder\SplFileInfo;
  * @internal
  *
  * @coversNothing
- *
- * @group auto-review
- * @group covers-nothing
  */
 final class ProjectCodeTest extends TestCase
 {

--- a/tests/AutoReview/ProjectFixerConfigurationTest.php
+++ b/tests/AutoReview/ProjectFixerConfigurationTest.php
@@ -23,9 +23,6 @@ use PhpCsFixer\ToolInfo;
  * @internal
  *
  * @coversNothing
- *
- * @group auto-review
- * @group covers-nothing
  */
 final class ProjectFixerConfigurationTest extends TestCase
 {

--- a/tests/AutoReview/ReadmeTest.php
+++ b/tests/AutoReview/ReadmeTest.php
@@ -22,9 +22,6 @@ use PhpCsFixer\Tests\TestCase;
  * @internal
  *
  * @coversNothing
- *
- * @group auto-review
- * @group covers-nothing
  */
 final class ReadmeTest extends TestCase
 {

--- a/tests/AutoReview/TransformerTest.php
+++ b/tests/AutoReview/TransformerTest.php
@@ -24,9 +24,6 @@ use PhpCsFixer\Tokenizer\Transformers;
  * @internal
  *
  * @coversNothing
- *
- * @group auto-review
- * @group covers-nothing
  */
 final class TransformerTest extends TestCase
 {

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -42,8 +42,6 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  *
- * @group legacy
- *
  * @covers \PhpCsFixer\Console\Command\DescribeCommand
  */
 final class DescribeCommandTest extends TestCase

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1174,8 +1174,6 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
      * @param array<string, mixed>|bool $ruleConfig
      *
      * @dataProvider provideDeprecatedFixerConfiguredCases
-     *
-     * @group legacy
      */
     public function testDeprecatedFixerConfigured($ruleConfig): void
     {
@@ -1200,8 +1198,6 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
 
     /**
      * @dataProvider provideDeprecatedRuleSetConfiguredCases
-     *
-     * @group legacy
      *
      * @param array<string> $successors
      */

--- a/tests/DocBlock/TagComparatorTest.php
+++ b/tests/DocBlock/TagComparatorTest.php
@@ -31,8 +31,6 @@ final class TagComparatorTest extends TestCase
 {
     /**
      * @dataProvider provideComparatorTogetherCases
-     *
-     * @group legacy
      */
     public function testComparatorTogether(string $first, string $second, bool $expected): void
     {
@@ -69,8 +67,6 @@ final class TagComparatorTest extends TestCase
      * @dataProvider provideComparatorTogetherWithDefinedGroupsCases
      *
      * @param string[][] $groups
-     *
-     * @group legacy
      */
     public function testComparatorTogetherWithDefinedGroups(array $groups, string $first, string $second, bool $expected): void
     {

--- a/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
+++ b/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
@@ -64,8 +64,6 @@ final class LowercaseCastFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFix74DeprecatedCases
      *
-     * @group legacy
-     *
      * @requires PHP <8.0
      */
     public function testFix74Deprecated(string $expected, ?string $input = null): void

--- a/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
+++ b/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
@@ -77,8 +77,6 @@ final class ShortScalarCastFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFix74DeprecatedCases
      *
-     * @group legacy
-     *
      * @requires PHP <8.0
      */
     public function testFix74Deprecated(string $expected, ?string $input = null): void

--- a/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
@@ -343,8 +343,6 @@ $a = new class{};',
     }
 
     /**
-     * @group legacy
-     *
      * @param array<mixed> $config
      *
      * @dataProvider provideInvalidConfigurationCases

--- a/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
@@ -21,8 +21,6 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  *
  * @internal
  *
- * @group phpdoc
- *
  * @covers \PhpCsFixer\Fixer\FunctionNotation\PhpdocToParamTypeFixer
  */
 final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase

--- a/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
@@ -19,8 +19,6 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 /**
  * @internal
  *
- * @group phpdoc
- *
  * @covers \PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer
  */
 final class PhpdocToPropertyTypeFixerTest extends AbstractFixerTestCase

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -21,8 +21,6 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  *
  * @internal
  *
- * @group phpdoc
- *
  * @covers \PhpCsFixer\Fixer\FunctionNotation\PhpdocToReturnTypeFixer
  */
 final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -669,8 +669,6 @@ $a = new Qux();',
 
     /**
      * @dataProvider provideRemoveBetweenUseTraitsCases
-     *
-     * @group legacy
      */
     public function testRemoveBetweenUseTraits(string $expected, string $input): void
     {

--- a/tests/FixerConfiguration/FixerConfigurationResolverTest.php
+++ b/tests/FixerConfiguration/FixerConfigurationResolverTest.php
@@ -28,8 +28,6 @@ use Symfony\Component\OptionsResolver\Options;
 /**
  * @internal
  *
- * @group legacy
- *
  * @covers \PhpCsFixer\FixerConfiguration\FixerConfigurationResolver
  */
 final class FixerConfigurationResolverTest extends TestCase

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -25,8 +25,6 @@ use PhpCsFixer\Tests\Test\InternalIntegrationCaseFactory;
  * @internal
  *
  * @coversNothing
- *
- * @group covers-nothing
  */
 final class IntegrationTest extends AbstractIntegrationTestCase
 {

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -30,8 +30,6 @@ use PhpCsFixer\Tests\TestCase;
  *
  * @internal
  *
- * @group legacy
- *
  * @covers \PhpCsFixer\RuleSet\RuleSet
  */
 final class RuleSetTest extends TestCase

--- a/tests/Smoke/AbstractSmokeTestCase.php
+++ b/tests/Smoke/AbstractSmokeTestCase.php
@@ -24,7 +24,5 @@ use PhpCsFixer\Tests\TestCase;
  * @requires OS Linux|Darwin
  *
  * @coversNothing
- *
- * @group covers-nothing
  */
 abstract class AbstractSmokeTestCase extends TestCase {}

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -28,8 +28,6 @@ use PhpCsFixer\Console\Application;
  *
  * @coversNothing
  *
- * @group covers-nothing
- *
  * @large
  */
 final class CiIntegrationTest extends AbstractSmokeTestCase

--- a/tests/Smoke/InstallViaComposerTest.php
+++ b/tests/Smoke/InstallViaComposerTest.php
@@ -26,8 +26,6 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * @coversNothing
  *
- * @group covers-nothing
- *
  * @large
  */
 final class InstallViaComposerTest extends AbstractSmokeTestCase

--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -27,9 +27,6 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @coversNothing
  *
- * @group covers-nothing
- * @group legacy
- *
  * @large
  */
 final class PharTest extends AbstractSmokeTestCase

--- a/tests/Smoke/StdinTest.php
+++ b/tests/Smoke/StdinTest.php
@@ -26,8 +26,6 @@ use PhpCsFixer\Preg;
  *
  * @coversNothing
  *
- * @group covers-nothing
- *
  * @large
  */
 final class StdinTest extends AbstractSmokeTestCase

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -136,8 +136,6 @@ abstract class AbstractIntegrationTestCase extends TestCase
      * @see doTest()
      *
      * @large
-     *
-     * @group legacy
      */
     public function testIntegration(IntegrationCase $case): void
     {

--- a/tests/TextDiffTest.php
+++ b/tests/TextDiffTest.php
@@ -24,8 +24,6 @@ use Symfony\Component\Console\Tester\CommandTester;
  * @internal
  *
  * @coversNothing
- *
- * @group covers-nothing
  */
 final class TextDiffTest extends TestCase
 {

--- a/tests/Tokenizer/TokenTest.php
+++ b/tests/Tokenizer/TokenTest.php
@@ -469,8 +469,6 @@ final class TokenTest extends TestCase
      * @param bool|list<bool> $caseSensitive
      *
      * @dataProvider provideIsKeyCaseSensitiveCases
-     *
-     * @group legacy
      */
     public function testIsKeyCaseSensitive(bool $isKeyCaseSensitive, $caseSensitive, int $key): void
     {

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -378,9 +378,6 @@ final class UtilsTest extends TestCase
         ];
     }
 
-    /**
-     * @group legacy
-     */
     public function testTriggerDeprecationWhenFutureModeIsOff(): void
     {
         putenv('PHP_CS_FIXER_FUTURE_MODE=0');


### PR DESCRIPTION
We define tests groups via testsuites, so we don't need `@group` annotation anymore, do we?