### PR TITLE
docs: drop extra note about 8.0.0 bug in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ projects. This tool does not only detect them, but also fixes them for you.
 ## Supported PHP Versions
 
 * PHP 7.4
-* PHP 8.0 (except PHP 8.0.0 due to [bug in PHP tokenizer](https://bugs.php.net/bug.php?id=80462))
+* PHP 8.0
 * PHP 8.1
 * PHP 8.2
 * PHP 8.3


### PR DESCRIPTION
it was needed when 8.0.0 was barely introduced.
now, it affects nobody and rather a noise. if someone would really get impacted by this, they will see it in runtime.