### PR TITLE
fix: Add test case

### DIFF
--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -1390,6 +1390,18 @@ class SomeClass
 }',
         ];
 
+        yield 'Leading backslash in global namespace disabled' => [
+            '<?php
+
+/**
+ * @param \DateTimeInterface $dateTime
+ * @return \DateTimeInterface
+ * @see \DateTimeImmutable
+ * @throws \Exception
+ */
+function foo($dateTime) {}',
+        ];
+
         yield 'Leading backslash in global namespace' => [
             '<?php
 


### PR DESCRIPTION
This pull request

- [x] adds a test case for the `FullyQualifiedStrictTypesFixer`

💁‍♂️ After updating https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/compare/v3.41.1...v3.42.0, the fixer removed a leading slash where I did not expect it to remove one:

```diff
diff --git a/test/Unit/RuleSetTest.php b/test/Unit/RuleSetTest.php
index a308cad..d9801f7 100644
--- a/test/Unit/RuleSetTest.php
+++ b/test/Unit/RuleSetTest.php
@@ -193,7 +193,7 @@ final class RuleSetTest extends Framework\TestCase
     }

     /**
-     * @return \Generator<string, array{0: string}>
+     * @return Generator<string, array{0: string}>
      */
     public static function provideValidHeader(): iterable
     {
```

For reference, see https://github.com/ergebnis/php-cs-fixer-config/pull/963.
