### PR TITLE
chore: Preg - rework catching the error

### DIFF
--- a/src/ExecutorWithoutErrorHandler.php
+++ b/src/ExecutorWithoutErrorHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ */
+final class ExecutorWithoutErrorHandler
+{
+    private function __construct() {}
+
+    /**
+     * @template T
+     *
+     * @param callable(): T $callback
+     *
+     * @return T
+     *
+     * @throws ExecutorWithoutErrorHandlerException
+     */
+    public static function execute(callable $callback): mixed
+    {
+        /** @var ?string */
+        $error = null;
+
+        set_error_handler(static function (int $errorNumber, string $errorString, string $errorFile, int $errorLine) use (&$error): bool {
+            $error = $errorString;
+
+            return true;
+        });
+
+        try {
+            $result = $callback();
+        } finally {
+            restore_error_handler();
+        }
+
+        if (null !== $error) {
+            throw new ExecutorWithoutErrorHandlerException($error);
+        }
+
+        return $result;
+    }
+}

--- a/src/ExecutorWithoutErrorHandlerException.php
+++ b/src/ExecutorWithoutErrorHandlerException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ */
+final class ExecutorWithoutErrorHandlerException extends \RuntimeException {}

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -71,6 +71,8 @@ final class ProjectCodeTest extends TestCase
         \PhpCsFixer\Documentation\FixerDocumentGenerator::class,
         \PhpCsFixer\Documentation\RstUtils::class,
         \PhpCsFixer\Documentation\RuleSetDocumentationGenerator::class,
+        \PhpCsFixer\ExecutorWithoutErrorHandler::class,
+        \PhpCsFixer\ExecutorWithoutErrorHandlerException::class,
         \PhpCsFixer\Runner\FileCachingLintingIterator::class,
     ];
 


### PR DESCRIPTION
Extracted from #7606

PHPUnit migration is not as trivial as some could assume: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7606/commits/4dc05a060ff67469cdf4d6cb45f8890d69449bd2

changing the way of catching internal errors - as... well... you guessed it! PHPUnit is grabbing it with PHPUnit's internal handler!