### PR TITLE
feat: add cast_spaces into `@PER-CS2.0`

### DIFF
--- a/doc/ruleSets/PER-CS2.0.rst
+++ b/doc/ruleSets/PER-CS2.0.rst
@@ -8,6 +8,7 @@ Rules
 -----
 
 - `@PER-CS1.0 <./PER-CS1.0.rst>`_
+- `cast_spaces <./../rules/cast_notation/cast_spaces.rst>`_
 - `concat_space <./../rules/operator/concat_space.rst>`_ with config:
 
   ``['spacing' => 'one']``

--- a/doc/rules/cast_notation/cast_spaces.rst
+++ b/doc/rules/cast_notation/cast_spaces.rst
@@ -69,6 +69,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+- `@PER <./../../ruleSets/PER.rst>`_
+- `@PER-CS <./../../ruleSets/PER-CS.rst>`_
+- `@PER-CS2.0 <./../../ruleSets/PER-CS2.0.rst>`_
 - `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
 - `@Symfony <./../../ruleSets/Symfony.rst>`_
 

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -40,7 +40,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class Application extends BaseApplication
 {
-    public const VERSION = '3.42.0';
+    public const VERSION = '3.42.1-DEV';
     public const VERSION_CODENAME = 'Three Keys';
 
     private ToolInfo $toolInfo;

--- a/src/RuleSet/Sets/PERCS2x0Set.php
+++ b/src/RuleSet/Sets/PERCS2x0Set.php
@@ -34,6 +34,7 @@ final class PERCS2x0Set extends AbstractRuleSetDescription
     {
         return [
             '@PER-CS1.0' => true,
+            'cast_spaces' => true,
             'concat_space' => ['spacing' => 'one'],
             'function_declaration' => [
                 'closure_fn_spacing' => 'none',

--- a/tests/Fixtures/Integration/set/@PER-CS2.0.test-in.php
+++ b/tests/Fixtures/Integration/set/@PER-CS2.0.test-in.php
@@ -38,7 +38,7 @@ class Aaa implements
     }
 
 $a = new Foo;
-$b = (boolean) 1;
+$b = (  boolean  )   1;
 $c = true  ? (INT) '1'  :  2;
 
 $fn = fn ($a) => $a;


### PR DESCRIPTION
PS
rule does to things, fix spaces inside `()` and ensure space after `()`.
PSR + PER1 require first, while PER2 requires both.
I'm not interested to split rule/make it configurable to support old rulesets better