### PR TITLE
feat: UnaryOperatorSpacesFixer - introduce only_dec_inc config

### DIFF
--- a/doc/ruleSets/PSR12.rst
+++ b/doc/ruleSets/PSR12.rst
@@ -47,5 +47,8 @@ Rules
 
 - `single_trait_insert_per_statement <./../rules/class_notation/single_trait_insert_per_statement.rst>`_
 - `ternary_operator_spaces <./../rules/operator/ternary_operator_spaces.rst>`_
-- `unary_operator_spaces <./../rules/operator/unary_operator_spaces.rst>`_
+- `unary_operator_spaces <./../rules/operator/unary_operator_spaces.rst>`_ with config:
+
+  ``['only_dec_inc' => true]``
+
 - `visibility_required <./../rules/class_notation/visibility_required.rst>`_

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -170,5 +170,6 @@ Rules
 - `trim_array_spaces <./../rules/array_notation/trim_array_spaces.rst>`_
 - `type_declaration_spaces <./../rules/whitespace/type_declaration_spaces.rst>`_
 - `types_spaces <./../rules/whitespace/types_spaces.rst>`_
+- `unary_operator_spaces <./../rules/operator/unary_operator_spaces.rst>`_
 - `whitespace_after_comma_in_array <./../rules/array_notation/whitespace_after_comma_in_array.rst>`_
 - `yoda_style <./../rules/control_structure/yoda_style.rst>`_

--- a/doc/rules/operator/unary_operator_spaces.rst
+++ b/doc/rules/operator/unary_operator_spaces.rst
@@ -4,11 +4,25 @@ Rule ``unary_operator_spaces``
 
 Unary operators should be placed adjacent to their operands.
 
+Configuration
+-------------
+
+``only_dec_inc``
+~~~~~~~~~~~~~~~~
+
+Limit to increment and decrement operators.
+
+Allowed types: ``bool``
+
+Default value: ``false``
+
 Examples
 --------
 
 Example #1
 ~~~~~~~~~~
+
+*Default* configuration.
 
 .. code-block:: diff
 
@@ -26,16 +40,57 @@ Example #1
    +$sample = ~$c;
    +function &foo(){}
 
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['only_dec_inc' => false]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -function foo($a, ...   $b) { return (--   $a) * ($b   ++);}
+   +function foo($a, ...$b) { return (--$a) * ($b++);}
+
+Example #3
+~~~~~~~~~~
+
+With configuration: ``['only_dec_inc' => true]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -function foo($a, ...   $b) { return (--   $a) * ($b   ++);}
+   +function foo($a, ...   $b) { return (--$a) * ($b++);}
+
 Rule sets
 ---------
 
 The rule is part of the following rule sets:
 
-- `@PER <./../../ruleSets/PER.rst>`_
-- `@PER-CS <./../../ruleSets/PER-CS.rst>`_
-- `@PER-CS1.0 <./../../ruleSets/PER-CS1.0.rst>`_
-- `@PER-CS2.0 <./../../ruleSets/PER-CS2.0.rst>`_
-- `@PSR12 <./../../ruleSets/PSR12.rst>`_
+- `@PER <./../../ruleSets/PER.rst>`_ with config:
+
+  ``['only_dec_inc' => true]``
+
+- `@PER-CS <./../../ruleSets/PER-CS.rst>`_ with config:
+
+  ``['only_dec_inc' => true]``
+
+- `@PER-CS1.0 <./../../ruleSets/PER-CS1.0.rst>`_ with config:
+
+  ``['only_dec_inc' => true]``
+
+- `@PER-CS2.0 <./../../ruleSets/PER-CS2.0.rst>`_ with config:
+
+  ``['only_dec_inc' => true]``
+
+- `@PSR12 <./../../ruleSets/PSR12.rst>`_ with config:
+
+  ``['only_dec_inc' => true]``
+
 - `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
 - `@Symfony <./../../ruleSets/Symfony.rst>`_
 

--- a/src/RuleSet/Sets/PSR12Set.php
+++ b/src/RuleSet/Sets/PSR12Set.php
@@ -64,7 +64,9 @@ final class PSR12Set extends AbstractRuleSetDescription
             'single_import_per_statement' => ['group_to_single_imports' => false],
             'single_trait_insert_per_statement' => true,
             'ternary_operator_spaces' => true,
-            'unary_operator_spaces' => true,
+            'unary_operator_spaces' => [
+                'only_dec_inc' => true,
+            ],
             'visibility_required' => true,
         ];
     }

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -211,6 +211,7 @@ final class SymfonySet extends AbstractRuleSetDescription
             'trim_array_spaces' => true,
             'type_declaration_spaces' => true,
             'types_spaces' => true,
+            'unary_operator_spaces' => true,
             'whitespace_after_comma_in_array' => true,
             'yoda_style' => true,
         ];

--- a/tests/Fixer/Operator/UnaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/UnaryOperatorSpacesFixerTest.php
@@ -26,10 +26,13 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class UnaryOperatorSpacesFixerTest extends AbstractFixerTestCase
 {
     /**
+     * @param array<string, mixed> $configuration
+     *
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $input = null, array $configuration = []): void
     {
+        $this->fixer->configure($configuration);
         $this->doTest($expected, $input);
     }
 
@@ -136,6 +139,18 @@ final class UnaryOperatorSpacesFixerTest extends AbstractFixerTestCase
         yield [
             '<?php foo($a, ...$b);',
             '<?php foo($a, ... $b);',
+        ];
+
+        yield [
+            '<?php function foo($a, ...$b) { return (--$a) * ($b++);}',
+            '<?php function foo($a, ...   $b) { return (--   $a) * ($b   ++);}',
+            ['only_dec_inc' => false],
+        ];
+
+        yield [
+            '<?php function foo($a, ...   $b) { return (--$a) * ($b++);}',
+            '<?php function foo($a, ...   $b) { return (--   $a) * ($b   ++);}',
+            ['only_dec_inc' => true],
         ];
     }
 }

--- a/tests/Fixtures/Integration/set/@PSR12.test-in.php
+++ b/tests/Fixtures/Integration/set/@PSR12.test-in.php
@@ -39,4 +39,6 @@ $a = new Foo;
 $b = (boolean) 1;
 $c = true  ? (INT) '1'  :  2;
 
+function callback($a, ...   $b) { return (--   $a) * ($b   ++);}
+
 ?>

--- a/tests/Fixtures/Integration/set/@PSR12.test-out.php
+++ b/tests/Fixtures/Integration/set/@PSR12.test-out.php
@@ -48,3 +48,8 @@ class Aaa implements
 $a = new Foo();
 $b = (bool) 1;
 $c = true ? (int) '1' : 2;
+
+function callback($a, ...   $b)
+{
+    return (--$a) * ($b++);
+}

--- a/tests/Fixtures/Integration/set/@PSR12_php70.test-in.php
+++ b/tests/Fixtures/Integration/set/@PSR12_php70.test-in.php
@@ -4,8 +4,6 @@ declare(strict_types = 1 );
 
 function foo() : void
 {
-    $a =& $b;
-    $c =  &  $d;
 }
 
 $class = new class() {};

--- a/tests/Fixtures/Integration/set/@PSR12_php70.test-out.php
+++ b/tests/Fixtures/Integration/set/@PSR12_php70.test-out.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 function foo(): void
 {
-    $a = &$b;
-    $c =  &$d;
 }
 
 $class = new class () {};

--- a/tests/Fixtures/Integration/set/@Symfony.test-in.php
+++ b/tests/Fixtures/Integration/set/@Symfony.test-in.php
@@ -116,4 +116,9 @@ final class FinalClass
     final function finalMethod(){}
 }
 
+function callback($a, ...   $b) { return (--   $a) * ($b   ++);}
+
+$a =& $b;
+$c =  &  $d;
+
 echo 1 ?>

--- a/tests/Fixtures/Integration/set/@Symfony.test-out.php
+++ b/tests/Fixtures/Integration/set/@Symfony.test-out.php
@@ -114,4 +114,12 @@ final class FinalClass
     }
 }
 
+function callback($a, ...$b)
+{
+    return (--$a) * ($b++);
+}
+
+$a = &$b;
+$c = &$d;
+
 echo 1;


### PR DESCRIPTION
Closes #7552


This rule is responsible only for ++/--, type casting is part of `cast_spaces` and thus vide #7625