### PR TITLE
feat: Configurable phpDoc tags for FQCN processing

### DIFF
--- a/doc/rules/import/fully_qualified_strict_types.rst
+++ b/doc/rules/import/fully_qualified_strict_types.rst
@@ -29,6 +29,16 @@ Allowed types: ``bool``
 
 Default value: ``false``
 
+``phpdoc_tags``
+~~~~~~~~~~~~~~~
+
+Collection of PHPDoc annotation tags where FQCNs should be processed. As of now
+only simple tags with ``@tag \F\Q\C\N`` format are supported (no complex types).
+
+Allowed types: ``array``
+
+Default value: ``['param', 'phpstan-param', 'phpstan-property', 'phpstan-property-read', 'phpstan-property-write', 'phpstan-return', 'phpstan-var', 'property', 'property-read', 'property-write', 'psalm-param', 'psalm-property', 'psalm-property-read', 'psalm-property-write', 'psalm-return', 'psalm-var', 'return', 'see', 'throws', 'var']``
+
 Examples
 --------
 

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -288,13 +288,19 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
      */
     private function fixPhpDoc(Tokens $tokens, int $index, array $uses, string $namespaceName): void
     {
+        $allowedTags = $this->configuration['phpdoc_tags'];
+
+        if ([] === $allowedTags) {
+            return;
+        }
+
         $phpDoc = $tokens[$index];
         $phpDocContent = $phpDoc->getContent();
         Preg::matchAll('#@([^\s]+)\s+([^\s]+)#', $phpDocContent, $matches);
 
         if ([] !== $matches) {
             foreach ($matches[2] as $i => $typeName) {
-                if (!\in_array($matches[1][$i], $this->configuration['phpdoc_tags'], true)) {
+                if (!\in_array($matches[1][$i], $allowedTags, true)) {
                     continue;
                 }
 

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -188,6 +188,34 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)
                 ->getOption(),
+            (new FixerOptionBuilder(
+                'phpdoc_tags',
+                'Collection of PHPDoc annotation tags where FQCNs should be processed. As of now only simple tags with `@tag \F\Q\C\N` format are supported (no complex types).'
+            ))
+                ->setAllowedTypes(['array'])
+                ->setDefault([
+                    'param',
+                    'phpstan-param',
+                    'phpstan-property',
+                    'phpstan-property-read',
+                    'phpstan-property-write',
+                    'phpstan-return',
+                    'phpstan-var',
+                    'property',
+                    'property-read',
+                    'property-write',
+                    'psalm-param',
+                    'psalm-property',
+                    'psalm-property-read',
+                    'psalm-property-write',
+                    'psalm-return',
+                    'psalm-var',
+                    'return',
+                    'see',
+                    'throws',
+                    'var',
+                ])
+                ->getOption(),
         ]);
     }
 
@@ -266,7 +294,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
 
         if ([] !== $matches) {
             foreach ($matches[2] as $i => $typeName) {
-                if (!\in_array($matches[1][$i], ['param', 'return', 'see', 'throws', 'var'], true)) {
+                if (!\in_array($matches[1][$i], $this->configuration['phpdoc_tags'], true)) {
                     continue;
                 }
 

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -1072,7 +1072,7 @@ class Two
     }
 
     /**
-     * @return iterable<string, array{0: string, 1?: string, 2?: array<string, mixed>}>
+     * @return iterable<string, array{0: string, 1?: null|string, 2?: array<string, mixed>}>
      */
     public static function provideCodeWithPhpDocCases(): iterable
     {
@@ -1251,14 +1251,24 @@ use Foo\Bar\SomeClass;
 /**
  * @see Baz
  * @see Bam
+ *
+ * @property SomeClass $foo
+ * @property-read Buz $buz
+ * @property-write Baz $baz
+ * @phpstan-property SomeClass $foo
+ * @phpstan-property-read Buz $buz
+ * @phpstan-property-write Baz $baz
+ * @psalm-property SomeClass $foo
+ * @psalm-property-read Buz $buz
+ * @psalm-property-write Baz $baz
  */
 interface SomeClass
 {
     /**
     * @param SomeClass $foo
-    * @param Buz $buz
+    * @phpstan-param Buz $buz
     *
-    * @return Baz
+    * @psalm-return Baz
     */
     public function doSomething(SomeClass $foo, Buz $buz): Baz;
 }',
@@ -1273,14 +1283,24 @@ use Foo\Bar\SomeClass;
 /**
  * @see \Foo\Bar\Baz
  * @see \Foo\Bar\Bam
+ *
+ * @property \Foo\Bar\SomeClass $foo
+ * @property-read \Foo\Bar\Buz $buz
+ * @property-write \Foo\Bar\Baz $baz
+ * @phpstan-property \Foo\Bar\SomeClass $foo
+ * @phpstan-property-read \Foo\Bar\Buz $buz
+ * @phpstan-property-write \Foo\Bar\Baz $baz
+ * @psalm-property \Foo\Bar\SomeClass $foo
+ * @psalm-property-read \Foo\Bar\Buz $buz
+ * @psalm-property-write \Foo\Bar\Baz $baz
  */
 interface SomeClass
 {
     /**
     * @param \Foo\Bar\SomeClass $foo
-    * @param \Foo\Bar\Buz $buz
+    * @phpstan-param \Foo\Bar\Buz $buz
     *
-    * @return \Foo\Bar\Baz
+    * @psalm-return \Foo\Bar\Baz
     */
     public function doSomething(\Foo\Bar\SomeClass $foo, \Foo\Bar\Buz $buz): \Foo\Bar\Baz;
 }',
@@ -1410,6 +1430,85 @@ function foo($dateTime) {}',
  */
 function foo($dateTime) {}',
             ['leading_backslash_in_global_namespace' => true],
+        ];
+
+        yield 'Do not touch PHPDoc if configured with empty collection' => [
+            '<?php
+
+namespace Foo\Bar;
+
+use Foo\Bar\Buz;
+use Foo\Bar\Baz;
+use Foo\Bar\SomeClass;
+
+/**
+ * @see \Foo\Bar\Baz
+ * @see \Foo\Bar\Bam
+ *
+ * @property \Foo\Bar\SomeClass $foo
+ * @property-read \Foo\Bar\Buz $buz
+ * @property-write \Foo\Bar\Baz $baz
+ */
+interface SomeClass
+{
+    /**
+    * @param \Foo\Bar\SomeClass $foo
+    * @phpstan-param \Foo\Bar\Buz $buz
+    *
+    * @psalm-return \Foo\Bar\Baz
+    */
+    public function doSomething($foo, $buz);
+}',
+            null,
+            ['phpdoc_tags' => []],
+        ];
+
+        yield 'Process only specified PHPDoc annotation' => [
+            '<?php
+
+namespace Foo\Bar;
+
+use Foo\Baz\Buzz;
+
+/**
+ * @see \Foo\Baz\Buzz
+ *
+ * @property \Foo\Baz\Buzz $buzz1
+ * @property-read Buzz $buzz2
+ */
+interface SomeClass
+{
+    /**
+    * @param \Foo\Baz\Buzz $a
+    * @phpstan-param Buzz $b
+    *
+    * @psalm-return \Foo\Baz\Buzz
+    */
+    public function doSomething($a, $b): void;
+}',
+            '<?php
+
+namespace Foo\Bar;
+
+use Foo\Baz\Buzz;
+
+/**
+ * @see \Foo\Baz\Buzz
+ *
+ * @property \Foo\Baz\Buzz $buzz1
+ * @property-read \Foo\Baz\Buzz $buzz2
+ */
+interface SomeClass
+{
+    /**
+    * @param \Foo\Baz\Buzz $a
+    * @phpstan-param \Foo\Baz\Buzz $b
+    *
+    * @psalm-return \Foo\Baz\Buzz
+    */
+    public function doSomething($a, $b): void;
+}',
+            ['phpdoc_tags' => ['property-read', 'phpstan-param']],
         ];
     }
 


### PR DESCRIPTION
Fixes #7620 by providing ability to choose which phpDoc tags should be processed (in that case `@see` can be omitted and  than problem is solved). I chose the approach with configurable list of phpDoc tags because it's more flexible - not only it allows disabling phpDoc support completely, but also allows narrowing/widening default scope by providing custom list of tags.