### PR TITLE
fix: PhpdocToReturnTypeFixerTest - support for arrow functions

### DIFF
--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -370,6 +370,31 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
             '<?php /** @return int */ fn(): int => 1;',
             '<?php /** @return int */ fn() => 1;',
         ];
+
+        yield 'support for arrow function' => [
+            '<?php
+            Utils::stableSort(
+                $elements,
+                /**
+                 * @param int $a
+                 *
+                 * @return array
+                 */
+                static fn($a): array => [$a],
+                fn($a, $b) => 1,
+            );',
+            '<?php
+            Utils::stableSort(
+                $elements,
+                /**
+                 * @param int $a
+                 *
+                 * @return array
+                 */
+                static fn($a) => [$a],
+                fn($a, $b) => 1,
+            );',
+        ];
     }
 
     /**


### PR DESCRIPTION
for now, proving bug.
notived on #7644