### PR TITLE
fix: `fully_qualified_strict_types` with `leading_backslash_in_global_namespace` enabled - handle reserved types in phpDoc

### DIFF
--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -1541,25 +1541,53 @@ class SomeClass
 }',
         ];
 
-        yield 'Leading backslash in global namespace' => [
+        yield 'Leading backslash in global namespace - standard phpdoc' => [
             '<?php
 
 /**
  * @param \DateTimeInterface $dateTime
+ * @param callable(): (\Closure(): void) $fx
  * @return \DateTimeInterface
  * @see \DateTimeImmutable
  * @throws \Exception
  */
-function foo($dateTime) {}',
+function foo($dateTime, $fx) {}',
             '<?php
 
 /**
  * @param DateTimeInterface $dateTime
+ * @param callable(): (\Closure(): void) $fx
  * @return DateTimeInterface
  * @see DateTimeImmutable
  * @throws Exception
  */
-function foo($dateTime) {}',
+function foo($dateTime, $fx) {}',
+            ['leading_backslash_in_global_namespace' => true],
+        ];
+
+        yield 'Leading backslash in global namespace - reserved phpdoc' => [
+            '<?php
+
+/**
+ * @param int $v
+ * @phpstan-param positive-int $v
+ * @param \'GET\'|\'POST\' $method
+ * @param \Closure $fx
+ * @psalm-param Closure(): (callable(): Closure) $fx
+ * @return list<int>
+ */
+function foo($v, $method, $fx) {}',
+            '<?php
+
+/**
+ * @param int $v
+ * @phpstan-param positive-int $v
+ * @param \'GET\'|\'POST\' $method
+ * @param Closure $fx
+ * @psalm-param Closure(): (callable(): Closure) $fx
+ * @return list<int>
+ */
+function foo($v, $method, $fx) {}',
             ['leading_backslash_in_global_namespace' => true],
         ];
 

--- a/tests/Fixtures/Integration/misc/fully_qualified_strict_types-leading_backslash_in_global_namespace.test
+++ b/tests/Fixtures/Integration/misc/fully_qualified_strict_types-leading_backslash_in_global_namespace.test
@@ -1,0 +1,47 @@
+--TEST--
+Integration of fixers: fully_qualified_strict_types /w leading_backslash_in_global_namespace
+--RULESET--
+{
+    "@PhpCsFixer": true,
+    "fully_qualified_strict_types": {"leading_backslash_in_global_namespace": true}
+}
+--EXPECT--
+<?php
+
+/**
+ * @param \DateTime $dateTime
+ * @param int       $v
+ *
+ * @phpstan-param positive-int $v
+ *
+ * @param \'GET\'|\'POST\' $method
+ * @param \Closure $fx
+ *
+ * @psalm-param Closure(): (callable(): Closure) $fx
+ *
+ * @return list<int>
+ */
+function foo($dateTime, $v, $method, $fx) {}
+
+try {
+    fx();
+} catch (\Exception $e) {
+}
+
+--INPUT--
+<?php
+
+/**
+ * @param DateTime $dateTime
+ * @param int $v
+ * @phpstan-param positive-int $v
+ * @param \'GET\'|\'POST\' $method
+ * @param Closure $fx
+ * @psalm-param Closure(): (callable(): Closure) $fx
+ * @return list<int>
+ */
+function foo($dateTime, $v, $method, $fx) {
+}
+
+try { fx(); } catch (Exception $e) {
+}


### PR DESCRIPTION
missed in #5620, tests cherrypicked from #7623

It is super important to not prepend `\` to reserved phpdoc types like `int` otherwise `leading_backslash_in_global_namespace: true` is useless/broken.