### PR TITLE
fix: FQCN parse phpdoc using full grammar regex

### DIFF
--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -290,7 +290,7 @@ final class Annotation
             }
 
             $matchingResult = Preg::match(
-                '{^(?:\s*\*|/\*\*)[\s\*]*@'.$name.'\s+'.TypeExpression::REGEX_TYPES.'(?:(?:[*\h\v]|\&?[\.\$]).*)?\r?$}is',
+                '{^(?:\h*\*|/\*\*)[\h*]*@'.$name.'\h+'.TypeExpression::REGEX_TYPES.'(?:(?:[*\h\v]|\&?[\.\$]).*)?\r?$}is',
                 $this->lines[0]->getContent(),
                 $matches
             );

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -302,26 +302,26 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
 
         $phpDoc = $tokens[$index];
         $phpDocContent = $phpDoc->getContent();
-        $phpDocContentNew = Preg::replaceCallback('/@([^\s]+)(\s+)('.TypeExpression::REGEX_TYPES.')(?!\S)/', function ($matches) use ($allowedTags, &$uses, $namespaceName) {
-            if (!\in_array($matches[1], $allowedTags, true)) {
+        $phpDocContentNew = Preg::replaceCallback('/(\*\s*@)([^\s]+)(\s+)('.TypeExpression::REGEX_TYPES.')(?!\S)/', function ($matches) use ($allowedTags, &$uses, $namespaceName) {
+            if (!\in_array($matches[2], $allowedTags, true)) {
                 return $matches[0];
             }
 
             // TODO fix all, even complex/nested, phpdoc types
-            if (!Preg::match('/^[a-zA-Z0-9_\\\\]+(\|null)?$/', $matches[3])) {
+            if (!Preg::match('/^[a-zA-Z0-9_\\\\]+(\|null)?$/', $matches[4])) {
                 return $matches[0];
             }
 
             if (true === $this->configuration['import_symbols']) {
-                $this->registerSymbolForImport('class', $matches[3], $uses, $namespaceName);
+                $this->registerSymbolForImport('class', $matches[4], $uses, $namespaceName);
             }
 
-            $shortTokens = $this->determineShortType($matches[3], $uses, $namespaceName);
+            $shortTokens = $this->determineShortType($matches[4], $uses, $namespaceName);
             if (null === $shortTokens) {
                 return $matches[0];
             }
 
-            return '@'.$matches[1].$matches[2].implode('', array_map(
+            return $matches[1].$matches[2].$matches[3].implode('', array_map(
                 static fn (Token $token) => $token->getContent(),
                 $shortTokens
             ));

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -307,6 +307,11 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
                 return $matches[0];
             }
 
+            // TODO fix all, even complex/nested, phpdoc types
+            if (!Preg::match('/^[a-zA-Z0-9_\\\\]+$/', $matches[3])) {
+                return $matches[0];
+            }
+
             if (true === $this->configuration['import_symbols']) {
                 $this->registerSymbolForImport('class', $matches[3], $uses, $namespaceName);
             }
@@ -706,8 +711,6 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
             || !str_starts_with($symbol, '\\')
             // or if it's a global symbol
             || strpos($symbol, '\\') === strrpos($symbol, '\\')
-            // or if the symbol is shape/generic/parentheses type
-            || str_contains($symbol, '{') || str_contains($symbol, '<') || str_contains($symbol, '(') || str_contains($symbol, '[')
         ) {
             return;
         }

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -303,31 +303,29 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
         $phpDocContent = $phpDoc->getContent();
         Preg::matchAll('#@([^\s]+)(\s+)([a-zA-Z0-9_\\\\]+)#', $phpDocContent, $matches);
 
-        if ([] !== $matches[0]) {
-            foreach ($matches[3] as $i => $typeName) {
-                if (!\in_array($matches[1][$i], $allowedTags, true)) {
-                    continue;
-                }
+        foreach ($matches[3] as $i => $typeName) {
+            if (!\in_array($matches[1][$i], $allowedTags, true)) {
+                continue;
+            }
 
-                if (true === $this->configuration['import_symbols'] && isset($matches[3][0])) {
-                    $this->registerSymbolForImport('class', $matches[3][0], $uses, $namespaceName);
-                }
+            if (true === $this->configuration['import_symbols'] && isset($matches[3][0])) {
+                $this->registerSymbolForImport('class', $matches[3][0], $uses, $namespaceName);
+            }
 
-                $shortTokens = $this->determineShortType($typeName, $uses, $namespaceName);
+            $shortTokens = $this->determineShortType($typeName, $uses, $namespaceName);
 
-                if (null !== $shortTokens) {
-                    // Replace tag+type in order to avoid replacing type multiple times (when same type is used in multiple places)
-                    $phpDocContent = str_replace(
-                        $matches[0][$i],
-                        '@'.$matches[1][$i].$matches[2][$i].implode('', array_map(
-                            static fn (Token $token) => $token->getContent(),
-                            $shortTokens
-                        )),
-                        $phpDocContent
-                    );
+            if (null !== $shortTokens) {
+                // Replace tag+type in order to avoid replacing type multiple times (when same type is used in multiple places)
+                $phpDocContent = str_replace(
+                    $matches[0][$i],
+                    '@'.$matches[1][$i].$matches[2][$i].implode('', array_map(
+                        static fn (Token $token) => $token->getContent(),
+                        $shortTokens
+                    )),
+                    $phpDocContent
+                );
 
-                    $tokens[$index] = new Token([T_DOC_COMMENT, $phpDocContent]);
-                }
+                $tokens[$index] = new Token([T_DOC_COMMENT, $phpDocContent]);
             }
         }
     }

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -302,7 +302,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
 
         $phpDoc = $tokens[$index];
         $phpDocContent = $phpDoc->getContent();
-        $phpDocContentNew = Preg::replaceCallback('/(\*\h*@)(\S+)(\h+)('.TypeExpression::REGEX_TYPES.')(?!\S)/', function ($matches) use ($allowedTags, &$uses, $namespaceName) {
+        $phpDocContentNew = Preg::replaceCallback('/([*{]\h*@)(\S+)(\h+)('.TypeExpression::REGEX_TYPES.')(?!(?!\})\S)/', function ($matches) use ($allowedTags, &$uses, $namespaceName) {
             if (!\in_array($matches[2], $allowedTags, true)) {
                 return $matches[0];
             }

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -302,7 +302,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
 
         $phpDoc = $tokens[$index];
         $phpDocContent = $phpDoc->getContent();
-        $phpDocContentNew = Preg::replaceCallback('/(\*\s*@)([^\s]+)(\s+)('.TypeExpression::REGEX_TYPES.')(?!\S)/', function ($matches) use ($allowedTags, &$uses, $namespaceName) {
+        $phpDocContentNew = Preg::replaceCallback('/(\*\h*@)([^\s]+)(\h+)('.TypeExpression::REGEX_TYPES.')(?!\S)/', function ($matches) use ($allowedTags, &$uses, $namespaceName) {
             if (!\in_array($matches[2], $allowedTags, true)) {
                 return $matches[0];
             }

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -307,7 +307,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
                 return $matches[0];
             }
 
-            // TODO fix all, even complex/nested, phpdoc types
+            // @TODO parse the complex type using TypeExpression and fix all names inside (like `int|string` or `list<int|string>`)
             if (!Preg::match('/^[a-zA-Z0-9_\\\\]+(\|null)?$/', $matches[4])) {
                 return $matches[0];
             }

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -308,7 +308,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
             }
 
             // TODO fix all, even complex/nested, phpdoc types
-            if (!Preg::match('/^[a-zA-Z0-9_\\\\]+$/', $matches[3])) {
+            if (!Preg::match('/^[a-zA-Z0-9_\\\\]+(\|null)?$/', $matches[3])) {
                 return $matches[0];
             }
 

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace PhpCsFixer\Fixer\Import;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\DocBlock\TypeExpression;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
@@ -301,7 +302,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
 
         $phpDoc = $tokens[$index];
         $phpDocContent = $phpDoc->getContent();
-        Preg::matchAll('#@([^\s]+)(\s+)([a-zA-Z0-9_\\\\]+)#', $phpDocContent, $matches);
+        Preg::matchAll('/@([^\s]+)(\s+)('.TypeExpression::REGEX_TYPES.')(?!\S)/', $phpDocContent, $matches);
 
         foreach ($matches[3] as $i => $typeName) {
             if (!\in_array($matches[1][$i], $allowedTags, true)) {

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -302,7 +302,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
 
         $phpDoc = $tokens[$index];
         $phpDocContent = $phpDoc->getContent();
-        $phpDocContentNew = Preg::replaceCallback('/(\*\h*@)([^\s]+)(\h+)('.TypeExpression::REGEX_TYPES.')(?!\S)/', function ($matches) use ($allowedTags, &$uses, $namespaceName) {
+        $phpDocContentNew = Preg::replaceCallback('/(\*\h*@)(\S+)(\h+)('.TypeExpression::REGEX_TYPES.')(?!\S)/', function ($matches) use ($allowedTags, &$uses, $namespaceName) {
             if (!\in_array($matches[2], $allowedTags, true)) {
                 return $matches[0];
             }

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -706,6 +706,8 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
             || !str_starts_with($symbol, '\\')
             // or if it's a global symbol
             || strpos($symbol, '\\') === strrpos($symbol, '\\')
+            // or if the symbol is shape/generic/parentheses type
+            || str_contains($symbol, '{') || str_contains($symbol, '<') || str_contains($symbol, '(') || str_contains($symbol, '[')
         ) {
             return;
         }

--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -520,11 +520,11 @@ class Foo {
         array $symbolShortNames
     ): bool {
         if ('param' === $annotation->getTag()->getName()) {
-            $regex = '{@param(?:\s+'.TypeExpression::REGEX_TYPES.')?(?!\S)(?:\s+(?:\&\s*)?(?:\.{3}\s*)?\$\S+)?(?:\s+(?<description>(?!\*+\/)\S+))?}s';
+            $regex = '{\*\h*@param(?:\h+'.TypeExpression::REGEX_TYPES.')?(?!\S)(?:\h+(?:\&\h*)?(?:\.{3}\h*)?\$\S+)?(?:\h+(?<description>(?!\*+\/)\S+))?}s';
         } elseif ('var' === $annotation->getTag()->getName()) {
-            $regex = '{@var(?:\s+'.TypeExpression::REGEX_TYPES.')?(?!\S)(?:\s+\$\S+)?(?:\s+(?<description>(?!\*\/)\S+))?}s';
+            $regex = '{\*\h*@var(?:\h+'.TypeExpression::REGEX_TYPES.')?(?!\S)(?:\h+\$\S+)?(?:\h+(?<description>(?!\*\/)\S+))?}s';
         } else {
-            $regex = '{@return(?:\s+'.TypeExpression::REGEX_TYPES.')?(?!\S)(?:\s+(?<description>(?!\*\/)\S+))?}s';
+            $regex = '{\*\h*@return(?:\h+'.TypeExpression::REGEX_TYPES.')?(?!\S)(?:\h+(?<description>(?!\*\/)\S+))?}s';
         }
 
         if (!Preg::match($regex, $annotation->getContent(), $matches)) {

--- a/src/Fixer/Phpdoc/PhpdocOrderByValueFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderByValueFixer.php
@@ -113,7 +113,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
 
                 if (\in_array($type, ['property', 'property-read', 'property-write'], true)) {
                     $replacePattern = sprintf(
-                        '/(?s)\*\s*@%s\s+(?P<optionalTypes>.+\s+)?\$(?P<comparableContent>[^\s]+).*/',
+                        '/(?s)\*\s*@%s\s+(?P<optionalTypes>.+\s+)?\$(?P<comparableContent>\S+).*/',
                         $type
                     );
 

--- a/src/Fixer/Phpdoc/PhpdocParamOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocParamOrderFixer.php
@@ -237,7 +237,7 @@ function m($a, array $b, Foo $c) {}
         $blockMatch = false;
         $blockIndices = [];
 
-        $paramRegex = '/\*\s*@param\s*(?:|'.TypeExpression::REGEX_TYPES.'\s*)&?(?=\$\b)'.preg_quote($identifier).'\b/';
+        $paramRegex = '/\*\h*@param\h*(?:|'.TypeExpression::REGEX_TYPES.'\h*)&?(?=\$\b)'.preg_quote($identifier).'\b/';
 
         foreach ($paramAnnotations as $i => $param) {
             $blockStart = Preg::match('/\s*{\s*/', $param->getContent());

--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -153,7 +153,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements ConfigurableF
 
                 // fix @method parameters types
                 $line = $doc->getLine($annotation->getStart());
-                $line->setContent(Preg::replaceCallback('/@method\s+'.TypeExpression::REGEX_TYPES.'\s+\K(?&callable)/', function (array $matches) {
+                $line->setContent(Preg::replaceCallback('/\*\h*@method\h+'.TypeExpression::REGEX_TYPES.'\h+\K(?&callable)/', function (array $matches) {
                     $typeExpression = new TypeExpression($matches[0], null, []);
 
                     return implode('|', $this->sortTypes($typeExpression));

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -1232,22 +1232,21 @@ use Foo\Bar\Baz;
 use Foo\Bar\Bam;
 
 /**
- * @see Baz|null
- * @see Bam|null
- */
-class SomeClass {}',
-            '<?php
-
-namespace Foo\Bar;
-
-use Foo\Bar\Baz;
-use Foo\Bar\Bam;
-
-/**
  * @see \Foo\Bar\Baz|null
  * @see \Foo\Bar\Bam|null
  */
 class SomeClass {}',
+        ];
+
+        yield 'Test PHPDoc union' => [
+            '<?php
+
+namespace Ns;
+
+/**
+ * @param \Exception|int|null $v
+ */
+function foo($v) {}',
         ];
 
         yield 'Test PHPDoc in interface' => [
@@ -1342,12 +1341,6 @@ final class SomeClass {}',
         ];
 
         yield 'PHPDoc with generics must not crash' => [
-            '<?php
-
-/**
- * @param Iterator<mixed, \SplFileInfo> $iter
- */
-function foo($iter) {}',
             '<?php
 
 /**

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -569,7 +569,6 @@ function foo(A $a, \Other\B $b) {}
         yield '@link shall not crash fixer' => [
             '<?php
 
-use Symfony\Component\Validator\Constraints\Valid;
 /**
  * {@link \Symfony\Component\Validator\Constraints\Valid} is assumed.
  *
@@ -577,15 +576,7 @@ use Symfony\Component\Validator\Constraints\Valid;
  */
 function validate(): void {}
 ',
-            '<?php
-
-/**
- * {@link \Symfony\Component\Validator\Constraints\Valid} is assumed.
- *
- * @return void
- */
-function validate(): void {}
-',
+            null,
             ['import_symbols' => true],
         ];
 

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -1265,7 +1265,7 @@ class SomeClass {}',
 namespace Ns;
 
 /**
- * @param \Exception|int|null $v
+ * @param \Exception|\Exception2|int|null $v
  */
 function foo($v) {}',
         ];

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -569,6 +569,16 @@ function foo(A $a, \Other\B $b) {}
         yield '@link shall not crash fixer' => [
             '<?php
 
+use Symfony\Component\Validator\Constraints\Valid;
+/**
+ * {@link Valid} is assumed.
+ *
+ * @return void
+ */
+function validate(): void {}
+',
+            '<?php
+
 /**
  * {@link \Symfony\Component\Validator\Constraints\Valid} is assumed.
  *
@@ -576,8 +586,7 @@ function foo(A $a, \Other\B $b) {}
  */
 function validate(): void {}
 ',
-            null,
-            ['import_symbols' => true],
+            ['import_symbols' => true, 'phpdoc_tags' => ['link']],
         ];
 
         yield 'import short name only once (ignore consequent same-name, different-namespace symbols)' => [

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -1232,6 +1232,18 @@ use Foo\Bar\Baz;
 use Foo\Bar\Bam;
 
 /**
+ * @see Baz|null
+ * @see Bam|null
+ */
+class SomeClass {}',
+            '<?php
+
+namespace Foo\Bar;
+
+use Foo\Bar\Baz;
+use Foo\Bar\Bam;
+
+/**
  * @see \Foo\Bar\Baz|null
  * @see \Foo\Bar\Bam|null
  */

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -1341,6 +1341,21 @@ namespace Foo\Bar;
 final class SomeClass {}',
         ];
 
+        yield 'PHPDoc with generics must not crash' => [
+            '<?php
+
+/**
+ * @param Iterator<mixed, \SplFileInfo> $iter
+ */
+function foo($iter) {}',
+            '<?php
+
+/**
+ * @param \Iterator<mixed, \SplFileInfo> $iter
+ */
+function foo($iter) {}',
+        ];
+
         yield 'Test multiple PHPDoc blocks' => [
             '<?php
 


### PR DESCRIPTION
This PR fixes all issues with partly parsed phpdoc type.

in short, it matches the type correctly using full grammar regex and then the parsed match is tested if it is a simple type:
- if yes, it is fixed
- if not, it is not fixed, as not supported yet (https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7622#discussion_r1436141100)