### PR TITLE
feat: `@PhpCsFixer` ruleset - enable no_whitespace_before_comma_in_array.after_heredoc

### DIFF
--- a/doc/ruleSets/PhpCsFixer.rst
+++ b/doc/ruleSets/PhpCsFixer.rst
@@ -50,6 +50,10 @@ Rules
 
 - `no_useless_else <./../rules/control_structure/no_useless_else.rst>`_
 - `no_useless_return <./../rules/return_notation/no_useless_return.rst>`_
+- `no_whitespace_before_comma_in_array <./../rules/array_notation/no_whitespace_before_comma_in_array.rst>`_ with config:
+
+  ``['after_heredoc' => true]``
+
 - `ordered_class_elements <./../rules/class_notation/ordered_class_elements.rst>`_
 - `ordered_types <./../rules/class_notation/ordered_types.rst>`_
 - `php_unit_internal_class <./../rules/php_unit/php_unit_internal_class.rst>`_

--- a/doc/rules/array_notation/no_whitespace_before_comma_in_array.rst
+++ b/doc/rules/array_notation/no_whitespace_before_comma_in_array.rst
@@ -77,7 +77,10 @@ The rule is part of the following rule sets:
 
   ``['after_heredoc' => true]``
 
-- `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
+- `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ with config:
+
+  ``['after_heredoc' => true]``
+
 - `@Symfony <./../../ruleSets/Symfony.rst>`_
 
 References

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -105,6 +105,7 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
             ],
             'no_useless_else' => true,
             'no_useless_return' => true,
+            'no_whitespace_before_comma_in_array' => ['after_heredoc' => true],
             'nullable_type_declaration_for_default_null_value' => false,
             'ordered_class_elements' => true,
             'ordered_types' => true,

--- a/tests/Fixer/Alias/BacktickToShellExecFixerTest.php
+++ b/tests/Fixer/Alias/BacktickToShellExecFixerTest.php
@@ -50,8 +50,7 @@ final class BacktickToShellExecFixerTest extends AbstractFixerTestCase
                 <?php
                 `echo a\'b`;
                 `echo 'ab'`;
-                EOT
-            ,
+                EOT,
         ];
 
         yield 'with double quote' => [
@@ -59,8 +58,7 @@ final class BacktickToShellExecFixerTest extends AbstractFixerTestCase
                 <?php
                 `echo a\"b`;
                 `echo 'a"b'`;
-                EOT
-            ,
+                EOT,
         ];
 
         yield 'with backtick' => [
@@ -68,8 +66,7 @@ final class BacktickToShellExecFixerTest extends AbstractFixerTestCase
                 <?php
                 `echo 'a\`b'`;
                 `echo a\\\`b`;
-                EOT
-            ,
+                EOT,
         ];
     }
 }

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -5438,8 +5438,7 @@ if(true) if(true) echo 1; elseif(true) echo 2; else echo 3;',
                 <?php
                 }
 
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
                 if (true) {
@@ -5449,8 +5448,7 @@ if(true) if(true) echo 1; elseif(true) echo 2; else echo 3;',
                 <?php
                 }
 
-                EOT
-            ,
+                EOT,
         ];
 
         yield [
@@ -5463,8 +5461,7 @@ if(true) if(true) echo 1; elseif(true) echo 2; else echo 3;',
                 <?php
                 }
 
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
                 if (true) {
@@ -5474,8 +5471,7 @@ if(true) if(true) echo 1; elseif(true) echo 2; else echo 3;',
                 <?php
                 }
 
-                EOT
-            ,
+                EOT,
         ];
     }
 

--- a/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
+++ b/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
@@ -234,8 +234,7 @@ TXT;
         yield [
             <<<'EXPECTED'
                 <?php echo "Double \" quote \u{200b} inside";
-                EXPECTED
-            ,
+                EXPECTED,
             sprintf(
                 <<<'INPUT'
                     <?php echo 'Double " quote %s inside';
@@ -249,8 +248,7 @@ TXT;
         yield [
             <<<'EXPECTED'
                 <?php echo "Single ' quote \u{200b} inside";
-                EXPECTED
-            ,
+                EXPECTED,
             sprintf(
                 <<<'INPUT'
                     <?php echo 'Single \' quote %s inside';
@@ -267,8 +265,7 @@ TXT;
                     Quotes ' and " to be handled \u{200b} properly \\' and \\"
                 STRING
                 ;
-                EXPECTED
-            ,
+                EXPECTED,
             sprintf(
                 <<<'INPUT'
                     <?php echo <<<'STRING'
@@ -285,8 +282,7 @@ TXT;
         yield [
             <<<'EXPECTED'
                 <?php echo "\\\u{200b}\"";
-                EXPECTED
-            ,
+                EXPECTED,
             sprintf(
                 <<<'INPUT'
                     <?php echo '\\%s"';
@@ -300,8 +296,7 @@ TXT;
         yield [
             <<<'EXPECTED'
                 <?php echo "\\\u{200b}'";
-                EXPECTED
-            ,
+                EXPECTED,
             sprintf(
                 <<<'INPUT'
                     <?php echo '\\%s\'';
@@ -315,8 +310,7 @@ TXT;
         yield [
             <<<'EXPECTED'
                 <?php echo "Backslash 1 \\ \u{200b}";
-                EXPECTED
-            ,
+                EXPECTED,
             sprintf(
                 <<<'INPUT'
                     <?php echo 'Backslash 1 \ %s';
@@ -330,8 +324,7 @@ TXT;
         yield [
             <<<'EXPECTED'
                 <?php echo "Backslash 2 \\ \u{200b}";
-                EXPECTED
-            ,
+                EXPECTED,
             sprintf(
                 <<<'INPUT'
                     <?php echo 'Backslash 2 \\ %s';
@@ -345,8 +338,7 @@ TXT;
         yield [
             <<<'EXPECTED'
                 <?php echo "Backslash 3 \\\\ \u{200b}";
-                EXPECTED
-            ,
+                EXPECTED,
             sprintf(
                 <<<'INPUT'
                     <?php echo 'Backslash 3 \\\ %s';
@@ -360,8 +352,7 @@ TXT;
         yield [
             <<<'EXPECTED'
                 <?php echo "Backslash 4 \\\\ \u{200b}";
-                EXPECTED
-            ,
+                EXPECTED,
             sprintf(
                 <<<'INPUT'
                     <?php echo 'Backslash 4 \\\\ %s';

--- a/tests/Fixer/ClassNotation/NoPhp4ConstructorFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoPhp4ConstructorFixerTest.php
@@ -73,8 +73,7 @@ final class NoPhp4ConstructorFixerTest extends AbstractFixerTestCase
                         var_dump(1);
                     }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -102,8 +101,7 @@ final class NoPhp4ConstructorFixerTest extends AbstractFixerTestCase
                     )#
                     {}
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -1029,8 +1027,7 @@ final class NoPhp4ConstructorFixerTest extends AbstractFixerTestCase
                         var_dump(1);
                     }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -57,8 +57,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                 <?php
 
                 class Foo { const C1 = 1; protected $abc = 'abc'; public function baz($y, $z) {} private function bar1($x) { return 1; } }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -91,8 +90,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
 
                     public function def();
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -202,8 +200,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     {
                     } // end foo5
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -305,8 +302,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     public function foo($a) { return 1; }
                     public function baz() {}
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -339,8 +335,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     protected function abc() {
                     }
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -372,8 +367,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     }
                 }
 
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -425,8 +419,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     protected static function protStatFunc() {}
                     public function __destruct() {}
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -459,8 +452,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     public $pubProp3;
                     protected static function protStatFunc() {}
                 }
-                EOT
-            ,
+                EOT,
             ['order' => ['use_trait', 'constant', 'property', 'construct', 'method', 'destruct']],
         ];
 
@@ -497,8 +489,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     use BarTrait;
                     use BazTrait;
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -531,8 +522,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     public $pubProp3;
                     protected static function protStatFunc() {}
                 }
-                EOT
-            ,
+                EOT,
             ['order' => ['public', 'protected', 'private']],
         ];
 
@@ -569,8 +559,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     protected function protFunc() {}
                     private function privFunc() {}
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -603,8 +592,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     public $pubProp3;
                     protected static function protStatFunc() {}
                 }
-                EOT
-            ,
+                EOT,
             [
                 'order' => [
                     'use_trait',
@@ -665,8 +653,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     protected static function protStatFunc() {}
                     public function __destruct() {}
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -703,8 +690,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     public $pubProp3;
                     protected static function protStatFunc() {}
                 }
-                EOT
-            ,
+                EOT,
             ['order' => ['use_trait', 'constant', 'property', 'construct', 'method', 'destruct']],
         ];
 
@@ -745,8 +731,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     use BarTrait;
                     use BazTrait;
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -783,8 +768,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     public $pubProp3;
                     protected static function protStatFunc() {}
                 }
-                EOT
-            ,
+                EOT,
             ['order' => ['public', 'protected', 'private']],
         ];
 
@@ -825,8 +809,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     abstract protected function absProtFunc();
                     private function privFunc() {}
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -863,8 +846,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     public $pubProp3;
                     protected static function protStatFunc() {}
                 }
-                EOT
-            ,
+                EOT,
             [
                 'order' => [
                     'use_trait',
@@ -901,8 +883,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     public function test2(){}
                     public abstract function test1();
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -911,8 +892,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     public abstract function test1();
                     public function test2(){}
                 }
-                EOT
-            ,
+                EOT,
             [
                 'order' => [
                     'method_public',
@@ -950,8 +930,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     public function __get($prop) {}
                     public function __toString() {}
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -980,8 +959,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     abstract public function custom3();
                     protected static function custom2() {}
                 }
-                EOT
-            ,
+                EOT,
             [
                 'order' => [
                     'construct',
@@ -1015,8 +993,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     public function bar() {}
                     public function __toString() {}
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -1026,8 +1003,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     public function pub() {}
                     public function bar() {}
                 }
-                EOT
-            ,
+                EOT,
             [
                 'order' => [
                     'method:foo',
@@ -1054,8 +1030,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     public function D(){}
                     private function E(){}
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
                 class Example
@@ -1070,8 +1045,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     public function C(){}
                     public function C1(){}
                 }
-                EOT
-            ,
+                EOT,
             [
                 'order' => [
                     'property_public_static',
@@ -1122,8 +1096,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     protected function protFunc() {}
                     private function privFunc() {}
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
                 class Foo
@@ -1163,8 +1136,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     protected function __construct() {}
                     protected static function protStatFunc() {}
                 }
-                EOT
-            ,
+                EOT,
             [
                 'order' => [
                     'use_trait',
@@ -1233,8 +1205,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     abstract protected function absProtFunc();
                     private function privFunc() {}
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
                 abstract class Foo
@@ -1278,8 +1249,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     protected static function protStatFunc() {}
                     abstract public static function absPubStatFunc1();
                 }
-                EOT
-            ,
+                EOT,
             [
                 'order' => [
                     'use_trait',
@@ -1320,8 +1290,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     protected const C4 = 4;
                     private const C5 = 5;
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -1348,8 +1317,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     protected const C4a = 4;
                     private const C5 = 5;
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -1375,8 +1343,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     const AA = 2;
                     const Ab = 3;
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
@@ -1400,8 +1367,7 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
                     const A_ = 1;
                     const Ab = 3;
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 

--- a/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
+++ b/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
@@ -86,8 +86,7 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { protected static $foo = 1; protected static $bar; protected static $baz=2 ; }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo { protected static $foo = 1,$bar,$baz=2 ; }
@@ -111,8 +110,7 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { protected static $foo = 1; protected static $bar; protected static $baz=2 ; }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo { protected static $foo = 1, $bar,  $baz=2 ; }
@@ -124,8 +122,7 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { const ONE = 1; const TWO = 2; protected static $foo = 1; protected static $bar; protected static $baz=2 ; const THREE = 3; }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo { const ONE = 1, TWO = 2; protected static $foo = 1, $bar,  $baz=2 ; const THREE = 3; }
@@ -141,8 +138,7 @@ echo Foo::A, Foo::B;
                     protected static $bar;
                     protected static $baz=2;
                 }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo {
@@ -165,8 +161,7 @@ echo Foo::A, Foo::B;
                     protected static $bar;
                     protected static $baz=2;
                 }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo {
@@ -194,8 +189,7 @@ echo Foo::A, Foo::B;
                     // this is an inline comment, not a docblock
                     private $var = false;
                 }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo {
@@ -227,8 +221,7 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo {
@@ -267,8 +260,7 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo
@@ -302,8 +294,7 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo
@@ -336,8 +327,7 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo
@@ -371,8 +361,7 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo
@@ -399,8 +388,7 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo
@@ -426,8 +414,7 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo
@@ -451,8 +438,7 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo {    public $one = 1; public $bar = null,$initialized = false,$configured = false,$called = false,$arguments = array();
@@ -474,8 +460,7 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo {    public $one = 1;  public $bar = null,$initialized = false,$configured = false,$called=false,$arguments = array();
@@ -492,8 +477,7 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { protected static $foo = 1; protected static $bar; protected static $baz=1; }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo { protected static $foo = 1, $bar, $baz=1; }
@@ -505,8 +489,7 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo {   protected static $foo = 1;   protected static $bar;   protected static $baz=1; }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo {   protected static $foo = 1, $bar, $baz=1; }
@@ -518,8 +501,7 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { protected $foo = 1; protected $bar; protected $baz=2; }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo { protected $foo = 1, $bar, $baz=2; }
@@ -531,8 +513,7 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { var $foo = 1; var $bar; var $baz=2; }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo { var $foo = 1, $bar, $baz=2; }
@@ -544,8 +525,7 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { var $foo = 1; var $bar; public function doSomething1() {} var $baz=2; }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo { var $foo = 1, $bar; public function doSomething1() {} var $baz=2; }
@@ -557,8 +537,7 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { var $foo = 1; var $bar; public function doSomething2() { global $one, $two, $three; } var $baz=2; }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo { var $foo = 1, $bar; public function doSomething2() { global $one, $two, $three; } var $baz=2; }
@@ -570,8 +549,7 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { public function doSomething3() {} protected $foo = 1; protected $bar; protected $baz=2; }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo { public function doSomething3() {} protected $foo = 1, $bar, $baz=2; }
@@ -583,8 +561,7 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { public function doSomethingElse() {} protected $foo = 1; protected $bar; protected $baz=2; private $acme =array(); }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo { public function doSomethingElse() {} protected $foo = 1, $bar, $baz=2; private $acme =array(); }
@@ -596,8 +573,7 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { public function doSomewhere() {} protected $foo = 1; protected $bar; protected $baz=2; private $acme1 =array(); }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo { public function doSomewhere() {} protected $foo = 1, $bar, $baz=2; private $acme1 =array(); }
@@ -609,8 +585,7 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { public function doThis() { global $one1, $two2, $three3; } protected $foo = 1; protected $bar; protected $baz=2; private $acme2 =array(); }
-                EOT
-            , <<<'EOT'
+                EOT, <<<'EOT'
                 <?php
 
                 class Foo { public function doThis() { global $one1, $two2, $three3; } protected $foo = 1, $bar, $baz=2; private $acme2 =array(); }

--- a/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
+++ b/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
@@ -86,7 +86,8 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { protected static $foo = 1; protected static $bar; protected static $baz=2 ; }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo { protected static $foo = 1,$bar,$baz=2 ; }
@@ -110,7 +111,8 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { protected static $foo = 1; protected static $bar; protected static $baz=2 ; }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo { protected static $foo = 1, $bar,  $baz=2 ; }
@@ -122,7 +124,8 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { const ONE = 1; const TWO = 2; protected static $foo = 1; protected static $bar; protected static $baz=2 ; const THREE = 3; }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo { const ONE = 1, TWO = 2; protected static $foo = 1, $bar,  $baz=2 ; const THREE = 3; }
@@ -138,7 +141,8 @@ echo Foo::A, Foo::B;
                     protected static $bar;
                     protected static $baz=2;
                 }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo {
@@ -161,7 +165,8 @@ echo Foo::A, Foo::B;
                     protected static $bar;
                     protected static $baz=2;
                 }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo {
@@ -189,7 +194,8 @@ echo Foo::A, Foo::B;
                     // this is an inline comment, not a docblock
                     private $var = false;
                 }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo {
@@ -221,7 +227,8 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo {
@@ -260,7 +267,8 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo
@@ -294,7 +302,8 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo
@@ -327,7 +336,8 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo
@@ -361,7 +371,8 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo
@@ -388,7 +399,8 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo
@@ -414,7 +426,8 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo
@@ -438,7 +451,8 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo {    public $one = 1; public $bar = null,$initialized = false,$configured = false,$called = false,$arguments = array();
@@ -460,7 +474,8 @@ echo Foo::A, Foo::B;
                     {
                     }
                 }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo {    public $one = 1;  public $bar = null,$initialized = false,$configured = false,$called=false,$arguments = array();
@@ -477,7 +492,8 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { protected static $foo = 1; protected static $bar; protected static $baz=1; }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo { protected static $foo = 1, $bar, $baz=1; }
@@ -489,7 +505,8 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo {   protected static $foo = 1;   protected static $bar;   protected static $baz=1; }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo {   protected static $foo = 1, $bar, $baz=1; }
@@ -501,7 +518,8 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { protected $foo = 1; protected $bar; protected $baz=2; }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo { protected $foo = 1, $bar, $baz=2; }
@@ -513,7 +531,8 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { var $foo = 1; var $bar; var $baz=2; }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo { var $foo = 1, $bar, $baz=2; }
@@ -525,7 +544,8 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { var $foo = 1; var $bar; public function doSomething1() {} var $baz=2; }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo { var $foo = 1, $bar; public function doSomething1() {} var $baz=2; }
@@ -537,7 +557,8 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { var $foo = 1; var $bar; public function doSomething2() { global $one, $two, $three; } var $baz=2; }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo { var $foo = 1, $bar; public function doSomething2() { global $one, $two, $three; } var $baz=2; }
@@ -549,7 +570,8 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { public function doSomething3() {} protected $foo = 1; protected $bar; protected $baz=2; }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo { public function doSomething3() {} protected $foo = 1, $bar, $baz=2; }
@@ -561,7 +583,8 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { public function doSomethingElse() {} protected $foo = 1; protected $bar; protected $baz=2; private $acme =array(); }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo { public function doSomethingElse() {} protected $foo = 1, $bar, $baz=2; private $acme =array(); }
@@ -573,7 +596,8 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { public function doSomewhere() {} protected $foo = 1; protected $bar; protected $baz=2; private $acme1 =array(); }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo { public function doSomewhere() {} protected $foo = 1, $bar, $baz=2; private $acme1 =array(); }
@@ -585,7 +609,8 @@ echo Foo::A, Foo::B;
                 <?php
 
                 class Foo { public function doThis() { global $one1, $two2, $three3; } protected $foo = 1; protected $bar; protected $baz=2; private $acme2 =array(); }
-                EOT, <<<'EOT'
+                EOT,
+            <<<'EOT'
                 <?php
 
                 class Foo { public function doThis() { global $one1, $two2, $three3; } protected $foo = 1, $bar, $baz=2; private $acme2 =array(); }

--- a/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+++ b/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
@@ -107,8 +107,7 @@ final class VisibilityRequiredFixerTest extends AbstractFixerTestCase
                     ) {
                     }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 class MyTestWithAnonymousClass extends TestCase
@@ -123,8 +122,7 @@ final class VisibilityRequiredFixerTest extends AbstractFixerTestCase
                     ) {
                     }
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -151,8 +149,7 @@ final class VisibilityRequiredFixerTest extends AbstractFixerTestCase
                             $bar = function($baz) {};
                         }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 abstract class Foo {
@@ -178,8 +175,7 @@ final class VisibilityRequiredFixerTest extends AbstractFixerTestCase
                             $bar = function($baz) {};
                         }
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -188,15 +184,13 @@ final class VisibilityRequiredFixerTest extends AbstractFixerTestCase
                 abstract class Foo1 {
                     public function& foo0($a) {}
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 abstract class Foo1 {
                     function& foo0($a) {}
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'leave functions alone' => [<<<'EOF'

--- a/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
+++ b/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
@@ -123,8 +123,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                  * @var string $bar
                  */
                 $bar = "baz";
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php /* header comment */ $foo = true;
 
@@ -132,8 +131,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                  * @var string $bar
                  */
                 $bar = "baz";
-                EOT
-            ,
+                EOT,
         ];
 
         yield [
@@ -147,8 +145,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                  * @deprecated since 1.2
                  */
                 $foo = 1;
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php /* header comment */ $foo = true;
 
@@ -157,8 +154,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                 // stop using it
                 // @deprecated since 1.2
                 $foo = 1;
-                EOT
-            ,
+                EOT,
         ];
 
         yield [
@@ -172,8 +168,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                      */
                     $foo = someValue();
                 }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php /* header comment */ $foo = true;
 
@@ -182,8 +177,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                     // @var string $foo
                     $foo = someValue();
                 }
-                EOT
-            ,
+                EOT,
         ];
 
         yield [
@@ -197,8 +191,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                  * @deprecated since 1.3
                  */
                 $foo = 1;
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php /* header comment */ $foo = true;
 
@@ -207,8 +200,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                 # stop using it
                 # @deprecated since 1.3
                 $foo = 1;
-                EOT
-            ,
+                EOT,
         ];
 
         yield [
@@ -219,8 +211,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                  * @Column(type="string", length=32, unique=true, nullable=false)
                  */
                 $bar = 'baz';
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php /* header comment */ $foo = true;
 
@@ -228,8 +219,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                  * @Column(type="string", length=32, unique=true, nullable=false)
                  */
                 $bar = 'baz';
-                EOT
-            ,
+                EOT,
         ];
 
         yield [
@@ -240,8 +230,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                  * @ORM\Column(name="id", type="integer")
                  */
                 $bar = 42;
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php /* header comment */ $foo = true;
 
@@ -249,8 +238,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                  * @ORM\Column(name="id", type="integer")
                  */
                 $bar = 42;
-                EOT
-            ,
+                EOT,
         ];
 
         yield [
@@ -260,8 +248,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                 // This is my var
                 // /** @var string $foo */
                 $foo = 1;
-                EOT
-            ,
+                EOT,
         ];
 
         yield [
@@ -270,8 +257,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
 
                 // @todo do something later
                 $foo = 1;
-                EOT
-            ,
+                EOT,
             null,
             ['ignored_tags' => ['todo']],
         ];
@@ -282,8 +268,7 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
 
                 // @TODO do something later
                 $foo = 1;
-                EOT
-            ,
+                EOT,
             null,
             ['ignored_tags' => ['todo']],
         ];
@@ -297,16 +282,14 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                  * @var int $foo
                  */
                 $foo = 1;
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php /* header comment */ $foo = true;
 
                 // @todo do something later
                 // @var int $foo
                 $foo = 1;
-                EOT
-            ,
+                EOT,
             ['ignored_tags' => ['todo']],
         ];
 
@@ -319,16 +302,14 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                  * @todo do something later
                  */
                 $foo = 1;
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php /* header comment */ $foo = true;
 
                 // @var int $foo
                 // @todo do something later
                 $foo = 1;
-                EOT
-            ,
+                EOT,
             ['ignored_tags' => ['todo']],
         ];
 

--- a/tests/Fixer/Comment/MultilineCommentOpeningClosingFixerTest.php
+++ b/tests/Fixer/Comment/MultilineCommentOpeningClosingFixerTest.php
@@ -74,16 +74,14 @@ final class MultilineCommentOpeningClosingFixerTest extends AbstractFixerTestCas
                 /*
                  * WUT
                  */
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
                 /********
                  * WUT
                  ********/
-                EOT
-            ,
+                EOT,
         ];
 
         yield [
@@ -93,16 +91,14 @@ final class MultilineCommentOpeningClosingFixerTest extends AbstractFixerTestCas
                 /*\
                  * False DocBlock
                  */
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
 
                 /**\
                  * False DocBlock
                  */
-                EOT
-            ,
+                EOT,
         ];
 
         yield [
@@ -119,8 +115,7 @@ final class MultilineCommentOpeningClosingFixerTest extends AbstractFixerTestCas
                 Weird multiline comment
                 */
 
-                EOT
-            ,
+                EOT,
         ];
     }
 }

--- a/tests/Fixer/ControlStructure/SimplifiedIfReturnFixerTest.php
+++ b/tests/Fixer/ControlStructure/SimplifiedIfReturnFixerTest.php
@@ -92,8 +92,7 @@ final class SimplifiedIfReturnFixerTest extends AbstractFixerTestCase
                 function f7() { return ! ($f7)      ; }
                 function f8() { return false; } return true;
                 function f9() { return ! ($f9)      ; }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
                 function f1() { if ($f1) { return true; } return false; }
@@ -105,8 +104,7 @@ final class SimplifiedIfReturnFixerTest extends AbstractFixerTestCase
                 function f7() { if ($f7) { return false; } return true; }
                 function f8() { return false; } return true;
                 function f9() { if ($f9) { return false; } return true; }
-                EOT
-            ,
+                EOT,
         ];
 
         yield 'preserve-comments' => [
@@ -137,8 +135,7 @@ final class SimplifiedIfReturnFixerTest extends AbstractFixerTestCase
                 # C12
                 ;
                 /* C13 */
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
                 // C1
@@ -166,8 +163,7 @@ final class SimplifiedIfReturnFixerTest extends AbstractFixerTestCase
                 # C12
                 ;
                 /* C13 */
-                EOT
-            ,
+                EOT,
         ];
 
         yield 'preserve-comments-braceless' => [
@@ -196,8 +192,7 @@ final class SimplifiedIfReturnFixerTest extends AbstractFixerTestCase
                 # C12
                 ;
                 /* C13 */
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
                 // C1
@@ -223,8 +218,7 @@ final class SimplifiedIfReturnFixerTest extends AbstractFixerTestCase
                 # C12
                 ;
                 /* C13 */
-                EOT
-            ,
+                EOT,
         ];
 
         yield 'else-if' => [

--- a/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
+++ b/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
@@ -583,8 +583,7 @@ $a
                         foo
                         EOD,
                 ];
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 $a = [
@@ -592,8 +591,7 @@ $a
                         foo
                         EOD
                 ];
-                INPUT
-            ,
+                INPUT,
             ['after_heredoc' => true],
         ];
 

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -387,16 +387,14 @@ $a#
                     'b',
                     'c'
                 );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 functionCall(
                     'a', 'b',
                     'c'
                 );
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'test wrongly formatted half-multiline function becomes fully-multiline' => [
@@ -422,8 +420,7 @@ f(1,2,
 
                 TEXT
                 );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 str_replace("\n", PHP_EOL, <<<'TEXT'
@@ -431,8 +428,7 @@ f(1,2,
 
                 TEXT
                 );
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'test barely multiline function with blank lines becomes fully-multiline' => [
@@ -443,15 +439,13 @@ f(1,2,
                     'b',
                     'c'
                 );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 functionCall('a', 'b',
 
                     'c');
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'test indentation is preserved' => [
@@ -464,8 +458,7 @@ f(1,2,
                         'c'
                     );
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 if (true) {
@@ -474,8 +467,7 @@ f(1,2,
                         'c'
                     );
                 }
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'test multiline array arguments do not trigger multiline' => [
@@ -486,8 +478,7 @@ f(1,2,
                     'b',
                     'c',
                 ), 42);
-                EXPECTED
-            ,
+                EXPECTED,
         ];
 
         yield 'test multiline function arguments do not trigger multiline' => [
@@ -496,8 +487,7 @@ f(1,2,
                 defraculate(1, function () {
                     $a = 42;
                 }, 42);
-                EXPECTED
-            ,
+                EXPECTED,
         ];
 
         yield 'test violation after opening parenthesis' => [
@@ -508,14 +498,12 @@ f(1,2,
                     2,
                     3
                 );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 defraculate(
                     1, 2, 3);
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'test violation after opening parenthesis, indented with two spaces' => [
@@ -526,14 +514,12 @@ f(1,2,
                   2,
                   3
                 );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 defraculate(
                   1, 2, 3);
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'test violation after opening parenthesis, indented with tabs' => [
@@ -544,14 +530,12 @@ f(1,2,
                 	2,
                 	3
                 );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 defraculate(
                 	1, 2, 3);
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'test violation before closing parenthesis' => [
@@ -562,14 +546,12 @@ f(1,2,
                     2,
                     3
                 );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 defraculate(1, 2, 3
                 );
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'test violation before closing parenthesis in nested call' => [
@@ -580,14 +562,12 @@ f(1,2,
                     2,
                     3
                 ), 'morty');
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 getSchwifty('rick', defraculate(1, 2, 3
                 ), 'morty');
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'test with comment between arguments' => [
@@ -598,16 +578,14 @@ f(1,2,
                     'b',
                     'c'
                 );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 functionCall(
                     'a',/* comment */'b',
                     'c'
                 );
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'test with deeply nested arguments' => [
@@ -627,8 +605,7 @@ f(1,2,
                         ),
                     ]
                 );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 foo('a',
@@ -641,8 +618,7 @@ f(1,2,
                                 'i',
                             ]),
                     ]);
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'multiline string argument' => [
@@ -653,8 +629,7 @@ f(1,2,
                 class FooClass
                 {
                 }', $comment, false);
-                UNAFFECTED
-            ,
+                UNAFFECTED,
         ];
 
         yield 'arrays with whitespace inside' => [
@@ -666,8 +641,7 @@ f(1,2,
                 $a = array/***/(123,  7);
                 $a = array (        1,
                 2);
-                UNAFFECTED
-            ,
+                UNAFFECTED,
         ];
 
         yield 'test code that should not be affected (because not a function nor a method)' => [
@@ -678,8 +652,7 @@ f(1,2,
                     ) {
                     // do whatever
                 }
-                UNAFFECTED
-            ,
+                UNAFFECTED,
         ];
 
         yield 'test ungodly code' => [
@@ -702,8 +675,7 @@ f(1,2,
                     $d1
                 ) {
                 };
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 $a = function#
@@ -719,8 +691,7 @@ f(1,2,
                 use ($b1,
                 $c1,$d1) {
                 };
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'test list' => [
@@ -736,8 +707,7 @@ f(1,2,
                 array(1,
                     2,3
                 );
-                UNAFFECTED
-            ,
+                UNAFFECTED,
         ];
 
         yield 'test function argument with multiline echo in it' => [
@@ -747,8 +717,7 @@ f(1,2,
                     echo 'a',
                       'b';
                 }, $argv);
-                UNAFFECTED
-            ,
+                UNAFFECTED,
         ];
 
         yield 'test function argument with oneline echo in it' => [
@@ -760,16 +729,14 @@ f(1,2,
                 },
                     $argv
                 );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 call_user_func(function ($arguments) {
                     echo 'a', 'b';
                 },
                 $argv);
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'ensure_single_line' => [
@@ -779,8 +746,7 @@ f(1,2,
                     // foo
                 }
                 foo($a, $b);
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 function foo(
@@ -793,8 +759,7 @@ f(1,2,
                     $a,
                     $b
                 );
-                INPUT
-            ,
+                INPUT,
             ['on_multiline' => 'ensure_single_line'],
         ];
 
@@ -811,8 +776,7 @@ f(1,2,
                     $a, /* foo */// bar
                     $b#foo
                 );
-                EXPECTED
-            ,
+                EXPECTED,
             null,
             ['on_multiline' => 'ensure_single_line'],
         ];
@@ -824,8 +788,7 @@ f(1,2,
                     // foo
                 }
                 foo($a, $b);
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 function foo(
@@ -850,8 +813,7 @@ f(1,2,
 
 
                 );
-                INPUT
-            ,
+                INPUT,
             ['on_multiline' => 'ensure_single_line'],
         ];
 
@@ -862,8 +824,7 @@ f(1,2,
                     public static function foo1($a, $b, $c) {}
                     private function foo2($a, $b, $c) {}
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 class Foo {
@@ -878,8 +839,7 @@ f(1,2,
                         $c
                     ) {}
                 }
-                INPUT
-            ,
+                INPUT,
             ['on_multiline' => 'ensure_single_line'],
         ];
 
@@ -890,8 +850,7 @@ f(1,2,
                     public static function foo1($a, $b, $c) {}
                     private function foo2($a, $b, $c) {}
                 };
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 new class {
@@ -906,8 +865,7 @@ f(1,2,
                         $c
                     ) {}
                 };
-                INPUT
-            ,
+                INPUT,
             ['on_multiline' => 'ensure_single_line'],
         ];
 
@@ -918,8 +876,7 @@ f(1,2,
                     // foo
                 }
                 foo($a,    $b);
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 function foo(
@@ -932,8 +889,7 @@ f(1,2,
                     $a,
                     $b
                 );
-                INPUT
-            ,
+                INPUT,
             [
                 'on_multiline' => 'ensure_single_line',
                 'keep_multiple_spaces_after_comma' => true,
@@ -1047,8 +1003,7 @@ foo(
                         EOD,
                     'baz'
                 );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 foo(
@@ -1058,8 +1013,7 @@ foo(
                     ,
                     'baz'
                 );
-                INPUT
-            ,
+                INPUT,
             ['after_heredoc' => true],
         ];
 
@@ -1070,8 +1024,7 @@ foo(
                     $bar,
                     $baz,
                 );
-                EXPECTED
-            ,
+                EXPECTED,
             null,
             ['on_multiline' => 'ensure_fully_multiline'],
         ];

--- a/tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
@@ -68,8 +68,7 @@ final class NoUnreachableDefaultArgumentValueFixerTest extends AbstractFixerTest
                                         function eFunction($foo, $bar, \SplFileInfo $baz, $x = 'default') {};
 
                                         function fFunction($foo, $bar, \SplFileInfo $baz, $x = 'default') {};
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                                     <?php
                                         function eFunction($foo, $bar, \SplFileInfo $baz, $x = 'default') {};
@@ -107,8 +106,7 @@ final class NoUnreachableDefaultArgumentValueFixerTest extends AbstractFixerTest
                                             $c, // abc
                                             $d
                                         ) {}
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                                     <?php
                                         function foo(

--- a/tests/Fixer/FunctionNotation/UseArrowFunctionsFixerTest.php
+++ b/tests/Fixer/FunctionNotation/UseArrowFunctionsFixerTest.php
@@ -67,8 +67,7 @@ final class UseArrowFunctionsFixerTest extends AbstractFixerTestCase
             <<<'EXPECTED'
                 <?php
                     foo(1, fn (int $a, Foo $b) => bar($a, $c), 2);
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                     foo(1, function (int $a, Foo $b) use ($c, $d) {
@@ -81,8 +80,7 @@ final class UseArrowFunctionsFixerTest extends AbstractFixerTestCase
             <<<'EXPECTED'
                 <?php
                     foo(fn () => 1);
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                     foo(function () {
@@ -99,8 +97,7 @@ final class UseArrowFunctionsFixerTest extends AbstractFixerTestCase
             <<<'EXPECTED'
                 <?php
                     foo(fn ($a) => fn () => $a + 1);
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                     foo(function ($a) {

--- a/tests/Fixer/Import/GlobalNamespaceImportFixerTest.php
+++ b/tests/Fixer/Import/GlobalNamespaceImportFixerTest.php
@@ -84,8 +84,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use const BAR;
                 use const FOO;
                 echo FOO, BAR;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -101,8 +100,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use const FOO;
                     echo FOO, BAR;
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test {
@@ -119,8 +117,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use const BAR;
                 use const FOO;
                 echo FOO, BAR;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -136,8 +133,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use const BAR;
                 use const FOO;
                 echo FOO, BAR;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -153,8 +149,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use const \BAR;
                 use const FOO;
                 echo FOO, BAR, BAR;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -172,8 +167,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use const Foo;
                 const foO = 1;
                 echo FOO, Foo;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -190,8 +184,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use const BAR as BAZ;
                 use const FOO;
                 echo FOO, BAZ;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -209,8 +202,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                     const FOO = 1;
                 }
                 echo FOO;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -304,8 +296,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use function foo;
                 foo();
                 bar();
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -323,8 +314,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                     foo();
                     bar();
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test {
@@ -343,8 +333,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use function foo;
                 foo();
                 bar();
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -362,8 +351,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use function foo;
                 foo();
                 Bar();
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -382,8 +370,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 foo();
                 Bar();
                 bar();
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -402,8 +389,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use function foo;
                 foo();
                 baz();
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -422,8 +408,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                     function foo() {}
                 }
                 foo();
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -546,8 +531,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
 
                 /** @return Baz<string, foo> */
                 function x() {}
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -569,8 +553,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                     new Foo();
                     Bar::baz();
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test {
@@ -588,8 +571,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
 
                 /** @throws Throwable */
                 function x() {}
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -608,8 +590,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use Foo;
                 new Foo();
                 Bar::baz();
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -627,8 +608,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use Foo;
                 new Foo();
                 bar::baz();
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -647,8 +627,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 new Foo();
                 new bar();
                 new Bar();
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -670,8 +649,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
 
                 /** @throws Throwable */
                 function y() {}
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -696,8 +674,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
 
                 /** @var Baz $bar */
                 $bar = new Baz();
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -720,8 +697,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 class Abc {
                     function bar(Foo $a, Bar $b, foo &$c, Baz ...$d) {}
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -740,8 +716,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 class Abc {
                     function bar(?Foo $a): ?Bar {}
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -759,8 +734,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 try {
                 } catch (Exception $e) {
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -778,8 +752,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 try {
                 } catch (/* ... */ Exception $e /* ... */) {
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -811,8 +784,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 try {
                 } catch (Exception) {
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -830,8 +802,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 try {
                 } catch (/* non-capturing catch */ Exception /* just because! */) {
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -869,8 +840,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use const FOO;
                 use const BAR;
                 echo \FOO, \BAR, \FOO;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace X;
@@ -888,8 +858,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 use const BAR;
                 use const Baz;
                 echo FOO, \BAR, BAZ, QUX;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -931,8 +900,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 \foo();
                 \bar();
                 \Foo();
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace X;
@@ -953,8 +921,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 foo();
                 \bar();
                 baz();
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -1012,8 +979,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                  * @return array<string, ?\Bar<int, \foo>>|null
                  */
                 function abc($foo, \Bar $bar = null) {}
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace X;
@@ -1042,8 +1008,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 new Foo();
                 new \Bar();
                 new Baz();
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -1063,8 +1028,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 try {
                 } catch (\Exception $e) {
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -1083,8 +1047,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 try {
                 } catch (/* ... */ \Exception $e /* ... */) {
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -1154,8 +1117,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 try {
                 } catch (\Exception) {
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -1174,8 +1136,7 @@ final class GlobalNamespaceImportFixerTest extends AbstractFixerTestCase
                 try {
                 } catch (/* non-capturing catch */ \Exception /* just because! */) {
                 }
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -1313,8 +1274,7 @@ class Bar
                     function foo() {}
                 }
                 foo();
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;
@@ -1334,8 +1294,7 @@ class Bar
                     const FOO = 1;
                 }
                 echo FOO;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 namespace Test;

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -61,8 +61,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                         /** @var ArrayInterface $bar */
                     }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -93,8 +92,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                         /** @var ArrayInterface $bar */
                     }
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'with_indents' => [
@@ -110,8 +108,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 $a = new FooBaz();
                 $a = new SomeClassIndented();
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -127,8 +124,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 $a = new FooBaz();
                 $a = new SomeClassIndented();
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'in_same_namespace_1' => [
@@ -147,8 +143,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 $d = new Bbb();
                 $e = new FQCN_Babo();
                 $f = new FQCN_XYZ();
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -167,8 +162,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 $d = new Bbb();
                 $e = new FQCN_Babo();
                 $f = new FQCN_XYZ();
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'in_same_namespace_2' => [
@@ -176,16 +170,14 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 <?php namespace App\Http\Controllers;
 
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php namespace App\Http\Controllers;
 
                 use Illuminate\Http\Request;
                 use App\Http\Controllers\Controller;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'in_same_namespace_multiple_1' => [
@@ -200,8 +192,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 $a = new Bar();
                 $b = new Baz();
                 $c = new Baaaaz();
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -216,8 +207,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 $a = new Bar();
                 $b = new Baz();
                 $c = new Baaaaz();
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'in_same_namespace_multiple_2' => [
@@ -239,8 +229,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 $a = new Bar();
                 $b = new Baz();
                 $c = new Baaaaz();
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -265,8 +254,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 $a = new Bar();
                 $b = new Baz();
                 $c = new Baaaaz();
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'in_same_namespace_multiple_braces' => [
@@ -290,8 +278,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                     $b = new Baz();
                     $c = new Baaaaz();
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -318,8 +305,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                     $b = new Baz();
                     $c = new Baaaaz();
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'multiple_use' => [
@@ -333,8 +319,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
 
                 $c = new D();
                 $e = new BarE();
-                EOF
-            ,
+                EOF,
 
             <<<'EOF'
                 <?php
@@ -350,8 +335,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
 
                 $c = new D();
                 $e = new BarE();
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'with_braces' => [
@@ -367,8 +351,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                     $c = new Bar\Fooz();
                     $d = new Bbb();
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -383,8 +366,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                     $c = new Bar\Fooz();
                     $d = new Bbb();
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'trailing_spaces' => [
@@ -396,8 +378,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
 
                 $a = new Bar();
                 $a = new FooBaz();
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -408,8 +389,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
 
                 $a = new Bar();
                 $a = new FooBaz();
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'traits' => [
@@ -425,8 +405,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 use MyTrait2;
                     use Bar;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -440,8 +419,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 use MyTrait2;
                     use Bar;
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'function_use' => [
@@ -454,8 +432,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 $a = function ($item) use ($f) {
                     return !in_array($item, $f);
                 };
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -466,8 +443,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 $a = function ($item) use ($f) {
                     return !in_array($item, $f);
                 };
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'similar_names' => [
@@ -483,8 +459,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                         $this->repo = $repo;
                     }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -498,8 +473,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                         $this->repo = $repo;
                     }
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'variable_name' => [
@@ -508,16 +482,14 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
 
 
                 $bar = null;
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
                 use Foo\Bar;
 
                 $bar = null;
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'property name, method name, static method call, static property' => [
@@ -529,8 +501,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 $foo->bar();
                 $foo::bar();
                 $foo::bar;
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -540,8 +511,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 $foo->bar();
                 $foo::bar();
                 $foo::bar;
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'constant_name' => [
@@ -553,8 +523,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 {
                     const BAR = 0;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -564,8 +533,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 {
                     const BAR = 0;
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'namespace_part' => [
@@ -574,16 +542,14 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
 
 
                 new \Baz\Bar();
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
                 use Foo\Bar;
 
                 new \Baz\Bar();
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'use_in_string_1' => [
@@ -594,8 +560,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 use b;
                 EOA;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'use_in_string_2' => [
@@ -605,8 +570,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 use a;
                 use b;
                 ';
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'use_in_string_3' => [
@@ -616,8 +580,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 use a;
                 use b;
                 ";
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'import_in_global_namespace' => [
@@ -626,8 +589,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 namespace A;
                 use \SplFileInfo;
                 new SplFileInfo(__FILE__);
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'no_import_in_global_namespace' => [
@@ -635,15 +597,13 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 <?php
                 namespace A;
                 new \SplFileInfo(__FILE__);
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 namespace A;
                 use SplFileInfo;
                 new \SplFileInfo(__FILE__);
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'no_import_attribute_in_global_namespace' => [
@@ -652,30 +612,26 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 namespace A;
                 #[\Attribute(\Attribute::TARGET_PROPERTY)]
                 final class B {}
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 namespace A;
                 use Attribute;
                 #[\Attribute(\Attribute::TARGET_PROPERTY)]
                 final class B {}
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'use_as_last_statement' => [
             <<<'EOF'
                 <?php
 
-                EOF
-            ,
+                EOF,
 
             <<<'EOF'
                 <?php
                 use Bar\Finder;
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'use_with_same_last_part_that_is_in_namespace' => [
@@ -685,16 +641,14 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 namespace Foo\Finder;
 
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
                 namespace Foo\Finder;
 
                 use Bar\Finder;
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'used_use_with_same_last_part_that_is_in_namespace' => [
@@ -708,8 +662,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 class Baz extends Finder
                 {
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'foo' => [
@@ -722,8 +675,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 {
                 }
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 namespace Aaa;
@@ -735,8 +687,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 {
                 }
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'close_tag_1' => [
@@ -806,8 +757,7 @@ use Baz;
                 {
                 }
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -821,8 +771,7 @@ use Baz;
                 {
                 }
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'with_same_namespace_import_and_unused_import_after_namespace_statement' => [
@@ -837,8 +786,7 @@ use Baz;
                 {
                 }
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -852,8 +800,7 @@ use Baz;
                 {
                 }
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'wrong_casing' => [
@@ -865,8 +812,7 @@ use Baz;
 
                 $a = new FOO();
                 $b = new bar();
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'phpdoc_unused' => [
@@ -881,8 +827,7 @@ use Baz;
                     public function testBar()
                     { }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 use Some\Exception;
@@ -895,8 +840,7 @@ use Baz;
                     public function testBar()
                     { }
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'imported_class_is_used_for_constants_1' => [
@@ -950,8 +894,7 @@ $b = $a-->ABC::Test;
                 {
                 const C = 'bar-bados';
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -961,8 +904,7 @@ $b = $a-->ABC::Test;
                 {
                 const C = 'bar-bados';
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'imported_class_name_is_suffix_with_dash_of_constant' => [
@@ -974,8 +916,7 @@ $b = $a-->ABC::Test;
                 {
                     const C = 'tool-bar';
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -985,8 +926,7 @@ $b = $a-->ABC::Test;
                 {
                     const C = 'tool-bar';
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'imported_class_name_is_inside_with_dash_of_constant' => [
@@ -998,8 +938,7 @@ $b = $a-->ABC::Test;
                 {
                     const C = 'tool-bar-bados';
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -1009,8 +948,7 @@ $b = $a-->ABC::Test;
                 {
                     const C = 'tool-bar-bados';
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'functions_in_the_global_namespace_should_not_be_removed_even_when_declaration_has_new_lines_and_is_uppercase' => [
@@ -1023,8 +961,7 @@ $b = $a-->ABC::Test;
 
                 is_int(1);
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -1035,8 +972,7 @@ $b = $a-->ABC::Test;
 
                 is_int(1);
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'constants_in_the_global_namespace_should_not_be_removed' => [
@@ -1049,8 +985,7 @@ $b = $a-->ABC::Test;
 
                 echo PHP_INT_MAX;
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -1061,8 +996,7 @@ $b = $a-->ABC::Test;
 
                 echo PHP_INT_MAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'functions_in_the_global_namespace_should_not_be_removed_even_when_declaration_has_ne_lines_and_is_uppercase' => [
@@ -1074,8 +1008,7 @@ $b = $a-->ABC::Test;
 
                 is_int(1);
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -1089,8 +1022,7 @@ $b = $a-->ABC::Test;
 
                 is_int(1);
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'use_trait should never be removed' => [
@@ -1126,8 +1058,7 @@ $b = $a-->ABC::Test;
                 {
                 }
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -669,8 +669,7 @@ B#
                         return function () use ($bar, $foo) {};
                     }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 The normal
                 use of this fixer
@@ -707,8 +706,7 @@ B#
                         return function () use ($bar, $foo) {};
                     }
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -1894,8 +1892,7 @@ use function some\a\{fn_a, fn_b, fn_c,};
                         return function () use ($bar, $foo) {};
                     }
                 }
-                EOF
-            ,
+                EOF,
 
             <<<'EOF'
                 The normal
@@ -1935,8 +1932,7 @@ use function some\a\{fn_a, fn_b, fn_c,};
                         return function () use ($bar, $foo) {};
                     }
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield [

--- a/tests/Fixer/Import/SingleImportPerStatementFixerTest.php
+++ b/tests/Fixer/Import/SingleImportPerStatementFixerTest.php
@@ -64,8 +64,7 @@ final class SingleImportPerStatementFixerTest extends AbstractFixerTestCase
                 use FooJ;
                 use FooZ;
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 use Some, Not, PHP, Like, Use, Statement;
                 <?php
@@ -116,8 +115,7 @@ final class SingleImportPerStatementFixerTest extends AbstractFixerTestCase
                     use BarZ;
                 }
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 

--- a/tests/Fixer/PhpTag/EchoTagSyntaxFixerTest.php
+++ b/tests/Fixer/PhpTag/EchoTagSyntaxFixerTest.php
@@ -64,8 +64,7 @@ final class EchoTagSyntaxFixerTest extends AbstractFixerTestCase
                 <?=/*comment*/
                   1
                 ?>
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php /*comment*/ echo
                   1
@@ -77,8 +76,7 @@ final class EchoTagSyntaxFixerTest extends AbstractFixerTestCase
             <<<'EOT'
                 <?=/*comment*/ 1
                 ?>
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
                   /*comment*/ echo 1
@@ -91,8 +89,7 @@ final class EchoTagSyntaxFixerTest extends AbstractFixerTestCase
                 <?=/*comment*/
                   1
                 ?>
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
                   /*comment*/

--- a/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
@@ -476,8 +476,7 @@ final class PhpUnitNoExpectationAnnotationFixerTest extends AbstractFixerTestCas
                             $this->View->element('non_existent_element');
                         }
                     }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                     <?php
                     final class MyTest extends \PHPUnit_Framework_TestCase
@@ -500,8 +499,7 @@ final class PhpUnitNoExpectationAnnotationFixerTest extends AbstractFixerTestCas
                             $this->View->element('non_existent_element');
                         }
                     }
-                EOT
-            ,
+                EOT,
         ];
 
         yield 'message on newline' => [
@@ -539,8 +537,7 @@ final class PhpUnitNoExpectationAnnotationFixerTest extends AbstractFixerTestCas
                             ccc();
                         }
                     }
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                     <?php
                     final class MyTest extends \PHPUnit_Framework_TestCase
@@ -584,8 +581,7 @@ final class PhpUnitNoExpectationAnnotationFixerTest extends AbstractFixerTestCas
                             ccc();
                         }
                     }
-                EOT
-            ,
+                EOT,
         ];
 
         yield 'annotation with double @' => [

--- a/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
@@ -88,8 +88,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                         static::fail('foo');
                     }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 class MyTest extends \PHPUnit_Framework_TestCase
@@ -101,8 +100,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                         $this->fail('foo');
                     }
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -127,8 +125,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                         ;
                     }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 class MyTest extends \PHPUnit_Framework_TestCase
@@ -150,8 +147,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                         ;
                     }
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -172,8 +168,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                         */
                     }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 class MyTest extends \PHPUnit_Framework_TestCase
@@ -191,8 +186,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                         */
                     }
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -213,8 +207,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                         };
                     }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 class MyTest extends \PHPUnit_Framework_TestCase
@@ -232,8 +225,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                         };
                     }
                 }
-                EOF
-            ,
+                EOF,
             ['call_type' => PhpUnitTestCaseStaticMethodCallsFixer::CALL_TYPE_THIS],
         ];
 
@@ -249,8 +241,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                         self::fail('foo');
                     }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 class MyTest extends \PHPUnit_Framework_TestCase
@@ -262,8 +253,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                         static::fail('foo');
                     }
                 }
-                EOF
-            ,
+                EOF,
             ['call_type' => PhpUnitTestCaseStaticMethodCallsFixer::CALL_TYPE_SELF],
         ];
 
@@ -284,8 +274,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                         OtherTest::setUpBeforeClass();
                     }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 class MyTest extends \PHPUnit_Framework_TestCase
@@ -302,8 +291,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                         OtherTest::setUpBeforeClass();
                     }
                 }
-                EOF
-            ,
+                EOF,
             [
                 'call_type' => PhpUnitTestCaseStaticMethodCallsFixer::CALL_TYPE_THIS,
                 'methods' => ['setUpBeforeClass' => PhpUnitTestCaseStaticMethodCallsFixer::CALL_TYPE_STATIC],
@@ -359,8 +347,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                         static::assertSame(1, 2);
                     }
                 }
-                EOF
-            ,
+                EOF,
             null,
             [
                 'call_type' => PhpUnitTestCaseStaticMethodCallsFixer::CALL_TYPE_THIS,
@@ -403,8 +390,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                     }
 
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 class MyTest extends \PHPUnit_Framework_TestCase
@@ -440,8 +426,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                     }
 
                 }
-                EOF
-            ,
+                EOF,
             [
                 'call_type' => PhpUnitTestCaseStaticMethodCallsFixer::CALL_TYPE_THIS,
             ],
@@ -459,8 +444,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
 
                     public function assertSame($foo, $bar){}
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'do not change when only case is different' => [
@@ -473,8 +457,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                         STATIC::assertSame(1, 1);
                     }
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'do not crash on abstract static function' => [
@@ -484,8 +467,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
                 {
                     abstract public static function dataProvider();
                 }
-                EOF
-            ,
+                EOF,
             null,
             [
                 'call_type' => PhpUnitTestCaseStaticMethodCallsFixer::CALL_TYPE_THIS,

--- a/tests/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixerTest.php
@@ -170,44 +170,48 @@ final class NoBlankLinesAfterPhpdocFixerTest extends AbstractFixerTestCase
 
     public static function provideLineBeforeIncludeOrRequireIsNotRemovedCases(): iterable
     {
-        yield [<<<'EOF'
-            <?php
-            /**
-             * This describes what my script does.
-             */
+        yield [
+            <<<'EOF'
+                <?php
+                /**
+                 * This describes what my script does.
+                 */
 
-            include 'vendor/autoload.php';
-            EOF
+                include 'vendor/autoload.php';
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php
-            /**
-             * This describes what my script does.
-             */
+        yield [
+            <<<'EOF'
+                <?php
+                /**
+                 * This describes what my script does.
+                 */
 
-            include_once 'vendor/autoload.php';
-            EOF
+                include_once 'vendor/autoload.php';
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php
-            /**
-             * This describes what my script does.
-             */
+        yield [
+            <<<'EOF'
+                <?php
+                /**
+                 * This describes what my script does.
+                 */
 
-            require 'vendor/autoload.php';
-            EOF
+                require 'vendor/autoload.php';
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php
-            /**
-             * This describes what my script does.
-             */
+        yield [
+            <<<'EOF'
+                <?php
+                /**
+                 * This describes what my script does.
+                 */
 
-            require_once 'vendor/autoload.php';
-            EOF
+                require_once 'vendor/autoload.php';
+                EOF
         ];
     }
 
@@ -377,85 +381,90 @@ class Foo {}'
 
     public static function provideInlineTypehintingDocsBeforeFlowBreakCases(): iterable
     {
-        yield [<<<'EOF'
-            <?php
-            function parseTag($tag)
-            {
-                $tagClass = get_class($tag);
-
-                if ('phpDocumentor\Reflection\DocBlock\Tag\VarTag' === $tagClass) {
-                    /** @var DocBlock\Tag\VarTag $tag */
-
-                    return $tag->getDescription();
-                }
-            }
-            EOF
-        ];
-
-        yield [<<<'EOF'
-            <?php
-            function parseTag($tag)
-            {
-                $tagClass = get_class($tag);
-
-                if ('phpDocumentor\Reflection\DocBlock\Tag\VarTag' === $tagClass) {
-                    /** @var DocBlock\Tag\VarTag $tag */
-
-                    throw new Exception($tag->getDescription());
-                }
-            }
-            EOF
-        ];
-
-        yield [<<<'EOF'
-            <?php
-            function parseTag($tag)
-            {
-                $tagClass = get_class($tag);
-
-                if ('phpDocumentor\Reflection\DocBlock\Tag\VarTag' === $tagClass) {
-                    /** @var DocBlock\Tag\VarTag $tag */
-
-                    goto FOO;
-                }
-
-            FOO:
-            }
-            EOF
-        ];
-
-        yield [<<<'EOF'
-            <?php
-            function parseTag($tag)
-            {
-                while (true) {
+        yield [
+            <<<'EOF'
+                <?php
+                function parseTag($tag)
+                {
                     $tagClass = get_class($tag);
 
                     if ('phpDocumentor\Reflection\DocBlock\Tag\VarTag' === $tagClass) {
                         /** @var DocBlock\Tag\VarTag $tag */
 
-                        continue;
+                        return $tag->getDescription();
                     }
                 }
-            }
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php
-            function parseTag($tag)
-            {
-                while (true) {
+        yield [
+            <<<'EOF'
+                <?php
+                function parseTag($tag)
+                {
                     $tagClass = get_class($tag);
 
                     if ('phpDocumentor\Reflection\DocBlock\Tag\VarTag' === $tagClass) {
                         /** @var DocBlock\Tag\VarTag $tag */
 
-                        break;
+                        throw new Exception($tag->getDescription());
                     }
                 }
-            }
-            EOF
+                EOF
+        ];
+
+        yield [
+            <<<'EOF'
+                <?php
+                function parseTag($tag)
+                {
+                    $tagClass = get_class($tag);
+
+                    if ('phpDocumentor\Reflection\DocBlock\Tag\VarTag' === $tagClass) {
+                        /** @var DocBlock\Tag\VarTag $tag */
+
+                        goto FOO;
+                    }
+
+                FOO:
+                }
+                EOF
+        ];
+
+        yield [
+            <<<'EOF'
+                <?php
+                function parseTag($tag)
+                {
+                    while (true) {
+                        $tagClass = get_class($tag);
+
+                        if ('phpDocumentor\Reflection\DocBlock\Tag\VarTag' === $tagClass) {
+                            /** @var DocBlock\Tag\VarTag $tag */
+
+                            continue;
+                        }
+                    }
+                }
+                EOF
+        ];
+
+        yield [
+            <<<'EOF'
+                <?php
+                function parseTag($tag)
+                {
+                    while (true) {
+                        $tagClass = get_class($tag);
+
+                        if ('phpDocumentor\Reflection\DocBlock\Tag\VarTag' === $tagClass) {
+                            /** @var DocBlock\Tag\VarTag $tag */
+
+                            break;
+                        }
+                    }
+                }
+                EOF
         ];
     }
 }

--- a/tests/Fixer/Phpdoc/PhpdocVarWithoutNameFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocVarWithoutNameFixerTest.php
@@ -59,8 +59,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                      */
                     public $foo;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -71,8 +70,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                      */
                     public $foo;
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'testFixType' => [
@@ -86,8 +84,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                      */
                     public $bar;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -98,8 +95,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                      */
                     public $bar;
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'testDoNothing' => [
@@ -130,8 +126,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                      */
                      public $options;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -157,8 +152,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                     /** @var Foo\Bar */
                     public $bar;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -167,8 +161,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                     /** @var Foo\Bar $bar */
                     public $bar;
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'testSingleLineProtected' => [
@@ -180,8 +173,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                     /** @var Foo\Bar */
                     protected $bar;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -190,8 +182,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                     /** @var Foo\Bar $bar */
                     protected $bar;
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'testSingleLinePrivate' => [
@@ -203,8 +194,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                     /** @var Foo\Bar */
                     private $bar;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -213,8 +203,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                     /** @var Foo\Bar $bar */
                     private $bar;
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'testSingleLineVar' => [
@@ -226,8 +215,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                     /** @var Foo\Bar */
                     var $bar;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -236,8 +224,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                     /** @var Foo\Bar $bar */
                     var $bar;
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'testSingleLineStatic' => [
@@ -249,8 +236,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                     /** @var Foo\Bar */
                     static public $bar;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -259,8 +245,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                     /** @var Foo\Bar $bar */
                     static public $bar;
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'testSingleLineNoSpace' => [
@@ -272,8 +257,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                     /** @var Foo\Bar*/
                     public $bar;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -282,8 +266,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                     /** @var Foo\Bar $bar*/
                     public $bar;
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'testInlineDoc' => [
@@ -305,8 +288,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                         // Do something
                     }
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'testSingleLineNoProperty' => [
@@ -352,8 +334,7 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
                      */
                     public $nestedFoo;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -425,8 +406,7 @@ class Foo{}
                         };
                     }
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -454,8 +434,7 @@ class Foo{}
                         };
                     }
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -542,8 +521,7 @@ class A
                     /** @var int Hello! */
                     public $foo4;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -563,8 +541,7 @@ class A
                     /** @var int $this2 Hello! */
                     public $foo4;
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield 'testFixMultibyteVariableName' => [
@@ -579,8 +556,7 @@ class A
                     /** @var 🚀 🚀 */
                     public $foo2;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -592,8 +568,7 @@ class A
                     /** @var 🚀 $my 🚀 */
                     public $foo2;
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield '@var with callable syntax' => [
@@ -605,8 +580,7 @@ class A
                     /** @var array<callable(string, Buzz): void> */
                     protected $bar;
                 }
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
 
@@ -615,8 +589,7 @@ class A
                     /** @var array<callable(string $baz, Buzz $buzz): void> */
                     protected $bar;
                 }
-                EOF
-            ,
+                EOF,
         ];
     }
 

--- a/tests/Fixer/StringNotation/EscapeImplicitBackslashesFixerTest.php
+++ b/tests/Fixer/StringNotation/EscapeImplicitBackslashesFixerTest.php
@@ -41,19 +41,16 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
         yield [
             <<<'EOF'
                 <?php $var = 'String (\\\'\r\n\x0) for My\Prefix\\';
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
             <<<'EOF'
                 <?php $var = 'String (\\\'\\r\\n\\x0) for My\\Prefix\\';
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php $var = 'String (\\\'\r\n\x0) for My\Prefix\\';
-                EOF
-            ,
+                EOF,
             ['single_quoted' => true],
         ];
 
@@ -84,8 +81,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 \u
                 NOWDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 $var = "\A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z";
@@ -112,8 +108,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 \u
                 NOWDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -128,8 +123,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 $foo \e\f\n\r\t\v \\ \$ ${bar}
                 HEREDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -144,8 +138,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 $foo \0 \00 \000 \0000 \00000 ${bar}
                 HEREDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -160,8 +153,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 $foo \xA \x99 \u{0} ${bar}
                 HEREDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -184,8 +176,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 code coverage
                 NOWDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -193,8 +184,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 <?php
                 $var = "\A\a \' \8\9 \xZ \u";
                 $var = "$foo \A\a \' \8\9 \xZ \u ${bar}";
-                EOF
-            ,
+                EOF,
             null,
             ['double_quoted' => false],
         ];
@@ -221,8 +211,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 ${bar}
                 HEREDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
             null,
             ['heredoc_syntax' => false],
         ];
@@ -230,19 +219,16 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
         yield [
             <<<'EOF'
                 <?php $var = b'String (\\\'\r\n\x0) for My\Prefix\\';
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
             <<<'EOF'
                 <?php $var = b'String (\\\'\\r\\n\\x0) for My\\Prefix\\';
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php $var = b'String (\\\'\r\n\x0) for My\Prefix\\';
-                EOF
-            ,
+                EOF,
             ['single_quoted' => true],
         ];
 
@@ -273,8 +259,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 \u
                 NOWDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 $var = b"\A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z";
@@ -301,8 +286,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 \u
                 NOWDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -317,8 +301,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 $foo \e\f\n\r\t\v \\ \$ ${bar}
                 HEREDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -333,8 +316,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 $foo \0 \00 \000 \0000 \00000 ${bar}
                 HEREDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -349,8 +331,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 $foo \xA \x99 \u{0} ${bar}
                 HEREDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -373,8 +354,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 code coverage
                 NOWDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -382,8 +362,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 <?php
                 $var = b"\A\a \' \8\9 \xZ \u";
                 $var = b"$foo \A\a \' \8\9 \xZ \u ${bar}";
-                EOF
-            ,
+                EOF,
             null,
             ['double_quoted' => false],
         ];
@@ -410,8 +389,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 ${bar}
                 HEREDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
             null,
             ['heredoc_syntax' => false],
         ];
@@ -419,19 +397,16 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
         yield [
             <<<'EOF'
                 <?php $var = B'String (\\\'\r\n\x0) for My\Prefix\\';
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
             <<<'EOF'
                 <?php $var = B'String (\\\'\\r\\n\\x0) for My\\Prefix\\';
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php $var = B'String (\\\'\r\n\x0) for My\Prefix\\';
-                EOF
-            ,
+                EOF,
             ['single_quoted' => true],
         ];
 
@@ -462,8 +437,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 \u
                 NOWDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 $var = B"\A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z";
@@ -490,8 +464,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 \u
                 NOWDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -506,8 +479,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 $foo \e\f\n\r\t\v \\ \$ ${bar}
                 HEREDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -522,8 +494,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 $foo \0 \00 \000 \0000 \00000 ${bar}
                 HEREDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -538,8 +509,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 $foo \xA \x99 \u{0} ${bar}
                 HEREDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -562,8 +532,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 code coverage
                 NOWDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -571,8 +540,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 <?php
                 $var = B"\A\a \' \8\9 \xZ \u";
                 $var = B"$foo \A\a \' \8\9 \xZ \u ${bar}";
-                EOF
-            ,
+                EOF,
             null,
             ['double_quoted' => false],
         ];
@@ -599,8 +567,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 ${bar}
                 HEREDOC_SYNTAX;
 
-                EOF
-            ,
+                EOF,
             null,
             ['heredoc_syntax' => false],
         ];
@@ -614,8 +581,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 $var = "\\\\bar";
                 $var = "\\\\\\bar";
                 $var = "\\\\\\bar";
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 $var = "\bar";
@@ -624,8 +590,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 $var = "\\\\bar";
                 $var = "\\\\\bar";
                 $var = "\\\\\\bar";
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -637,8 +602,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 $var = '\\\\bar';
                 $var = '\\\\\\bar';
                 $var = '\\\\\\bar';
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 $var = '\bar';
@@ -647,8 +611,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 $var = '\\\\bar';
                 $var = '\\\\\bar';
                 $var = '\\\\\\bar';
-                EOF
-            ,
+                EOF,
             ['single_quoted' => true],
         ];
 
@@ -664,8 +627,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 \\\\\\bar
                 TXT;
 
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 $var = <<<TXT
@@ -677,8 +639,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 \\\\\\bar
                 TXT;
 
-                EOF
-            ,
+                EOF,
         ];
 
         yield [
@@ -693,8 +654,7 @@ final class EscapeImplicitBackslashesFixerTest extends AbstractFixerTestCase
                 \\\\\\bar
                 TXT;
 
-                EOF
-            ,
+                EOF,
         ];
     }
 }

--- a/tests/Fixer/StringNotation/HeredocToNowdocFixerTest.php
+++ b/tests/Fixer/StringNotation/HeredocToNowdocFixerTest.php
@@ -47,11 +47,12 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             <?php $a = <<<'TEST'
             TEST;
 
-            EOF, <<<'EOF'
-            <?php $a = <<<TEST
-            TEST;
+            EOF,
+            <<<'EOF'
+                <?php $a = <<<TEST
+                TEST;
 
-            EOF
+                EOF
         ];
 
         yield [<<<'EOF'
@@ -59,12 +60,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo \\ $bar \n
             TEST;
 
-            EOF, <<<'EOF'
-            <?php $a = <<<TEST
-            Foo \\\\ \$bar \\n
-            TEST;
+            EOF,
+            <<<'EOF'
+                <?php $a = <<<TEST
+                Foo \\\\ \$bar \\n
+                TEST;
 
-            EOF
+                EOF
         ];
 
         yield [<<<'EOF'
@@ -72,12 +74,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo
             TEST;
 
-            EOF, <<<'EOF'
-            <?php $a = <<<"TEST"
-            Foo
-            TEST;
+            EOF,
+            <<<'EOF'
+                <?php $a = <<<"TEST"
+                Foo
+                TEST;
 
-            EOF
+                EOF
         ];
 
         yield [<<<'EOF'
@@ -118,13 +121,14 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             a
             HTML;
 
-            EOF, <<<'EOF'
-            <?php
-            $html = <<<   HTML
-            a
-            HTML;
+            EOF,
+            <<<'EOF'
+                <?php
+                $html = <<<   HTML
+                a
+                HTML;
 
-            EOF
+                EOF
         ];
 
         yield [<<<'EOF'
@@ -132,21 +136,23 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo
             TEST;
 
-            EOF, <<<'EOF'
-            <?php $a = <<<           "TEST"
-            Foo
-            TEST;
+            EOF,
+            <<<'EOF'
+                <?php $a = <<<           "TEST"
+                Foo
+                TEST;
 
-            EOF
+                EOF
         ];
 
         yield [<<<EOF
             <?php echo <<<'TEST'\r\nFoo\r\nTEST;
 
-            EOF, <<<EOF
-            <?php echo <<<TEST\r\nFoo\r\nTEST;
+            EOF,
+            <<<EOF
+                <?php echo <<<TEST\r\nFoo\r\nTEST;
 
-            EOF
+                EOF
         ];
 
         yield [<<<'EOF'
@@ -161,11 +167,12 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             <?php $a = b<<<'TEST'
             TEST;
 
-            EOF, <<<'EOF'
-            <?php $a = b<<<TEST
-            TEST;
+            EOF,
+            <<<'EOF'
+                <?php $a = b<<<TEST
+                TEST;
 
-            EOF
+                EOF
         ];
 
         yield [<<<'EOF'
@@ -173,12 +180,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo \\ $bar \n
             TEST;
 
-            EOF, <<<'EOF'
-            <?php $a = b<<<TEST
-            Foo \\\\ \$bar \\n
-            TEST;
+            EOF,
+            <<<'EOF'
+                <?php $a = b<<<TEST
+                Foo \\\\ \$bar \\n
+                TEST;
 
-            EOF
+                EOF
         ];
 
         yield [<<<'EOF'
@@ -186,12 +194,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo
             TEST;
 
-            EOF, <<<'EOF'
-            <?php $a = b<<<"TEST"
-            Foo
-            TEST;
+            EOF,
+            <<<'EOF'
+                <?php $a = b<<<"TEST"
+                Foo
+                TEST;
 
-            EOF
+                EOF
         ];
 
         yield [<<<'EOF'
@@ -232,13 +241,14 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             a
             HTML;
 
-            EOF, <<<'EOF'
-            <?php
-            $html = b<<<   HTML
-            a
-            HTML;
+            EOF,
+            <<<'EOF'
+                <?php
+                $html = b<<<   HTML
+                a
+                HTML;
 
-            EOF
+                EOF
         ];
 
         yield [<<<'EOF'
@@ -246,21 +256,23 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo
             TEST;
 
-            EOF, <<<'EOF'
-            <?php $a = b<<<           "TEST"
-            Foo
-            TEST;
+            EOF,
+            <<<'EOF'
+                <?php $a = b<<<           "TEST"
+                Foo
+                TEST;
 
-            EOF
+                EOF
         ];
 
         yield [<<<EOF
             <?php echo b<<<'TEST'\r\nFoo\r\nTEST;
 
-            EOF, <<<EOF
-            <?php echo b<<<TEST\r\nFoo\r\nTEST;
+            EOF,
+            <<<EOF
+                <?php echo b<<<TEST\r\nFoo\r\nTEST;
 
-            EOF
+                EOF
         ];
 
         yield [<<<'EOF'
@@ -275,11 +287,12 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             <?php $a = B<<<'TEST'
             TEST;
 
-            EOF, <<<'EOF'
-            <?php $a = B<<<TEST
-            TEST;
+            EOF,
+            <<<'EOF'
+                <?php $a = B<<<TEST
+                TEST;
 
-            EOF
+                EOF
         ];
 
         yield [<<<'EOF'
@@ -287,12 +300,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo \\ $bar \n
             TEST;
 
-            EOF, <<<'EOF'
-            <?php $a = B<<<TEST
-            Foo \\\\ \$bar \\n
-            TEST;
+            EOF,
+            <<<'EOF'
+                <?php $a = B<<<TEST
+                Foo \\\\ \$bar \\n
+                TEST;
 
-            EOF
+                EOF
         ];
 
         yield [<<<'EOF'
@@ -300,12 +314,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo
             TEST;
 
-            EOF, <<<'EOF'
-            <?php $a = B<<<"TEST"
-            Foo
-            TEST;
+            EOF,
+            <<<'EOF'
+                <?php $a = B<<<"TEST"
+                Foo
+                TEST;
 
-            EOF
+                EOF
         ];
 
         yield [<<<'EOF'
@@ -346,13 +361,14 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             a
             HTML;
 
-            EOF, <<<'EOF'
-            <?php
-            $html = B<<<   HTML
-            a
-            HTML;
+            EOF,
+            <<<'EOF'
+                <?php
+                $html = B<<<   HTML
+                a
+                HTML;
 
-            EOF
+                EOF
         ];
 
         yield [<<<'EOF'
@@ -360,21 +376,23 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo
             TEST;
 
-            EOF, <<<'EOF'
-            <?php $a = B<<<           "TEST"
-            Foo
-            TEST;
+            EOF,
+            <<<'EOF'
+                <?php $a = B<<<           "TEST"
+                Foo
+                TEST;
 
-            EOF
+                EOF
         ];
 
         yield [<<<EOF
             <?php echo B<<<'TEST'\r\nFoo\r\nTEST;
 
-            EOF, <<<EOF
-            <?php echo B<<<TEST\r\nFoo\r\nTEST;
+            EOF,
+            <<<EOF
+                <?php echo B<<<TEST\r\nFoo\r\nTEST;
 
-            EOF
+                EOF
         ];
     }
 }

--- a/tests/Fixer/StringNotation/HeredocToNowdocFixerTest.php
+++ b/tests/Fixer/StringNotation/HeredocToNowdocFixerTest.php
@@ -47,12 +47,11 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             <?php $a = <<<'TEST'
             TEST;
 
-            EOF
-            , <<<'EOF'
-                <?php $a = <<<TEST
-                TEST;
+            EOF, <<<'EOF'
+            <?php $a = <<<TEST
+            TEST;
 
-                EOF
+            EOF
         ];
 
         yield [<<<'EOF'
@@ -60,13 +59,12 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo \\ $bar \n
             TEST;
 
-            EOF
-            , <<<'EOF'
-                <?php $a = <<<TEST
-                Foo \\\\ \$bar \\n
-                TEST;
+            EOF, <<<'EOF'
+            <?php $a = <<<TEST
+            Foo \\\\ \$bar \\n
+            TEST;
 
-                EOF
+            EOF
         ];
 
         yield [<<<'EOF'
@@ -74,13 +72,12 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo
             TEST;
 
-            EOF
-            , <<<'EOF'
-                <?php $a = <<<"TEST"
-                Foo
-                TEST;
+            EOF, <<<'EOF'
+            <?php $a = <<<"TEST"
+            Foo
+            TEST;
 
-                EOF
+            EOF
         ];
 
         yield [<<<'EOF'
@@ -121,14 +118,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             a
             HTML;
 
-            EOF
-            , <<<'EOF'
-                <?php
-                $html = <<<   HTML
-                a
-                HTML;
+            EOF, <<<'EOF'
+            <?php
+            $html = <<<   HTML
+            a
+            HTML;
 
-                EOF
+            EOF
         ];
 
         yield [<<<'EOF'
@@ -136,23 +132,21 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo
             TEST;
 
-            EOF
-            , <<<'EOF'
-                <?php $a = <<<           "TEST"
-                Foo
-                TEST;
+            EOF, <<<'EOF'
+            <?php $a = <<<           "TEST"
+            Foo
+            TEST;
 
-                EOF
+            EOF
         ];
 
         yield [<<<EOF
             <?php echo <<<'TEST'\r\nFoo\r\nTEST;
 
-            EOF
-            , <<<EOF
-                <?php echo <<<TEST\r\nFoo\r\nTEST;
+            EOF, <<<EOF
+            <?php echo <<<TEST\r\nFoo\r\nTEST;
 
-                EOF
+            EOF
         ];
 
         yield [<<<'EOF'
@@ -167,12 +161,11 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             <?php $a = b<<<'TEST'
             TEST;
 
-            EOF
-            , <<<'EOF'
-                <?php $a = b<<<TEST
-                TEST;
+            EOF, <<<'EOF'
+            <?php $a = b<<<TEST
+            TEST;
 
-                EOF
+            EOF
         ];
 
         yield [<<<'EOF'
@@ -180,13 +173,12 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo \\ $bar \n
             TEST;
 
-            EOF
-            , <<<'EOF'
-                <?php $a = b<<<TEST
-                Foo \\\\ \$bar \\n
-                TEST;
+            EOF, <<<'EOF'
+            <?php $a = b<<<TEST
+            Foo \\\\ \$bar \\n
+            TEST;
 
-                EOF
+            EOF
         ];
 
         yield [<<<'EOF'
@@ -194,13 +186,12 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo
             TEST;
 
-            EOF
-            , <<<'EOF'
-                <?php $a = b<<<"TEST"
-                Foo
-                TEST;
+            EOF, <<<'EOF'
+            <?php $a = b<<<"TEST"
+            Foo
+            TEST;
 
-                EOF
+            EOF
         ];
 
         yield [<<<'EOF'
@@ -241,14 +232,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             a
             HTML;
 
-            EOF
-            , <<<'EOF'
-                <?php
-                $html = b<<<   HTML
-                a
-                HTML;
+            EOF, <<<'EOF'
+            <?php
+            $html = b<<<   HTML
+            a
+            HTML;
 
-                EOF
+            EOF
         ];
 
         yield [<<<'EOF'
@@ -256,23 +246,21 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo
             TEST;
 
-            EOF
-            , <<<'EOF'
-                <?php $a = b<<<           "TEST"
-                Foo
-                TEST;
+            EOF, <<<'EOF'
+            <?php $a = b<<<           "TEST"
+            Foo
+            TEST;
 
-                EOF
+            EOF
         ];
 
         yield [<<<EOF
             <?php echo b<<<'TEST'\r\nFoo\r\nTEST;
 
-            EOF
-            , <<<EOF
-                <?php echo b<<<TEST\r\nFoo\r\nTEST;
+            EOF, <<<EOF
+            <?php echo b<<<TEST\r\nFoo\r\nTEST;
 
-                EOF
+            EOF
         ];
 
         yield [<<<'EOF'
@@ -287,12 +275,11 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             <?php $a = B<<<'TEST'
             TEST;
 
-            EOF
-            , <<<'EOF'
-                <?php $a = B<<<TEST
-                TEST;
+            EOF, <<<'EOF'
+            <?php $a = B<<<TEST
+            TEST;
 
-                EOF
+            EOF
         ];
 
         yield [<<<'EOF'
@@ -300,13 +287,12 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo \\ $bar \n
             TEST;
 
-            EOF
-            , <<<'EOF'
-                <?php $a = B<<<TEST
-                Foo \\\\ \$bar \\n
-                TEST;
+            EOF, <<<'EOF'
+            <?php $a = B<<<TEST
+            Foo \\\\ \$bar \\n
+            TEST;
 
-                EOF
+            EOF
         ];
 
         yield [<<<'EOF'
@@ -314,13 +300,12 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo
             TEST;
 
-            EOF
-            , <<<'EOF'
-                <?php $a = B<<<"TEST"
-                Foo
-                TEST;
+            EOF, <<<'EOF'
+            <?php $a = B<<<"TEST"
+            Foo
+            TEST;
 
-                EOF
+            EOF
         ];
 
         yield [<<<'EOF'
@@ -361,14 +346,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             a
             HTML;
 
-            EOF
-            , <<<'EOF'
-                <?php
-                $html = B<<<   HTML
-                a
-                HTML;
+            EOF, <<<'EOF'
+            <?php
+            $html = B<<<   HTML
+            a
+            HTML;
 
-                EOF
+            EOF
         ];
 
         yield [<<<'EOF'
@@ -376,23 +360,21 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
             Foo
             TEST;
 
-            EOF
-            , <<<'EOF'
-                <?php $a = B<<<           "TEST"
-                Foo
-                TEST;
+            EOF, <<<'EOF'
+            <?php $a = B<<<           "TEST"
+            Foo
+            TEST;
 
-                EOF
+            EOF
         ];
 
         yield [<<<EOF
             <?php echo B<<<'TEST'\r\nFoo\r\nTEST;
 
-            EOF
-            , <<<EOF
-                <?php echo B<<<TEST\r\nFoo\r\nTEST;
+            EOF, <<<EOF
+            <?php echo B<<<TEST\r\nFoo\r\nTEST;
 
-                EOF
+            EOF
         ];
     }
 }

--- a/tests/Fixer/StringNotation/HeredocToNowdocFixerTest.php
+++ b/tests/Fixer/StringNotation/HeredocToNowdocFixerTest.php
@@ -35,19 +35,21 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
 
     public static function provideFixCases(): iterable
     {
-        yield [<<<'EOF'
-            <?php $a = <<<'TEST'
-            Foo $bar \n
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = <<<'TEST'
+                Foo $bar \n
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = <<<'TEST'
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = <<<'TEST'
+                TEST;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php $a = <<<TEST
                 TEST;
@@ -55,12 +57,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = <<<'TEST'
-            Foo \\ $bar \n
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = <<<'TEST'
+                Foo \\ $bar \n
+                TEST;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php $a = <<<TEST
                 Foo \\\\ \$bar \\n
@@ -69,12 +72,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = <<<'TEST'
-            Foo
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = <<<'TEST'
+                Foo
+                TEST;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php $a = <<<"TEST"
                 Foo
@@ -83,45 +87,50 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = <<<TEST
-            Foo $bar
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = <<<TEST
+                Foo $bar
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = <<<TEST
-            Foo \\$bar
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = <<<TEST
+                Foo \\$bar
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = <<<TEST
-            Foo \n $bar
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = <<<TEST
+                Foo \n $bar
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = <<<TEST
-            Foo \x00 $bar
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = <<<TEST
+                Foo \x00 $bar
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php
-            $html = <<<   'HTML'
-            a
-            HTML;
+        yield [
+            <<<'EOF'
+                <?php
+                $html = <<<   'HTML'
+                a
+                HTML;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php
                 $html = <<<   HTML
@@ -131,12 +140,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = <<<           'TEST'
-            Foo
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = <<<           'TEST'
+                Foo
+                TEST;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php $a = <<<           "TEST"
                 Foo
@@ -145,29 +155,32 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<EOF
-            <?php echo <<<'TEST'\r\nFoo\r\nTEST;
+        yield [
+            <<<EOF
+                <?php echo <<<'TEST'\r\nFoo\r\nTEST;
 
-            EOF,
+                EOF,
             <<<EOF
                 <?php echo <<<TEST\r\nFoo\r\nTEST;
 
                 EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = b<<<'TEST'
-            Foo $bar \n
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = b<<<'TEST'
+                Foo $bar \n
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = b<<<'TEST'
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = b<<<'TEST'
+                TEST;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php $a = b<<<TEST
                 TEST;
@@ -175,12 +188,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = b<<<'TEST'
-            Foo \\ $bar \n
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = b<<<'TEST'
+                Foo \\ $bar \n
+                TEST;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php $a = b<<<TEST
                 Foo \\\\ \$bar \\n
@@ -189,12 +203,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = b<<<'TEST'
-            Foo
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = b<<<'TEST'
+                Foo
+                TEST;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php $a = b<<<"TEST"
                 Foo
@@ -203,45 +218,50 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = b<<<TEST
-            Foo $bar
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = b<<<TEST
+                Foo $bar
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = b<<<TEST
-            Foo \\$bar
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = b<<<TEST
+                Foo \\$bar
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = b<<<TEST
-            Foo \n $bar
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = b<<<TEST
+                Foo \n $bar
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = b<<<TEST
-            Foo \x00 $bar
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = b<<<TEST
+                Foo \x00 $bar
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php
-            $html = b<<<   'HTML'
-            a
-            HTML;
+        yield [
+            <<<'EOF'
+                <?php
+                $html = b<<<   'HTML'
+                a
+                HTML;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php
                 $html = b<<<   HTML
@@ -251,12 +271,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = b<<<           'TEST'
-            Foo
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = b<<<           'TEST'
+                Foo
+                TEST;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php $a = b<<<           "TEST"
                 Foo
@@ -265,29 +286,32 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<EOF
-            <?php echo b<<<'TEST'\r\nFoo\r\nTEST;
+        yield [
+            <<<EOF
+                <?php echo b<<<'TEST'\r\nFoo\r\nTEST;
 
-            EOF,
+                EOF,
             <<<EOF
                 <?php echo b<<<TEST\r\nFoo\r\nTEST;
 
                 EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = B<<<'TEST'
-            Foo $bar \n
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = B<<<'TEST'
+                Foo $bar \n
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = B<<<'TEST'
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = B<<<'TEST'
+                TEST;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php $a = B<<<TEST
                 TEST;
@@ -295,12 +319,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = B<<<'TEST'
-            Foo \\ $bar \n
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = B<<<'TEST'
+                Foo \\ $bar \n
+                TEST;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php $a = B<<<TEST
                 Foo \\\\ \$bar \\n
@@ -309,12 +334,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = B<<<'TEST'
-            Foo
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = B<<<'TEST'
+                Foo
+                TEST;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php $a = B<<<"TEST"
                 Foo
@@ -323,45 +349,50 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = B<<<TEST
-            Foo $bar
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = B<<<TEST
+                Foo $bar
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = B<<<TEST
-            Foo \\$bar
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = B<<<TEST
+                Foo \\$bar
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = B<<<TEST
-            Foo \n $bar
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = B<<<TEST
+                Foo \n $bar
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = B<<<TEST
-            Foo \x00 $bar
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = B<<<TEST
+                Foo \x00 $bar
+                TEST;
 
-            EOF
+                EOF
         ];
 
-        yield [<<<'EOF'
-            <?php
-            $html = B<<<   'HTML'
-            a
-            HTML;
+        yield [
+            <<<'EOF'
+                <?php
+                $html = B<<<   'HTML'
+                a
+                HTML;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php
                 $html = B<<<   HTML
@@ -371,12 +402,13 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<'EOF'
-            <?php $a = B<<<           'TEST'
-            Foo
-            TEST;
+        yield [
+            <<<'EOF'
+                <?php $a = B<<<           'TEST'
+                Foo
+                TEST;
 
-            EOF,
+                EOF,
             <<<'EOF'
                 <?php $a = B<<<           "TEST"
                 Foo
@@ -385,10 +417,11 @@ final class HeredocToNowdocFixerTest extends AbstractFixerTestCase
                 EOF
         ];
 
-        yield [<<<EOF
-            <?php echo B<<<'TEST'\r\nFoo\r\nTEST;
+        yield [
+            <<<EOF
+                <?php echo B<<<'TEST'\r\nFoo\r\nTEST;
 
-            EOF,
+                EOF,
             <<<EOF
                 <?php echo B<<<TEST\r\nFoo\r\nTEST;
 

--- a/tests/Fixer/StringNotation/SimpleToComplexStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/SimpleToComplexStringVariableFixerTest.php
@@ -40,14 +40,12 @@ final class SimpleToComplexStringVariableFixerTest extends AbstractFixerTestCase
                 <?php
                 $name = "World";
                 echo "Hello {$name}!";
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 $name = "World";
                 echo "Hello ${name}!";
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'heredoc' => [
@@ -58,8 +56,7 @@ final class SimpleToComplexStringVariableFixerTest extends AbstractFixerTestCase
                 Hello {$name}!
                 TEST;
 
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 $name = 'World';
@@ -67,8 +64,7 @@ final class SimpleToComplexStringVariableFixerTest extends AbstractFixerTestCase
                 Hello ${name}!
                 TEST;
 
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'implicit' => [
@@ -76,8 +72,7 @@ final class SimpleToComplexStringVariableFixerTest extends AbstractFixerTestCase
                 <?php
                 $name = 'World';
                 echo "Hello $name!";
-                EXPECTED
-            ,
+                EXPECTED,
         ];
 
         yield 'implicit again' => [
@@ -85,8 +80,7 @@ final class SimpleToComplexStringVariableFixerTest extends AbstractFixerTestCase
                 <?php
                 $name = 'World';
                 echo "Hello { $name }!";
-                EXPECTED
-            ,
+                EXPECTED,
         ];
 
         yield 'escaped' => [
@@ -94,8 +88,7 @@ final class SimpleToComplexStringVariableFixerTest extends AbstractFixerTestCase
                 <?php
                 $name = 'World';
                 echo "Hello \${name}";
-                EXPECTED
-            ,
+                EXPECTED,
         ];
 
         yield 'double dollar' => [
@@ -103,14 +96,12 @@ final class SimpleToComplexStringVariableFixerTest extends AbstractFixerTestCase
                 <?php
                 $name = 'World';
                 echo "Hello \${$name}";
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 $name = 'World';
                 echo "Hello $${name}";
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'double dollar heredoc' => [
@@ -121,8 +112,7 @@ final class SimpleToComplexStringVariableFixerTest extends AbstractFixerTestCase
                 Hello \${$name}!
                 TEST;
 
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                 $name = 'World';
@@ -130,8 +120,7 @@ final class SimpleToComplexStringVariableFixerTest extends AbstractFixerTestCase
                 Hello $${name}!
                 TEST;
 
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'double dollar single quote' => [
@@ -139,8 +128,7 @@ final class SimpleToComplexStringVariableFixerTest extends AbstractFixerTestCase
                 <?php
                 $name = 'World';
                 echo 'Hello $${name}';
-                EXPECTED
-            ,
+                EXPECTED,
         ];
     }
 }

--- a/tests/Fixer/StringNotation/SingleQuoteFixerTest.php
+++ b/tests/Fixer/StringNotation/SingleQuoteFixerTest.php
@@ -144,9 +144,10 @@ final class SingleQuoteFixerTest extends AbstractFixerTestCase
 
         yield ['<?php $a = B"foo\n bar";'];
 
-        yield [<<<'EOF'
-            <?php $a = "\\\n";
-            EOF
+        yield [
+            <<<'EOF'
+                <?php $a = "\\\n";
+                EOF
         ];
 
         yield [

--- a/tests/Fixer/StringNotation/SingleQuoteFixerTest.php
+++ b/tests/Fixer/StringNotation/SingleQuoteFixerTest.php
@@ -93,8 +93,7 @@ final class SingleQuoteFixerTest extends AbstractFixerTestCase
         yield [
             <<<'EOF'
                 <?php $a = '\\foo\\bar\\\\';
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php $a = "\\foo\\bar\\\\";
                 EOF
@@ -165,8 +164,7 @@ final class SingleQuoteFixerTest extends AbstractFixerTestCase
                 $b = 'start \\\' end';
                 // two escaped baskslash
                 $c = 'start \\\\\' end';
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
                 // none
@@ -175,8 +173,7 @@ final class SingleQuoteFixerTest extends AbstractFixerTestCase
                 $b = "start \\' end";
                 // two escaped baskslash
                 $c = "start \\\\' end";
-                EOT
-            ,
+                EOT,
             ['strings_containing_single_quote_chars' => true],
         ];
 
@@ -187,8 +184,7 @@ final class SingleQuoteFixerTest extends AbstractFixerTestCase
                 $a = "start \' end";
                 // one escaped + one unescaped baskslash
                 $b = "start \\\' end";
-                EOT
-            ,
+                EOT,
             null,
             ['strings_containing_single_quote_chars' => true],
         ];

--- a/tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
@@ -42,16 +42,14 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                         'foo',
                         'bar' => 'baz',
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
                       'foo',
                             'bar' => 'baz',
                      ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -60,16 +58,14 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                             'foo',
                             'bar' => 'baz',
                         ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                         $foo = [
                       'foo',
                             'bar' => 'baz',
                      ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -81,8 +77,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                             'baz'
                         ],
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
@@ -92,8 +87,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                              'baz'
                              ],
                      ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -108,8 +102,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                                     'baz']],
                             'baz'],
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
@@ -122,8 +115,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                         'baz']],
                       'baz'],
                      ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -149,8 +141,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                             ];
                         }
                     }
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     class Foo
@@ -174,8 +165,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                              ];
                         }
                     }
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -194,8 +184,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                                     2
                                  ),
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
@@ -212,8 +201,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                                          2
                                       ),
                     ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -224,8 +212,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                         ]],
                         'qux',
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
@@ -234,8 +221,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                       ]],
                       'qux',
                     ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -246,8 +232,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                                        ->foo(),
                         ],
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
@@ -256,8 +241,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                                     ->foo(),
                       ],
                     ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -268,8 +252,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                         [new Foo(
                                 )],
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
@@ -278,8 +261,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                       [new Foo(
                               )],
                     ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -297,8 +279,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                               ])
                         ,
                     ]);
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = new Foo([
@@ -314,8 +295,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                                    ])
                              ,
                     ]);
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -336,8 +316,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                             ];
                         }
                     }
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
 
@@ -356,8 +335,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                                      ];
                         }
                     }
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -383,8 +361,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                         }
                     }
 
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
 
@@ -408,8 +385,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                         }
                     }
 
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -421,8 +397,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                             .bar()
                         ,
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
 
@@ -432,8 +407,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                           .bar()
                     ,
                     ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -442,16 +416,14 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                         [new \stdClass()],
                         'foo',
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
                       [new \stdClass()],
                      'foo',
                     ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -462,8 +434,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                             : 'foo'
                         ,
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
@@ -472,8 +443,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                           : 'foo'
                           ,
                     ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -484,8 +454,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                             'foo'
                         ,
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
@@ -494,8 +463,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                           'foo'
                           ,
                     ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -508,8 +476,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                             'bar',
                         ],
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
 
@@ -520,8 +487,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                        'bar',
                       ],
                     ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -530,16 +496,14 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                         'foo', // comment
                         'bar',
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
                       'foo', // comment
                     'bar',
                      ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -550,8 +514,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                     ],
                     ],
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [[[
@@ -560,8 +523,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                     ],
                      ],
                       ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -572,8 +534,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                                 'foo',
                                 'bar',
                             ]]];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
@@ -582,8 +543,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                         'foo',
                         'bar',
                      ]]];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -599,8 +559,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                             ]
                             ]
                         ]];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
@@ -614,8 +573,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                     ]
                      ]
                     ]];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -633,8 +591,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                             ],[]],[]]
                     ]
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [[
@@ -650,8 +607,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                     ],[]],[]]
                     ]
                     ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -661,8 +617,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                             'baz',
                         ]) ?>
                     <?php endif ?>
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php if ($foo): ?>
                         <?php foo([
@@ -670,8 +625,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                           'baz',
                        ]) ?>
                     <?php endif ?>
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -686,8 +640,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                             Link text
                         </a>
                     </div>
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <div>
                         <a
@@ -700,8 +653,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                             Link text
                         </a>
                     </div>
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -711,8 +663,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
 
                         //  'c' => 'd',
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $arr = [
@@ -720,8 +671,7 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
 
                     //  'c' => 'd',
                     ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 '<?php
@@ -744,8 +694,7 @@ $foo = [
                              .' long'
                               .' string'
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
@@ -758,8 +707,7 @@ $foo = [
                                  .' long'
                                   .' string'
                     ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -773,8 +721,7 @@ $foo = [
                                   321,
                               ],
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
@@ -786,8 +733,7 @@ $foo = [
                                        321,
                               ],
                     ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -797,8 +743,7 @@ $foo = [
                             'foo'
                         ),
                     ]];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [[
@@ -806,8 +751,7 @@ $foo = [
                               'foo'
                           ),
                     ]];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -819,8 +763,7 @@ $foo = [
                             ],
                         ], // <- this one
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $array = [
@@ -830,8 +773,7 @@ $foo = [
                             ],
                     ], // <- this one
                     ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<'EXPECTED'
@@ -840,16 +782,14 @@ $foo = [
                         ...$foo,
                         ...$bar,
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
                       ...$foo,
                             ...$bar,
                      ];
-                    INPUT
-                ,
+                    INPUT,
             ],
         ]);
 
@@ -861,8 +801,7 @@ $foo = [
                         $bar,
                         $baz
                     ] = $arr;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                     <?php
                     [
@@ -870,8 +809,7 @@ $foo = [
                                 $bar,
                       $baz
                     ] = $arr;
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'array destructuring using list' => [
@@ -882,8 +820,7 @@ $foo = [
                         $bar,
                         $baz
                     ) = $arr;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                     <?php
                     list(
@@ -891,8 +828,7 @@ $foo = [
                                 $bar,
                       $baz
                     ) = $arr;
-                INPUT
-            ,
+                INPUT,
         ];
     }
 
@@ -915,16 +851,14 @@ $foo = [
                     \t'foo',
                     \t'bar' => 'baz',
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<'INPUT'
                     <?php
                     $foo = [
                       'foo',
                             'bar' => 'baz',
                      ];
-                    INPUT
-                ,
+                    INPUT,
             ],
             [
                 <<<EXPECTED
@@ -933,16 +867,14 @@ $foo = [
                     \t'foo',
                     \t'bar' => 'baz',
                     ];
-                    EXPECTED
-                ,
+                    EXPECTED,
                 <<<INPUT
                     <?php
                     \$foo = [
                     \t\t\t'foo',
                     \t\t'bar' => 'baz',
                      ];
-                    INPUT
-                ,
+                    INPUT,
             ],
         ]);
 
@@ -954,8 +886,7 @@ $foo = [
                     \t\$bar,
                     \t\$baz
                     ] = \$arr;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                     <?php
                     [
@@ -963,8 +894,7 @@ $foo = [
                                 $bar,
                       $baz
                     ] = $arr;
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield 'array destructuring using list' => [
@@ -975,8 +905,7 @@ $foo = [
                     \t\$bar,
                     \t\$baz
                     ) = \$arr;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                     <?php
                     list(
@@ -984,8 +913,7 @@ $foo = [
                                 $bar,
                       $baz
                     ) = $arr;
-                INPUT
-            ,
+                INPUT,
         ];
     }
 

--- a/tests/Fixer/Whitespace/HeredocIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/HeredocIndentationFixerTest.php
@@ -45,15 +45,13 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
                     foo(<<<EOD
                         EOD
                     );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                     foo(<<<EOD
                 EOD
                     );
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield [
@@ -63,16 +61,14 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
 
                         EOD
                     );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                     foo(<<<EOD
 
                 EOD
                     );
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield [
@@ -84,8 +80,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
                             def
                         EOD
                     );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                     foo(<<<EOD
@@ -94,8 +89,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
                     def
                 EOD
                     );
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield [
@@ -108,8 +102,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
 
                         EOD
                     );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                     foo(<<<'EOD'
@@ -119,8 +112,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
 
                 EOD
                     );
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield [
@@ -131,8 +123,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
                             def
                         EOD
                     );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                     foo(<<<'EOD'
@@ -140,8 +131,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
                                 def
                             EOD
                     );
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield [
@@ -153,8 +143,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
                         {$ghi}
                         EOD
                     );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                     foo(<<<EOD
@@ -163,8 +152,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
                 {$ghi}
                 EOD
                     );
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield [
@@ -176,8 +164,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
                         abc
                         FOO;
                         EOD;
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                     $a = <<<'EOD'
@@ -186,8 +173,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
                 abc
                 FOO;
                 EOD;
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield [
@@ -241,14 +227,12 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
                 <?php foo(<<<EOD
                     EOD
                 );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php foo(<<<EOD
                 EOD
                 );
-                INPUT
-            ,
+                INPUT,
         ];
 
         yield [
@@ -260,8 +244,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
                         def
                     EOD
                     );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                     foo(<<<EOD
@@ -270,8 +253,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
                     def
                 EOD
                     );
-                INPUT
-            ,
+                INPUT,
             ['indentation' => 'same_as_start'],
         ];
 
@@ -284,8 +266,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
                         def
                     EOD
                     );
-                EXPECTED
-            ,
+                EXPECTED,
             <<<'INPUT'
                 <?php
                     foo(<<<EOD
@@ -294,8 +275,7 @@ final class HeredocIndentationFixerTest extends AbstractFixerTestCase
                             def
                         EOD
                     );
-                INPUT
-            ,
+                INPUT,
             ['indentation' => 'same_as_start'],
         ];
     }

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -381,8 +381,7 @@ TEXT;
                 //
 
                 $d;
-                EOF
-            ,
+                EOF,
             <<<'EOF'
                 <?php
                 //class Test
@@ -590,8 +589,7 @@ use const some\Z\{ConstX,ConstY,ConstZ,};
                 $a = new Bar2();
                 $a = new Baz();
                 $a = new Qux();
-                EOF
-            ,
+                EOF,
 
             <<<'EOF'
                 <?php
@@ -613,8 +611,7 @@ use const some\Z\{ConstX,ConstY,ConstZ,};
                 $a = new Bar2();
                 $a = new Baz();
                 $a = new Qux();
-                EOF
-            ,
+                EOF,
         ];
 
         yield [

--- a/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
@@ -402,13 +402,11 @@ $var = $arr[0]{     0
             <<<'EOT'
                 <?php
                 $arr1[]  ["some_offset"] [] {"foo"} = 3;
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
                 $arr1[  ]  [ "some_offset"   ] [     ] { "foo" } = 3;
-                EOT
-            ,
+                EOT,
             ['positions' => ['inside']],
         ];
 
@@ -416,13 +414,11 @@ $var = $arr[0]{     0
             <<<'EOT'
                 <?php
                 $arr1[  ][ "some_offset"   ][     ]{ "foo" } = 3;
-                EOT
-            ,
+                EOT,
             <<<'EOT'
                 <?php
                 $arr1[  ]  [ "some_offset"   ] [     ] { "foo" } = 3;
-                EOT
-            ,
+                EOT,
             ['positions' => ['outside']],
         ];
     }

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -188,8 +188,7 @@ final class TokensAnalyzerTest extends TestCase
                     use Foo\Bar; // expected in the return value
                 }
 
-                PHP
-            ,
+                PHP,
         ];
     }
 
@@ -2602,8 +2601,7 @@ namespace b { use D\C; }
                 class AnnotatedClass
                 {
                 }
-                EOF
-            ,
+                EOF,
         ];
 
         yield [

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -1555,8 +1555,7 @@ $bar;',
 
                 $after = /*foo*/get_class($after);
                 $before = /*foo*/get_class($before);
-                EOF
-            ,
+                EOF,
             [new Token([T_COMMENT, '/*foo*/'])],
         ];
 
@@ -1566,8 +1565,7 @@ $bar;',
 
                 $after = (string) get_class($after);
                 $before = (string) get_class($before);
-                EOF
-            ,
+                EOF,
             [new Token([T_STRING_CAST, '(string)']), new Token([T_WHITESPACE, ' '])],
         ];
 
@@ -1577,8 +1575,7 @@ $bar;',
 
                 $after = !(bool) get_class($after);
                 $before = !(bool) get_class($before);
-                EOF
-            ,
+                EOF,
             [new Token('!'), new Token([T_BOOL_CAST, '(bool)']), new Token([T_WHITESPACE, ' '])],
         ];
     }

--- a/tests/Tokenizer/TransformersTest.php
+++ b/tests/Tokenizer/TransformersTest.php
@@ -67,8 +67,7 @@ final class TransformersTest extends TestCase
                     }
                 }
 
-                SOURCE
-            ,
+                SOURCE,
             [46 => CT::T_USE_TRAIT],
         ];
     }


### PR DESCRIPTION
The fixer makes a lot of sense.