### PR TITLE
feat: Add `union_types` option to `phpdoc_to_param_type`, `phpdoc_to_property_type`, and `phpdoc_to_return_type` fixers

### DIFF
--- a/doc/rules/function_notation/phpdoc_to_param_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_param_type.rst
@@ -33,7 +33,7 @@ Default value: ``true``
 ``union_types``
 ~~~~~~~~~~~~~~~
 
-Fix also union types; turned on by default on PHP > 8.0.0.
+Fix also union types; turned on by default on PHP >= 8.0.0.
 
 Allowed types: ``bool``
 

--- a/doc/rules/function_notation/phpdoc_to_param_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_param_type.rst
@@ -33,7 +33,7 @@ Default value: ``true``
 ``union_types``
 ~~~~~~~~~~~~~~~
 
-Fix also union types.
+Fix also union types; turned on by default on PHP > 8.0.0.
 
 Allowed types: ``bool``
 

--- a/doc/rules/function_notation/phpdoc_to_param_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_param_type.rst
@@ -30,6 +30,16 @@ Allowed types: ``bool``
 
 Default value: ``true``
 
+``union_types``
+~~~~~~~~~~~~~~~
+
+Fix also union types; may have unexpected behaviour due to PHP bad type coercion
+system.
+
+Allowed types: ``bool``
+
+Default value: ``true``
+
 Examples
 --------
 
@@ -67,6 +77,23 @@ With configuration: ``['scalar_types' => false]``.
    -function foo($foo) {}
    +function foo(Foo $foo) {}
     /** @param string $foo */
+    function bar($foo) {}
+
+Example #3
+~~~~~~~~~~
+
+With configuration: ``['union_types' => false]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+
+    /** @param Foo $foo */
+   -function foo($foo) {}
+   +function foo(Foo $foo) {}
+    /** @param int|string $foo */
     function bar($foo) {}
 References
 ----------

--- a/doc/rules/function_notation/phpdoc_to_param_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_param_type.rst
@@ -33,8 +33,7 @@ Default value: ``true``
 ``union_types``
 ~~~~~~~~~~~~~~~
 
-Fix also union types; may have unexpected behaviour due to PHP bad type coercion
-system.
+Fix also union types.
 
 Allowed types: ``bool``
 

--- a/doc/rules/function_notation/phpdoc_to_property_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_property_type.rst
@@ -30,6 +30,16 @@ Allowed types: ``bool``
 
 Default value: ``true``
 
+``union_types``
+~~~~~~~~~~~~~~~
+
+Fix also union types; may have unexpected behaviour due to PHP bad type coercion
+system.
+
+Allowed types: ``bool``
+
+Default value: ``true``
+
 Examples
 --------
 
@@ -64,6 +74,24 @@ With configuration: ``['scalar_types' => false]``.
     <?php
     class Foo {
         /** @var int */
+        private $foo;
+        /** @var \Traversable */
+   -    private $bar;
+   +    private \Traversable $bar;
+    }
+
+Example #3
+~~~~~~~~~~
+
+With configuration: ``['union_types' => false]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    class Foo {
+        /** @var int|string */
         private $foo;
         /** @var \Traversable */
    -    private $bar;

--- a/doc/rules/function_notation/phpdoc_to_property_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_property_type.rst
@@ -33,7 +33,7 @@ Default value: ``true``
 ``union_types``
 ~~~~~~~~~~~~~~~
 
-Fix also union types; turned on by default on PHP > 8.0.0.
+Fix also union types; turned on by default on PHP >= 8.0.0.
 
 Allowed types: ``bool``
 

--- a/doc/rules/function_notation/phpdoc_to_property_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_property_type.rst
@@ -33,7 +33,7 @@ Default value: ``true``
 ``union_types``
 ~~~~~~~~~~~~~~~
 
-Fix also union types.
+Fix also union types; turned on by default on PHP > 8.0.0.
 
 Allowed types: ``bool``
 

--- a/doc/rules/function_notation/phpdoc_to_property_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_property_type.rst
@@ -33,8 +33,7 @@ Default value: ``true``
 ``union_types``
 ~~~~~~~~~~~~~~~
 
-Fix also union types; may have unexpected behaviour due to PHP bad type coercion
-system.
+Fix also union types.
 
 Allowed types: ``bool``
 

--- a/doc/rules/function_notation/phpdoc_to_return_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_return_type.rst
@@ -30,6 +30,16 @@ Allowed types: ``bool``
 
 Default value: ``true``
 
+``union_types``
+~~~~~~~~~~~~~~~
+
+Fix also union types; may have unexpected behaviour due to PHP bad type coercion
+system.
+
+Allowed types: ``bool``
+
+Default value: ``true``
+
 Examples
 --------
 
@@ -77,6 +87,23 @@ With configuration: ``['scalar_types' => false]``.
     function bar() {}
 
 Example #3
+~~~~~~~~~~
+
+With configuration: ``['union_types' => false]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+
+    /** @return Foo */
+   -function foo() {}
+   +function foo(): Foo {}
+    /** @return int|string */
+    function bar() {}
+
+Example #4
 ~~~~~~~~~~
 
 *Default* configuration.

--- a/doc/rules/function_notation/phpdoc_to_return_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_return_type.rst
@@ -33,7 +33,7 @@ Default value: ``true``
 ``union_types``
 ~~~~~~~~~~~~~~~
 
-Fix also union types; turned on by default on PHP > 8.0.0.
+Fix also union types; turned on by default on PHP >= 8.0.0.
 
 Allowed types: ``bool``
 

--- a/doc/rules/function_notation/phpdoc_to_return_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_return_type.rst
@@ -33,7 +33,7 @@ Default value: ``true``
 ``union_types``
 ~~~~~~~~~~~~~~~
 
-Fix also union types.
+Fix also union types; turned on by default on PHP > 8.0.0.
 
 Allowed types: ``bool``
 

--- a/doc/rules/function_notation/phpdoc_to_return_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_return_type.rst
@@ -33,8 +33,7 @@ Default value: ``true``
 ``union_types``
 ~~~~~~~~~~~~~~~
 
-Fix also union types; may have unexpected behaviour due to PHP bad type coercion
-system.
+Fix also union types.
 
 Allowed types: ``bool``
 

--- a/src/AbstractPhpdocToTypeDeclarationFixer.php
+++ b/src/AbstractPhpdocToTypeDeclarationFixer.php
@@ -75,6 +75,10 @@ abstract class AbstractPhpdocToTypeDeclarationFixer extends AbstractFixer implem
                 ->setAllowedTypes(['bool'])
                 ->setDefault(true)
                 ->getOption(),
+            (new FixerOptionBuilder('union_types', 'Fix also union types; may have unexpected behaviour due to PHP bad type coercion system.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(true)
+                ->getOption(),
         ]);
     }
 
@@ -211,6 +215,10 @@ abstract class AbstractPhpdocToTypeDeclarationFixer extends AbstractFixer implem
         }
 
         if (!$typesExpression->isUnionType() || '|' !== $typesExpression->getTypesGlue()) {
+            return null;
+        }
+
+        if (false === $this->configuration['union_types']) {
             return null;
         }
 

--- a/src/AbstractPhpdocToTypeDeclarationFixer.php
+++ b/src/AbstractPhpdocToTypeDeclarationFixer.php
@@ -77,7 +77,7 @@ abstract class AbstractPhpdocToTypeDeclarationFixer extends AbstractFixer implem
                 ->getOption(),
             (new FixerOptionBuilder('union_types', 'Fix also union types; turned on by default on PHP > 8.0.0.'))
                 ->setAllowedTypes(['bool'])
-                ->setDefault(PHP_VERSION_ID >= 8_00_00)
+                ->setDefault(\PHP_VERSION_ID >= 8_00_00)
                 ->getOption(),
         ]);
     }

--- a/src/AbstractPhpdocToTypeDeclarationFixer.php
+++ b/src/AbstractPhpdocToTypeDeclarationFixer.php
@@ -75,7 +75,7 @@ abstract class AbstractPhpdocToTypeDeclarationFixer extends AbstractFixer implem
                 ->setAllowedTypes(['bool'])
                 ->setDefault(true)
                 ->getOption(),
-            (new FixerOptionBuilder('union_types', 'Fix also union types; turned on by default on PHP > 8.0.0.'))
+            (new FixerOptionBuilder('union_types', 'Fix also union types; turned on by default on PHP >= 8.0.0.'))
                 ->setAllowedTypes(['bool'])
                 ->setDefault(\PHP_VERSION_ID >= 8_00_00)
                 ->getOption(),

--- a/src/AbstractPhpdocToTypeDeclarationFixer.php
+++ b/src/AbstractPhpdocToTypeDeclarationFixer.php
@@ -75,7 +75,7 @@ abstract class AbstractPhpdocToTypeDeclarationFixer extends AbstractFixer implem
                 ->setAllowedTypes(['bool'])
                 ->setDefault(true)
                 ->getOption(),
-            (new FixerOptionBuilder('union_types', 'Fix also union types.'))
+            (new FixerOptionBuilder('union_types', 'Fix also union types; turned on by default on PHP > 8.0.0.'))
                 ->setAllowedTypes(['bool'])
                 ->setDefault(PHP_VERSION_ID >= 8_00_00)
                 ->getOption(),

--- a/src/AbstractPhpdocToTypeDeclarationFixer.php
+++ b/src/AbstractPhpdocToTypeDeclarationFixer.php
@@ -77,7 +77,7 @@ abstract class AbstractPhpdocToTypeDeclarationFixer extends AbstractFixer implem
                 ->getOption(),
             (new FixerOptionBuilder('union_types', 'Fix also union types.'))
                 ->setAllowedTypes(['bool'])
-                ->setDefault(true)
+                ->setDefault(PHP_VERSION_ID >= 8_00_00)
                 ->getOption(),
         ]);
     }

--- a/src/AbstractPhpdocToTypeDeclarationFixer.php
+++ b/src/AbstractPhpdocToTypeDeclarationFixer.php
@@ -75,7 +75,7 @@ abstract class AbstractPhpdocToTypeDeclarationFixer extends AbstractFixer implem
                 ->setAllowedTypes(['bool'])
                 ->setDefault(true)
                 ->getOption(),
-            (new FixerOptionBuilder('union_types', 'Fix also union types; may have unexpected behaviour due to PHP bad type coercion system.'))
+            (new FixerOptionBuilder('union_types', 'Fix also union types.'))
                 ->setAllowedTypes(['bool'])
                 ->setDefault(true)
                 ->getOption(),

--- a/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
@@ -72,6 +72,16 @@ function bar($foo) {}
 ',
                     ['scalar_types' => false]
                 ),
+                new CodeSample(
+                    '<?php
+
+/** @param Foo $foo */
+function foo($foo) {}
+/** @param int|string $foo */
+function bar($foo) {}
+',
+                    ['union_types' => false]
+                ),
             ],
             null,
             'This rule is EXPERIMENTAL and [1] is not covered with backward compatibility promise. [2] `@param` annotation is mandatory for the fixer to make changes, signatures of methods without it (no docblock, inheritdocs) will not be fixed. [3] Manual actions are required if inherited signatures are not properly documented.'

--- a/src/Fixer/FunctionNotation/PhpdocToPropertyTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToPropertyTypeFixer.php
@@ -60,6 +60,17 @@ class Foo {
 ',
                     ['scalar_types' => false]
                 ),
+                new CodeSample(
+                    '<?php
+class Foo {
+    /** @var int|string */
+    private $foo;
+    /** @var \Traversable */
+    private $bar;
+}
+',
+                    ['union_types' => false]
+                ),
             ],
             null,
             'This rule is EXPERIMENTAL and [1] is not covered with backward compatibility promise. [2] `@var` annotation is mandatory for the fixer to make changes, signatures of properties without it (no docblock) will not be fixed. [3] Manual actions might be required for newly typed properties that are read before initialization.'

--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -80,6 +80,16 @@ function bar() {}
 ',
                     ['scalar_types' => false]
                 ),
+                new CodeSample(
+                    '<?php
+
+/** @return Foo */
+function foo() {}
+/** @return int|string */
+function bar() {}
+',
+                    ['union_types' => false]
+                ),
                 new VersionSpecificCodeSample(
                     '<?php
 final class Foo {

--- a/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
@@ -440,6 +440,12 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
             ['scalar_types' => false],
         ];
 
+        yield 'do not fix union types when configured as such' => [
+            '<?php /** @param int|string $foo */ function my_foo($foo) {}',
+            null,
+            ['union_types' => false],
+        ];
+
         yield 'do not fix function call' => [
             '<?php
                     /** @param string $foo */

--- a/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
@@ -135,6 +135,12 @@ final class PhpdocToPropertyTypeFixerTest extends AbstractFixerTestCase
             ['scalar_types' => false],
         ];
 
+        yield 'do not fix union types when configured as such' => [
+            '<?php class Foo { /** @var int|string */ private $foo; }',
+            null,
+            ['union_types' => false],
+        ];
+
         yield 'array native type' => [
             '<?php class Foo { /** @var array */ private array $foo; }',
             '<?php class Foo { /** @var array */ private $foo; }',

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -170,6 +170,12 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
             ['scalar_types' => false],
         ];
 
+        yield 'do not fix union types when configured as such' => [
+            '<?php /** @return int|string */ function my_foo() {}',
+            null,
+            ['union_types' => false],
+        ];
+
         yield 'array native type' => [
             '<?php /** @return array */ function my_foo(): array {}',
             '<?php /** @return array */ function my_foo() {}',


### PR DESCRIPTION
This pull request

- [x] adds a `union_types` option to the `phpdoc_to_param_type`, `phpdoc_to_property_type`, and `phpdoc_to_return_type` fixers

💁‍♂️ This option could be useful for applying changes with `php-cs-fixer/php-cs-fixer` to a code base that uses a PHP version that does not support union types yet.