### PR TITLE
feat: Simplify closing marker when possible in `heredoc_closing_marker` fixer

### DIFF
--- a/src/Fixer/StringNotation/HeredocClosingMarkerFixer.php
+++ b/src/Fixer/StringNotation/HeredocClosingMarkerFixer.php
@@ -139,7 +139,18 @@ final class HeredocClosingMarkerFixer extends AbstractFixer implements Configura
                     }
                 }
 
-                $newClosingMarker = $reservedClosingMarkersMap[mb_strtoupper($existingClosingMarker)] ?? $this->configuration['closing_marker'];
+                $existingClosingMarker = mb_strtoupper($existingClosingMarker);
+                do {
+                    $newClosingMarker = $reservedClosingMarkersMap[$existingClosingMarker] ?? null;
+                    if (!str_ends_with($existingClosingMarker, '_')) {
+                        break;
+                    }
+                    $existingClosingMarker = substr($existingClosingMarker, 0, -1);
+                } while (null === $newClosingMarker);
+
+                if (null === $newClosingMarker) {
+                    $newClosingMarker = $this->configuration['closing_marker'];
+                }
 
                 $content = $tokens->generatePartialCode($startIndex + 1, $index - 1);
                 while (Preg::match('~(^|[\r\n])\s*'.preg_quote($newClosingMarker, '~').'(?!\w)~', $content)) {

--- a/tests/Fixer/StringNotation/HeredocClosingMarkerFixerTest.php
+++ b/tests/Fixer/StringNotation/HeredocClosingMarkerFixerTest.php
@@ -212,6 +212,35 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
             ['reserved_closing_markers' => ['Žlutý']],
         ];
 
+        yield 'no longer colliding reserved marker recovery' => [
+            <<<'PHP'
+                <?php
+                $a = <<<CSS
+                    CSS;
+                $a = <<<CSS
+                    CSS;
+                $a = <<<CSS_
+                    CSS
+                    CSS_;
+                $a = <<<CSS
+                    CSS_
+                    CSS;
+                PHP,
+            <<<'PHP'
+                <?php
+                $a = <<<CSS_
+                    CSS_;
+                $a = <<<CSS__
+                    CSS__;
+                $a = <<<CSS__
+                    CSS
+                    CSS__;
+                $a = <<<CSS__
+                    CSS_
+                    CSS__;
+                PHP,
+        ];
+
         yield 'heredoc /w content starting with preferred closing marker' => [
             <<<'PHP'
                 <?php $a = <<<EOD_

--- a/tests/Fixer/StringNotation/HeredocClosingMarkerFixerTest.php
+++ b/tests/Fixer/StringNotation/HeredocClosingMarkerFixerTest.php
@@ -45,13 +45,11 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 <?php $a = <<<EOD
                 xxx EOD xxx
                 EOD;
-
                 PHP,
             <<<'PHP'
                 <?php $a = <<<TEST
                 xxx EOD xxx
                 TEST;
-
                 PHP,
         ];
 
@@ -60,13 +58,11 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 <?php $a = <<<'EOD'
                 xxx EOD xxx
                 EOD;
-
                 PHP,
             <<<'PHP'
                 <?php $a = <<<'TEST'
                 xxx EOD xxx
                 TEST;
-
                 PHP,
         ];
 
@@ -75,13 +71,11 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 <?php $a = <<<EOF
                 xxx
                 EOF;
-
                 PHP,
             <<<'PHP'
                 <?php $a = <<<TEST
                 xxx
                 TEST;
-
                 PHP,
             ['closing_marker' => 'EOF'],
         ];
@@ -97,7 +91,6 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 $b = <<<'EOD'
                 xxx3
                 EOD;
-
                 PHP,
             <<<'PHP'
                 <?php $a = <<<TEST
@@ -109,7 +102,6 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 $b = <<<'TEST'
                 xxx3
                 TEST;
-
                 PHP,
             ['explicit_heredoc_style' => true],
         ];
@@ -119,13 +111,11 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 <?php $a = b<<<EOD
                 xxx EOD xxx
                 EOD;
-
                 PHP,
             <<<'PHP'
                 <?php $a = b<<<TEST
                 xxx EOD xxx
                 TEST;
-
                 PHP,
         ];
 
@@ -134,13 +124,11 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 <?php $a = B<<<EOD
                 xxx EOD xxx
                 EOD;
-
                 PHP,
             <<<'PHP'
                 <?php $a = B<<<TEST
                 xxx EOD xxx
                 TEST;
-
                 PHP,
         ];
 
@@ -149,7 +137,6 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 <?php $a = <<<PHP
                 xxx
                 PHP;
-
                 PHP_,
         ];
 
@@ -160,7 +147,6 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 PHP;
                 $a = <<<PHP
                 PHP;
-
                 PHP_,
             <<<'PHP'
                 <?php $a = <<<php
@@ -168,7 +154,6 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 php;
                 $a = <<<Php
                 Php;
-
                 PHP,
         ];
 
@@ -189,7 +174,6 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 $c = <<<EOD
                 xxx3
                 EOD;
-
                 PHP,
             <<<'PHP_'
                 <?php $a = <<<Žlutý
@@ -207,7 +191,6 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 $c = <<<PHP
                 xxx3
                 PHP;
-
                 PHP_,
             ['reserved_closing_markers' => ['Žlutý']],
         ];
@@ -246,13 +229,11 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 <?php $a = <<<EOD_
                 EOD xxx
                 EOD_;
-
                 PHP,
             <<<'PHP'
                 <?php $a = <<<TEST
                 EOD xxx
                 TEST;
-
                 PHP,
         ];
 
@@ -261,13 +242,11 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 <?php $a = <<<EOD_
                  EOD xxx
                 EOD_;
-
                 PHP,
             <<<'PHP'
                 <?php $a = <<<TEST
                  EOD xxx
                 TEST;
-
                 PHP,
         ];
 
@@ -276,13 +255,11 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 <?php $a = <<<EOD_
                 EOD'
                 EOD_;
-
                 PHP,
             <<<'PHP'
                 <?php $a = <<<TEST
                 EOD'
                 TEST;
-
                 PHP,
         ];
 
@@ -291,13 +268,11 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 <?php $a = <<<EOD_
                 EOD;
                 EOD_;
-
                 PHP,
             <<<'PHP'
                 <?php $a = <<<TEST
                 EOD;
                 TEST;
-
                 PHP,
         ];
 
@@ -306,13 +281,11 @@ final class HeredocClosingMarkerFixerTest extends AbstractFixerTestCase
                 <?php $a = <<<EOD
                 xxx EOD
                 EOD;
-
                 PHP,
             <<<'PHP'
                 <?php $a = <<<TEST
                 xxx EOD
                 TEST;
-
                 PHP,
         ];
     }


### PR DESCRIPTION
minor improvement of #7660 although improving very rare case

closing marker might be extended when colliding, but if no longer colliding, it should restore back even if reserved :)