### PR TITLE
fix: Several improvements for `fully_qualified_strict_types` (respect declared symbols, relative imports, leading backslash in global namespace)

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
 $header = <<<'EOF'
     This file is part of PHP CS Fixer.
 
@@ -22,14 +25,14 @@ $header = <<<'EOF'
     with this source code in the file LICENSE.
     EOF;
 
-$finder = (new PhpCsFixer\Finder())
+$finder = (new Finder())
     ->ignoreDotFiles(false)
     ->ignoreVCSIgnored(true)
     ->exclude(['dev-tools/phpstan', 'tests/Fixtures'])
     ->in(__DIR__)
 ;
 
-return (new PhpCsFixer\Config())
+return (new Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PHP74Migration' => true,

--- a/dev-tools/info-extractor.php
+++ b/dev-tools/info-extractor.php
@@ -11,12 +11,14 @@
  * with this source code in the file LICENSE.
  */
 
+use PhpCsFixer\Console\Application;
+
 require_once __DIR__.'/../vendor/autoload.php';
 
 $version = [
-    'number' => PhpCsFixer\Console\Application::VERSION,
-    'vnumber' => 'v'.PhpCsFixer\Console\Application::VERSION,
-    'codename' => PhpCsFixer\Console\Application::VERSION_CODENAME,
+    'number' => Application::VERSION,
+    'vnumber' => 'v'.Application::VERSION,
+    'codename' => Application::VERSION_CODENAME,
 ];
 
 echo json_encode([

--- a/src/Doctrine/Annotation/Tokens.php
+++ b/src/Doctrine/Annotation/Tokens.php
@@ -233,7 +233,7 @@ final class Tokens extends \SplFixedArray
     /**
      * Inserts a token at the given index.
      */
-    public function insertAt(int $index, Token $token): void
+    public function insertAt(int $index, AnnotationToken $token): void
     {
         $this->setSize($this->getSize() + 1);
 

--- a/src/Doctrine/Annotation/Tokens.php
+++ b/src/Doctrine/Annotation/Tokens.php
@@ -97,7 +97,7 @@ final class Tokens extends \SplFixedArray
             if (0 !== $nbScannedTokensToUse) {
                 $ignoredTextLength = $nextAtPosition - $ignoredTextPosition;
                 if (0 !== $ignoredTextLength) {
-                    $tokens[] = new Token(DocLexer::T_NONE, substr($content, $ignoredTextPosition, $ignoredTextLength));
+                    $tokens[] = new AnnotationToken(DocLexer::T_NONE, substr($content, $ignoredTextPosition, $ignoredTextLength));
                 }
 
                 $lastTokenEndIndex = 0;
@@ -112,14 +112,14 @@ final class Tokens extends \SplFixedArray
 
                     $missingTextLength = $token->getPosition() - $lastTokenEndIndex;
                     if ($missingTextLength > 0) {
-                        $tokens[] = new Token(DocLexer::T_NONE, substr(
+                        $tokens[] = new AnnotationToken(DocLexer::T_NONE, substr(
                             $content,
                             $nextAtPosition + $lastTokenEndIndex,
                             $missingTextLength
                         ));
                     }
 
-                    $tokens[] = new Token($token->getType(), $token->getContent());
+                    $tokens[] = new AnnotationToken($token->getType(), $token->getContent());
                     $lastTokenEndIndex = $token->getPosition() + \strlen($token->getContent());
                 }
 
@@ -130,7 +130,7 @@ final class Tokens extends \SplFixedArray
         }
 
         if ($ignoredTextPosition < \strlen($content)) {
-            $tokens[] = new Token(DocLexer::T_NONE, substr($content, $ignoredTextPosition));
+            $tokens[] = new AnnotationToken(DocLexer::T_NONE, substr($content, $ignoredTextPosition));
         }
 
         return self::fromArray($tokens);
@@ -238,7 +238,7 @@ final class Tokens extends \SplFixedArray
         $this->setSize($this->getSize() + 1);
 
         for ($i = $this->getSize() - 1; $i > $index; --$i) {
-            $this[$i] = $this[$i - 1] ?? new Token();
+            $this[$i] = $this[$i - 1] ?? new AnnotationToken();
         }
 
         $this[$index] = $token;
@@ -250,7 +250,7 @@ final class Tokens extends \SplFixedArray
             throw new \InvalidArgumentException('Token must be an instance of PhpCsFixer\\Doctrine\\Annotation\\Token, "null" given.');
         }
 
-        if (!$token instanceof Token) {
+        if (!$token instanceof AnnotationToken) {
             $type = \gettype($token);
 
             if ('object' === $type) {

--- a/src/Doctrine/Annotation/Tokens.php
+++ b/src/Doctrine/Annotation/Tokens.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Doctrine\Annotation;
 
-use PhpCsFixer\Doctrine\Annotation\Token as AnnotationToken;
 use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token as PhpToken;
 
@@ -97,13 +96,13 @@ final class Tokens extends \SplFixedArray
             if (0 !== $nbScannedTokensToUse) {
                 $ignoredTextLength = $nextAtPosition - $ignoredTextPosition;
                 if (0 !== $ignoredTextLength) {
-                    $tokens[] = new AnnotationToken(DocLexer::T_NONE, substr($content, $ignoredTextPosition, $ignoredTextLength));
+                    $tokens[] = new Token(DocLexer::T_NONE, substr($content, $ignoredTextPosition, $ignoredTextLength));
                 }
 
                 $lastTokenEndIndex = 0;
                 foreach (\array_slice($scannedTokens, 0, $nbScannedTokensToUse) as $token) {
                     if ($token->isType(DocLexer::T_STRING)) {
-                        $token = new AnnotationToken(
+                        $token = new Token(
                             $token->getType(),
                             '"'.str_replace('"', '""', $token->getContent()).'"',
                             $token->getPosition()
@@ -112,14 +111,14 @@ final class Tokens extends \SplFixedArray
 
                     $missingTextLength = $token->getPosition() - $lastTokenEndIndex;
                     if ($missingTextLength > 0) {
-                        $tokens[] = new AnnotationToken(DocLexer::T_NONE, substr(
+                        $tokens[] = new Token(DocLexer::T_NONE, substr(
                             $content,
                             $nextAtPosition + $lastTokenEndIndex,
                             $missingTextLength
                         ));
                     }
 
-                    $tokens[] = new AnnotationToken($token->getType(), $token->getContent());
+                    $tokens[] = new Token($token->getType(), $token->getContent());
                     $lastTokenEndIndex = $token->getPosition() + \strlen($token->getContent());
                 }
 
@@ -130,7 +129,7 @@ final class Tokens extends \SplFixedArray
         }
 
         if ($ignoredTextPosition < \strlen($content)) {
-            $tokens[] = new AnnotationToken(DocLexer::T_NONE, substr($content, $ignoredTextPosition));
+            $tokens[] = new Token(DocLexer::T_NONE, substr($content, $ignoredTextPosition));
         }
 
         return self::fromArray($tokens);
@@ -233,12 +232,12 @@ final class Tokens extends \SplFixedArray
     /**
      * Inserts a token at the given index.
      */
-    public function insertAt(int $index, AnnotationToken $token): void
+    public function insertAt(int $index, Token $token): void
     {
         $this->setSize($this->getSize() + 1);
 
         for ($i = $this->getSize() - 1; $i > $index; --$i) {
-            $this[$i] = $this[$i - 1] ?? new AnnotationToken();
+            $this[$i] = $this[$i - 1] ?? new Token();
         }
 
         $this[$index] = $token;
@@ -250,7 +249,7 @@ final class Tokens extends \SplFixedArray
             throw new \InvalidArgumentException('Token must be an instance of PhpCsFixer\\Doctrine\\Annotation\\Token, "null" given.');
         }
 
-        if (!$token instanceof AnnotationToken) {
+        if (!$token instanceof Token) {
             $type = \gettype($token);
 
             if ('object' === $type) {

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -654,7 +654,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
             return 0;
         }
 
-        $this->replaceClassWithShort($tokens, $class, $newTokens);
+        $tokens->overrideRange(reset($class['tokens']), end($class['tokens']), $newTokens);
 
         return \count($newTokens) - \count($class['tokens']);
     }
@@ -707,34 +707,6 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
         }
 
         return $this->namespacedStringToTokens($shortenedType);
-    }
-
-    /**
-     * @param array{content: string, tokens: array<int>} $class
-     * @param list<Token>                                $newTokens
-     */
-    private function replaceClassWithShort(Tokens $tokens, array $class, array $newTokens): void
-    {
-        [$newTokens, $extraTokens] = [
-            \array_slice($newTokens, 0, -\count($class['tokens'])),
-            \array_slice($newTokens, -\count($class['tokens'])),
-        ];
-
-        $i = 0; // override the tokens
-
-        foreach ($extraTokens as $token) {
-            $tokens->insertAt($class['tokens'][0], $token);
-        }
-
-        foreach ($newTokens as $token) {
-            $tokens[$class['tokens'][$i]] = $token;
-            ++$i;
-        }
-
-        // clear the leftovers
-        for ($j = \count($class['tokens']) - 1; $j >= $i; --$j) {
-            $tokens->clearTokenAndMergeSurroundingWhitespace($class['tokens'][$j]);
-        }
     }
 
     /**

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -42,6 +42,9 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 final class FullyQualifiedStrictTypesFixer extends AbstractFixer implements ConfigurableFixerInterface, WhitespacesAwareFixerInterface
 {
+    private const REGEX_CLASS = '(?:\\\\?+'.TypeExpression::REGEX_IDENTIFIER
+        .'(\\\\'.TypeExpression::REGEX_IDENTIFIER.')*+)';
+
     /**
      * @var array{
      *     const?: array<string, class-string>,
@@ -262,6 +265,8 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
                         }
                     } elseif (\defined('T_ATTRIBUTE') && $tokens[$index]->isGivenKind(T_ATTRIBUTE)) { // @TODO: drop const check when PHP 8.0+ is required
                         $this->fixNextName($analyseRelativeUses, $tokens, $index, $uses, $namespaceName);
+                    } elseif ($analyseRelativeUses && !\defined('T_ATTRIBUTE') && $tokens[$index]->isComment() && Preg::match('/#\[\s*('.self::REGEX_CLASS.')/', $tokens[$index]->getContent(), $matches)) { // @TODO: drop when PHP 8.0+ is required
+                        $this->determineShortType($analyseRelativeUses, $matches[1], $uses, $namespaceName);
                     }
 
                     if ($tokens[$index]->isGivenKind(T_DOC_COMMENT)) {

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -736,7 +736,16 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
     {
         if ($analyseRelativeUses) {
             if (!str_starts_with($symbol, '\\')) {
-                $uses['implicit-use-'.\count($uses)] = explode('\\', $symbol, 2)[0];
+                $symbolArr = explode('\\', $symbol, 2);
+                $symbolFirstPartLower = strtolower($symbolArr[0]);
+                $resolvedSymbol = $namespaceName.'\\'.$symbol;
+                foreach ($uses as $useFullName => $useShortName) {
+                    if (strtolower($useShortName) === $symbolFirstPartLower) {
+                        $resolvedSymbol = $useFullName.(isset($symbolArr[1]) ? '\\'.$symbolArr[1] : '');
+                    }
+                }
+
+                $uses[$this->normaliseSymbolName($resolvedSymbol)] = $symbolArr[0];
             }
 
             return;

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -268,6 +268,14 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
                         $this->fixPhpDoc($analyseRelativeUses, $tokens, $index, $uses, $namespaceName);
                     }
                 }
+
+                if ($analyseRelativeUses) {
+                    foreach ($uses as $useLongNameLower => $useShortName) {
+                        if (strtolower($useShortName) === $useLongNameLower) {
+                            unset($uses[$useLongNameLower]);
+                        }
+                    }
+                }
             }
 
             if (true === $this->configuration['import_symbols'] && [] !== $this->symbolsForImport) {
@@ -776,8 +784,10 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
             return;
         }
 
-        $this->symbolsForImport[$kind][$normalisedName] = ltrim($symbol, '\\');
-        ksort($this->symbolsForImport[$kind], SORT_NATURAL);
+        if ($normalisedName !== $this->normaliseSymbolName($namespaceName.'\\'.$shortSymbol)) {
+            $this->symbolsForImport[$kind][$normalisedName] = ltrim($symbol, '\\');
+            ksort($this->symbolsForImport[$kind], SORT_NATURAL);
+        }
 
         // We must fake that the symbol is imported, so that it can be shortened.
         $uses[$normalisedName] = $shortSymbol;

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -743,7 +743,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
     private function registerSymbolForImport(bool $analyseRelativeUses, string $kind, string $symbol, array &$uses, string $namespaceName): void
     {
         if ($analyseRelativeUses) {
-            if (!str_starts_with($symbol, '\\')) {
+            if (!str_starts_with($symbol, '\\') && '' !== $namespaceName) {
                 $symbolArr = explode('\\', $symbol, 2);
                 $symbolFirstPartLower = strtolower($symbolArr[0]);
                 $resolvedSymbol = $namespaceName.'\\'.$symbol;
@@ -757,6 +757,10 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
             }
 
             return;
+        }
+
+        if ('' === $namespaceName && !str_starts_with($symbol, '\\')) {
+            $symbol = '\\'.$symbol;
         }
 
         $normalisedName = $this->normaliseSymbolName($symbol);

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -306,7 +306,18 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
             }
 
             if ([] !== $this->symbolsForImport) {
-                $atIndex = (null !== $lastUse) ? $lastUse->getEndIndex() + 1 : $namespace->getEndIndex() + 1;
+                if (null !== $lastUse) {
+                    $atIndex = $lastUse->getEndIndex() + 1;
+                } elseif (0 !== $namespace->getEndIndex()) {
+                    $atIndex = $namespace->getEndIndex() + 1;
+                } else {
+                    $firstTokenIndex = $tokens->getNextMeaningfulToken($namespace->getScopeStartIndex());
+                    if (null !== $firstTokenIndex && $tokens[$firstTokenIndex]->isGivenKind(T_DECLARE)) {
+                        $atIndex = $tokens->getNextTokenOfKind($firstTokenIndex, [';']) + 1;
+                    } else {
+                        $atIndex = $namespace->getScopeStartIndex() + 1;
+                    }
+                }
 
                 // Insert all registered FQCNs
                 $this->createImportProcessor()->insertImports($tokens, $this->symbolsForImport, $atIndex);

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -332,14 +332,16 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
      */
     private function refreshUsesCache(array $uses): void
     {
-        if ($this->cacheUsesLast !== $uses) {
-            $this->cacheUsesLast = $uses;
-            $this->cacheUseNameByShortNameLower = [];
-            $this->cacheUseShortNameByNameLower = [];
-            foreach ($uses as $useLongName => $useShortName) {
-                $this->cacheUseNameByShortNameLower[strtolower($useShortName)] = $useLongName;
-                $this->cacheUseShortNameByNameLower[strtolower($useLongName)] = $useShortName;
-            }
+        if ($this->cacheUsesLast === $uses) {
+            return;
+        }
+
+        $this->cacheUsesLast = $uses;
+        $this->cacheUseNameByShortNameLower = [];
+        $this->cacheUseShortNameByNameLower = [];
+        foreach ($uses as $useLongName => $useShortName) {
+            $this->cacheUseNameByShortNameLower[strtolower($useShortName)] = $useLongName;
+            $this->cacheUseShortNameByNameLower[strtolower($useLongName)] = $useShortName;
         }
     }
 

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -270,9 +270,15 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
             foreach (true === $this->configuration['import_symbols'] ? [true, false] : [false] as $discoverSymbolsPhase) {
                 $this->discoveredSymbols = $discoverSymbolsPhase ? [] : null;
 
+                $classyKinds = [T_CLASS, T_INTERFACE, T_TRAIT];
+                if (\defined('T_ENUM')) { // @TODO: drop condition when PHP 8.1+ is required
+                    $classyKinds[] = T_ENUM;
+                }
+
                 for ($index = $namespace->getScopeStartIndex(); $index < $namespace->getScopeEndIndex() + $indexDiff; ++$index) {
                     $origSize = \count($tokens);
-                    if ($discoverSymbolsPhase && $tokens[$index]->isGivenKind([T_CLASS, T_INTERFACE, T_TRAIT])) {
+
+                    if ($discoverSymbolsPhase && $tokens[$index]->isGivenKind($classyKinds)) {
                         $this->fixNextName($tokens, $index, $uses, $namespaceName);
                     } elseif ($tokens[$index]->isGivenKind(T_FUNCTION)) {
                         $this->fixFunction($functionsAnalyzer, $tokens, $index, $uses, $namespaceName);

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -604,10 +604,10 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
             $typeNameShort = substr($typeName, $namespaceNameLength + 1);
 
             // if short names are the same, but long one are different then it cannot be shortened
-            foreach ($uses as $useLongName => $useShortName) {
+            foreach ($uses as $useLongNameLower => $useShortName) {
                 if (
                     strtolower($typeNameShort) === strtolower($useShortName)
-                    && strtolower($typeName) !== strtolower($useLongName)
+                    && strtolower($typeName) !== $useLongNameLower
                 ) {
                     return null;
                 }
@@ -739,9 +739,9 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
                 $symbolArr = explode('\\', $symbol, 2);
                 $symbolFirstPartLower = strtolower($symbolArr[0]);
                 $resolvedSymbol = $namespaceName.'\\'.$symbol;
-                foreach ($uses as $useFullName => $useShortName) {
+                foreach ($uses as $useLongNameLower => $useShortName) {
                     if (strtolower($useShortName) === $symbolFirstPartLower) {
-                        $resolvedSymbol = $useFullName.(isset($symbolArr[1]) ? '\\'.$symbolArr[1] : '');
+                        $resolvedSymbol = $useLongNameLower.(isset($symbolArr[1]) ? '\\'.$symbolArr[1] : '');
                     }
                 }
 

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -400,7 +400,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
             }
         }
 
-        // shortening is not possible, add leading backslash is needed
+        // shortening is not possible, add leading backslash if needed
         if (null === $res) {
             $res = $fqcn;
             if ('' !== $namespaceName

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -337,7 +337,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
      *
      * @param array<string, string> $uses
      */
-    private function resolveSymbol(string $symbol, array $uses, string $namespaceName)
+    private function resolveSymbol(string $symbol, array $uses, string $namespaceName): string
     {
         if (str_starts_with($symbol, '\\')) {
             $resolvedSymbol = substr($symbol, 1);

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -1224,12 +1224,12 @@ use Ping\Pong\Pyng\Pung;
 class SomeClass
 {
     public function doSomething(
-        \Ping\Something $something,
-        Pung\Pang $other,
-        \Ping\Pong\Pung $other1,
+        Ping\Something $something,
+        Ping\Pong\Pung\Pang $other,
+        Ping\Pong\Pung $other1,
         Pang\Pung $other2,
-        Pyng\Pung\Pong $other3,
-        \Foo\Bar\Baz\Buz $other4
+        Pung\Pong $other3,
+        Bar\Baz\Buz $other4
     ){}
 }',
             '<?php

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -711,6 +711,73 @@ class Foo extends \A\A implements \B\A, \C\A
             null,
             ['import_symbols' => true],
         ];
+
+        yield 'import with relative and absolute symbols - global' => [
+            <<<'EOD'
+                <?php
+
+                new Exception();
+                new Exception();
+                EOD,
+            <<<'EOD'
+                <?php
+
+                new \Exception();
+                new Exception();
+                EOD,
+            ['import_symbols' => true],
+        ];
+
+        yield 'import with relative and absolute symbols - global and leading backslash' => [
+            <<<'EOD'
+                <?php
+
+                new \Exception();
+                new \Exception();
+                EOD,
+            <<<'EOD'
+                <?php
+
+                new \Exception();
+                new Exception();
+                EOD,
+            ['import_symbols' => true, 'leading_backslash_in_global_namespace' => true],
+        ];
+
+        yield 'import with relative and absolute symbols - namespaced' => [
+            <<<'EOD'
+                <?php
+
+                namespace Ns;
+                use Ns2\Foo4;
+                use Ns\Foo3\Sub3;
+                use Ns\Foo\Sub2;
+
+                new Foo();
+                new Foo\Sub();
+                new Foo();
+                new Foo2();
+                new Sub2();
+                new Sub3();
+                new \Ns2\Foo();
+                new Foo4();
+                EOD,
+            <<<'EOD'
+                <?php
+
+                namespace Ns;
+
+                new Foo();
+                new Foo\Sub();
+                new \Ns\Foo();
+                new \Ns\Foo2();
+                new \Ns\Foo\Sub2();
+                new \Ns\Foo3\Sub3();
+                new \Ns2\Foo();
+                new \Ns2\Foo4();
+                EOD,
+            ['import_symbols' => true],
+        ];
     }
 
     /**

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -2114,6 +2114,21 @@ class SomeClass
     public function doSomethingElse(\Foo\Bar&\A\Z $foo): \Foo\Bar\Baz{}
 }',
         ];
+
+        yield 'import only if not already implicitly used by enum declaration' => [
+            <<<'EOD'
+                <?php
+
+                namespace Ns;
+
+                enum City
+                {
+                    public function f(\Ns2\City $city) {}
+                }
+                EOD,
+            null,
+            ['import_symbols' => true],
+        ];
     }
 
     /**

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -699,6 +699,20 @@ class Foo extends \A\A implements \B\A, \C\A
             ['import_symbols' => true],
         ];
 
+        yield 'import only if not already implicitly used by short name usage in attribute' => [
+            <<<'EOD'
+                <?php
+
+                namespace Ns;
+
+                new \Ns2\MyCl();
+                #[MyCl]
+                class Cl {}
+                EOD,
+            null,
+            ['import_symbols' => true],
+        ];
+
         yield 'import only if not already implicitly used by short name usage in phpdoc' => [
             <<<'EOD'
                 <?php

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -732,7 +732,7 @@ class Foo extends \A\A implements \B\A, \C\A
             ['import_symbols' => true],
         ];
 
-        yield 'import only if not already implicitly used by short name usage via native type' => [
+        yield 'import only if not already implicitly used by short name usage in class instantiation' => [
             <<<'EOD'
                 <?php
 

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -716,14 +716,17 @@ class Foo extends \A\A implements \B\A, \C\A
             <<<'EOD'
                 <?php
 
+                use Foo\Bar;
                 new Exception();
                 new Exception();
+                new Bar();
                 EOD,
             <<<'EOD'
                 <?php
 
                 new \Exception();
                 new Exception();
+                new Foo\Bar();
                 EOD,
             ['import_symbols' => true],
         ];
@@ -732,14 +735,17 @@ class Foo extends \A\A implements \B\A, \C\A
             <<<'EOD'
                 <?php
 
+                use Foo\Bar;
                 new \Exception();
                 new \Exception();
+                new Bar();
                 EOD,
             <<<'EOD'
                 <?php
 
                 new \Exception();
                 new Exception();
+                new Foo\Bar();
                 EOD,
             ['import_symbols' => true, 'leading_backslash_in_global_namespace' => true],
         ];

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -798,6 +798,37 @@ class Foo extends \A\A implements \B\A, \C\A
                 EOD,
             ['import_symbols' => true],
         ];
+
+        yield 'fix to longest imported name' => [
+            <<<'EOD'
+                <?php
+
+                use A\B;
+                use A\X as Y;
+                use S as R;
+                use S\T;
+
+                new B();
+                new B\C();
+                new X();
+                new X\Z();
+                new T();
+                EOD,
+            <<<'EOD'
+                <?php
+
+                use A\B;
+                use A\X as Y;
+                use S as R;
+                use S\T;
+
+                new \A\B();
+                new \A\B\C();
+                new \A\X();
+                new \A\X\Z();
+                new R\T();
+                EOD,
+        ];
     }
 
     /**

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -640,6 +640,77 @@ class Foo extends \A\A implements \B\A, \C\A
 }',
             ['import_symbols' => true],
         ];
+
+        yield 'import only if not already implicitly used by class declaration' => [
+            <<<'EOD'
+                <?php
+
+                namespace Ns;
+
+                class City
+                {
+                    public \Ns2\City $city;
+                }
+                EOD,
+            null,
+            ['import_symbols' => true],
+        ];
+
+        yield 'import only if not already implicitly used by interface declaration' => [
+            <<<'EOD'
+                <?php
+
+                namespace Ns;
+
+                interface City
+                {
+                    public function f(\Ns2\City $city);
+                }
+                EOD,
+            null,
+            ['import_symbols' => true],
+        ];
+
+        yield 'import only if not already implicitly used by trait declaration' => [
+            <<<'EOD'
+                <?php
+
+                namespace Ns;
+
+                trait City
+                {
+                    public \Ns2\City $city;
+                }
+                EOD,
+            null,
+            ['import_symbols' => true],
+        ];
+
+        yield 'import only if not already implicitly used by short name usage via native type' => [
+            <<<'EOD'
+                <?php
+
+                namespace Ns;
+
+                new \Ns2\MyCl();
+                new MyCl();
+                EOD,
+            null,
+            ['import_symbols' => true],
+        ];
+
+        yield 'import only if not already implicitly used by short name usage in phpdoc' => [
+            <<<'EOD'
+                <?php
+
+                namespace Ns;
+
+                new \Ns2\MyCl();
+                /** @var MyCl */;
+                EOD,
+            null,
+            ['import_symbols' => true],
+        ];
     }
 
     /**

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -2053,7 +2053,7 @@ use Foo\Bar\Baz;
 
 class SomeClass
 {
-    public function doSomething(Bar $foo): Foo\Bar\Ba3{}
+    public function doSomething(Bar $foo): Bar\Ba3{}
     public function doSomethingMore(Bar|B $foo): Baz{}
     public function doSomethingElse(Bar&A\Z $foo): Baz{}
 }',

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -541,6 +541,52 @@ namespace Foo\Baz {
             ['import_symbols' => true],
         ];
 
+        yield 'import new symbols with no existing imports nor namespace /wo declare' => [
+            <<<'EOD'
+                <?php
+
+                use Ns\A;
+                // comment
+
+                foo();
+
+                function foo(A $v) {}
+                EOD,
+            <<<'EOD'
+                <?php
+
+                // comment
+
+                foo();
+
+                function foo(\Ns\A $v) {}
+                EOD,
+            ['import_symbols' => true],
+        ];
+
+        yield 'import new symbols with no existing imports nor namespace /w declare' => [
+            <<<'EOD'
+                <?php
+
+                // comment
+
+                declare(strict_types=1);
+                use Ns\A;
+
+                function foo(A $v) {}
+                EOD,
+            <<<'EOD'
+                <?php
+
+                // comment
+
+                declare(strict_types=1);
+
+                function foo(\Ns\A $v) {}
+                EOD,
+            ['import_symbols' => true],
+        ];
+
         yield 'import new symbols with custom whitespace config' => [
             '<?php
 

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -856,8 +856,8 @@ class Foo extends \A\A implements \B\A, \C\A
 
                 new B();
                 new B\C();
-                new X();
-                new X\Z();
+                new Y();
+                new Y\Z();
                 new T();
                 EOD,
             <<<'EOD'

--- a/tests/Fixtures/Integration/misc/PHP8_0.test
+++ b/tests/Fixtures/Integration/misc/PHP8_0.test
@@ -98,7 +98,7 @@ class T_Mixed
 
 // https://wiki.php.net/rfc/throw_expression
 if (1) {
-    foo() ?? throw new Exception();
+    foo() ?? throw new \Exception();
     $a = $condition && throw new Exception();
     $callable = static fn () => throw new Exception();
     $value = $falsableValue ?: throw new InvalidArgumentException();

--- a/tests/Fixtures/Integration/misc/PHP8_0.test
+++ b/tests/Fixtures/Integration/misc/PHP8_0.test
@@ -15,8 +15,6 @@ PHP 8.0 test.
 
 declare(strict_types=1);
 
-use MyExample\MyAttribute2;
-
 // https://wiki.php.net/rfc/named_params
 array_fill(start_index: 0, num: 100, value: 50);
 htmlspecialchars($string, double_encode: false);
@@ -32,7 +30,7 @@ $country = $session?->user?->getAddress()?->country;
 // https://wiki.php.net/rfc/shorter_attribute_syntax
 // https://wiki.php.net/rfc/shorter_attribute_syntax_change
 #[MyAttribute]
-#[MyAttribute2]
+#[\MyExample\MyAttribute]
 #[MyAttribute(1234)]
 #[MyAttribute(value: 1234)]
 #[MyAttribute(MyAttribute::VALUE)]
@@ -192,7 +190,7 @@ $country = $session?->user?->getAddress()?->country;
 // https://wiki.php.net/rfc/shorter_attribute_syntax
 // https://wiki.php.net/rfc/shorter_attribute_syntax_change
 #[MyAttribute]
-#[\MyExample\MyAttribute2]
+#[\MyExample\MyAttribute]
 #[MyAttribute(1234)]
 #[MyAttribute(value: 1234)]
 #[MyAttribute(MyAttribute::VALUE)]

--- a/tests/Fixtures/Integration/misc/PHP8_0.test
+++ b/tests/Fixtures/Integration/misc/PHP8_0.test
@@ -30,7 +30,7 @@ $country = $session?->user?->getAddress()?->country;
 // https://wiki.php.net/rfc/shorter_attribute_syntax
 // https://wiki.php.net/rfc/shorter_attribute_syntax_change
 #[MyAttribute]
-#[\MyExample\MyAttribute]
+#[MyExample\MyAttribute]
 #[MyAttribute(1234)]
 #[MyAttribute(value: 1234)]
 #[MyAttribute(MyAttribute::VALUE)]

--- a/tests/Fixtures/Integration/misc/PHP8_0.test
+++ b/tests/Fixtures/Integration/misc/PHP8_0.test
@@ -98,7 +98,7 @@ class T_Mixed
 
 // https://wiki.php.net/rfc/throw_expression
 if (1) {
-    foo() ?? throw new \Exception();
+    foo() ?? throw new Exception();
     $a = $condition && throw new Exception();
     $callable = static fn () => throw new Exception();
     $value = $falsableValue ?: throw new InvalidArgumentException();


### PR DESCRIPTION
fix #5199
fix #7642 (and #7677 duplicate)
fix #7680
fix #7686