### PR TITLE
docs: Add information about allowing maintainers to update PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,14 @@ You can do some things to increase the chance that your pull request is accepted
 * Remember about tests and documentation.
 * Don't bump `PhpCsFixer\Console\Application::VERSION`, it's done during release.
 
+> [!IMPORTANT]
+> Your pull request will have much higher chance of getting merged if you allow maintainers to push changes to your
+> branch.
+> You can do it by ticking "Allow edits and access to secrets by maintainers" checkbox, but please keep in mind this
+> option is available only if your PR is created from user's fork. If your fork is a part of organisation, then
+> you can add [Fixer maintainers](https://github.com/orgs/PHP-CS-Fixer/people) as a members of that repository. This way
+> maintainers will be able to provide required changes or rebase your branch (only up-to-date PRs can be merged).
+
 ## Working With Docker
 
 This project provides a Docker setup that allows working on it using any of the PHP versions supported by the tool.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,8 @@ You can do some things to increase the chance that your pull request is accepted
 > [!IMPORTANT]
 > Your pull request will have much higher chance of getting merged if you allow maintainers to push changes to your
 > branch. You can do it by ticking "Allow edits and access to secrets by maintainers" checkbox, but please keep in mind
-> this option is available only if your PR is created from user's fork. If your fork is a part of organisation, then
-> you can add [Fixer maintainers](https://github.com/orgs/PHP-CS-Fixer/people) as a members of that repository. This way
+> this option is available only if your PR is created from a user's fork. If your fork is a part of organisation, then
+> you can add [Fixer maintainers](https://github.com/orgs/PHP-CS-Fixer/people) as members of that repository. This way
 > maintainers will be able to provide required changes or rebase your branch (only up-to-date PRs can be merged).
 
 ## Working With Docker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,8 @@ A *config* knows about the code style rules and the files and directories that m
 
 > [!IMPORTANT]
 > Before contributing with _really_ significant changes that require a lot of effort or are crucial from this tool's
-> architecture perspective, please
-> open [RFC on GitHub Discussion](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/discussions/categories/rfc). The
-> development effort should start only after the proposal is discussed and the approach aligned.
+> architecture perspective, please open [RFC on GitHub Discussion](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/discussions/categories/rfc).
+> The development effort should start only after the proposal is discussed and the approach aligned.
 
 ### Development
 
@@ -49,9 +48,8 @@ You can do some things to increase the chance that your pull request is accepted
 
 > [!IMPORTANT]
 > Your pull request will have much higher chance of getting merged if you allow maintainers to push changes to your
-> branch.
-> You can do it by ticking "Allow edits and access to secrets by maintainers" checkbox, but please keep in mind this
-> option is available only if your PR is created from user's fork. If your fork is a part of organisation, then
+> branch. You can do it by ticking "Allow edits and access to secrets by maintainers" checkbox, but please keep in mind
+> this option is available only if your PR is created from user's fork. If your fork is a part of organisation, then
 > you can add [Fixer maintainers](https://github.com/orgs/PHP-CS-Fixer/people) as a members of that repository. This way
 > maintainers will be able to provide required changes or rebase your branch (only up-to-date PRs can be merged).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,11 @@ A *config* knows about the code style rules and the files and directories that m
 
 ## How to contribute
 
-ℹ️ **IMPORTANT**: before contributing with really significant changes that require a lot of effort or are crucial from this tool's architecture perspective, please open [RFC on GitHub Discussion](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/discussions/categories/rfc). The development effort should start only after the proposal is discussed and the approach aligned.
+> [!IMPORTANT]
+> Before contributing with _really_ significant changes that require a lot of effort or are crucial from this tool's
+> architecture perspective, please
+> open [RFC on GitHub Discussion](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/discussions/categories/rfc). The
+> development effort should start only after the proposal is discussed and the approach aligned.
 
 ### Development
 


### PR DESCRIPTION
Following today's discussion, let's provide clear information about allowing maintainers to update PRs.