### PR TITLE
fix: `ClassReferenceNameCasingFixer` capitalizes the property name after the nullsafe operator

### DIFF
--- a/src/Fixer/Casing/ClassReferenceNameCasingFixer.php
+++ b/src/Fixer/Casing/ClassReferenceNameCasingFixer.php
@@ -84,6 +84,10 @@ final class ClassReferenceNameCasingFixer extends AbstractFixer
                 T_TRAIT,
             ];
 
+            if (\defined('T_NULLSAFE_OBJECT_OPERATOR')) {  // @TODO: drop condition when PHP 8.0+ is required
+                $notBeforeKinds[] = T_NULLSAFE_OBJECT_OPERATOR;
+            }
+
             if (\defined('T_ENUM')) { // @TODO: drop condition when PHP 8.1+ is required
                 $notBeforeKinds[] = T_ENUM;
             }

--- a/tests/Fixer/Casing/ClassReferenceNameCasingFixerTest.php
+++ b/tests/Fixer/Casing/ClassReferenceNameCasingFixerTest.php
@@ -247,6 +247,26 @@ use Sonata\\Exporter\\Writer\\EXCEPTION;
     }
 
     /**
+     * @dataProvider provideFix80Cases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFix80(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<array{0: string, 1?: string}>
+     */
+    public static function provideFix80Cases(): iterable
+    {
+        yield [
+            '<?php if ($var?->exception instanceof Exception) {};',
+        ];
+    }
+
+    /**
      * @dataProvider provideFix81Cases
      *
      * @requires PHP 8.1


### PR DESCRIPTION
Spotted this issue on my jobs project and finally had time to find the source of the issue.