### PR TITLE
fix: `SingleSpaceAroundConstructFixer` - correctly recognise multiple constants

### DIFF
--- a/src/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixer.php
@@ -345,7 +345,7 @@ yield  from  baz();
                 continue;
             }
 
-            if ($token->isGivenKind(T_CONST) && $this->isMultilineConstant($tokens, $index)) {
+            if ($token->isGivenKind(T_CONST) && $this->isMultilineCommaSeparatedConstant($tokens, $index)) {
                 continue;
             }
 
@@ -457,7 +457,7 @@ yield  from  baz();
         return false;
     }
 
-    private function isMultilineConstant(Tokens $tokens, int $constantIndex): bool
+    private function isMultilineCommaSeparatedConstant(Tokens $tokens, int $constantIndex): bool
     {
         $isMultilineConstant = false;
         $hasMoreThanOneConstant = false;

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixerTest.php
@@ -864,6 +864,25 @@ FOO = 9000; }',
             '<?php class Foo { const  /* foo */FOO = 9000; }',
         ];
 
+        yield [
+            '<?php class Foo {
+                const FOO = [
+                    1
+                ];
+                const BAR = [
+                    2,
+                ];
+            }',
+            '<?php class Foo {
+                const    FOO = [
+                    1
+                ];
+                const    BAR = [
+                    2,
+                ];
+            }',
+        ];
+
         yield ['<?php class Foo {
     const
         FOO = 9000,


### PR DESCRIPTION
Revives #7565. All credits to @kubawerlos.