### PR TITLE
chore: Add IndexRange class

### DIFF
--- a/src/Tokenizer/IndexRange.php
+++ b/src/Tokenizer/IndexRange.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer;
+
+/**
+ * Class for storing start index and end index pair withing one variable.
+ *
+ * @author Michael Vorisek <https://github.com/mvorisek>
+ *
+ * @final
+ */
+class IndexRange
+{
+    /** @var 0|positive-int */
+    public int $start;
+
+    /** @var 0|positive-int */
+    public int $end;
+
+    /**
+     * @param 0|positive-int $start
+     * @param 0|positive-int $end
+     */
+    public function __construct(int $start = null, int $end = null)
+    {
+        if (null !== $start) {
+            $this->start = $start;
+        }
+
+        if (null !== $end) {
+            $this->end = $end;
+        }
+    }
+
+    public function count(): int
+    {
+        return 1 + $this->end - $this->start;
+    }
+}

--- a/tests/Tokenizer/IndexRangeTest.php
+++ b/tests/Tokenizer/IndexRangeTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Tokenizer;
+
+use PhpCsFixer\Tests\TestCase;
+use PhpCsFixer\Tokenizer\IndexRange;
+
+/**
+ * @author Michael Vorisek <https://github.com/mvorisek>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Tokenizer\IndexRange
+ */
+final class IndexRangeTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $indexRange = new IndexRange();
+        self::assertFalse((new \ReflectionProperty($indexRange, 'start'))->isInitialized($indexRange));
+        self::assertFalse((new \ReflectionProperty($indexRange, 'end'))->isInitialized($indexRange));
+
+        $indexRange = new IndexRange(5);
+        self::assertTrue((new \ReflectionProperty($indexRange, 'start'))->isInitialized($indexRange));
+        self::assertFalse((new \ReflectionProperty($indexRange, 'end'))->isInitialized($indexRange));
+        self::assertSame(5, $indexRange->start);
+
+        $indexRange = new IndexRange(null, 5);
+        self::assertFalse((new \ReflectionProperty($indexRange, 'start'))->isInitialized($indexRange));
+        self::assertTrue((new \ReflectionProperty($indexRange, 'end'))->isInitialized($indexRange));
+        self::assertSame(5, $indexRange->end);
+
+        $indexRange = new IndexRange(5, 6);
+        self::assertTrue((new \ReflectionProperty($indexRange, 'start'))->isInitialized($indexRange));
+        self::assertTrue((new \ReflectionProperty($indexRange, 'end'))->isInitialized($indexRange));
+        self::assertSame(5, $indexRange->start);
+        self::assertSame(6, $indexRange->end);
+    }
+
+    public function testCount(): void
+    {
+        $indexRange = new IndexRange(5, 6);
+        self::assertSame(2, $indexRange->count());
+    }
+}


### PR DESCRIPTION
add proper data structrure for storing and passing start and end index pairs

the performance should be fine - https://3v4l.org/CMktE - average file have about 2k tokens, so the overhead per file should not be more than 0.5ms when assuming extreme case the RangeToken class used for every token once