### PR TITLE
CI: Use `actions/stale` v9

### DIFF
--- a/.github/workflows/issues_and_pull_requests.yml
+++ b/.github/workflows/issues_and_pull_requests.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # Config reference: https://github.com/actions/stale
       - name: "Handle stale issues and pull requests"
-        uses: "actions/stale@v8"
+        uses: "actions/stale@v9"
         with:
           close-issue-message: "${{ env.CLOSE_MESSAGE }}"
           close-pr-message: "${{ env.CLOSE_MESSAGE }} When it comes to pull requests it may be better to create new one, on top of main branch."


### PR DESCRIPTION
Recently I discovered that Stale Bot does not work. It's still executed once a day as before, but [can't add comments and labels](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/actions/runs/7474599119/job/20350112991#step:2:1302). Let's update to newest version and see what happens 🤷‍♂️.