### PR TITLE
CI: Allow running Stale Bot on demand

### DIFF
--- a/.github/workflows/issues_and_pull_requests.yml
+++ b/.github/workflows/issues_and_pull_requests.yml
@@ -3,6 +3,8 @@
 name: "Issues and Pull Requests"
 
 on:
+  # Allow running on demand using Github UI
+  workflow_dispatch:
   schedule:
     - cron: "0 12 * * *"
 


### PR DESCRIPTION
See [docs](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow).