### PR TITLE
CI: Give write permissions to Stale Bot

### DIFF
--- a/.github/workflows/issues_and_pull_requests.yml
+++ b/.github/workflows/issues_and_pull_requests.yml
@@ -33,6 +33,12 @@ jobs:
 
     runs-on: "ubuntu-latest"
 
+    # See: https://github.com/actions/stale#recommended-permissions
+    permissions:
+      contents: write # only for delete-branch option
+      issues: write
+      pull-requests: write
+
     steps:
       # Config reference: https://github.com/actions/stale
       - name: "Handle stale issues and pull requests"


### PR DESCRIPTION
FYI: Stale Bot stopped working December 3rd, 2023 ([this is first run with errors](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/actions/runs/7076688492)). [Here](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pulls?q=is%3Apr+sort%3Aupdated-desc+closed%3A%3E%3D2023-12-02+merged%3A%3C%3D2023-12-03+is%3Amerged) are the PRs merged that time - nothing related. Probably it was caused by changes in how runners work.