### PR TITLE
fix: Priorities for `MethodChainingIndentationFixer` and `NoSpaceAroundDoubleColonFixer`

### DIFF
--- a/src/Fixer/Operator/NoSpaceAroundDoubleColonFixer.php
+++ b/src/Fixer/Operator/NoSpaceAroundDoubleColonFixer.php
@@ -30,6 +30,16 @@ final class NoSpaceAroundDoubleColonFixer extends AbstractFixer
         );
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * Must run before MethodChainingIndentationFixer.
+     */
+    public function getPriority(): int
+    {
+        return 1;
+    }
+
     public function isCandidate(Tokens $tokens): bool
     {
         return $tokens->isTokenKindFound(T_DOUBLE_COLON);

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -618,6 +618,9 @@ final class FixerFactoryTest extends TestCase
             'no_short_bool_cast' => [
                 'cast_spaces',
             ],
+            'no_space_around_double_colon' => [
+                'method_chaining_indentation',
+            ],
             'no_spaces_after_function_name' => [
                 'function_to_constant',
                 'get_class_to_class_keyword',

--- a/tests/Fixtures/Integration/priority/method_chaining_indentation,no_space_around_double_colon.test
+++ b/tests/Fixtures/Integration/priority/method_chaining_indentation,no_space_around_double_colon.test
@@ -1,0 +1,22 @@
+--TEST--
+Integration of fixers: method_chaining_indentation,no_space_around_double_colon.
+--RULESET--
+{"method_chaining_indentation": true, "no_space_around_double_colon": true}
+--EXPECT--
+<?php
+
+use Foo;
+
+Foo::bar()
+    ->baz()
+    ->cux();
+
+--INPUT--
+<?php
+
+use Foo;
+
+Foo
+        ::bar()
+    ->baz()
+->cux();


### PR DESCRIPTION
Fixes #7699

The `NoSpaceAroundDoubleColonFixer` should run before `MethodChainingIndentationFixer` to ensure correct indentation.