### PR TITLE
feat: `PhpdocTypesOrderFixer` Support DNF types

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -169,7 +169,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements ConfigurableF
      */
     private function sortTypes(TypeExpression $typeExpression): array
     {
-        $normalizeType = static fn (string $type): string => Preg::replace('/^\\??\\\?/', '', $type);
+        $normalizeType = static fn (string $type): string => Preg::replace('/^\\(?\\??\\\\?/', '', $type);
 
         $typeExpression->sortTypes(
             function (TypeExpression $a, TypeExpression $b) use ($normalizeType): int {

--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -169,7 +169,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements ConfigurableF
      */
     private function sortTypes(TypeExpression $typeExpression): array
     {
-        $normalizeType = static fn (string $type): string => Preg::replace('/^\\(?\\??\\\\?/', '', $type);
+        $normalizeType = static fn (string $type): string => Preg::replace('/^\(*\??\\\?/', '', $type);
 
         $typeExpression->sortTypes(
             function (TypeExpression $a, TypeExpression $b) use ($normalizeType): int {

--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -522,6 +522,21 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
             '<?php /** @return A&B<X|Y|Z>&C&D */',
             '<?php /** @return A&D&B<X|Y|Z>&C */',
         ];
+
+        yield [
+            '<?php /** @param A|(B&C) */',
+            '<?php /** @param (C&B)|A */',
+        ];
+
+        yield [
+            '<?php /** @param (A&C)|(B&C)|(C&D) */',
+            '<?php /** @param (C&A)|(C&B)|(C&D) */',
+        ];
+
+        yield [
+            '<?php /** @param \A|(\B&\C)|D */',
+            '<?php /** @param D|\A|(\C&\B) */',
+        ];
     }
 
     /**

--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -529,11 +529,6 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
-            '<?php /** @param A|(B&C) */',
-            '<?php /** @param (C&B)|A */',
-        ];
-
-        yield [
             '<?php /** @param A|((A&B)|(B&C)) */',
             '<?php /** @param ((B&C)|(B&A))|A */',
         ];

--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -529,6 +529,16 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
+            '<?php /** @param A|(B&C) */',
+            '<?php /** @param (C&B)|A */',
+        ];
+
+        yield [
+            '<?php /** @param A|((A&B)|(B&C)) */',
+            '<?php /** @param ((B&C)|(B&A))|A */',
+        ];
+
+        yield [
             '<?php /** @param A&(B&C) */',
             '<?php /** @param (C&B)&A */',
         ];
@@ -539,11 +549,6 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
-            '<?php /** @param (A|C)&(B|C)&(C&D) */',
-            '<?php /** @param (C|A)&(C|B)&(C&D) */',
-        ];
-
-        yield [
             '<?php /** @param \A|(\B&\C)|D */',
             '<?php /** @param D|\A|(\C&\B) */',
         ];
@@ -551,11 +556,6 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
         yield [
             '<?php /** @param A|((B&C)|D) */',
             '<?php /** @param (D|(C&B))|A */',
-        ];
-
-        yield [
-            '<?php /** @param A&((B|C)&D) */',
-            '<?php /** @param (D&(C|B))&A */',
         ];
     }
 

--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -529,13 +529,33 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
+            '<?php /** @param A&(B&C) */',
+            '<?php /** @param (C&B)&A */',
+        ];
+
+        yield [
             '<?php /** @param (A&C)|(B&C)|(C&D) */',
             '<?php /** @param (C&A)|(C&B)|(C&D) */',
         ];
 
         yield [
+            '<?php /** @param (A|C)&(B|C)&(C&D) */',
+            '<?php /** @param (C|A)&(C|B)&(C&D) */',
+        ];
+
+        yield [
             '<?php /** @param \A|(\B&\C)|D */',
             '<?php /** @param D|\A|(\C&\B) */',
+        ];
+
+        yield [
+            '<?php /** @param A|((B&C)|D) */',
+            '<?php /** @param (D|(C&B))|A */',
+        ];
+
+        yield [
+            '<?php /** @param A&((B|C)&D) */',
+            '<?php /** @param (D&(C|B))&A */',
         ];
     }
 


### PR DESCRIPTION
Not sure if this is something that should be supported or not 


(C&B)|(D&A)

=> 

(A&D)|(B&C)