### PR TITLE
fix: `numeric_literal_separator` - Handle zero-leading floats properly

### DIFF
--- a/src/Fixer/Basic/NumericLiteralSeparatorFixer.php
+++ b/src/Fixer/Basic/NumericLiteralSeparatorFixer.php
@@ -161,8 +161,8 @@ final class NumericLiteralSeparatorFixer extends AbstractFixer implements Config
             // Octal
             return $this->insertEveryRight($value, 3, 2);
         }
-        if (str_starts_with($lowerValue, '0')) {
-            // Octal prior PHP 8.1
+        if (str_starts_with($lowerValue, '0') && !str_contains($lowerValue, '.')) {
+            // Octal notation prior PHP 8.1 but still valid
             return $this->insertEveryRight($value, 3, 1);
         }
 

--- a/tests/Fixer/Basic/NumericLiteralSeparatorFixerTest.php
+++ b/tests/Fixer/Basic/NumericLiteralSeparatorFixerTest.php
@@ -171,7 +171,7 @@ final class NumericLiteralSeparatorFixerTest extends AbstractFixerTestCase
     {
         foreach ($cases as $pairsType => $pairs) {
             foreach ($pairs as $withoutSeparator => $withSeparator) {
-                if ($withSeparator === null) {
+                if (null === $withSeparator) {
                     yield "do not modify valid {$pairsType} {$withoutSeparator}" => [
                         sprintf('<?php echo %s;', $withoutSeparator),
                         null,
@@ -187,9 +187,10 @@ final class NumericLiteralSeparatorFixerTest extends AbstractFixerTestCase
             }
 
             foreach ($pairs as $withoutSeparator => $withSeparator) {
-                if ($withSeparator === null) {
+                if (null === $withSeparator) {
                     continue;
                 }
+
                 yield "remove separator from {$pairsType} {$withoutSeparator}" => [
                     sprintf('<?php echo %s;', $withoutSeparator),
                     sprintf('<?php echo %s;', $withSeparator),

--- a/tests/Fixer/Basic/NumericLiteralSeparatorFixerTest.php
+++ b/tests/Fixer/Basic/NumericLiteralSeparatorFixerTest.php
@@ -86,7 +86,10 @@ final class NumericLiteralSeparatorFixerTest extends AbstractFixerTestCase
                 '0b110001000' => '0b1_10001000',
             ],
             'float' => [
+                '.001' => null,
                 '.1001' => '.100_1',
+                '0.0001' => '0.000_1',
+                '0.001' => null,
                 '1234.5' => '1_234.5',
                 '1.2345' => '1.234_5',
                 '1234e5' => '1_234e5',
@@ -168,14 +171,25 @@ final class NumericLiteralSeparatorFixerTest extends AbstractFixerTestCase
     {
         foreach ($cases as $pairsType => $pairs) {
             foreach ($pairs as $withoutSeparator => $withSeparator) {
-                yield "add separator to {$pairsType} {$withoutSeparator}" => [
-                    sprintf('<?php echo %s;', $withSeparator),
-                    sprintf('<?php echo %s;', $withoutSeparator),
-                    ['strategy' => NumericLiteralSeparatorFixer::STRATEGY_USE_SEPARATOR],
-                ];
+                if ($withSeparator === null) {
+                    yield "do not modify valid {$pairsType} {$withoutSeparator}" => [
+                        sprintf('<?php echo %s;', $withoutSeparator),
+                        null,
+                        ['strategy' => NumericLiteralSeparatorFixer::STRATEGY_USE_SEPARATOR],
+                    ];
+                } else {
+                    yield "add separator to {$pairsType} {$withoutSeparator}" => [
+                        sprintf('<?php echo %s;', $withSeparator),
+                        sprintf('<?php echo %s;', $withoutSeparator),
+                        ['strategy' => NumericLiteralSeparatorFixer::STRATEGY_USE_SEPARATOR],
+                    ];
+                }
             }
 
             foreach ($pairs as $withoutSeparator => $withSeparator) {
+                if ($withSeparator === null) {
+                    continue;
+                }
                 yield "remove separator from {$pairsType} {$withoutSeparator}" => [
                     sprintf('<?php echo %s;', $withoutSeparator),
                     sprintf('<?php echo %s;', $withSeparator),


### PR DESCRIPTION
- added tests to cover some cases where integers should not be modified
- fixed zero leading floats that were handled as octal due to `str_starts_with` zero

fixes: #7736