### PR TITLE
fix: Proper Docker image name suffix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           flavor: |
             latest=false
-            suffix=-${{ matrix.php-version }}
+            suffix=-php${{ matrix.php-version }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}
           tags: |
             type=semver,pattern={{version}}


### PR DESCRIPTION
Appendix to #7555

I don't know how it sneaked into, because [I asked for such suffix](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7555#pullrequestreview-1781457630), most probably it was unintentionally removed in one of numerous refactorings.