### PR TITLE
fix: `FullyQualifiedStrictTypesFixer` - do not modify statements with property fetch and `::`

### DIFF
--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -617,6 +617,9 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
 
         while (true) {
             $index = $tokens->getPrevMeaningfulToken($index);
+            if ($tokens[$index]->isObjectOperator()) {
+                break;
+            }
 
             if ($tokens[$index]->equalsAny([[T_STRING], [T_NS_SEPARATOR]])) {
                 $typeStartIndex = $index;

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -875,6 +875,21 @@ class Foo extends \A\A implements \B\A, \C\A
                 new R\T();
                 EOD,
         ];
+
+        yield 'do not fix property named the same as class' => [
+            <<<'EOD'
+                <?php
+                namespace Foo;
+                use Bar\Service;
+                class Baz {
+                    public function getValue()
+                    {
+                        return $this->service::getValueFromService();
+                    }
+
+                }
+                EOD,
+        ];
     }
 
     /**
@@ -2056,6 +2071,15 @@ class Foo
 }
             ',
             ['import_symbols' => true],
+        ];
+
+        yield 'do not fix property named the same as class' => [
+            <<<'EOD'
+                <?php
+                namespace Foo;
+                use Bar\Baz;
+                echo $x?->baz::CONSTANT_1;
+                EOD,
         ];
     }
 


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7746