### PR TITLE
fix: `FullyQualifiedStrictTypesFixer` - do not change case of the symbol when there's name collision between imported class and imported function

### DIFF
--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -262,6 +262,9 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
             $lastUse = null;
 
             foreach ($namespaceUsesAnalyzer->getDeclarationsInNamespace($tokens, $namespace) as $use) {
+                if (!$use->isClass()) {
+                    continue;
+                }
                 $uses[ltrim($use->getFullName(), '\\')] = $use->getShortName();
                 $lastUse = $use;
             }

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -876,6 +876,23 @@ class Foo extends \A\A implements \B\A, \C\A
                 EOD,
         ];
 
+        yield 'do not fix class named the same as imported function' => [
+            <<<'EOD'
+                <?php
+                namespace Foo;
+                use Bar\Request;
+                use function Baz\request;
+                class Test
+                {
+                    public function request(Request $request = null)
+                    {
+                        $request = $request ?? Request::create('/docs.json');
+                    }
+                }
+                $request = new Request();
+                EOD,
+        ];
+
         yield 'do not fix property named the same as class' => [
             <<<'EOD'
                 <?php


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7744