### PR TITLE
`fully_qualified_strict_types` should not change type if in same namespace

### DIFF
--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -55,6 +55,22 @@ final class FullyQualifiedStrictTypesFixerTest extends AbstractFixerTestCase
      */
     public static function provideFixCases(): iterable
     {
+        yield 'namespace === non global type name' => [
+            '<?php
+namespace App {
+    class Foo {}
+}
+namespace App\View {
+    use App\View;
+
+    class HasView {}
+
+    class ViewFactory {
+        public function make(HasView $view): View {}
+    }
+}'
+        ];
+
         yield 'namespace === type name' => [
             '<?php
 namespace Foo\Bar;


### PR DESCRIPTION
This is a failing test for the issue I'm having after upgrading to 3.47.0.