### PR TITLE
docs: Add PHP-CS-Fixer integration in a GitHub Action step

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -77,6 +77,18 @@ Install `PHIVE <https://phar.io>`_ and issue the following command:
 
     phive install php-cs-fixer # use `--global` for global install
 
+GitHub Action (Docker)
+~~~~~~~~~~~~~~~~~~
+
+To integrate php-cs-fixer as check into a GitHub Action step, you can use a configuration like this:
+
+.. code-block:: yaml
+
+    - name: PHP-CS-Fixer
+      uses: docker://ghcr.io/php-cs-fixer/php-cs-fixer:3-php8.3
+        with:
+          args: check src
+
 Gitlab-CI (Docker)
 ~~~~~~~~~~~~~~~~~~
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -85,7 +85,7 @@ To integrate php-cs-fixer as check into a GitHub Action step, you can use a conf
 .. code-block:: yaml
 
     - name: PHP-CS-Fixer
-      uses: docker://ghcr.io/php-cs-fixer/php-cs-fixer:${FIXER_VERSION:-3-php8.3}
+      uses: docker://ghcr.io/php-cs-fixer/php-cs-fixer:3-php8.3
         with:
           args: check src
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -78,14 +78,14 @@ Install `PHIVE <https://phar.io>`_ and issue the following command:
     phive install php-cs-fixer # use `--global` for global install
 
 GitHub Action (Docker)
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 To integrate php-cs-fixer as check into a GitHub Action step, you can use a configuration like this:
 
 .. code-block:: yaml
 
     - name: PHP-CS-Fixer
-      uses: docker://ghcr.io/php-cs-fixer/php-cs-fixer:3-php8.3
+      uses: docker://ghcr.io/php-cs-fixer/php-cs-fixer:${FIXER_VERSION:-3-php8.3}
         with:
           args: check src
 


### PR DESCRIPTION
Working on my side using : 

```yml
-  name: PHP-CS-Fixer
   uses: docker://ghcr.io/php-cs-fixer/php-cs-fixer:3-php8.3
   with:
     args: check --config=api/.php-cs-fixer.dist.php --show-progress=none -v
```

![image](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/23474605/96a92d8b-6896-49fb-af15-f31a7c87e177)
