### PR TITLE
fix: `NoUselessConcatOperatorFixer` - do not remove new line

### DIFF
--- a/src/Fixer/Operator/NoUselessConcatOperatorFixer.php
+++ b/src/Fixer/Operator/NoUselessConcatOperatorFixer.php
@@ -244,8 +244,8 @@ final class NoUselessConcatOperatorFixer extends AbstractFixer implements Config
             ],
         );
 
-        $tokens->clearTokenAndMergeSurroundingWhitespace($secondOperand['start']);
         $this->clearConcatAndAround($tokens, $concatOperatorIndex);
+        $tokens->clearTokenAndMergeSurroundingWhitespace($secondOperand['start']);
     }
 
     /**

--- a/tests/Fixer/Operator/NoUselessConcatOperatorFixerTest.php
+++ b/tests/Fixer/Operator/NoUselessConcatOperatorFixerTest.php
@@ -160,6 +160,19 @@ line 2 indent" ?>',
 ;
 ",
         ];
+
+        yield 'concat without linebreak, followed by one with linebreak' => [
+            <<<'PHP'
+                <?php
+                $foo = 'ab'
+                    . 'c';
+                PHP,
+            <<<'PHP'
+                <?php
+                $foo = 'a' . 'b'
+                    . 'c';
+                PHP,
+        ];
     }
 
     public function testWithConfigJuggling(): void


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7585