### PR TITLE
docs: docker in CI - don't suggest command that overrides path from config file

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -87,7 +87,8 @@ To integrate php-cs-fixer as check into a GitHub Action step, you can use a conf
     - name: PHP-CS-Fixer
       uses: docker://ghcr.io/php-cs-fixer/php-cs-fixer:3-php8.3
         with:
-          args: check src
+          args: check
+          # use `check .` if your repository not having paths configured in .php-cs-fixer[.dist].php
 
 Gitlab-CI (Docker)
 ~~~~~~~~~~~~~~~~~~
@@ -99,7 +100,9 @@ To integrate php-cs-fixer as check into Gitlab-CI, you can use a configuration l
     php-cs-fixer:
       image: ghcr.io/php-cs-fixer/php-cs-fixer:${FIXER_VERSION:-3-php8.3}
       script:
-        php-cs-fixer check --diff --format=txt src
+        php-cs-fixer check --diff --format=txt
+        # use `check .` if your repository not having paths configured in .php-cs-fixer[.dist].php
+
 
 Update
 ------


### PR DESCRIPTION


Paths from configuration file have been overridden by paths provided as command arguments.