### PR TITLE
fix: `ClassKeywordFixer` must run before `FullyQualifiedStrictTypesFixer`

### DIFF
--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -175,7 +175,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
      * {@inheritdoc}
      *
      * Must run before NoSuperfluousPhpdocTagsFixer, OrderedImportsFixer, OrderedInterfacesFixer, StatementIndentationFixer.
-     * Must run after PhpdocToReturnTypeFixer.
+     * Must run after ClassKeywordFixer, PhpdocToReturnTypeFixer.
      */
     public function getPriority(): int
     {

--- a/src/Fixer/LanguageConstruct/ClassKeywordFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordFixer.php
@@ -53,7 +53,7 @@ $bar = "\PhpCsFixer\Tokenizer\Tokens";
     {
         return 8;
     }
-    
+
     public function isCandidate(Tokens $tokens): bool
     {
         return true;

--- a/src/Fixer/LanguageConstruct/ClassKeywordFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordFixer.php
@@ -44,6 +44,16 @@ $bar = "\PhpCsFixer\Tokenizer\Tokens";
         );
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * Must run after FullyQualifiedStrictTypesFixer.
+     */
+    public function getPriority(): int
+    {
+        return 8;
+    }
+    
     public function isCandidate(Tokens $tokens): bool
     {
         return true;

--- a/src/Fixer/LanguageConstruct/ClassKeywordFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordFixer.php
@@ -47,7 +47,7 @@ $bar = "\PhpCsFixer\Tokenizer\Tokens";
     /**
      * {@inheritdoc}
      *
-     * Must run after FullyQualifiedStrictTypesFixer.
+     * Must run before FullyQualifiedStrictTypesFixer.
      */
     public function getPriority(): int
     {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -376,6 +376,9 @@ final class FixerFactoryTest extends TestCase
                 'braces',
                 'single_line_empty_body',
             ],
+            'class_keyword' => [
+                'fully_qualified_strict_types',
+            ],
             'class_keyword_remove' => [
                 'no_unused_imports',
             ],

--- a/tests/Fixtures/Integration/priority/class_keyword,fully_qualified_strict_types.test
+++ b/tests/Fixtures/Integration/priority/class_keyword,fully_qualified_strict_types.test
@@ -1,0 +1,14 @@
+--TEST--
+Integration of fixers: class_keyword,fully_qualified_strict_types.
+--RULESET--
+{"class_keyword": true, "fully_qualified_strict_types": true}
+--EXPECT--
+<?php
+use Foo\Bar\Thing;
+
+echo Thing::class;
+
+--INPUT--
+<?php
+
+echo 'Foo\Bar\Thing';

--- a/tests/Fixtures/Integration/priority/class_keyword,fully_qualified_strict_types.test
+++ b/tests/Fixtures/Integration/priority/class_keyword,fully_qualified_strict_types.test
@@ -1,7 +1,7 @@
 --TEST--
 Integration of fixers: class_keyword,fully_qualified_strict_types.
 --RULESET--
-{"class_keyword": true, "fully_qualified_strict_types": true}
+{"class_keyword": true, "fully_qualified_strict_types": {"import_symbols": true}}
 --EXPECT--
 <?php
 use Foo\Bar\Thing;

--- a/tests/Fixtures/Integration/priority/class_keyword,fully_qualified_strict_types.test
+++ b/tests/Fixtures/Integration/priority/class_keyword,fully_qualified_strict_types.test
@@ -4,11 +4,11 @@ Integration of fixers: class_keyword,fully_qualified_strict_types.
 {"class_keyword": true, "fully_qualified_strict_types": {"import_symbols": true}}
 --EXPECT--
 <?php
-use Foo\Bar\Thing;
 
-echo Thing::class;
+use PhpCsFixer\Fixer\FixerInterface;
+echo FixerInterface::class;
 
 --INPUT--
 <?php
 
-echo 'Foo\Bar\Thing';
+echo 'PhpCsFixer\Fixer\FixerInterface';


### PR DESCRIPTION
Without specified priority, `ClassKeywordFixer` works bad when combined with `FullyQualifiedStrictTypesFixer`.

For example this:
```php
<?php

class Whatever
{
    protected string $component = '\Company\Project\Component';
}
```

Would be transformed into:
```php
<?php

class Whatever
{
    protected string $component = \Company\Project\Component::class;
}
```

and running CS check would fail, because we would need to run fixer again to receive expected:

```php
<?php

use Company\Project\Component;

class Whatever
{
    protected string $component = Component::class;
}
```