### PR TITLE
fix: Allow using cache when running in Docker distribution

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -194,13 +194,11 @@ To visualize all the rules that belong to a ruleset:
 Caching
 -------
 
-The caching mechanism is enabled by default. This will speed up further runs by
-fixing only files that were modified since the last run. The tool will fix all
-files if the tool version has changed or the list of rules has changed.
-The cache is supported only when the tool was downloaded as a phar file or
-installed via Composer. The cache is written to the drive progressively, so do
-not be afraid of interruption - rerun the command and start where you left.
-The cache mechanism also supports executing the command in parallel.
+The caching mechanism is enabled by default. This will speed up further runs by fixing only files that were modified
+since the last run. The tool will fix all files if the tool version has changed or the list of rules has changed.
+The cache is supported only when the tool was downloaded as a PHAR file, executed within pre-built Docker image
+or installed via Composer. The cache is written to the drive progressively, so do not be afraid of interruption -
+rerun the command and start where you left. The cache mechanism also supports executing the command in parallel.
 
 Cache can be disabled via ``--using-cache`` option or config file:
 

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -479,7 +479,7 @@ final class ConfigurationResolver
             }
         }
 
-        $this->usingCache = $this->usingCache && ($this->toolInfo->isInstalledAsPhar() || $this->toolInfo->isInstalledByComposer());
+        $this->usingCache = $this->usingCache && $this->isCachingAllowedForRuntime();
 
         return $this->usingCache;
     }
@@ -948,5 +948,12 @@ final class ConfigurationResolver
         }
 
         return $config;
+    }
+
+    private function isCachingAllowedForRuntime(): bool
+    {
+        return $this->toolInfo->isInstalledAsPhar()
+            || $this->toolInfo->isInstalledByComposer()
+            || $this->toolInfo->isRunInsideDocker();
     }
 }

--- a/src/ToolInfo.php
+++ b/src/ToolInfo.php
@@ -98,6 +98,11 @@ final class ToolInfo implements ToolInfoInterface
         return $this->isInstalledByComposer;
     }
 
+    public function isRunInsideDocker(): bool
+    {
+        return is_file('/.dockerenv') && str_starts_with(__FILE__, '/fixer/');
+    }
+
     public function getPharDownloadUri(string $version): string
     {
         return sprintf(

--- a/src/ToolInfo.php
+++ b/src/ToolInfo.php
@@ -98,6 +98,10 @@ final class ToolInfo implements ToolInfoInterface
         return $this->isInstalledByComposer;
     }
 
+    /**
+     * Determines if the tool is run inside our pre-built Docker image.
+     * The `/fixer/` path comes from our Dockerfile, tool is installed there and added to global PATH via symlinked binary.
+     */
     public function isRunInsideDocker(): bool
     {
         return is_file('/.dockerenv') && str_starts_with(__FILE__, '/fixer/');

--- a/src/ToolInfoInterface.php
+++ b/src/ToolInfoInterface.php
@@ -32,5 +32,7 @@ interface ToolInfoInterface
 
     public function isInstalledByComposer(): bool;
 
+    public function isRunInsideDocker(): bool;
+
     public function getPharDownloadUri(string $version): string;
 }

--- a/tests/Console/Command/SelfUpdateCommandTest.php
+++ b/tests/Console/Command/SelfUpdateCommandTest.php
@@ -431,6 +431,11 @@ final class SelfUpdateCommandTest extends TestCase
                 throw new \LogicException('Not implemented.');
             }
 
+            public function isRunInsideDocker(): bool
+            {
+                return false;
+            }
+
             public function getPharDownloadUri(string $version): string
             {
                 return sprintf('%s/%s.phar', $this->directory->url(), $version);

--- a/tests/Console/WarningsDetectorTest.php
+++ b/tests/Console/WarningsDetectorTest.php
@@ -108,6 +108,11 @@ final class WarningsDetectorTest extends TestCase
                 return $this->isInstalledByComposer;
             }
 
+            public function isRunInsideDocker(): bool
+            {
+                return false;
+            }
+
             public function getPharDownloadUri(string $version): string
             {
                 throw new \LogicException('Not implemented.');


### PR DESCRIPTION
Fixes #7768.

-----

```shell
docker build --target dist -t fixer:local .
docker run --rm -it -v $(pwd):/code --entrypoint="" fixer:local sh

/code # php-cs-fixer check
PHP CS Fixer 3.48.1-DEV Small Changes by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.3.2
Loaded config default from "/code/.php-cs-fixer.php".
 1070/1070 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


Found 0 of 1070 files that can be fixed in 40.647 seconds, 26.000 MB memory used

/code # php-cs-fixer check
PHP CS Fixer 3.48.1-DEV Small Changes by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.3.2
Loaded config default from "/code/.php-cs-fixer.php".
Using cache file "/code/.php-cs-fixer.cache.json".
 1070/1070 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


Found 0 of 1070 files that can be fixed in 0.136 seconds, 16.000 MB memory used
```

Second run inside Docker container uses cache.