### PR TITLE
fix: `function_to_constant` `get_class()` replacement

### DIFF
--- a/doc/rules/language_construct/function_to_constant.rst
+++ b/doc/rules/language_construct/function_to_constant.rst
@@ -49,7 +49,7 @@ Example #1
         {
    -        echo get_class();
    -        echo get_called_class();
-   +        echo __CLASS__;
+   +        echo self::class;
    +        echo static::class;
         }
     }

--- a/src/Console/Output/Progress/DotsOutput.php
+++ b/src/Console/Output/Progress/DotsOutput.php
@@ -65,7 +65,7 @@ final class DotsOutput implements ProgressOutputInterface
      */
     public function __sleep(): array
     {
-        throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
+        throw new \BadMethodCallException('Cannot serialize '.self::class);
     }
 
     /**
@@ -76,7 +76,7 @@ final class DotsOutput implements ProgressOutputInterface
      */
     public function __wakeup(): void
     {
-        throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+        throw new \BadMethodCallException('Cannot unserialize '.self::class);
     }
 
     public function onFixerFileProcessed(FixerFileProcessedEvent $event): void

--- a/src/Console/Output/Progress/PercentageBarOutput.php
+++ b/src/Console/Output/Progress/PercentageBarOutput.php
@@ -49,7 +49,7 @@ final class PercentageBarOutput implements ProgressOutputInterface
      */
     public function __sleep(): array
     {
-        throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
+        throw new \BadMethodCallException('Cannot serialize '.self::class);
     }
 
     /**
@@ -60,7 +60,7 @@ final class PercentageBarOutput implements ProgressOutputInterface
      */
     public function __wakeup(): void
     {
-        throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+        throw new \BadMethodCallException('Cannot unserialize '.self::class);
     }
 
     public function onFixerFileProcessed(FixerFileProcessedEvent $event): void

--- a/src/FileRemoval.php
+++ b/src/FileRemoval.php
@@ -47,7 +47,7 @@ final class FileRemoval
      */
     public function __sleep(): array
     {
-        throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
+        throw new \BadMethodCallException('Cannot serialize '.self::class);
     }
 
     /**
@@ -58,7 +58,7 @@ final class FileRemoval
      */
     public function __wakeup(): void
     {
-        throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+        throw new \BadMethodCallException('Cannot unserialize '.self::class);
     }
 
     /**

--- a/src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+++ b/src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
@@ -49,7 +49,11 @@ final class FunctionToConstantFixer extends AbstractFixer implements Configurabl
                     new Token([T_DOUBLE_COLON, '::']),
                     new Token([CT::T_CLASS_CONSTANT, 'class']),
                 ],
-                'get_class' => [new Token([T_CLASS_C, '__CLASS__'])],
+                'get_class' => [
+                    new Token([T_STRING, 'self']),
+                    new Token([T_DOUBLE_COLON, '::']),
+                    new Token([CT::T_CLASS_CONSTANT, 'class']),
+                ],
                 'get_class_this' => [
                     new Token([T_STATIC, 'static']),
                     new Token([T_DOUBLE_COLON, '::']),
@@ -167,7 +171,9 @@ final class FunctionToConstantFixer extends AbstractFixer implements Configurabl
             $tokens->clearTokenAndMergeSurroundingWhitespace($i);
         }
 
-        if ($replacements[0]->isGivenKind([T_CLASS_C, T_STATIC])) {
+        if ($replacements[0]->isGivenKind([T_CLASS_C, T_STATIC])
+            || ($replacements[0]->isGivenKind(T_STRING) && $replacements[0]->getContent() === 'self')
+        ) {
             $prevIndex = $tokens->getPrevMeaningfulToken($index);
             $prevToken = $tokens[$prevIndex];
             if ($prevToken->isGivenKind(T_NS_SEPARATOR)) {

--- a/src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+++ b/src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
@@ -172,7 +172,7 @@ final class FunctionToConstantFixer extends AbstractFixer implements Configurabl
         }
 
         if ($replacements[0]->isGivenKind([T_CLASS_C, T_STATIC])
-            || ($replacements[0]->isGivenKind(T_STRING) && $replacements[0]->getContent() === 'self')
+            || ($replacements[0]->isGivenKind(T_STRING) && 'self' === $replacements[0]->getContent())
         ) {
             $prevIndex = $tokens->getPrevMeaningfulToken($index);
             $prevToken = $tokens[$prevIndex];

--- a/src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+++ b/src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
@@ -171,7 +171,8 @@ final class FunctionToConstantFixer extends AbstractFixer implements Configurabl
             $tokens->clearTokenAndMergeSurroundingWhitespace($i);
         }
 
-        if ($replacements[0]->isGivenKind([T_CLASS_C, T_STATIC])
+        if (
+            $replacements[0]->isGivenKind([T_CLASS_C, T_STATIC])
             || ($replacements[0]->isGivenKind(T_STRING) && 'self' === $replacements[0]->getContent())
         ) {
             $prevIndex = $tokens->getPrevMeaningfulToken($index);

--- a/src/Linter/ProcessLinter.php
+++ b/src/Linter/ProcessLinter.php
@@ -84,7 +84,7 @@ final class ProcessLinter implements LinterInterface
      */
     public function __sleep(): array
     {
-        throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
+        throw new \BadMethodCallException('Cannot serialize '.self::class);
     }
 
     /**
@@ -95,7 +95,7 @@ final class ProcessLinter implements LinterInterface
      */
     public function __wakeup(): void
     {
-        throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+        throw new \BadMethodCallException('Cannot unserialize '.self::class);
     }
 
     public function isAsync(): bool

--- a/src/Tokenizer/CT.php
+++ b/src/Tokenizer/CT.php
@@ -97,7 +97,7 @@ final class CT
         static $constants;
 
         if (null === $constants) {
-            $reflection = new \ReflectionClass(__CLASS__);
+            $reflection = new \ReflectionClass(self::class);
             $constants = array_flip($reflection->getConstants());
         }
 

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -115,7 +115,7 @@ final class ProjectCodeTest extends TestCase
         $testClassName = 'PhpCsFixer\\Tests'.substr($className, 10).'Test';
 
         if (\in_array($className, self::$classesWithoutTests, true)) {
-            self::assertFalse(class_exists($testClassName), sprintf('Class "%s" already has tests, so it should be removed from "%s::$classesWithoutTests".', $className, __CLASS__));
+            self::assertFalse(class_exists($testClassName), sprintf('Class "%s" already has tests, so it should be removed from "%s::$classesWithoutTests".', $className, self::class));
             self::markTestIncomplete(sprintf('Class "%s" has no tests yet, please help and add it.', $className));
         }
 

--- a/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
@@ -153,8 +153,8 @@ $a =
                         public function echoClassName($notMe)
                         {
                             echo get_class($notMe);
-                            echo __CLASS__/** 1 *//* 2 */;
-                            echo __CLASS__;
+                            echo self::class/** 1 *//* 2 */;
+                            echo self::class;
                         }
                     }
 
@@ -182,7 +182,7 @@ $a =
         ];
 
         yield 'get_class with leading backslash' => [
-            '<?php __CLASS__;',
+            '<?php self::class;',
             '<?php \get_class();',
         ];
 
@@ -251,7 +251,7 @@ get_called_class#1
         ];
 
         yield [
-            '<?php class Foo{ public function Bar(){ echo static::class; echo __CLASS__; }}',
+            '<?php class Foo{ public function Bar(){ echo static::class; echo self::class; }}',
             '<?php class Foo{ public function Bar(){ echo \get_class((($this))); echo get_class(); }}',
             ['functions' => ['get_class_this', 'get_class']],
         ];


### PR DESCRIPTION
fix #2944

repro: https://3v4l.org/j0daX#v8.2.0

also modernize `__CLASS__` usages to `self::class` as done by Rector