### PR TITLE
fix: `LowercaseStaticReferenceFixer` - do not change typed constants

### DIFF
--- a/src/Fixer/Casing/LowercaseStaticReferenceFixer.php
+++ b/src/Fixer/Casing/LowercaseStaticReferenceFixer.php
@@ -84,7 +84,7 @@ class Foo extends Bar
             }
 
             $prevIndex = $tokens->getPrevMeaningfulToken($index);
-            if ($tokens[$prevIndex]->isGivenKind([T_CONST, T_DOUBLE_COLON, T_FUNCTION, T_NAMESPACE, T_NS_SEPARATOR]) || $tokens[$prevIndex]->isObjectOperator()) {
+            if ($tokens[$prevIndex]->isGivenKind([T_CONST, T_DOUBLE_COLON, T_FUNCTION, T_NAMESPACE, T_NS_SEPARATOR, T_STATIC, T_STRING, CT::T_ARRAY_TYPEHINT, CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_CLOSE]) || $tokens[$prevIndex]->isObjectOperator()) {
                 continue;
             }
 

--- a/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
@@ -327,4 +327,56 @@ class Foo
             '<?php enum Foo: string { case PARENT = \'parent\'; }',
         ];
     }
+
+    /**
+     * @dataProvider provideFix83Cases
+     *
+     * @requires PHP 8.3
+     */
+    public function testFix83(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<array{0: string, 1?: null|string}>
+     */
+    public static function provideFix83Cases(): iterable
+    {
+        yield [<<<'PHP'
+            <?php
+            class Foo {
+                private const array PARENT = ['parent'];
+                private const array SELF = ['self'];
+                private const array STATIC = ['static'];
+            }
+            PHP];
+
+        yield [<<<'PHP'
+            <?php
+            class Foo {
+                private const int PARENT = 1;
+                private const int SELF = 2;
+                private const int STATIC = 3;
+            }
+            PHP];
+
+        yield [<<<'PHP'
+            <?php
+            class Foo {
+                private const int|static PARENT = 1;
+                private const int|static SELF = 2;
+                private const int|static STATIC = 3;
+            }
+            PHP];
+
+        yield [<<<'PHP'
+            <?php
+            class Foo {
+                private const string|(Bar&Baz) PARENT = 'parent';
+                private const string|(Bar&Baz) SELF = 'self';
+                private const string|(Bar&Baz) STATIC = 'static';
+            }
+            PHP];
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7771