### PR TITLE
chore: `DescribeCommand` - better handling of deprecations

### DIFF
--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -164,8 +164,11 @@ final class DescribeCommand extends Command
         if ($fixer instanceof DeprecatedFixerInterface) {
             $successors = $fixer->getSuccessorsNames();
             $message = [] === $successors
-                ? 'will be removed in the next major version'
+                ? sprintf('it will be removed in version %d.0', Application::getMajorVersion() + 1)
                 : sprintf('use %s instead', Utils::naturalLanguageJoinWithBackticks($successors));
+
+            $endMessage = '. '.ucfirst($message);
+            Utils::triggerDeprecation(new \RuntimeException(str_replace('`', '"', "Rule \"{$name}\" is deprecated{$endMessage}.")));
             $message = Preg::replace('/(`[^`]+`)/', '<info>$1</info>', $message);
             $output->writeln(sprintf('<error>DEPRECATED</error>: %s.', $message));
             $output->writeln('');

--- a/tests/AutoReview/DescribeCommandTest.php
+++ b/tests/AutoReview/DescribeCommandTest.php
@@ -35,6 +35,8 @@ final class DescribeCommandTest extends TestCase
 {
     /**
      * @dataProvider provideDescribeCommandCases
+     *
+     * @param list<string> $successorsNames
      */
     public function testDescribeCommand(FixerFactory $factory, string $fixerName, ?array $successorsNames): void
     {

--- a/tests/AutoReview/DescribeCommandTest.php
+++ b/tests/AutoReview/DescribeCommandTest.php
@@ -16,8 +16,10 @@ namespace PhpCsFixer\Tests\AutoReview;
 
 use PhpCsFixer\Console\Application;
 use PhpCsFixer\Console\Command\DescribeCommand;
+use PhpCsFixer\Fixer\DeprecatedFixerInterface;
 use PhpCsFixer\FixerFactory;
 use PhpCsFixer\Tests\TestCase;
+use PhpCsFixer\Utils;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -34,8 +36,16 @@ final class DescribeCommandTest extends TestCase
     /**
      * @dataProvider provideDescribeCommandCases
      */
-    public function testDescribeCommand(FixerFactory $factory, string $fixerName): void
+    public function testDescribeCommand(FixerFactory $factory, string $fixerName, ?array $successorsNames): void
     {
+        if (null !== $successorsNames) {
+            $message = "Rule \"{$fixerName}\" is deprecated. "
+                .([] === $successorsNames
+                    ? 'It will be removed in version 4.0.'
+                    : sprintf('Use %s instead.', Utils::naturalLanguageJoin($successorsNames)));
+            $this->expectDeprecation($message);
+        }
+
         // @TODO 4.0 Remove this expectation
         $this->expectDeprecation('Rule set "@PER" is deprecated. Use "@PER-CS" instead.');
         $this->expectDeprecation('Rule set "@PER:risky" is deprecated. Use "@PER-CS:risky" instead.');
@@ -60,7 +70,11 @@ final class DescribeCommandTest extends TestCase
         $factory->registerBuiltInFixers();
 
         foreach ($factory->getFixers() as $fixer) {
-            yield [$factory, $fixer->getName()];
+            yield [
+                $factory,
+                $fixer->getName(),
+                $fixer instanceof DeprecatedFixerInterface ? $fixer->getSuccessorsNames() : null,
+            ];
         }
     }
 }

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -51,13 +51,13 @@ final class DescribeCommandTest extends TestCase
     /**
      * @dataProvider provideExecuteOutputCases
      */
-    public function testExecuteOutput(string $expected, bool $expectedIsRegEx, bool $decorated, ?FixerInterface $fixer = null): void
+    public function testExecuteOutput(string $expected, bool $expectedIsRegEx, bool $decorated, FixerInterface $fixer): void
     {
-        // @TODO 4.0 Remove this expectation
+        // @TODO 4.0 Remove these expectations:
         $this->expectDeprecation('Rule set "@PER" is deprecated. Use "@PER-CS" instead.');
         $this->expectDeprecation('Rule set "@PER:risky" is deprecated. Use "@PER-CS:risky" instead.');
 
-        $actual = $this->execute(null !== $fixer ? $fixer->getName() : 'Foo/bar', $decorated, $fixer)->getDisplay(true);
+        $actual = $this->execute($fixer->getName(), $decorated, $fixer)->getDisplay(true);
 
         if (true === $expectedIsRegEx) {
             self::assertMatchesRegularExpression($expected, $actual);
@@ -107,6 +107,7 @@ Fixing examples:
 ',
             false,
             false,
+            self::createConfigurableDeprecatedFixerDouble(),
         ];
 
         yield 'rule is configurable, risky and deprecated [with decoration]' => [
@@ -148,6 +149,7 @@ Fixing examples:
 ",
             false,
             true,
+            self::createConfigurableDeprecatedFixerDouble(),
         ];
 
         yield 'rule without code samples' => [
@@ -281,7 +283,7 @@ $/s',
 
     public function testExecuteStatusCode(): void
     {
-        // @TODO 4.0 Remove this expectations
+        // @TODO 4.0 Remove these expectations:
         $this->expectDeprecation('Rule set "@PER" is deprecated. Use "@PER-CS" instead.');
         $this->expectDeprecation('Rule set "@PER:risky" is deprecated. Use "@PER-CS:risky" instead.');
 
@@ -347,7 +349,7 @@ $/s',
 
     public function testFixerClassNameIsExposedWhenVerbose(): void
     {
-        // @TODO 4.0 Remove this expectations
+        // @TODO 4.0 Remove these expectations:
         $this->expectDeprecation('Rule set "@PER" is deprecated. Use "@PER-CS" instead.');
         $this->expectDeprecation('Rule set "@PER:risky" is deprecated. Use "@PER-CS:risky" instead.');
 
@@ -412,7 +414,7 @@ $/s',
 
     public function testCommandDescribesCustomFixer(): void
     {
-        // @TODO 4.0 Remove this expectations
+        // @TODO 4.0 Remove these expectations:
         $this->expectDeprecation('Rule set "@PER" is deprecated. Use "@PER-CS" instead.');
         $this->expectDeprecation('Rule set "@PER:risky" is deprecated. Use "@PER-CS:risky" instead.');
 
@@ -501,7 +503,7 @@ Fixing examples:
         };
     }
 
-    private function createConfigurableDeprecatedFixerDouble(): FixerInterface
+    private static function createConfigurableDeprecatedFixerDouble(): FixerInterface
     {
         return new class() implements ConfigurableFixerInterface, DeprecatedFixerInterface {
             /** @var array<string, mixed> */
@@ -590,7 +592,7 @@ Fixing examples:
 
     private function execute(string $name, bool $decorated, ?FixerInterface $fixer = null): CommandTester
     {
-        $fixer ??= $this->createConfigurableDeprecatedFixerDouble();
+        $fixer ??= self::createConfigurableDeprecatedFixerDouble();
 
         $fixerClassName = \get_class($fixer);
         $isBuiltIn = str_starts_with($fixerClassName, 'PhpCsFixer') && !str_contains($fixerClassName, '@anon');

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -53,6 +53,10 @@ final class DescribeCommandTest extends TestCase
      */
     public function testExecuteOutput(string $expected, bool $expectedIsRegEx, bool $decorated, FixerInterface $fixer): void
     {
+        if ($fixer instanceof DeprecatedFixerInterface) {
+            $this->expectDeprecation(sprintf('Rule "%s" is deprecated. Use "%s" instead.', $fixer->getName(), implode('", "', $fixer->getSuccessorsNames())));
+        }
+
         // @TODO 4.0 Remove these expectations:
         $this->expectDeprecation('Rule set "@PER" is deprecated. Use "@PER-CS" instead.');
         $this->expectDeprecation('Rule set "@PER:risky" is deprecated. Use "@PER-CS:risky" instead.');
@@ -283,6 +287,7 @@ $/s',
 
     public function testExecuteStatusCode(): void
     {
+        $this->expectDeprecation('Rule "Foo/bar" is deprecated. Use "Foo/baz" instead.');
         // @TODO 4.0 Remove these expectations:
         $this->expectDeprecation('Rule set "@PER" is deprecated. Use "@PER-CS" instead.');
         $this->expectDeprecation('Rule set "@PER:risky" is deprecated. Use "@PER-CS:risky" instead.');


### PR DESCRIPTION
Resolves https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7772

With the changes the command will display 
```cli
$ PHP_CS_FIXER_FUTURE_MODE=0 php php-cs-fixer describe braces -vvv
PHP CS Fixer 3.48.1-DEV Small Changes by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.3.2
Description of the `braces` rule.

Fixer class: PhpCsFixer\Fixer\Basic\BracesFixer.

DEPRECATED: use `single_space_around_construct`, `control_structure_braces`, `control_structure_continuation_position`, `declare_parentheses`, `no_multiple_statements_per_line`, `curly_braces_position`, `statement_indentation` and `no_extra_blank_lines` instead.

The body of each structure MUST be enclosed by braces. Braces should be properly placed. Body of braces should be properly indented.

Fixer is configurable using following options:
* allow_single_line_anonymous_class_with_empty_body (bool): whether single line anonymous class with empty body notation should be allowed; defaults to false
* allow_single_line_closure (bool): whether single line lambda notation should be allowed; defaults to false
* position_after_anonymous_constructs ('next' and 'same'): whether the opening brace should be placed on "next" or "same" line after anonymous constructs (anonymous classes and lambda functions); defaults to 'same'
* position_after_control_structures ('next' and 'same'): whether the opening brace should be placed on "next" or "same" line after control structures; defaults to 'same'
* position_after_functions_and_oop_constructs ('next' and 'same'): whether the opening brace should be placed on "next" or "same" line after classy constructs (non-anonymous classes, interfaces, traits, methods and non-lambda functions); defaults to 'next'

Fixing examples:
 * Example #1. Fixing with the default configuration.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,25 +1,27 @@
    <?php

   -class Foo {
   -    public function bar($baz) {
   -        if ($baz = 900) echo "Hello!";
   +class Foo
   +{
   +    public function bar($baz)
   +    {
   +        if ($baz = 900) {
   +            echo "Hello!";
   +        }

   -        if ($baz = 9000)
   +        if ($baz = 9000) {
                echo "Wait!";
   +        }

   -        if ($baz == true)
   -        {
   +        if ($baz == true) {
                echo "Why?";
   -        }
   -        else
   -        {
   +        } else {
                echo "Ha?";
            }

   -        if (is_array($baz))
   -            foreach ($baz as $b)
   -            {
   +        if (is_array($baz)) {
   +            foreach ($baz as $b) {
                    echo $b;
                }
   +        }
        }
    }

   ----------- end diff -----------

 * Example #2. Fixing with configuration: ['allow_single_line_closure' => true].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,4 +1,5 @@
    <?php
    $positive = function ($item) { return $item >= 0; };
    $negative = function ($item) {
   -                return $item < 0; };
   +    return $item < 0;
   +};

   ----------- end diff -----------

 * Example #3. Fixing with configuration: ['position_after_functions_and_oop_constructs' => 'same'].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,27 +1,25 @@
    <?php

   -class Foo
   -{
   -    public function bar($baz)
   -    {
   -        if ($baz = 900) echo "Hello!";
   +class Foo {
   +    public function bar($baz) {
   +        if ($baz = 900) {
   +            echo "Hello!";
   +        }

   -        if ($baz = 9000)
   +        if ($baz = 9000) {
                echo "Wait!";
   +        }

   -        if ($baz == true)
   -        {
   +        if ($baz == true) {
                echo "Why?";
   -        }
   -        else
   -        {
   +        } else {
                echo "Ha?";
            }

   -        if (is_array($baz))
   -            foreach ($baz as $b)
   -            {
   +        if (is_array($baz)) {
   +            foreach ($baz as $b) {
                    echo $b;
                }
   +        }
        }
    }

   ----------- end diff -----------


Detected deprecations in use:
- Rule "braces" is deprecated. Use "single_space_around_construct", "control_structure_braces", "control_structure_continuation_position", "declare_parentheses", "no_multiple_statements_per_line", "curly_braces_position", "statement_indentation" and "no_extra_blank_lines" instead.
- Rule set "@PER" is deprecated. Use "@PER-CS" instead.
- Rule set "@PER:risky" is deprecated. Use "@PER-CS:risky" instead.
```
and
```cli
$ PHP_CS_FIXER_FUTURE_MODE=1 php php-cs-fixer describe braces
PHP CS Fixer 3.48.1-DEV Small Changes by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.3.2
Description of the `braces` rule.


In Utils.php line 174:

  Your are using something deprecated, see previous exception. Aborting execution because `PHP_CS_FIXER_FUTURE_MODE` environment variable is
  set.


In DescribeCommand.php line 171:

  Rule "braces" is deprecated. Use "single_space_around_construct", "control_structure_braces", "control_structure_continuation_position", "d
  eclare_parentheses", "no_multiple_statements_per_line", "curly_braces_position", "statement_indentation" and "no_extra_blank_lines" instead
  .


describe [--config CONFIG] [--] <name>
```