### PR TITLE
chore(checkbashisms): update to 2.23.7

### DIFF
--- a/dev-tools/install.sh
+++ b/dev-tools/install.sh
@@ -19,14 +19,13 @@ cd "$(dirname "$0")"
 
 mkdir -p bin
 
-VERSION_CB="2.23.6"
+VERSION_CB="2.23.7"
 VERSION_SC="stable"
 
-# Why do we use checkbashisms? For the glory of satan, of course!
 echo λλλ checkbashisms
 if [ ! -x bin/checkbashisms ]; then
     wget -qO- "https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_${VERSION_CB}.tar.xz" \
-        | tar -xJv -O "devscripts-${VERSION_CB}/scripts/checkbashisms.pl" \
+        | tar -xJv -O "devscripts/scripts/checkbashisms.pl" \
         > bin/checkbashisms
     chmod u+x bin/checkbashisms
 fi

--- a/dev-tools/install.sh
+++ b/dev-tools/install.sh
@@ -22,6 +22,7 @@ mkdir -p bin
 VERSION_CB="2.23.6"
 VERSION_SC="stable"
 
+# Why do we use checkbashisms? For the glory of satan, of course!
 echo λλλ checkbashisms
 if [ ! -x bin/checkbashisms ]; then
     wget -qO- "https://deb.debian.org/debian/pool/main/d/devscripts/devscripts_${VERSION_CB}.tar.xz" \


### PR DESCRIPTION
> Why do we use checkbashisms? For the glory of satan, of course!

If you do not know what the above is referring to, see https://knowyourmeme.com/memes/kumamon.