### PR TITLE
fix: Ensure PCNTL extension is always installed in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,24 @@ CMD git ls-files --cached -z -- '*.rst' \
     | xargs -0 -- python3 -m sphinxlint --enable all --disable trailing-whitespace --max-line-length 2000
 
 FROM php:${PHP_VERSION}-cli-alpine${ALPINE_VERSION} as base
+
+RUN curl --location --output /usr/local/bin/install-php-extensions https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions \
+    && chmod +x /usr/local/bin/install-php-extensions \
+    && install-php-extensions pcntl
+
+FROM base as base-dev
+
 # https://blog.codito.dev/2022/11/composer-binary-only-docker-images/
 # https://github.com/composer/docker/pull/250
 COPY --from=composer/composer:2-bin /composer /usr/local/bin/composer
 
-FROM base as vendor
+FROM base-dev as vendor
 COPY composer.json /fixer/composer.json
 WORKDIR /fixer
 RUN composer install --prefer-dist --no-dev --optimize-autoloader --no-scripts
 
-FROM php:${PHP_VERSION}-cli-alpine${ALPINE_VERSION} as dist
+FROM base as dist
+
 RUN mkdir /code
 WORKDIR /code
 COPY src /fixer/src
@@ -30,7 +38,7 @@ COPY --from=vendor /fixer/vendor /fixer/vendor
 RUN ln -s /fixer/php-cs-fixer /usr/local/bin/php-cs-fixer
 ENTRYPOINT ["/usr/local/bin/php-cs-fixer"]
 
-FROM base as php
+FROM base-dev as dev
 ARG DOCKER_USER_ID
 ARG DOCKER_GROUP_ID
 ARG PHP_XDEBUG_VERSION
@@ -42,14 +50,8 @@ RUN if [ ! -z "$DOCKER_GROUP_ID" ] && [ ! getent group "${DOCKER_GROUP_ID}" > /d
         then adduser -S -u "${DOCKER_USER_ID}" -G "$(getent group "${DOCKER_GROUP_ID}" | awk -F: '{printf $1}')" dev; \
     fi \
     && apk add git \
-    # php extensions
-    && curl --location --output /usr/local/bin/install-php-extensions https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions \
-    && chmod +x /usr/local/bin/install-php-extensions \
     && sync \
-    && install-php-extensions \
-        pcntl \
-        xdebug-${PHP_XDEBUG_VERSION} \
-    # xdebug command
+    && install-php-extensions xdebug-${PHP_XDEBUG_VERSION} \
     && curl --location --output /usr/local/bin/xdebug https://github.com/julienfalque/xdebug/releases/download/v2.0.0/xdebug \
     && chmod +x /usr/local/bin/xdebug
 


### PR DESCRIPTION
We need signals support both in local development and in official releases.

Related to #7783, but does not completely resolve it.

---

Explanation:
- we need `pcntl` extension both for official releases and local development, so it's extracted to the lowest `base` layer
- Composer is required for local development and for preparing Docker releases, so it's extracted to `base-dev` layer
- `vendor` layer is only an intermediate layer used to `COPY --from` to copy pre-installed vendor packages to the Docker release
- `dist` is a layer with official Docker releases, built on top of `base` (with `pcntl`), with vendors copied from `vendor`
- `dev` is a top layer for local development, built od top of `base-dev` (with `pcntl` _and_ Composer)