### PR TITLE
chore: Exclude `topic/core` issues/PRs from Stale Bot

### DIFF
--- a/.github/workflows/issues_and_pull_requests.yml
+++ b/.github/workflows/issues_and_pull_requests.yml
@@ -52,6 +52,8 @@ jobs:
           days-before-pr-close: "${{ env.DAYS_BEFORE_PR_CLOSE }}"
           days-before-pr-stale: "${{ env.DAYS_BEFORE_PR_STALE }}"
           exempt-all-milestones: true
+          exempt-issue-labels: "topic/core"
+          exempt-pr-labels: "topic/core"
           labels-to-add-when-unstale: "status/to verify"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           stale-issue-label: "status/stale"


### PR DESCRIPTION
Issues/PRs related to core features should be excluded from Stale Bot as these are part of internal vision for project development. We should apply `topic/core` label when we agree that something must be done in the Fixer's engine/architecture/design and keep it open (of course reviewing these issues from time to time is highly recommended).