### PR TITLE
fix: Correct type annotation in Config

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -55,7 +55,7 @@ class Config implements ConfigInterface
     /**
      * @TODO: 4.0 - update to @PER
      *
-     * @var array<string, array<string, mixed>|bool>
+     * @var array<string, array<array-key, mixed>|bool>
      */
     private array $rules;
 


### PR DESCRIPTION
This updates the type annotation to be the proper type allowed in the variable.