### PR TITLE
chore: some improvements around array typehints

### DIFF
--- a/src/Fixer/Alias/NoAliasFunctionsFixer.php
+++ b/src/Fixer/Alias/NoAliasFunctionsFixer.php
@@ -156,7 +156,7 @@ final class NoAliasFunctionsFixer extends AbstractFixer implements ConfigurableF
     ];
 
     /**
-     * @var array<string, array<int|string>|string> stores alias (key) - master (value) functions mapping
+     * @var array<string, array{string, int}|string> stores alias (key) - master (value) functions mapping
      */
     private array $aliases = [];
 

--- a/src/Fixer/ControlStructure/YodaStyleFixer.php
+++ b/src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -44,7 +44,7 @@ final class YodaStyleFixer extends AbstractFixer implements ConfigurableFixerInt
     private $candidateTypesConfiguration;
 
     /**
-     * @var array<int|string>
+     * @var list<int|string>
      */
     private $candidateTypes;
 

--- a/src/Tokenizer/Analyzer/DataProviderAnalyzer.php
+++ b/src/Tokenizer/Analyzer/DataProviderAnalyzer.php
@@ -30,7 +30,7 @@ final class DataProviderAnalyzer
         .'(\\\\'.TypeExpression::REGEX_IDENTIFIER.')*+)';
 
     /**
-     * @return array<DataProviderAnalysis>
+     * @return list<DataProviderAnalysis>
      */
     public function getDataProviders(Tokens $tokens, int $startIndex, int $endIndex): array
     {
@@ -50,7 +50,7 @@ final class DataProviderAnalyzer
 
             Preg::matchAll('/@dataProvider\h+(('.self::REGEX_CLASS.'::)?'.TypeExpression::REGEX_IDENTIFIER.')/', $tokens[$docCommentIndex]->getContent(), $matches);
 
-            /** @var array<string> $matches */
+            /** @var list<string> $matches */
             $matches = $matches[1];
 
             foreach ($matches as $dataProviderName) {

--- a/src/Tokenizer/Analyzer/SwitchAnalyzer.php
+++ b/src/Tokenizer/Analyzer/SwitchAnalyzer.php
@@ -22,7 +22,7 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 final class SwitchAnalyzer
 {
-    /** @var array<string, array<int>> */
+    /** @var array<string, list<int>> */
     private static array $cache = [];
 
     public static function belongsToSwitch(Tokens $tokens, int $index): bool

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -216,7 +216,7 @@ final class Utils
     }
 
     /**
-     * @param array<mixed, mixed> $value
+     * @param array<array-key, mixed> $value
      */
     private static function arrayToString(array $value): string
     {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -216,7 +216,7 @@ final class Utils
     }
 
     /**
-     * @param array<mixed> $value
+     * @param array<mixed, mixed> $value
      */
     private static function arrayToString(array $value): string
     {


### PR DESCRIPTION
as we see, we shall not blindly apply, but rule is great to find the cases and pre-fill the fix.

unfortunately, PHPStan is not able to detect violations. (so we cannot apply the rule, run Stan, and assume all good if there was no error)