### PR TITLE
fix: `NumericLiteralSeparatorFixer` - do not change `float` to `int` when there is nothing after the dot

### DIFF
--- a/src/Fixer/Basic/NumericLiteralSeparatorFixer.php
+++ b/src/Fixer/Basic/NumericLiteralSeparatorFixer.php
@@ -171,7 +171,7 @@ final class NumericLiteralSeparatorFixer extends AbstractFixer implements Config
         /** If its a negative value we need an offset */
         $negativeOffset = static fn ($v) => str_contains($v, '-') ? 1 : 0;
 
-        Preg::matchAll('/([0-9-_]+)?((\.)([0-9_]+))?((e)([0-9-_]+))?/i', $value, $result);
+        Preg::matchAll('/([0-9-_]+)?((\.)([0-9_]*))?((e)([0-9-_]+))?/i', $value, $result);
 
         $integer = $result[1][0];
         $joinedValue = $this->insertEveryRight($integer, 3, $negativeOffset($integer));

--- a/tests/Fixer/Basic/NumericLiteralSeparatorFixerTest.php
+++ b/tests/Fixer/Basic/NumericLiteralSeparatorFixerTest.php
@@ -116,6 +116,8 @@ final class NumericLiteralSeparatorFixerTest extends AbstractFixerTestCase
                 '01234567' => '01_234_567',
             ],
         ]);
+
+        yield 'do not change float to int when there is nothing after the dot' => ['<?php $x = 100.;'];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7803