### PR TITLE
feat: Ability to remove unused imports from multi-use statements

### DIFF
--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -421,26 +421,30 @@ final class NoUnusedImportsFixer extends AbstractFixer
      *
      * @param -1|1 $direction
      *
-     * @return array{0: int, 1: bool}
+     * @return array{0: null|int, 1: bool}
      */
     private function scanForNonEmptyTokensUntilNewLineFound(Tokens $tokens, int $index, int $direction): array
     {
         $hasNonEmptyToken = false;
+        $newLineTokenIndex = null;
 
-        while (\is_int($index) && $index > 0) {
+        // Iterate until we find new line OR we get out of $tokens bounds (next sibling index is `null`).
+        while (\is_int($index)) {
             $index = $tokens->getNonEmptySibling($index, $direction);
 
-            if (null === $tokens[$index]->getId()) {
+            if (null === $index || null === $tokens[$index]->getId()) {
                 continue;
             }
 
             if (!$tokens[$index]->isWhitespace()) {
                 $hasNonEmptyToken = true;
             } elseif (str_starts_with($tokens[$index]->getContent(), "\n")) {
+                $newLineTokenIndex = $index;
+
                 break;
             }
         }
 
-        return [$index, $hasNonEmptyToken];
+        return [$newLineTokenIndex, $hasNonEmptyToken];
     }
 }

--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -59,7 +59,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
-        $useDeclarations = (new NamespaceUsesAnalyzer())->getDeclarationsFromTokens($tokens);
+        $useDeclarations = (new NamespaceUsesAnalyzer())->getDeclarationsFromTokens($tokens, true);
 
         if (0 === \count($useDeclarations)) {
             return;

--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -410,7 +410,12 @@ final class NoUnusedImportsFixer extends AbstractFixer
             1
         );
 
-        if (!$hasNonEmptyTokenBefore[1] && !$hasNonEmptyTokenAfter[1]) {
+        if (
+            \is_int($hasNonEmptyTokenBefore[0])
+            && !$hasNonEmptyTokenBefore[1]
+            && \is_int($hasNonEmptyTokenAfter[0])
+            && !$hasNonEmptyTokenAfter[1]
+        ) {
             $tokens->clearRange($hasNonEmptyTokenBefore[0], $hasNonEmptyTokenAfter[0] - 1);
         }
     }

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -169,7 +169,6 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
             <<<'EOF'
                 <?php namespace App\Http\Controllers;
 
-
                 EOF,
             <<<'EOF'
                 <?php namespace App\Http\Controllers;
@@ -315,6 +314,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 namespace Foo;
 
                 use BarE;
+
                 $c = new D();
                 $e = new BarE();
                 EOF,
@@ -669,7 +669,6 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
             <<<'EOF'
                 <?php
                 namespace Aaa;
-
 
                 class Ddd
                 {
@@ -1340,18 +1339,14 @@ Bar3:
                 EOF
         ];
 
-        $empty = '';
-
         yield 'grouped imports' => [
-            <<<EOF
+            <<<'EOF'
                 <?php
-                use some\\y\\{ClassA, ClassC as C,};
-                use function some\\a\\{
-                    {$empty}
+                use some\y\{ClassA, ClassC as C,};
+                use function some\a\{
                     fn_b,
-                    {$empty}
                 };
-                use const some\\Z\\{ConstA,ConstC,};
+                use const some\Z\{ConstA,ConstC,};
 
                 echo ConstA.ConstC;
                 fn_b(ClassA::test, new C());
@@ -1373,6 +1368,31 @@ Bar3:
 
                 echo ConstA.ConstC;
                 fn_b(ClassA::test, new C());
+                EOF,
+        ];
+
+        yield 'multiline grouped imports with comments' => [
+            <<<'EOF'
+                <?php
+                use function some\a\{
+                     // Foo
+                    fn_b,
+                    /* Bar *//** Baz */
+                     # Buzz
+                };
+
+                fn_b();
+                EOF,
+            <<<'EOF'
+                <?php
+                use function some\a\{
+                    fn_a, // Foo
+                    fn_b,
+                    /* Bar */ fn_c, /** Baz */
+                    fn_d, # Buzz
+                };
+
+                fn_b();
                 EOF,
         ];
 

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -314,9 +314,7 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
 
                 namespace Foo;
 
-                use BarB, BarC as C, BarD;
                 use BarE;
-
                 $c = new D();
                 $e = new BarE();
                 EOF,
@@ -332,6 +330,8 @@ final class NoUnusedImportsFixerTest extends AbstractFixerTestCase
                 use BarB2;
                 use BarB\B2;
                 use BarE;
+                use function fun_a, fun_b, fun_c;
+                use const CONST_A, CONST_B, CONST_C;
 
                 $c = new D();
                 $e = new BarE();
@@ -1319,7 +1319,16 @@ Bar3:
         ];
 
         yield [
-            $expected = <<<'EOF'
+            <<<'EOF'
+                <?php
+                use some\a\{ClassD};
+                use function some\c\{fn_a};
+                use const some\d\{ConstB};
+
+                new CLassD();
+                echo fn_a(ConstB);
+                EOF,
+            <<<'EOF'
                 <?php
                 use some\a\{ClassD};
                 use some\b\{ClassA, ClassB, ClassC as C};
@@ -1327,21 +1336,25 @@ Bar3:
                 use const some\d\{ConstA, ConstB, ConstC};
 
                 new CLassD();
-                echo fn_a();
+                echo fn_a(ConstB);
                 EOF
         ];
 
+        $empty = '';
+
         yield 'grouped imports' => [
-            <<<'EOF'
+            <<<EOF
                 <?php
-                use some\y\{ClassA, ClassC as C,};
-                use function some\a\{
-                    fn_a,
+                use some\\y\\{ClassA, ClassC as C,};
+                use function some\\a\\{
+                    {$empty}
+                    fn_b,
+                    {$empty}
                 };
-                use const some\Z\{ConstA,ConstC,};
+                use const some\\Z\\{ConstA,ConstC,};
 
                 echo ConstA.ConstC;
-                fn_a(ClassA::test, new C());
+                fn_b(ClassA::test, new C());
                 EOF,
             <<<'EOF'
                 <?php
@@ -1359,7 +1372,7 @@ Bar3:
                 use Z;
 
                 echo ConstA.ConstC;
-                fn_a(ClassA::test, new C());
+                fn_b(ClassA::test, new C());
                 EOF,
         ];
 

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -1414,6 +1414,46 @@ Bar3:
                 fn_b(new A(), ConstC);
                 EOF,
         ];
+
+        yield 'only unused comma-separated imports in single line' => [
+            '<?php ',
+            '<?php use A, B, C;',
+        ];
+
+        yield 'only unused grouped imports in single line' => [
+            '<?php ',
+            '<?php use A\{B, C};',
+        ];
+
+        yield 'unused comma-separated imports right after open tag, with consecutive lines' => [
+            "<?php \n# Comment",
+            "<?php use A, B, C;\n\n# Comment",
+        ];
+
+        yield 'unused grouped imports right after open tag, with consecutive lines' => [
+            "<?php \n# Comment",
+            "<?php use A\\{B, C};\n\n# Comment",
+        ];
+
+        yield 'unused comma-separated imports right after open tag with a non-empty token after it, and with consecutive lines' => [
+            "<?php # Comment\n\n# Another comment",
+            "<?php use A, B, C; # Comment\n\n# Another comment",
+        ];
+
+        yield 'unused grouped imports right after open tag with a non-empty token after it, and with consecutive lines' => [
+            "<?php # Comment\n\n# Another comment",
+            "<?php use A\\{B, C}; # Comment\n\n# Another comment",
+        ];
+
+        yield 'only unused comma-separated imports in the last line, with whitespace after' => [
+            "<?php \n",
+            "<?php \nuse A, B, C;     \t\t",
+        ];
+
+        yield 'only unused grouped imports in the last line, with whitespace after' => [
+            "<?php \n",
+            "<?php \nuse A\\{B, C};     \t\t",
+        ];
     }
 
     /**

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -1331,30 +1331,55 @@ Bar3:
                 EOF
         ];
 
-        yield [ // TODO test shows lot of cases where imports are not removed while could be
-            '<?php use A\{B,};
-use some\y\{ClassA, ClassB, ClassC as C,};
-use function some\a\{fn_a, fn_b, fn_c,};
-use const some\Z\{ConstAA,ConstBB,ConstCC,};
-use const some\X\{ConstA,ConstB,ConstC,ConstF};
-use C\{D,E,};
+        yield 'grouped imports' => [
+            <<<'EOF'
+                <?php
+                use some\y\{ClassA, ClassC as C,};
+                use function some\a\{
+                    fn_a,
+                };
+                use const some\Z\{ConstA,ConstC,};
 
-    echo ConstA.ConstB.ConstC,ConstF;
-    echo ConstBB.ConstCC;
-    fn_a(ClassA::test, new C());
-',
-            '<?php use A\{B,};
-use some\y\{ClassA, ClassB, ClassC as C,};
-use function some\a\{fn_a, fn_b, fn_c,};
-use const some\Z\{ConstAA,ConstBB,ConstCC,};
-use const some\X\{ConstA,ConstB,ConstC,ConstF};
-use C\{D,E,};
-use Z;
+                echo ConstA.ConstC;
+                fn_a(ClassA::test, new C());
+                EOF,
+            <<<'EOF'
+                <?php
+                use A\{B,};
+                use some\y\{ClassA, ClassB, ClassC as C,};
+                use function some\a\{
+                    fn_a,
+                    fn_b,
+                    fn_c,
+                };
+                use function some\b\{fn_x, fn_y, fn_z,};
+                use const some\Z\{ConstA,ConstB,ConstC,};
+                use const some\X\{ConstX,ConstY,ConstZ};
+                use C\{D,E,};
+                use Z;
 
-    echo ConstA.ConstB.ConstC,ConstF;
-    echo ConstBB.ConstCC;
-    fn_a(ClassA::test, new C());
-',
+                echo ConstA.ConstC;
+                fn_a(ClassA::test, new C());
+                EOF,
+        ];
+
+        yield 'comma-separated imports' => [
+            <<<'EOF'
+                <?php
+                use A;
+                use function fn_b;
+                use const ConstC;
+
+                fn_b(new A(), ConstC);
+                EOF,
+            <<<'EOF'
+                <?php
+                use A, B, C;
+                use function fn_a, fn_b, fn_c;
+                use const ConstA, ConstB, ConstC;
+
+                fn_b(new A(), ConstC);
+                EOF,
         ];
     }
 


### PR DESCRIPTION
Built on top of #7814 and that PR must be merged before.

This utilises chunk-based `NamespaceUseAnalysis` to remove parts of the multi-use statements and can also clean whole statement if every chunk was removed.