### PR TITLE
fix: PhpdocListTypeFixer - support key types containing `<…>`

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocListTypeFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocListTypeFixer.php
@@ -65,6 +65,6 @@ final class PhpdocListTypeFixer extends AbstractPhpdocTypesFixer
 
     protected function normalize(string $type): string
     {
-        return Preg::replace('/array(?=<[^,]+(>|<|{|\\())/i', 'list', $type);
+        return Preg::replace('/array(?=<(?:[^,<]|<[^>]+>)+(>|{|\\())/i', 'list', $type);
     }
 }

--- a/tests/Fixer/Phpdoc/PhpdocListTypeFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocListTypeFixerTest.php
@@ -42,6 +42,14 @@ final class PhpdocListTypeFixerTest extends AbstractFixerTestCase
 
         yield ['<?php /** @var array<int, array<string, bool>> */'];
 
+        yield ['<?php /** @var array<class-string<Foo>, bool> */'];
+
+        yield ['<?php /** @var array<int<1, 10>, bool> */'];
+
+        yield ['<?php /** @var array<Foo::BAR_*, bool> */'];
+
+        yield ['<?php /** @var array<\'foo\'|\'bar\', bool> */'];
+
         yield ['<?php /** @var array{} */'];
 
         yield ['<?php /** @var array{string, string, string} */'];
@@ -78,6 +86,11 @@ final class PhpdocListTypeFixerTest extends AbstractFixerTestCase
         yield [
             '<?php /** @var array{string, list<array{Foo, list<int>, Bar}>} */',
             '<?php /** @var array{string, array<array{Foo, array<int>, Bar}>} */',
+        ];
+
+        yield [
+            '<?php /** @var list<int<1, 10>> */',
+            '<?php /** @var array<int<1, 10>> */',
         ];
     }
 }


### PR DESCRIPTION
This PR fixes these false positives:

```diff
-'<?php /** @var array<class-string<Foo>, bool> */'
+'<?php /** @var list<class-string<Foo>, bool> */'
```

```diff
-'<?php /** @var array<int<1, 10>, bool> */'
+'<?php /** @var list<int<1, 10>, bool> */'
```