### PR TITLE
feat: allow arbitrary space indentation

### DIFF
--- a/src/WhitespacesFixerConfig.php
+++ b/src/WhitespacesFixerConfig.php
@@ -25,7 +25,7 @@ final class WhitespacesFixerConfig
 
     public function __construct(string $indent = '    ', string $lineEnding = "\n")
     {
-        if (!preg_match('/^(?: +|\t)$/', $indent)) {
+        if (!Preg::match('/^(?: +|\t)$/', $indent)) {
             throw new \InvalidArgumentException('Invalid "indent" param, expected tab or spaces.');
         }
 

--- a/src/WhitespacesFixerConfig.php
+++ b/src/WhitespacesFixerConfig.php
@@ -25,8 +25,8 @@ final class WhitespacesFixerConfig
 
     public function __construct(string $indent = '    ', string $lineEnding = "\n")
     {
-        if (!\in_array($indent, ['  ', '    ', "\t"], true)) {
-            throw new \InvalidArgumentException('Invalid "indent" param, expected tab or two or four spaces.');
+        if (!preg_match('/^(?: +|\t)$/', $indent)) {
+            throw new \InvalidArgumentException('Invalid "indent" param, expected tab or spaces.');
         }
 
         if (!\in_array($lineEnding, ["\n", "\r\n"], true)) {

--- a/tests/WhitespacesFixerConfigTest.php
+++ b/tests/WhitespacesFixerConfigTest.php
@@ -50,12 +50,14 @@ final class WhitespacesFixerConfigTest extends TestCase
 
         yield ["\t", "\n"];
 
+        yield [str_repeat(' ', 12), "\n"];
+
         yield ['    ', "\r\n"];
 
         yield ["\t", "\r\n"];
 
         yield ['    ', 'asd', 'Invalid "lineEnding" param, expected "\n" or "\r\n".'];
 
-        yield ['std', "\n", 'Invalid "indent" param, expected tab or two or four spaces.'];
+        yield ['std', "\n", 'Invalid "indent" param, expected tab or spaces.'];
     }
 }


### PR DESCRIPTION
I created this PR to address the issue in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/discussions/7810.

Removes the limitation of having only 2 or 4 space indentation and allows for any number of spaces or one tab in the indentation settings.

This could be modified to also allow for any number of tabs but I don't see a reason for it since tabs are already arbitrary sized.