### PR TITLE
fix: do not use wrongly named arguments in data providers

### DIFF
--- a/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
@@ -659,7 +659,7 @@ else?><?php echo 5;',
             ';
 
         foreach ($cases as $index => $case) {
-            yield [sprintf('PHP8 Negative case %d', $index) => sprintf($template, $case)];
+            yield sprintf('PHP8 Negative case %d', $index) => [sprintf($template, $case)];
         }
     }
 

--- a/tests/Fixer/ControlStructure/SwitchContinueToBreakFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchContinueToBreakFixerTest.php
@@ -407,7 +407,7 @@ case $b:
 }}}}}}}}}}',
         ];
 
-        yield [
+        yield 'numeric literal separator' => [
             '<?php
             switch($a) {
                 case "a":
@@ -422,7 +422,7 @@ case $b:
                     continue;
             }
             ',
-            'numeric literal separator' => [
+            [
                 '<?php
 switch ($a) {
 case $b:


### PR DESCRIPTION
PHPUnit v11 started supporting [https://github.com/sebastianbergmann/phpunit/pull/5225](https://github.com/sebastianbergmann/phpunit/pull/5225) and these 2 providers had keys misplaced.

Errors are visible at https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/actions/runs/7797534997/job/21264325381?pr=7808:
![image](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/9282069/a5c361af-b528-4f83-a830-e052887a18d8)
