### PR TITLE
fix: `MethodArgumentSpaceFixer` - do not break heredoc/nowdoc

### DIFF
--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -301,7 +301,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurab
         do {
             $prevWhitespaceTokenIndex = $tokens->getPrevTokenOfKind(
                 $searchIndex,
-                [[T_WHITESPACE]]
+                [[T_ENCAPSED_AND_WHITESPACE], [T_WHITESPACE]],
             );
 
             $searchIndex = $prevWhitespaceTokenIndex;
@@ -311,6 +311,8 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurab
 
         if (null === $prevWhitespaceTokenIndex) {
             $existingIndentation = '';
+        } elseif (!$tokens[$prevWhitespaceTokenIndex]->isGivenKind(T_WHITESPACE)) {
+            return;
         } else {
             $existingIndentation = $tokens[$prevWhitespaceTokenIndex]->getContent();
             $lastLineIndex = strrpos($existingIndentation, "\n");

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -974,6 +974,48 @@ foo(
 );
             ',
         ];
+
+        yield [<<<'PHP'
+            <?php
+            function f()
+            {
+                echo <<<TEXT
+                    some text
+                    {$object->method(
+                        42
+                    )}
+                    some text
+                TEXT;
+            }
+            PHP];
+
+        yield [<<<'PHP'
+            <?php
+            function f()
+            {
+                echo <<<'TEXT'
+                    some text
+                    {$object->method(
+                        42
+                    )}
+                    some text
+                TEXT;
+            }
+            PHP];
+
+        yield [<<<'PHP'
+            <?php
+            function f()
+            {
+                echo <<<TEXT
+                    some text
+                    some value: {$object->method(
+                        42
+                    )}
+                    some text
+                TEXT;
+            }
+            PHP];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/5487