### PR TITLE
fix: `NullableTypeDeclarationForDefaultNullValueFixer` - do not create implicitly nullable parameter types

### DIFF
--- a/src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php
+++ b/src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php
@@ -128,13 +128,18 @@ final class NullableTypeDeclarationForDefaultNullValueFixer extends AbstractFixe
             $constructorPropertyModifiers[] = T_READONLY;
         }
 
+        $requiredParameterFound = false;
         foreach (array_reverse($arguments) as $argumentInfo) {
+            $requiredParameterFound = $requiredParameterFound || !$argumentInfo->hasDefault();
+
             if (
                 // Skip, if the parameter
                 // - doesn't have a type declaration
                 !$argumentInfo->hasTypeAnalysis()
                 // - has a mixed or standalone null type
                 || \in_array(strtolower($argumentInfo->getTypeAnalysis()->getName()), ['mixed', 'null'], true)
+                // - required parameter is after and strategy is to remove null
+                || $requiredParameterFound && false === $this->configuration['use_nullable_type_declaration']
                 // - a default value is not null we can continue
                 || !$argumentInfo->hasDefault() || 'null' !== strtolower($argumentInfo->getDefault())
             ) {

--- a/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
@@ -167,10 +167,10 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
             ['use_nullable_type_declaration' => false],
         ];
 
-        yield 'create implicitly nullable parameter types' => [
+        yield 'do not create implicitly nullable parameter types' => [
             // @see https://wiki.php.net/rfc/deprecate-implicitly-nullable-types
-            '<?php function foo(int $a = null, string $b) {}',
             '<?php function foo(?int $a = null, string $b) {}',
+            null,
             ['use_nullable_type_declaration' => false],
         ];
     }

--- a/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
@@ -166,6 +166,13 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
             '<?php function foo(? /*comment*/ string $param = null) {}',
             ['use_nullable_type_declaration' => false],
         ];
+
+        yield 'create implicitly nullable parameter types' => [
+            // @see https://wiki.php.net/rfc/deprecate-implicitly-nullable-types
+            '<?php function foo(int $a = null, string $b) {}',
+            '<?php function foo(?int $a = null, string $b) {}',
+            ['use_nullable_type_declaration' => false],
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7787