### PR TITLE
chore: do not use `@large` on method level

### DIFF
--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -135,8 +135,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
      *
      * @see doTest()
      *
-     * @large
-     *
+     * @group large
      * @group legacy
      */
     public function testIntegration(IntegrationCase $case): void


### PR DESCRIPTION
Technically, this changes nothing, as ["The `@large` annotation is an alias for `@group large`"](https://docs.phpunit.de/en/11.0/annotations.html#large), but:

`@large` is equivalent to `PHPUnit\Framework\Attributes\Large` - see https://github.com/sebastianbergmann/phpunit/issues/4502:
> `@large` will be implemented as `PHPUnit\Framework\Attributes\Large` (only allowed on classes; `@large` was allowed on methods but it does not make sense to mix tests of different sizes in a test case class)

`@group large` is equivalent to `#[Group('large')]` and this is allowed on method level: https://github.com/sebastianbergmann/phpunit/blob/11.0.2/tests/end-to-end/_files/size-groups/SizeGroupsTest.php