### PR TITLE
chore: do not use `@medium` on method level

### DIFF
--- a/tests/Linter/AbstractLinterTestCase.php
+++ b/tests/Linter/AbstractLinterTestCase.php
@@ -41,6 +41,8 @@ abstract class AbstractLinterTestCase extends TestCase
     }
 
     /**
+     * @group medium
+     *
      * @dataProvider provideLintFileCases
      */
     public function testLintFile(string $file, ?string $errorMessage = null): void
@@ -56,9 +58,6 @@ abstract class AbstractLinterTestCase extends TestCase
         $linter->lintFile($file)->check();
     }
 
-    /**
-     * @medium
-     */
     public static function provideLintFileCases(): iterable
     {
         yield [


### PR DESCRIPTION
Same as https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7832

~For my defence, when the migration job failed because of `#[Large]` there was no info about `#[Medium]`.~

I have nothing for my defence, both `Large` and `Medium` are [here](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/actions/runs/7842389265/job/21400634090).

Yes, I've checked for `@small`.