### PR TITLE
fix: Proper build target for local Docker Compose

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "compose.yaml"
       - "Dockerfile"
+      - "docker/**"
   # Allow running on demand using Github UI
   workflow_dispatch:
   schedule:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,18 @@ name: Create and publish a Docker images
 
 on:
   push:
+    branches:
+      - "master"
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+  pull_request:
+    paths:
+      - "compose.yaml"
+      - "Dockerfile"
+  # Allow running on demand using Github UI
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * *"
 
 env:
   REGISTRY: ghcr.io
@@ -12,7 +22,8 @@ env:
 jobs:
   build-and-push-image:
     name: PHP ${{ matrix.php-version }}, Fixer ${{ github.ref_name }}
-    if: github.repository == 'PHP-CS-Fixer/PHP-CS-Fixer'
+    # Run only for tags in the main repository (official releases)
+    if: github.repository == 'PHP-CS-Fixer/PHP-CS-Fixer' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -72,3 +83,22 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  docker-compose-build:
+    name: Docker Compose build PHP ${{ matrix.php-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - php-version: '7.4'
+          - php-version: '8.0'
+          - php-version: '8.1'
+          - php-version: '8.2'
+          - php-version: '8.3'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Docker Compose build
+        run: docker compose build --no-cache --pull php-${{ matrix.php-version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Create and publish a Docker images
+name: Docker
 
 on:
   push:
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build-and-push-image:
-    name: PHP ${{ matrix.php-version }}, Fixer ${{ github.ref_name }}
+    name: Release PHP ${{ matrix.php-version }}, Fixer ${{ github.ref_name }}
     # Run only for tags in the main repository (official releases)
     if: github.repository == 'PHP-CS-Fixer/PHP-CS-Fixer' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - "master"
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:
     paths:
       - "compose.yaml"
@@ -15,77 +13,10 @@ on:
   schedule:
     - cron: "0 5 * * *"
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
-  build-and-push-image:
-    name: Release PHP ${{ matrix.php-version }}, Fixer ${{ github.ref_name }}
-    # Run only for tags in the main repository (official releases)
-    if: github.repository == 'PHP-CS-Fixer/PHP-CS-Fixer' && startsWith(github.ref, 'refs/tags')
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - php-version: '7.4'
-            alpine-version: '3.16'
-          - php-version: '8.0'
-            alpine-version: '3.16'
-          - php-version: '8.1'
-            alpine-version: '3.18'
-          - php-version: '8.2'
-            alpine-version: '3.18'
-          - php-version: '8.3'
-            alpine-version: '3.18'
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Make image lowercase
-        run: |
-          echo IMAGE_NAME_LOWER=$(echo ${{ env.IMAGE_NAME }} | tr '[:upper:]' '[:lower:]') >> ${GITHUB_ENV}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          flavor: |
-            latest=false
-            suffix=-php${{ matrix.php-version }}
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile
-          target: dist
-          build-args: |
-            PHP_VERSION=${{ matrix.php-version }}
-            ALPINE_VERSION=${{ matrix.alpine-version }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
   docker-compose-build:
-    name: Docker Compose build PHP ${{ matrix.php-version }}
+    name: Compose build PHP ${{ matrix.php-version }}
+    if: startsWith(github.ref, 'refs/heads')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   docker-compose-build:
     name: Compose build PHP ${{ matrix.php-version }}
-    if: startsWith(github.ref, 'refs/heads')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker-images:
+    name: Docker with PHP ${{ matrix.php-version }}, Fixer ${{ github.ref_name }}
+    if: github.repository == 'PHP-CS-Fixer/PHP-CS-Fixer'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - php-version: '7.4'
+            alpine-version: '3.16'
+          - php-version: '8.0'
+            alpine-version: '3.16'
+          - php-version: '8.1'
+            alpine-version: '3.18'
+          - php-version: '8.2'
+            alpine-version: '3.18'
+          - php-version: '8.3'
+            alpine-version: '3.18'
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Make image lowercase
+        run: |
+          echo IMAGE_NAME_LOWER=$(echo ${{ env.IMAGE_NAME }} | tr '[:upper:]' '[:lower:]') >> ${GITHUB_ENV}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          flavor: |
+            latest=false
+            suffix=-php${{ matrix.php-version }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          target: dist
+          build-args: |
+            PHP_VERSION=${{ matrix.php-version }}
+            ALPINE_VERSION=${{ matrix.alpine-version }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   php-7.4: &php
     build:
-      target: php
+      target: dev
       args:
         ALPINE_VERSION: "3.16"
         PHP_VERSION: "7.4"

--- a/tests/AutoReview/CiConfigurationTest.php
+++ b/tests/AutoReview/CiConfigurationTest.php
@@ -71,7 +71,8 @@ final class CiConfigurationTest extends TestCase
 
         self::assertSupportedPhpVersionsAreCoveredByCiJobs($supportedVersions, $ciVersions);
         self::assertUpcomingPhpVersionIsCoveredByCiJob(end($supportedVersions), $ciVersions);
-        self::assertSupportedPhpVersionsAreCoveredByCiJobs($supportedVersions, $this->getPhpVersionsUsedByGitHubDocker());
+        self::assertSupportedPhpVersionsAreCoveredByCiJobs($supportedVersions, $this->getPhpVersionsUsedForBuildingOfficialImages());
+        self::assertSupportedPhpVersionsAreCoveredByCiJobs($supportedVersions, $this->getPhpVersionsUsedForBuildingLocalImages());
     }
 
     public function testDeploymentJobsRunOnLatestStablePhpThatIsSupportedByTool(): void
@@ -262,13 +263,26 @@ final class CiConfigurationTest extends TestCase
     /**
      * @return list<numeric-string>
      */
-    private function getPhpVersionsUsedByGitHubDocker(): array
+    private function getPhpVersionsUsedForBuildingOfficialImages(): array
     {
         $yaml = Yaml::parse(file_get_contents(__DIR__.'/../../.github/workflows/docker.yml'));
 
         return array_map(
             static fn ($item) => $item['php-version'],
             $yaml['jobs']['build-and-push-image']['strategy']['matrix']['include']
+        );
+    }
+
+    /**
+     * @return list<numeric-string>
+     */
+    private function getPhpVersionsUsedForBuildingLocalImages(): array
+    {
+        $yaml = Yaml::parse(file_get_contents(__DIR__.'/../../.github/workflows/docker.yml'));
+
+        return array_map(
+            static fn ($item) => $item['php-version'],
+            $yaml['jobs']['docker-compose-build']['strategy']['matrix']['include']
         );
     }
 }

--- a/tests/AutoReview/CiConfigurationTest.php
+++ b/tests/AutoReview/CiConfigurationTest.php
@@ -265,11 +265,11 @@ final class CiConfigurationTest extends TestCase
      */
     private function getPhpVersionsUsedForBuildingOfficialImages(): array
     {
-        $yaml = Yaml::parse(file_get_contents(__DIR__.'/../../.github/workflows/docker.yml'));
+        $yaml = Yaml::parse(file_get_contents(__DIR__.'/../../.github/workflows/release.yml'));
 
         return array_map(
             static fn ($item) => $item['php-version'],
-            $yaml['jobs']['build-and-push-image']['strategy']['matrix']['include']
+            $yaml['jobs']['docker-images']['strategy']['matrix']['include']
         );
     }
 


### PR DESCRIPTION
Bug introduced in #7782, I probably had `compose.override.yml` and did not encounter this before. Now I wanted to check lower PHP versions because `#7777` stopped working for <8.1 and got an error during build.

To make sure it won't happen again, I've added new CI workflow that will test Docker Compose builds when PR has Docker-related changes, on `master` branch push and once a day as a scheduled pipeline.

I've moved current Docker workflow to "Release" workflow, we can later add more jobs that should happen on tags (like publishing official page).