### PR TITLE
feat: `MbStrFunctionsFixer` - add support for `mb_trim`, `mb_ltrim` and `mb_rtrim` functions

### DIFF
--- a/src/Fixer/Alias/MbStrFunctionsFixer.php
+++ b/src/Fixer/Alias/MbStrFunctionsFixer.php
@@ -73,6 +73,12 @@ final class MbStrFunctionsFixer extends AbstractFunctionReferenceFixer
             self::$functionsMap['str_pad'] = ['alternativeName' => 'mb_str_pad', 'argumentCount' => [1, 2, 3, 4]];
         }
 
+        if (\PHP_VERSION_ID >= 8_04_00) {
+            self::$functionsMap['trim'] = ['alternativeName' => 'mb_trim', 'argumentCount' => [1, 2]];
+            self::$functionsMap['ltrim'] = ['alternativeName' => 'mb_ltrim', 'argumentCount' => [1, 2]];
+            self::$functionsMap['rtrim'] = ['alternativeName' => 'mb_rtrim', 'argumentCount' => [1, 2]];
+        }
+
         $this->functions = array_filter(
             self::$functionsMap,
             static fn (array $mapping): bool => (new \ReflectionFunction($mapping['alternativeName']))->isInternal()

--- a/tests/Fixer/Alias/MbStrFunctionsFixerTest.php
+++ b/tests/Fixer/Alias/MbStrFunctionsFixerTest.php
@@ -101,4 +101,40 @@ final class MbStrFunctionsFixerTest extends AbstractFixerTestCase
             '<?php $x = str_pad("bar", 2, "0", STR_PAD_LEFT);',
         ];
     }
+
+    /**
+     * @requires PHP 8.4
+     *
+     * @dataProvider provideFix84Cases
+     */
+    public function testFix84(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string, array{string, null|string}>
+     */
+    public static function provideFix84Cases(): iterable
+    {
+        yield 'mb_trim 1 argument' => [
+            '<?php $x = mb_trim("    foo  ");',
+            '<?php $x = trim("    foo  ");',
+        ];
+
+        yield 'mb_trim 2 arguments' => [
+            '<?php $x = mb_trim("____foo__", "_");',
+            '<?php $x = trim("____foo__", "_");',
+        ];
+
+        yield 'ltrim' => [
+            '<?php $x = mb_ltrim("    foo  ");',
+            '<?php $x = ltrim("    foo  ");',
+        ];
+
+        yield 'rtrim' => [
+            '<?php $x = mb_rtrim("    foo  ");',
+            '<?php $x = rtrim("    foo  ");',
+        ];
+    }
 }

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -519,7 +519,7 @@ abstract class AbstractFixerTestCase extends TestCase
             YodaStyleFixerTest::class,
         ];
 
-        $names = ['Fix', 'Fix74Deprecated', 'FixPre80', 'Fix80', 'FixPre81', 'Fix81', 'Fix82', 'Fix83', 'WithWhitespacesConfig', 'InvalidConfiguration'];
+        $names = ['Fix', 'Fix74Deprecated', 'FixPre80', 'Fix80', 'FixPre81', 'Fix81', 'Fix82', 'Fix83', 'Fix84', 'WithWhitespacesConfig', 'InvalidConfiguration'];
         $methodNames = ['testConfigure'];
         foreach ($names as $name) {
             $methodNames[] = 'test'.$name;


### PR DESCRIPTION
So, there will be one less thing to carry about for PHP 8.4 support.

Ref. https://wiki.php.net/rfc/mb_trim