### PR TITLE
fix: `TypeExpression` - handle array shape key with dash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit --filter=issue_7839
+        run: vendor/bin/paraunit run --testsuite unit,integration
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/phpunit --filter=issue_7839
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -53,7 +53,7 @@ final class TypeExpression
                     (?<array_shape_start>(?i)(?:array|list|object)(?-i)\h*\{\h*)
                     (?<array_shape_inners>
                         (?<array_shape_inner>
-                            (?<array_shape_inner_key>(?:(?&constant)|(?&identifier))\h*\??\h*:\h*|)
+                            (?<array_shape_inner_key>(?:(?&constant)|(?&identifier)|(?&name))\h*\??\h*:\h*|)
                             (?<array_shape_inner_value>(?&types_inner))
                         )
                         (?:

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -230,6 +230,10 @@ final class TypeExpressionTest extends TestCase
         yield ['($foo🚀3 is int ? false : true)'];
 
         yield ['\'a\\\'s"\\\\\n\r\t\'|"b\\"s\'\\\\\n\r\t"', ['\'a\\\'s"\\\\\n\r\t\'', '"b\\"s\'\\\\\n\r\t"']];
+
+        yield '[issue_7839]a' => ['array{a: int, b: int, c: int, d: int, e: int, f: int, g: int, h: int, i: int, j: int, with-dash: int}'];
+
+        yield '[issue_7839]b' => ['array{a: int, b: int, c: int, d: int, e: int, f: int, g: int, h: int, i: int, j: int, k: int, l: int, with-dash: int}'];
     }
 
     public static function provideGetConstTypesCases(): iterable

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -231,9 +231,9 @@ final class TypeExpressionTest extends TestCase
 
         yield ['\'a\\\'s"\\\\\n\r\t\'|"b\\"s\'\\\\\n\r\t"', ['\'a\\\'s"\\\\\n\r\t\'', '"b\\"s\'\\\\\n\r\t"']];
 
-        yield '[issue_7839]a' => ['array{a: int, b: int, c: int, d: int, e: int, f: int, g: int, h: int, i: int, j: int, with-dash: int}'];
+        yield ['array{a: int, b: int, c: int, d: int, e: int, f: int, g: int, h: int, i: int, j: int, with-dash: int}'];
 
-        yield '[issue_7839]b' => ['array{a: int, b: int, c: int, d: int, e: int, f: int, g: int, h: int, i: int, j: int, k: int, l: int, with-dash: int}'];
+        yield ['array{a: int, b: int, c: int, d: int, e: int, f: int, g: int, h: int, i: int, j: int, k: int, l: int, with-dash: int}'];
     }
 
     public static function provideGetConstTypesCases(): iterable

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -1528,6 +1528,17 @@ class Foo extends \A\A implements \B\A, \C\A
                 \Bar\func2(new \Bar\Service2(\Bar\CONST2));
                 EOD,
         ];
+
+        yield '[issue_7839] do not crash on large PHPDoc' => [<<<'PHP'
+            <?php
+            class Foo
+            {
+                /**
+                 * @return array{k0: int, k1: int, k2: int, k3: int, k4: int, k5: int, k6: int, k7: int, k8: int, k9: int, k10: int, k11: int, with-dash: int}
+                 */
+                function bar() {}
+            }
+            PHP];
     }
 
     /**

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -1529,7 +1529,7 @@ class Foo extends \A\A implements \B\A, \C\A
                 EOD,
         ];
 
-        yield '[issue_7839] do not crash on large PHPDoc' => [<<<'PHP'
+        yield 'do not crash on large PHPDoc' => [<<<'PHP'
             <?php
             class Foo
             {


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7839

You can see in the CI of the first commit that a very long type with a dash causes "Backtrack limit exhausted":
```
PhpCsFixer\Tests\DocBlock\TypeExpressionTest::testGetTypes with data set "[issue_7839]b" ('array{a: int, b: int, c: int,...: int}')
PhpCsFixer\PregException: Error occurred when calling PhpCsFixer\Preg::match: Backtrack limit exhausted.
```

But, also shorter type with a dash in an array shape key results in an error:
```
PhpCsFixer\Tests\DocBlock\TypeExpressionTest::testGetTypes with data set "[issue_7839]a" ('array{a: int, b: int, c: int,...: int}')
Exception: Unable to parse phpdoc type 'array{a: int, b: int, c: int, d: int, e: int, f: int, g: int, h: int, i: int, j: int, with-dash: int}'
```