### PR TITLE
feat: Add strict option to array indentation

### DIFF
--- a/doc/rules/whitespace/array_indentation.rst
+++ b/doc/rules/whitespace/array_indentation.rst
@@ -4,11 +4,25 @@ Rule ``array_indentation``
 
 Each element of an array must be indented exactly once.
 
+Configuration
+-------------
+
+``strict``
+~~~~~~~~~~
+
+Whether the indentation must be exactly (true) or at least (false) once.
+
+Allowed types: ``bool``
+
+Default value: ``true``
+
 Examples
 --------
 
 Example #1
 ~~~~~~~~~~
+
+*Default* configuration.
 
 .. code-block:: diff
 
@@ -22,6 +36,22 @@ Example #1
    +    'bar' => [
    +        'baz' => true,
    +    ],
+    ];
+
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['strict' => false]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    $foo = [
+   -  'bar' => 1,
+   +    'bar' => 1,
+            'baz' => 2,
     ];
 
 Rule sets

--- a/doc/rules/whitespace/array_indentation.rst
+++ b/doc/rules/whitespace/array_indentation.rst
@@ -33,9 +33,11 @@ Example #1
    -   'bar' => [
    -    'baz' => true,
    -  ],
+   -        'qux' => false,
    +    'bar' => [
    +        'baz' => true,
    +    ],
+   +    'qux' => false,
     ];
 
 Example #2
@@ -49,9 +51,13 @@ With configuration: ``['strict' => false]``.
    +++ New
     <?php
     $foo = [
-   -  'bar' => 1,
-   +    'bar' => 1,
-            'baz' => 2,
+   -   'bar' => [
+   -    'baz' => true,
+   -  ],
+   +    'bar' => [
+   +        'baz' => true,
+   +    ],
+            'qux' => false,
     ];
 
 Rule sets

--- a/src/Fixer/Whitespace/ArrayIndentationFixer.php
+++ b/src/Fixer/Whitespace/ArrayIndentationFixer.php
@@ -38,8 +38,8 @@ final class ArrayIndentationFixer extends AbstractFixer implements WhitespacesAw
         return new FixerDefinition(
             'Each element of an array must be indented exactly once.',
             [
-                new CodeSample("<?php\n\$foo = [\n   'bar' => [\n    'baz' => true,\n  ],\n];\n"),
-                new CodeSample("<?php\n\$foo = [\n  'bar' => 1,\n        'baz' => 2,\n];\n", ['strict' => false]),
+                new CodeSample("<?php\n\$foo = [\n   'bar' => [\n    'baz' => true,\n  ],\n        'qux' => false,\n];\n"),
+                new CodeSample("<?php\n\$foo = [\n   'bar' => [\n    'baz' => true,\n  ],\n        'qux' => false,\n];\n", ['strict' => false]),
             ]
         );
     }

--- a/tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
@@ -25,10 +25,14 @@ use PhpCsFixer\WhitespacesFixerConfig;
 final class ArrayIndentationFixerTest extends AbstractFixerTestCase
 {
     /**
+     * @param array<string, mixed> $config
+     *
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
+        $this->fixer->configure($config);
+
         $this->doTest($expected, $input);
     }
 
@@ -50,6 +54,23 @@ final class ArrayIndentationFixerTest extends AbstractFixerTestCase
                             'bar' => 'baz',
                      ];
                     INPUT,
+            ],
+            [
+                <<<'EXPECTED'
+                    <?php
+                    $foo = [
+                        'foo',
+                            'bar' => 'baz',
+                    ];
+                    EXPECTED,
+                <<<'INPUT'
+                    <?php
+                    $foo = [
+                      'foo',
+                            'bar' => 'baz',
+                    ];
+                    INPUT,
+                ['strict' => false],
             ],
             [
                 <<<'EXPECTED'
@@ -964,9 +985,9 @@ class Foo {
     }
 
     /**
-     * @param list<array{0: string, 1?: string}> $cases
+     * @param list<array{0: string, 1?: null|string, 2?: array<string, mixed>}> $cases
      *
-     * @return list<array{0: string, 1?: string}>
+     * @return list<array{0: string, 1?: null|string, 2?: array<string, mixed>}>
      */
     private static function withLongArraySyntaxCases(array $cases): array
     {


### PR DESCRIPTION
Hi @Wirone,

When working on https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7813, I discovered that:
- I need the `array_indentation` to be use if someone wants to use `single_expression_per_line` for arrays
- The `array_indentation` is not added to any PSR sets.

If we wants to add the `single_expression_per_line` for arrays to the PERCS 2, which would resolve the part
> When the array declaration is split across multiple lines, the opening bracket MUST be placed on the same line as the equals sign. The closing bracket MUST be placed on the next line after the last value. There MUST NOT be more than one value assignment per line. Value assignments MAY use a single line or multiple lines.

we will need to indent correctly the array. So we will need `array_indentation` in PERCS 2 too or at least in a less strict version: "Each element of an array must be indented AT LEAST once."

When looking at PSR12 and PSR2, there is the following section
> Code MUST use an indent of 4 spaces for each indent level, and MUST NOT use tabs for indenting.

I think the `array_indentation` is going in this direction and therefore could be added to the PSR2 ruleset (with the option `strict => false` to minimize the impact). This would be similar to the `statement_indentation` which is already added to the PSR2 ruleset.

WDYT ?
- Should we add `array_indentation` with `strict => false` to the PSR2 ?
- Should we add `array_indentation` with `strict => false` to the PERCS 2 only ?
- Should we add `array_indentation` with `strict => true` to the PERCS 2 ?

For the records, 
- PHPCsFixer already use the `array_indentation` with `strict => true` (since the option didn't exist)
- Symfony don't use the `array_indentation` but with `strict => false` there are some fixes in the code base which seems to be typo most of the time (like 3 spaces instead of 4) ; there was way more fixes with `strict => true`, so maybe it's voluntary to sometime use more indentations.