### PR TITLE
fix: `StatementIndentationFixer` - handle monolithic php only

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -21,6 +21,6 @@ parameters:
         -
             message: '#^Method PhpCsFixer\\Tests\\.+::provide.+Cases\(\) return type has no value type specified in iterable type iterable\.$#'
             path: tests
-            count: 1021
+            count: 1020
     tipsOfTheDay: false
     tmpDir: dev-tools/phpstan/cache

--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -106,7 +106,7 @@ if ($foo) {
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return true;
+        return $tokens->isMonolithicPhp();
     }
 
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -1404,7 +1404,7 @@ function mixedComplex()
 
         yield [
             '<?php if (true) {
-    echo "s";
+echo "s";
 } ?>x',
             '<?php if (true) echo "s" ?>x',
         ];
@@ -2437,7 +2437,7 @@ function mixedComplex()
 
         yield [
             '<?php if (true) {
-    echo "s";
+echo "s";
 } ?>x',
             '<?php if (true) echo "s" ?>x',
             self::CONFIGURATION_OOP_POSITION_SAME_LINE,
@@ -3233,10 +3233,6 @@ function foo()
         ];
 
         yield [
-            '<?php
-if ($a) { //
-    ?><?php ++$a;
-} ?>',
             '<?php
 if ($a) { //
 ?><?php ++$a;
@@ -5419,63 +5415,6 @@ if(true) if(true) echo 1; elseif(true) echo 2; else echo 3;',
     }
 
     /**
-     * @dataProvider provideNowdocInTemplatesCases
-     */
-    public function testNowdocInTemplates(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public static function provideNowdocInTemplatesCases(): iterable
-    {
-        yield [
-            <<<'EOT'
-                <?php
-                if (true) {
-                    $var = <<<'NOWDOC'
-                NOWDOC;
-                    ?>
-                <?php
-                }
-
-                EOT,
-            <<<'EOT'
-                <?php
-                if (true) {
-                $var = <<<'NOWDOC'
-                NOWDOC;
-                ?>
-                <?php
-                }
-
-                EOT,
-        ];
-
-        yield [
-            <<<'EOT'
-                <?php
-                if (true) {
-                    $var = <<<HEREDOC
-                HEREDOC;
-                    ?>
-                <?php
-                }
-
-                EOT,
-            <<<'EOT'
-                <?php
-                if (true) {
-                $var = <<<HEREDOC
-                HEREDOC;
-                ?>
-                <?php
-                }
-
-                EOT,
-        ];
-    }
-
-    /**
      * @dataProvider provideFixCommentsCases
      */
     public function testFixComments(string $expected, ?string $input = null): void
@@ -5809,7 +5748,7 @@ return foo($i);
 
         yield [
             '<?php if ($a) {
-    foreach ($b as $c): ?> X <?php endforeach;
+foreach ($b as $c): ?> X <?php endforeach;
 } ?>',
             '<?php if ($a) foreach ($b as $c): ?> X <?php endforeach; ?>',
         ];
@@ -5843,25 +5782,25 @@ return foo($i);
         yield [
             '<?php
 if ($a) {
-    foreach ($b as $c): ?>
+foreach ($b as $c): ?>
     <?php if ($a) {
-        for (;;): ?>
+    for (;;): ?>
         <?php if ($a) {
-            foreach ($b as $c): ?>
+        foreach ($b as $c): ?>
             <?php if ($a) {
-                for (;;): ?>
+            for (;;): ?>
                 <?php if ($a) {
-                    while ($b): ?>
+                while ($b): ?>
                     <?php if ($a) {
-                        while ($b): ?>
+                    while ($b): ?>
                         <?php if ($a) {
-                            foreach ($b as $c): ?>
+                        foreach ($b as $c): ?>
                             <?php if ($a) {
-                                for (;;): ?>
+                            for (;;): ?>
                                 <?php if ($a) {
-                                    while ($b): ?>
+                                while ($b): ?>
                                     <?php if ($a) {
-                                        while ($b): ?>
+                                    while ($b): ?>
                                     <?php endwhile;
                                     } ?>
                                 <?php endwhile;


### PR DESCRIPTION
Fixing indentation in non-monolithic files is difficult. Multiple issues regarding this were closed as not planned (e.g. https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7836 and https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7754).

So I think the fixer should not try to fix non-monolithic files. It would avoid these issues.

I know there is also https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6517. However, I would prefer to only disable rules that actually have issues with non-monolithic files.