### PR TITLE
Add operator linebreak to psr12

### DIFF
--- a/doc/ruleSets/PSR12.rst
+++ b/doc/ruleSets/PSR12.rst
@@ -31,6 +31,10 @@ Rules
 - `no_blank_lines_after_class_opening <./../rules/class_notation/no_blank_lines_after_class_opening.rst>`_
 - `no_leading_import_slash <./../rules/import/no_leading_import_slash.rst>`_
 - `no_whitespace_in_blank_line <./../rules/whitespace/no_whitespace_in_blank_line.rst>`_
+- `operator_linebreak <./../rules/operator/operator_linebreak.rst>`_ with config:
+
+  ``['only_booleans' => true]``
+
 - `ordered_class_elements <./../rules/class_notation/ordered_class_elements.rst>`_ with config:
 
   ``['order' => ['use_trait']]``

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -101,10 +101,6 @@ Rules
 - `normalize_index_brace <./../rules/array_notation/normalize_index_brace.rst>`_
 - `nullable_type_declaration_for_default_null_value <./../rules/function_notation/nullable_type_declaration_for_default_null_value.rst>`_
 - `object_operator_without_whitespace <./../rules/operator/object_operator_without_whitespace.rst>`_
-- `operator_linebreak <./../rules/operator/operator_linebreak.rst>`_ with config:
-
-  ``['only_booleans' => true]``
-
 - `ordered_imports <./../rules/import/ordered_imports.rst>`_ with config:
 
   ``['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha']``

--- a/doc/rules/operator/operator_linebreak.rst
+++ b/doc/rules/operator/operator_linebreak.rst
@@ -68,6 +68,26 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+- `@PER <./../../ruleSets/PER.rst>`_ with config:
+
+  ``['only_booleans' => true]``
+
+- `@PER-CS <./../../ruleSets/PER-CS.rst>`_ with config:
+
+  ``['only_booleans' => true]``
+
+- `@PER-CS1.0 <./../../ruleSets/PER-CS1.0.rst>`_ with config:
+
+  ``['only_booleans' => true]``
+
+- `@PER-CS2.0 <./../../ruleSets/PER-CS2.0.rst>`_ with config:
+
+  ``['only_booleans' => true]``
+
+- `@PSR12 <./../../ruleSets/PSR12.rst>`_ with config:
+
+  ``['only_booleans' => true]``
+
 - `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ with config:
 
   ``['only_booleans' => true]``

--- a/src/RuleSet/Sets/PSR12Set.php
+++ b/src/RuleSet/Sets/PSR12Set.php
@@ -46,6 +46,9 @@ final class PSR12Set extends AbstractRuleSetDescription
             'no_blank_lines_after_class_opening' => true,
             'no_leading_import_slash' => true,
             'no_whitespace_in_blank_line' => true,
+            'operator_linebreak' => [
+                'only_booleans' => true,
+            ],
             'ordered_class_elements' => [
                 'order' => [
                     'use_trait',

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -137,9 +137,6 @@ final class SymfonySet extends AbstractRuleSetDescription
             'normalize_index_brace' => true,
             'nullable_type_declaration_for_default_null_value' => true,
             'object_operator_without_whitespace' => true,
-            'operator_linebreak' => [
-                'only_booleans' => true,
-            ],
             'ordered_imports' => [
                 'imports_order' => [
                     'class',


### PR DESCRIPTION
Hi @Wirone 

The rule is:
"Operators - when multiline - must always be at the beginning or at the end of the line."
cf https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.49.0/doc/rules/operator/operator_linebreak.rst

Which comply with
"Boolean operators between conditions MUST always be at the beginning or at the end of the line, not a mix of both."
from https://www.php-fig.org/psr/psr-12/#51-if-elseif-else