### PR TITLE
feat: `PhpCsFixer` ruleset - enable `nullable_type_declaration_for_default_null_value`

### DIFF
--- a/doc/ruleSets/PhpCsFixer.rst
+++ b/doc/ruleSets/PhpCsFixer.rst
@@ -79,5 +79,4 @@ Rules
 Disabled rules
 --------------
 
-- `nullable_type_declaration_for_default_null_value <./../rules/function_notation/nullable_type_declaration_for_default_null_value.rst>`_
 - `single_line_throw <./../rules/function_notation/single_line_throw.rst>`_

--- a/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.rst
+++ b/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.rst
@@ -113,8 +113,9 @@ With configuration: ``['use_nullable_type_declaration' => false]``.
 Rule sets
 ---------
 
-The rule is part of the following rule set:
+The rule is part of the following rule sets:
 
+- `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
 - `@Symfony <./../../ruleSets/Symfony.rst>`_
 
 References

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -152,7 +152,7 @@ class Foo
         return array_keys($this->proxyFixers);
     }
 
-    public function configure(?array $configuration = null): void
+    public function configure(array $configuration): void
     {
         parent::configure($configuration);
 

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -152,7 +152,7 @@ class Foo
         return array_keys($this->proxyFixers);
     }
 
-    public function configure(array $configuration = null): void
+    public function configure(?array $configuration = null): void
     {
         parent::configure($configuration);
 

--- a/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
@@ -111,7 +111,7 @@ function returnClassName() {
         );
     }
 
-    public function configure(?array $configuration = null): void
+    public function configure(array $configuration): void
     {
         parent::configure($configuration);
 

--- a/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
@@ -111,7 +111,7 @@ function returnClassName() {
         );
     }
 
-    public function configure(array $configuration = null): void
+    public function configure(?array $configuration = null): void
     {
         parent::configure($configuration);
 

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -105,7 +105,6 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
             'no_useless_else' => true,
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => ['after_heredoc' => true],
-            'nullable_type_declaration_for_default_null_value' => false,
             'ordered_class_elements' => true,
             'ordered_types' => true,
             'php_unit_internal_class' => true,

--- a/src/Tokenizer/Analyzer/Analysis/TypeAnalysis.php
+++ b/src/Tokenizer/Analyzer/Analysis/TypeAnalysis.php
@@ -62,7 +62,7 @@ final class TypeAnalysis implements StartEndTokenAwareAnalysis
     /**
      * @param ($startIndex is null ? null : int) $endIndex
      */
-    public function __construct(string $name, int $startIndex = null, int $endIndex = null)
+    public function __construct(string $name, ?int $startIndex = null, ?int $endIndex = null)
     {
         $this->name = $name;
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1378,9 +1378,9 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
      */
     private function createConfigurationResolver(
         array $options,
-        Config $config = null,
+        ?Config $config = null,
         string $cwdPath = '',
-        ToolInfoInterface $toolInfo = null
+        ?ToolInfoInterface $toolInfo = null
     ): ConfigurationResolver {
         return new ConfigurationResolver(
             $config ?? new Config(),

--- a/tests/DocBlock/DocBlockTest.php
+++ b/tests/DocBlock/DocBlockTest.php
@@ -156,7 +156,7 @@ final class DocBlockTest extends TestCase
     /**
      * @dataProvider provideMakeMultiLIneCases
      */
-    public function testMakeMultiLIne(string $inputDocBlock, string $outputDocBlock = null, string $indent = '', string $newLine = "\n"): void
+    public function testMakeMultiLIne(string $inputDocBlock, ?string $outputDocBlock = null, string $indent = '', string $newLine = "\n"): void
     {
         $doc = new DocBlock($inputDocBlock);
         $doc->makeMultiLine($indent, $newLine);
@@ -204,7 +204,7 @@ final class DocBlockTest extends TestCase
     /**
      * @dataProvider provideMakeSingleLineCases
      */
-    public function testMakeSingleLine(string $inputDocBlock, string $outputDocBlock = null): void
+    public function testMakeSingleLine(string $inputDocBlock, ?string $outputDocBlock = null): void
     {
         $doc = new DocBlock($inputDocBlock);
         $doc->makeSingleLine();

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -32,7 +32,7 @@ final class TypeExpressionTest extends TestCase
      * @dataProvider provideGetConstTypesCases
      * @dataProvider provideGetTypesCases
      */
-    public function testGetTypes(string $typesExpression, array $expectedTypes = null): void
+    public function testGetTypes(string $typesExpression, ?array $expectedTypes = null): void
     {
         if (null === $expectedTypes) {
             $expectedTypes = [$typesExpression];
@@ -449,7 +449,7 @@ final class TypeExpressionTest extends TestCase
      *
      * @dataProvider provideGetCommonTypeCases
      */
-    public function testGetCommonType(string $typesExpression, ?string $expectedCommonType, NamespaceAnalysis $namespace = null, array $namespaceUses = []): void
+    public function testGetCommonType(string $typesExpression, ?string $expectedCommonType, ?NamespaceAnalysis $namespace = null, array $namespaceUses = []): void
     {
         $expression = new TypeExpression($typesExpression, $namespace, $namespaceUses);
         self::assertSame($expectedCommonType, $expression->getCommonType());

--- a/tests/Fixer/Alias/ArrayPushFixerTest.php
+++ b/tests/Fixer/Alias/ArrayPushFixerTest.php
@@ -270,7 +270,7 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -293,7 +293,7 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP 8.0
      */
-    public function testFix80(string $expected, string $input = null): void
+    public function testFix80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Alias/PowToExponentiationFixerTest.php
+++ b/tests/Fixer/Alias/PowToExponentiationFixerTest.php
@@ -297,7 +297,7 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+++ b/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
@@ -231,7 +231,7 @@ class srand extends SrandClass{
      *
      * @requires PHP 8.1
      */
-    public function testFix81(string $expected, string $input = null): void
+    public function testFix81(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixerTest.php
+++ b/tests/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixerTest.php
@@ -30,7 +30,7 @@ final class NoWhitespaceBeforeCommaInArrayFixerTest extends AbstractFixerTestCas
      *
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, string $input = null, array $config = []): void
+    public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
         $this->fixer->configure($config);
 

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -5694,7 +5694,7 @@ function example()
     /**
      * @dataProvider provideIndentCommentCases
      */
-    public function testIndentComment(string $expected, ?string $input, WhitespacesFixerConfig $config = null): void
+    public function testIndentComment(string $expected, ?string $input, ?WhitespacesFixerConfig $config = null): void
     {
         if (null !== $config) {
             $this->fixer->setWhitespacesConfig($config);

--- a/tests/Fixer/Basic/EncodingFixerTest.php
+++ b/tests/Fixer/Basic/EncodingFixerTest.php
@@ -28,7 +28,7 @@ final class EncodingFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, ?string $input = null, \SplFileInfo $file = null): void
+    public function testFix(string $expected, ?string $input = null, ?\SplFileInfo $file = null): void
     {
         $this->doTest($expected, $input, $file);
     }

--- a/tests/Fixer/Basic/NoTrailingCommaInSinglelineFixerTest.php
+++ b/tests/Fixer/Basic/NoTrailingCommaInSinglelineFixerTest.php
@@ -487,7 +487,7 @@ $a#
      *
      * @requires PHP 8.0
      */
-    public function testFix80(string $expected, string $input = null): void
+    public function testFix80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Casing/ClassReferenceNameCasingFixerTest.php
+++ b/tests/Fixer/Casing/ClassReferenceNameCasingFixerTest.php
@@ -26,7 +26,7 @@ final class ClassReferenceNameCasingFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Casing/IntegerLiteralCaseFixerTest.php
+++ b/tests/Fixer/Casing/IntegerLiteralCaseFixerTest.php
@@ -26,7 +26,7 @@ final class IntegerLiteralCaseFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
+++ b/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
@@ -350,7 +350,7 @@ function __Tostring() {}',
      *
      * @requires PHP 8.1
      */
-    public function testFix81(string $expected, string $input = null): void
+    public function testFix81(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
@@ -413,7 +413,7 @@ function Foo(INTEGER $a) {}
      *
      * @requires PHP 8.3
      */
-    public function testFix83(string $expected, string $input = null): void
+    public function testFix83(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
+++ b/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
@@ -48,7 +48,7 @@ final class LowercaseCastFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
+++ b/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
@@ -215,7 +215,7 @@ final class ModernizeTypesCastingFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
+++ b/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
@@ -55,7 +55,7 @@ final class ShortScalarCastFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -79,7 +79,7 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
      *
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, string $input = null, array $configuration = []): void
+    public function testFix(string $expected, ?string $input = null, array $configuration = []): void
     {
         $this->fixer->configure($configuration);
         $this->doTest($expected, $input);

--- a/tests/Fixer/ControlStructure/ControlStructureContinuationPositionFixerTest.php
+++ b/tests/Fixer/ControlStructure/ControlStructureContinuationPositionFixerTest.php
@@ -273,7 +273,7 @@ final class ControlStructureContinuationPositionFixerTest extends AbstractFixerT
      *
      * @dataProvider provideWithWhitespacesConfigCases
      */
-    public function testWithWhitespacesConfig(string $expected, ?string $input = null, array $configuration = null): void
+    public function testWithWhitespacesConfig(string $expected, ?string $input = null, ?array $configuration = null): void
     {
         if (null !== $configuration) {
             $this->fixer->configure($configuration);

--- a/tests/Fixer/ControlStructure/NoUnneededBracesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededBracesFixerTest.php
@@ -210,7 +210,7 @@ namespace Foo {
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
@@ -136,7 +136,7 @@ final class NoUnneededCurlyBracesFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixerTest.php
@@ -245,7 +245,7 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/ControlStructure/SwitchCaseSpaceFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchCaseSpaceFixerTest.php
@@ -350,7 +350,7 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -1221,7 +1221,7 @@ if ($a = $obj instanceof (foo()) === true) {
      *
      * @requires PHP 8.1
      */
-    public function testFix81(string $expected, string $input = null): void
+    public function testFix81(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
@@ -223,7 +223,7 @@ $$e(2);
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/FunctionNotation/NoTrailingCommaInSinglelineFunctionCallFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoTrailingCommaInSinglelineFunctionCallFixerTest.php
@@ -26,7 +26,7 @@ final class NoTrailingCommaInSinglelineFunctionCallFixerTest extends AbstractFix
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -203,7 +203,7 @@ $g["e"](1,); // foo',
      *
      * @requires PHP 8.0
      */
-    public function testFix80(string $expected, string $input = null): void
+    public function testFix80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/FunctionNotation/NoUselessSprintfFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoUselessSprintfFixerTest.php
@@ -111,7 +111,7 @@ final class NoUselessSprintfFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
@@ -516,7 +516,7 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
@@ -523,7 +523,7 @@ final class PhpdocToPropertyTypeFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -409,7 +409,7 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/FunctionNotation/StaticLambdaFixerTest.php
+++ b/tests/Fixer/FunctionNotation/StaticLambdaFixerTest.php
@@ -26,7 +26,7 @@ final class StaticLambdaFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, string $input = null): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Import/GroupImportFixerTest.php
+++ b/tests/Fixer/Import/GroupImportFixerTest.php
@@ -361,7 +361,7 @@ use function Foo\b;
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -2040,7 +2040,7 @@ use function some\f\{fn_c, fn_d, fn_e};
      *
      * @param string[] $importOrder
      */
-    public function testFixTypesOrderAndAlphabet(string $expected, ?string $input = null, array $importOrder = null): void
+    public function testFixTypesOrderAndAlphabet(string $expected, ?string $input = null, ?array $importOrder = null): void
     {
         $this->fixer->configure([
             'sort_algorithm' => OrderedImportsFixer::SORT_ALPHA,
@@ -2106,7 +2106,7 @@ use function some\a\{fn_a, fn_b};
      *
      * @param null|string[] $importOrder
      */
-    public function testFixTypesOrderAndNone(string $expected, ?string $input = null, array $importOrder = null): void
+    public function testFixTypesOrderAndNone(string $expected, ?string $input = null, ?array $importOrder = null): void
     {
         $this->fixer->configure([
             'sort_algorithm' => OrderedImportsFixer::SORT_NONE,

--- a/tests/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixerTest.php
@@ -142,7 +142,7 @@ final class CombineConsecutiveUnsetsFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
@@ -143,7 +143,7 @@ Trigger_Error/**/("This is a deprecation warning.", E_USER_DEPRECATED/***/); ?>'
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -160,7 +160,7 @@ Trigger_Error/**/("This is a deprecation warning.", E_USER_DEPRECATED/***/); ?>'
      *
      * @requires PHP 8.1
      */
-    public function testFix81(string $expected, string $input = null): void
+    public function testFix81(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
@@ -306,7 +306,7 @@ get_called_class#1
      *
      * @requires PHP 8.1
      */
-    public function testFix81(string $expected, string $input = null): void
+    public function testFix81(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/LanguageConstruct/NoUnsetOnPropertyFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NoUnsetOnPropertyFixerTest.php
@@ -232,7 +232,7 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/ListNotation/ListSyntaxFixerTest.php
+++ b/tests/Fixer/ListNotation/ListSyntaxFixerTest.php
@@ -266,7 +266,7 @@ $a;#
      *
      * @requires PHP 8.1
      */
-    public function testFix81(string $expected, string $input = null): void
+    public function testFix81(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixerTest.php
@@ -29,7 +29,7 @@ final class NoBlankLinesBeforeNamespaceFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, ?string $input = null, WhitespacesFixerConfig $whitespaces = null): void
+    public function testFix(string $expected, ?string $input = null, ?WhitespacesFixerConfig $whitespaces = null): void
     {
         if (null !== $whitespaces) {
             $this->fixer->setWhitespacesConfig($whitespaces);

--- a/tests/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixerTest.php
@@ -29,7 +29,7 @@ final class SingleBlankLineBeforeNamespaceFixerTest extends AbstractFixerTestCas
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, ?string $input = null, WhitespacesFixerConfig $whitespaces = null): void
+    public function testFix(string $expected, ?string $input = null, ?WhitespacesFixerConfig $whitespaces = null): void
     {
         if (null !== $whitespaces) {
             $this->fixer->setWhitespacesConfig($whitespaces);

--- a/tests/Fixer/Operator/StandardizeIncrementFixerTest.php
+++ b/tests/Fixer/Operator/StandardizeIncrementFixerTest.php
@@ -734,7 +734,7 @@ $i#3
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Operator/TernaryToElvisOperatorFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToElvisOperatorFixerTest.php
@@ -440,7 +440,7 @@ EOT
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -233,7 +233,7 @@ null
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
@@ -581,7 +581,7 @@ class Foo
      *
      * @param array<string, mixed> $config
      */
-    public function testFix80(string $expected, string $input = null, array $config = []): void
+    public function testFix80(string $expected, ?string $input = null, array $config = []): void
     {
         $this->fixer->configure($config);
         $this->doTest($expected, $input);
@@ -729,7 +729,7 @@ class Foo
      *
      * @param array<string, mixed> $config
      */
-    public function testFix81(string $expected, string $input = null, array $config = []): void
+    public function testFix81(string $expected, ?string $input = null, array $config = []): void
     {
         $this->fixer->configure($config);
         $this->doTest($expected, $input);

--- a/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
+++ b/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
@@ -95,7 +95,7 @@ A is equal to 5
      *
      * @requires PHP <8.0
      */
-    public function testFixPre80(string $expected, string $input = null): void
+    public function testFixPre80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -1571,7 +1571,7 @@ enum UserStatus: string {
     /**
      * @dataProvider provideFixWithDocCommentCases
      */
-    public function testFixWithDocComment(string $expected, string $input = null): void
+    public function testFixWithDocComment(string $expected, ?string $input = null): void
     {
         $this->fixer->configure([
             'statements' => ['phpdoc'],

--- a/tests/Fixer/Whitespace/BlankLineBetweenImportGroupsFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBetweenImportGroupsFixerTest.php
@@ -532,7 +532,7 @@ use const C\D; // bar
      *
      * @requires PHP <8.0
      */
-    public function testFix80(string $expected, string $input = null): void
+    public function testFix80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -1129,7 +1129,7 @@ class Foo {}'
      *
      * @requires PHP 8.0
      */
-    public function testFix80(array $config, string $expected, string $input = null): void
+    public function testFix80(array $config, string $expected, ?string $input = null): void
     {
         $this->fixer->configure($config);
 
@@ -1227,7 +1227,7 @@ function foo(){}
      *
      * @requires PHP 8.1
      */
-    public function testFix81(string $expected, string $input = null): void
+    public function testFix81(string $expected, ?string $input = null): void
     {
         $this->fixer->configure(['tokens' => ['case']]);
 

--- a/tests/Fixer/Whitespace/NoTrailingWhitespaceFixerTest.php
+++ b/tests/Fixer/Whitespace/NoTrailingWhitespaceFixerTest.php
@@ -161,7 +161,7 @@ EOT;
      *
      * @requires PHP 8.0
      */
-    public function testFix80(string $expected, string $input = null): void
+    public function testFix80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }

--- a/tests/Fixtures/Integration/misc/PHP8_0.test
+++ b/tests/Fixtures/Integration/misc/PHP8_0.test
@@ -80,7 +80,7 @@ class T
 // nothing we can do
 
 // https://wiki.php.net/rfc/trailing_comma_in_parameter_list
-function foo(string $param = null): void {}
+function foo(?string $param = null): void {}
 call_user_func('foo', 1);
 
 // https://wiki.php.net/rfc/trailing_comma_in_closure_use_list

--- a/tests/Linter/ProcessLintingResultTest.php
+++ b/tests/Linter/ProcessLintingResultTest.php
@@ -29,7 +29,7 @@ final class ProcessLintingResultTest extends TestCase
     public function testCheckOK(): void
     {
         $process = new class([]) extends Process {
-            public function wait(callable $callback = null): int
+            public function wait(?callable $callback = null): int
             {
                 return 0;
             }
@@ -49,7 +49,7 @@ final class ProcessLintingResultTest extends TestCase
     public function testCheckFail(): void
     {
         $process = new class([]) extends Process {
-            public function wait(callable $callback = null): int
+            public function wait(?callable $callback = null): int
             {
                 return 0;
             }

--- a/tests/Runner/RunnerTest.php
+++ b/tests/Runner/RunnerTest.php
@@ -166,7 +166,7 @@ final class RunnerTest extends TestCase
         return new class() implements DifferInterface {
             public ?\SplFileInfo $passedFile = null;
 
-            public function diff(string $old, string $new, \SplFileInfo $file = null): string
+            public function diff(string $old, string $new, ?\SplFileInfo $file = null): string
             {
                 $this->passedFile = $file;
 

--- a/tests/Test/AbstractIntegrationCaseFactory.php
+++ b/tests/Test/AbstractIntegrationCaseFactory.php
@@ -229,7 +229,7 @@ abstract class AbstractIntegrationCaseFactory implements IntegrationCaseFactoryI
      *
      * @return array<string, mixed>
      */
-    private function parseJson(?string $encoded, array $template = null): array
+    private function parseJson(?string $encoded, ?array $template = null): array
     {
         // content is optional if template is provided
         if ((null === $encoded || '' === $encoded) && null !== $template) {

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -60,7 +60,7 @@ final class TokensTest extends TestCase
         ?array $expected,
         array $sequence,
         int $start = 0,
-        int $end = null,
+        ?int $end = null,
         $caseSensitive = true
     ): void {
         $tokens = Tokens::fromCode($source);
@@ -1150,7 +1150,7 @@ echo $a;',
     /**
      * @dataProvider provideRemoveLeadingWhitespaceCases
      */
-    public function testRemoveLeadingWhitespace(int $index, ?string $whitespaces, string $expected, string $input = null): void
+    public function testRemoveLeadingWhitespace(int $index, ?string $whitespaces, string $expected, ?string $input = null): void
     {
         Tokens::clearCache();
 
@@ -1221,7 +1221,7 @@ echo $a;',
     /**
      * @dataProvider provideRemoveTrailingWhitespaceCases
      */
-    public function testRemoveTrailingWhitespace(int $index, ?string $whitespaces, string $expected, string $input = null): void
+    public function testRemoveTrailingWhitespace(int $index, ?string $whitespaces, string $expected, ?string $input = null): void
     {
         Tokens::clearCache();
 
@@ -1853,7 +1853,7 @@ $bar;',
      * @param null|Token[] $expected
      * @param null|Token[] $input
      */
-    private static function assertEqualsTokensArray(array $expected = null, array $input = null): void
+    private static function assertEqualsTokensArray(?array $expected = null, ?array $input = null): void
     {
         if (null === $expected) {
             self::assertNull($input);

--- a/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php
@@ -39,7 +39,7 @@ final class NameQualifiedTransformerTest extends AbstractTransformerTestCase
      *
      * @requires PHP 8.0
      */
-    public function testProcess(array $expected, array $input = null): void
+    public function testProcess(array $expected, ?array $input = null): void
     {
         $expectedTokens = Tokens::fromArray($expected);
         $tokens = null === $input

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -53,7 +53,7 @@ final class UtilsTest extends TestCase
      *
      * @dataProvider provideCamelCaseToUnderscoreCases
      */
-    public function testCamelCaseToUnderscore(string $expected, string $input = null): void
+    public function testCamelCaseToUnderscore(string $expected, ?string $input = null): void
     {
         if (null !== $input) {
             self::assertSame($expected, Utils::camelCaseToUnderscore($input));


### PR DESCRIPTION
I personally do not like this style, but given https://wiki.php.net/rfc/deprecate-implicitly-nullable-types is very likely pass, we have no choice. Also, in Symfony ruleset `nullable_type_declaration_for_default_null_value` is already enabled.