### PR TITLE
chore: update PHPStan

### DIFF
--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -7,7 +7,7 @@
         "mi-schi/phpmd-extension": "^4.3.0",
         "phpmd/phpmd": "^2.15.0",
         "phpstan/extension-installer": "^1.3.1",
-        "phpstan/phpstan": "^1.10.59",
+        "phpstan/phpstan": "^1.10.60",
         "phpstan/phpstan-phpunit": "^1.3.16",
         "phpstan/phpstan-strict-rules": "^1.5.2"
     },

--- a/dev-tools/composer.lock
+++ b/dev-tools/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88f0a6e88433b6c987c9e50fe9de98a3",
+    "content-hash": "34bfda7faca8f509024a89b0043f6f15",
     "packages": [
         {
             "name": "composer-unused/contracts",
@@ -714,16 +714,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.59",
+            "version": "1.10.60",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e607609388d3a6d418a50a49f7940e8086798281"
+                "reference": "95dcea7d6c628a3f2f56d091d8a0219485a86bbe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e607609388d3a6d418a50a49f7940e8086798281",
-                "reference": "e607609388d3a6d418a50a49f7940e8086798281"
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/95dcea7d6c628a3f2f56d091d8a0219485a86bbe",
+                "reference": "95dcea7d6c628a3f2f56d091d8a0219485a86bbe"
             },
             "require": {
                 "php": "^7.2|^8.0"

--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -82,19 +82,9 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Fixer/ListNotation/ListSyntaxFixer.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in an if condition, int\\|null given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Fixer/Naming/NoHomoglyphNamesFixer.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Variable method call on \\$this\\(PhpCsFixer\\\\Fixer\\\\Operator\\\\ConcatSpaceFixer\\)\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/Operator/ConcatSpaceFixer.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in a negated boolean, int\\|null given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Fixer/PhpTag/FullOpeningTagFixer.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Variable method call on \\$this\\(PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitConstructFixer\\)\\.$#',
@@ -105,11 +95,6 @@ $ignoreErrors[] = [
 	'message' => '#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in an if condition, int\\|null given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#',
@@ -125,16 +110,6 @@ $ignoreErrors[] = [
 	'message' => '#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in a negated boolean, string given\\.$#',
-	'count' => 2,
-	'path' => __DIR__ . '/../../src/Fixer/Whitespace/HeredocIndentationFixer.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in an elseif condition, string given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Fixer/Whitespace/HeredocIndentationFixer.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Variable \\$end might not be defined\\.$#',

--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -7,6 +7,11 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Console/ConfigurationResolver.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Binary operation "\\+" between int and string results in an error\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/DocBlock/TypeExpression.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Foreach overwrites \\$token with its value variable\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Doctrine/Annotation/Tokens.php',
@@ -37,7 +42,17 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Fixer/CastNotation/NoShortBoolCastFixer.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Fixer/Import/FullyQualifiedStrictTypesFixer.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^For loop initial assignment overwrites variable \\$index\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Fixer/Import/GlobalNamespaceImportFixer.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$array of function array_reverse expects array, string given\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/Import/GlobalNamespaceImportFixer.php',
 ];
@@ -67,9 +82,19 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Fixer/ListNotation/ListSyntaxFixer.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Only booleans are allowed in an if condition, int\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Fixer/Naming/NoHomoglyphNamesFixer.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Variable method call on \\$this\\(PhpCsFixer\\\\Fixer\\\\Operator\\\\ConcatSpaceFixer\\)\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/Operator/ConcatSpaceFixer.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Only booleans are allowed in a negated boolean, int\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Fixer/PhpTag/FullOpeningTagFixer.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Variable method call on \\$this\\(PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitConstructFixer\\)\\.$#',
@@ -77,9 +102,39 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Fixer/PhpUnit/PhpUnitConstructFixer.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Only booleans are allowed in an if condition, int\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Fixer/Phpdoc/PhpdocToCommentFixer.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Foreach overwrites \\$index with its key variable\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/Phpdoc/PhpdocTrimConsecutiveBlankLineSeparationFixer.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Argument of an invalid type string supplied for foreach, only iterables are supported\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Only booleans are allowed in a negated boolean, string given\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../src/Fixer/Whitespace/HeredocIndentationFixer.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Only booleans are allowed in an elseif condition, string given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Fixer/Whitespace/HeredocIndentationFixer.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Variable \\$end might not be defined\\.$#',
@@ -97,6 +152,36 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Fixer/Whitespace/StatementIndentationFixer.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Method PhpCsFixer\\\\Preg\\:\\:match\\(\\) never assigns null to &\\$matches so it can be removed from the by\\-ref type\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Preg.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method PhpCsFixer\\\\Preg\\:\\:matchAll\\(\\) never assigns null to &\\$matches so it can be removed from the by\\-ref type\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Preg.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method PhpCsFixer\\\\Preg\\:\\:replace\\(\\) never assigns null to &\\$count so it can be removed from the by\\-ref type\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Preg.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Method PhpCsFixer\\\\Preg\\:\\:replaceCallback\\(\\) never assigns null to &\\$count so it can be removed from the by\\-ref type\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Preg.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter &\\$matches by\\-ref type of method PhpCsFixer\\\\Preg\\:\\:match\\(\\) expects array\\<string\\>\\|null, \\(int is int \\? array\\<array\\<int, int\\<\\-1, max\\>\\|string\\>\\> \\: \\(int is int \\? array\\<string\\|null\\> \\: \\(int is int \\? array\\<array\\<int, int\\|string\\|null\\>\\> \\: array\\<string\\>\\)\\)\\) given\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../src/Preg.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter &\\$matches by\\-ref type of method PhpCsFixer\\\\Preg\\:\\:matchAll\\(\\) expects array\\<string\\>\\|null, \\(int is int \\? array\\<array\\<int, string\\>\\> \\: \\(int is int \\? array\\<int, array\\<string\\>\\> \\: \\(int is int \\? array\\<array\\<int, array\\<int, int\\|string\\>\\>\\> \\: \\(int is int \\? array\\<int, array\\<array\\<int, int\\|string\\>\\>\\> \\: \\(int is int \\? array\\<array\\<int, string\\|null\\>\\> \\: \\(int is int \\? array\\<int, array\\<string\\|null\\>\\> \\: \\(int is int \\? array\\<int, array\\<array\\<int, int\\|string\\|null\\>\\>\\> \\: array\\)\\)\\)\\)\\)\\)\\) given\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../src/Preg.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$className \\(string\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getFileInfo\\(\\) should be contravariant with parameter \\$class \\(string\\|null\\) of method SplFileInfo\\:\\:getFileInfo\\(\\)$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/StdinFileInfo.php',
@@ -105,6 +190,11 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$className \\(string\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getPathInfo\\(\\) should be contravariant with parameter \\$class \\(string\\|null\\) of method SplFileInfo\\:\\:getPathInfo\\(\\)$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/StdinFileInfo.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc tag @var with type array\\<int, string\\> is not subtype of type string\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Tokenizer/Analyzer/DataProviderAnalyzer.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$array \\(array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\) of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:fromArray\\(\\) should be contravariant with parameter \\$array \\(array\\<int, mixed\\>\\) of method SplFixedArray\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\:\\:fromArray\\(\\)$#',

--- a/src/Fixer/Naming/NoHomoglyphNamesFixer.php
+++ b/src/Fixer/Naming/NoHomoglyphNamesFixer.php
@@ -222,7 +222,7 @@ final class NoHomoglyphNamesFixer extends AbstractFixer
 
             $replaced = Preg::replaceCallback('/[^[:ascii:]]/u', static fn (array $matches): string => self::$replacements[$matches[0]] ?? $matches[0], $token->getContent(), -1, $count);
 
-            if ($count) {
+            if ($count > 0) {
                 $tokens->offsetSet($index, new Token([$token->getId(), $replaced]));
             }
         }

--- a/src/Fixer/PhpTag/FullOpeningTagFixer.php
+++ b/src/Fixer/PhpTag/FullOpeningTagFixer.php
@@ -62,7 +62,7 @@ echo "Hello!";
         // replace all <? with <?php to replace all short open tags even without short_open_tag option enabled
         $newContent = Preg::replace('/<\?(?:phP|pHp|pHP|Php|PhP|PHp|PHP)?(\s|$)/', '<?php$1', $content, -1, $count);
 
-        if (!$count) {
+        if (0 === $count) {
             return;
         }
 

--- a/src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
@@ -121,7 +121,7 @@ final class PhpdocNoUselessInheritdocFixer extends AbstractFixer
             $count
         );
 
-        if ($count) {
+        if ($count > 0) {
             $tokens[$tokenIndex] = new Token([T_DOC_COMMENT, $content]);
         }
     }

--- a/src/Fixer/Whitespace/HeredocIndentationFixer.php
+++ b/src/Fixer/Whitespace/HeredocIndentationFixer.php
@@ -140,7 +140,7 @@ final class HeredocIndentationFixer extends AbstractFixer implements Configurabl
                 $content = Preg::replace('/(?<=\v)(?!'.$currentIndent.')\h+/', '', $content);
             }
 
-            $regexEnd = $last && !$currentIndent ? '(?!\v|$)' : '(?!\v)';
+            $regexEnd = $last && '' === $currentIndent ? '(?!\v|$)' : '(?!\v)';
             $content = Preg::replace('/(?<=\v)'.$currentIndent.$regexEnd.'/', $indent, $content);
 
             $tokens[$index] = new Token([$tokens[$index]->getId(), $content]);
@@ -156,9 +156,9 @@ final class HeredocIndentationFixer extends AbstractFixer implements Configurabl
 
         $content = $tokens[$index]->getContent();
 
-        if (!\in_array($content[0], ["\r", "\n"], true) && (!$currentIndent || str_starts_with($content, $currentIndent))) {
+        if (!\in_array($content[0], ["\r", "\n"], true) && ('' === $currentIndent || str_starts_with($content, $currentIndent))) {
             $content = $indent.substr($content, $currentIndentLength);
-        } elseif ($currentIndent) {
+        } elseif ('' !== $currentIndent) {
             $content = Preg::replace('/^(?!'.$currentIndent.')\h+/', '', $content);
         }
 

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -305,7 +305,7 @@ final class ProjectCodeTest extends TestCase
         $doc = $reflectionClass->getDocComment();
         self::assertNotFalse($doc);
 
-        if (Preg::match('/@coversNothing/', $doc, $matches)) {
+        if (Preg::match('/@coversNothing/', $doc)) {
             return;
         }
 


### PR DESCRIPTION
This will fix failing CI on main branch.

I've fixed all the straightforward issues.

All added entries to baseline are related to `preg_*` functions - types of `$matches` and `$count` - fixing them will need some discussion and time, as we might end up with adding some generic types e.g. https://github.com/phpstan/phpstan-src/blob/1.10.60/stubs/core.stub#L181-L203, so let's do it separately.