### PR TITLE
depr: `nullable_type_declaration_for_default_null_value` - deprecate option that is against `@PHP84Migration`

### DIFF
--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -1,7 +1,7 @@
 {
     "title": [
         {
-            "pattern": "^(feat|fix|chore|CI|deps|docs|DX|refactor|test)(\\([\\-.@:`a-zA-Z0-9]+\\))?!?:\\s{1}\\S.+\\S$",
+            "pattern": "^(feat|fix|chore|CI|depr|deps|docs|DX|refactor|test)(\\([\\-.@:`a-zA-Z0-9]+\\))?!?:\\s{1}\\S.+\\S$",
             "message": "PR title does not meet requirement, use Conventional Commits format using one of these categories: feat, fix, chore, CI, docs, DX, refactor, test"
         },
         {

--- a/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.rst
+++ b/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.rst
@@ -16,6 +16,8 @@ Configuration
 ``use_nullable_type_declaration``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. warning:: This option is deprecated and will be removed in the next major version. Behaviour will follow default one.
+
 Whether to add or remove ``?`` or ``|null`` to parameters with a default
 ``null`` value.
 

--- a/src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php
+++ b/src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php
@@ -92,6 +92,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixer extends AbstractFixe
             (new FixerOptionBuilder('use_nullable_type_declaration', 'Whether to add or remove `?` or `|null` to parameters with a default `null` value.'))
                 ->setAllowedTypes(['bool'])
                 ->setDefault(true)
+                ->setDeprecationMessage('Behaviour will follow default one.') // @TODO remove the option on next major 4.0
                 ->getOption(),
         ]);
     }

--- a/tests/AutoReview/DescribeCommandTest.php
+++ b/tests/AutoReview/DescribeCommandTest.php
@@ -51,6 +51,7 @@ final class DescribeCommandTest extends TestCase
         // @TODO 4.0 Remove this expectation
         $this->expectDeprecation('Rule set "@PER" is deprecated. Use "@PER-CS" instead.');
         $this->expectDeprecation('Rule set "@PER:risky" is deprecated. Use "@PER-CS:risky" instead.');
+        $this->expectDeprecation('Option "use_nullable_type_declaration" for rule "nullable_type_declaration_for_default_null_value" is deprecated and will be removed in version 4.0. Behaviour will follow default one.');
 
         $command = new DescribeCommand($factory);
 

--- a/tests/AutoReview/DescribeCommandTest.php
+++ b/tests/AutoReview/DescribeCommandTest.php
@@ -48,10 +48,12 @@ final class DescribeCommandTest extends TestCase
             $this->expectDeprecation($message);
         }
 
-        // @TODO 4.0 Remove this expectation
+        // @TODO 4.0 Remove this expectations
         $this->expectDeprecation('Rule set "@PER" is deprecated. Use "@PER-CS" instead.');
         $this->expectDeprecation('Rule set "@PER:risky" is deprecated. Use "@PER-CS:risky" instead.');
-        $this->expectDeprecation('Option "use_nullable_type_declaration" for rule "nullable_type_declaration_for_default_null_value" is deprecated and will be removed in version 4.0. Behaviour will follow default one.');
+        if ('nullable_type_declaration_for_default_null_value' === $fixerName) {
+            $this->expectDeprecation('Option "use_nullable_type_declaration" for rule "nullable_type_declaration_for_default_null_value" is deprecated and will be removed in version 4.0. Behaviour will follow default one.');
+        }
 
         $command = new DescribeCommand($factory);
 

--- a/tests/AutoReview/DocumentationTest.php
+++ b/tests/AutoReview/DocumentationTest.php
@@ -42,7 +42,9 @@ final class DocumentationTest extends TestCase
         // @TODO 4.0 Remove this expectations
         $this->expectDeprecation('Rule set "@PER" is deprecated. Use "@PER-CS" instead.');
         $this->expectDeprecation('Rule set "@PER:risky" is deprecated. Use "@PER-CS:risky" instead.');
-        $this->expectDeprecation('Option "use_nullable_type_declaration" for rule "nullable_type_declaration_for_default_null_value" is deprecated and will be removed in version 4.0. Behaviour will follow default one.');
+        if ('nullable_type_declaration_for_default_null_value' === $fixer->getName()) {
+            $this->expectDeprecation('Option "use_nullable_type_declaration" for rule "nullable_type_declaration_for_default_null_value" is deprecated and will be removed in version 4.0. Behaviour will follow default one.');
+        }
 
         $locator = new DocumentationLocator();
         $generator = new FixerDocumentGenerator($locator);

--- a/tests/AutoReview/DocumentationTest.php
+++ b/tests/AutoReview/DocumentationTest.php
@@ -42,6 +42,7 @@ final class DocumentationTest extends TestCase
         // @TODO 4.0 Remove this expectations
         $this->expectDeprecation('Rule set "@PER" is deprecated. Use "@PER-CS" instead.');
         $this->expectDeprecation('Rule set "@PER:risky" is deprecated. Use "@PER-CS:risky" instead.');
+        $this->expectDeprecation('Option "use_nullable_type_declaration" for rule "nullable_type_declaration_for_default_null_value" is deprecated and will be removed in version 4.0. Behaviour will follow default one.');
 
         $locator = new DocumentationLocator();
         $generator = new FixerDocumentGenerator($locator);


### PR DESCRIPTION
ref #7774