### PR TITLE
test: Introduce Infection for mutation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,8 +178,8 @@ jobs:
           PHP_CS_FIXER_FUTURE_MODE: 1
         run: php php-cs-fixer fix --config .php-cs-fixer.php-highest.php -q
 
-      - name: Disable time limit for tests when collecting coverage
-        if: matrix.collect-code-coverage == 'yes'
+      - name: Custom PHPUnit config with v10 alignments
+        if: matrix.collect-code-coverage == 'yes' || matrix.run-mutation-tests
         run: sed -e 's/enforceTimeLimit="true"/enforceTimeLimit="false"/g' -e 's/coverage/source/g' phpunit.xml.dist > phpunit.xml
 
       - name: Disable time limit for tests under Windows # due to https://github.com/sebastianbergmann/phpunit/issues/5589

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,11 @@ jobs:
             run-tests: 'yes'
             collect-code-coverage: 'yes'
 
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.3'
+            job-description: 'mutation tests'
+            run-mutation-tests: 'yes'
+
           - operating-system: 'windows-latest'
             php-version: '8.3'
             job-description: 'Fixer on Windows'
@@ -151,12 +156,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Remove Infection requirement if not needed
+        if: matrix.run-mutation-tests != 'yes'
+        run: composer remove --dev infection/infection --no-update
+
       - name: Setup PHP with Composer deps
         uses: ./.github/composite-actions/setup-php-with-composer-deps
         with:
           os: ${{ runner.os }}
           php: ${{ matrix.php-version }}
-          php-coverage: ${{ matrix.collect-code-coverage }}
+          php-coverage: ${{ matrix.collect-code-coverage || matrix.run-mutation-tests }}
           composer-flags: ${{ matrix.composer-flags }}
           composer-flex-with-symfony-version: ${{ matrix.execute-flex-with-symfony-version }}
 
@@ -202,6 +211,14 @@ jobs:
         env:
           FAST_LINT_TEST_CASES: 1
         run: vendor/bin/paraunit coverage --testsuite unit --pass-through=--exclude-group=covers-nothing --clover=build/logs/clover.xml
+
+      - name: Run mutation tests (Infection)
+        if: matrix.run-mutation-tests == 'yes'
+        env:
+          FAST_LINT_TEST_CASES: 1
+        run: |
+          git fetch origin $GITHUB_BASE_REF
+          vendor/bin/infection --threads=max --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations --only-covered
 
       - name: Upload coverage results to Coveralls
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Remove Infection
+        run: composer remove --dev infection/infection --no-update
+
       - name: Setup PHP with Composer deps
         uses: ./.github/composite-actions/setup-php-with-composer-deps
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
           FAST_LINT_TEST_CASES: 1
         run: |
           git fetch origin $GITHUB_BASE_REF
-          vendor/bin/infection --threads=max --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations --only-covered
+          vendor/bin/infection --threads=max --map-source-class-to-test --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations --only-covered
 
       - name: Upload coverage results to Coveralls
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage == 'yes'

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /compose.override.yaml
 /composer.lock
 /dev-tools/bin/
+/dev-tools/infection/
 /dev-tools/phpstan/cache/
 /dev-tools/vendor/
 /php-cs-fixer.phar

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /dev-tools/infection/
 /dev-tools/phpstan/cache/
 /dev-tools/vendor/
+/infection.json5
 /php-cs-fixer.phar
 /php-cs-fixer.phar.asc
 /phpstan.neon

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "require-dev": {
         "facile-it/paraunit": "^1.3 || ^2.0",
-        "infection/infection": "^0.27",
+        "infection/infection": "^0.27.11",
         "justinrainbow/json-schema": "^5.2",
         "keradus/cli-executor": "^2.1",
         "mikey179/vfsstream": "^1.6.11",

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     },
     "require-dev": {
         "facile-it/paraunit": "^1.3 || ^2.0",
+        "infection/infection": "^0.27",
         "justinrainbow/json-schema": "^5.2",
         "keradus/cli-executor": "^2.1",
         "mikey179/vfsstream": "^1.6.11",

--- a/composer.json
+++ b/composer.json
@@ -89,6 +89,7 @@
         "cs:fix": "@php php-cs-fixer fix",
         "cs:fix:parallel": "echo '🔍 Will run in batches of 50 files.'; if [[ -f .php-cs-fixer.php ]]; then FIXER_CONFIG=.php-cs-fixer.php; else FIXER_CONFIG=.php-cs-fixer.dist.php; fi; php php-cs-fixer list-files --config=$FIXER_CONFIG | xargs -n 50 -P 8 php php-cs-fixer fix --config=$FIXER_CONFIG --path-mode intersection 2> /dev/null",
         "docs": "@php dev-tools/doc.php",
+        "infection": "@test:mutation",
         "install-tools": "@composer --working-dir=dev-tools install",
         "mess-detector": "@php dev-tools/vendor/bin/phpmd . ansi dev-tools/mess-detector/phpmd.xml --exclude vendor/*,dev-tools/vendor/*,dev-tools/phpstan/*,tests/Fixtures/*",
         "normalize": [
@@ -133,6 +134,10 @@
             "Composer\\Config::disableProcessTimeout",
             "paraunit run --testsuite integration"
         ],
+        "test:mutation": [
+            "Composer\\Config::disableProcessTimeout",
+            "infection --threads=max --only-covered --min-covered-msi=80"
+        ],
         "test:short-open-tag": [
             "Composer\\Config::disableProcessTimeout",
             "@php -d short_open_tag=1 ./vendor/bin/phpunit --do-not-cache-result --testsuite short-open-tag"
@@ -153,6 +158,7 @@
         "cs:fix": "Fix coding standards",
         "cs:fix:parallel": "Fix coding standards in naive parallel mode (using xargs)",
         "docs": "Regenerate docs",
+        "infection": "Alias for 'test:mutation'",
         "install-tools": "Install DEV tools",
         "mess-detector": "Analyse code with Mess Detector",
         "normalize": "Run normalization for composer.json files",
@@ -169,6 +175,7 @@
         "test:all": "Run Unit and Integration tests (but *NOT* Smoke tests)",
         "test:coverage": "Run tests that provide code coverage",
         "test:integration": "Run Integration tests",
+        "test:mutation": "Run mutation tests",
         "test:short-open-tag": "Run tests with \"short_open_tag\" enabled",
         "test:smoke": "Run Smoke tests",
         "test:unit": "Run Unit tests",

--- a/infection.json5.dist
+++ b/infection.json5.dist
@@ -1,0 +1,21 @@
+{
+    "$schema": "vendor/infection/infection/resources/schema.json",
+    "testFrameworkOptions": "--testsuite=unit",
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "mutators": {
+        "@default": true,
+        "Throw_": {
+            "ignore": [
+                "PhpCsFixer\\Cache\\FileHandler"
+            ]
+        }
+    },
+    "logs": {
+        "text": "dev-tools/infection/run.log",
+        "html": "dev-tools/infection/report.html"
+    }
+}

--- a/infection.json5.dist
+++ b/infection.json5.dist
@@ -14,9 +14,5 @@
                 "PhpCsFixer\\Cache\\FileHandler"
             ]
         }
-    },
-    "logs": {
-        "text": "dev-tools/infection/run.log",
-        "html": "dev-tools/infection/report.html"
     }
 }

--- a/infection.json5.dist
+++ b/infection.json5.dist
@@ -10,6 +10,7 @@
         "@default": true,
         "Throw_": {
             "ignore": [
+                // It makes `tests/Fixtures/cache-file-handler/cache-file` unreadable (permissions)
                 "PhpCsFixer\\Cache\\FileHandler"
             ]
         }

--- a/infection.json5.dist
+++ b/infection.json5.dist
@@ -13,6 +13,12 @@
                 // It makes `tests/Fixtures/cache-file-handler/cache-file` unreadable (permissions)
                 "PhpCsFixer\\Cache\\FileHandler"
             ]
+        },
+        "LogicalNot": {
+            "ignore": [
+                // Causes modifications in `tests/Fixtures/FixerTest/fix/*.php`
+                "PhpCsFixer\\Runner\\Runner::fixFile"
+            ]
         }
     }
 }

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -1701,8 +1701,8 @@ $bar;',
         }
 
         yield 'overlapping inserts of bunch of comments ' => [
-            Tokens::fromCode(sprintf("<?php\n%s/* line 1 */\n%s/* line 2 */\n%s/* line 3 */%s", $sets[0]['content'], $sets[1]['content'], $sets[2]['content'], $sets[3]['content'])),
-            Tokens::fromCode("<?php\n/* line 1 */\n/* line 2 */\n/* line 3 */"),
+            Tokens::fromCode(sprintf("<?php\n%s/* line #1 */\n%s/* line #2 */\n%s/* line #3 */%s", $sets[0]['content'], $sets[1]['content'], $sets[2]['content'], $sets[3]['content'])),
+            Tokens::fromCode("<?php\n/* line #1 */\n/* line #2 */\n/* line #3 */"),
             [1 => $sets[0]['tokens'], 3 => $sets[1]['tokens'], 5 => $sets[2]['tokens'], 6 => $sets[3]['tokens']],
         ];
     }


### PR DESCRIPTION
After recent [discussion](https://twitter.com/maks_rafalko/status/1765841854702981331) I decided to verify what is our mutation score 😁. It does look good to be honest with initial setup:

```
23750 mutations were generated:
   18693 mutants were killed
       0 mutants were configured to be ignored
       0 mutants were not covered by tests
    4581 covered mutants were not detected
      70 errors were encountered
     136 syntax errors were encountered
     231 time outs were encountered
      39 mutants required more time than configured

Metrics:
         Mutation Score Indicator (MSI): 80%
         Mutation Code Coverage: 100%
         Covered Code MSI: 80%
```

## Concerns to address

- Infection is currently the slowest part of our QA workflow (with _this initial_ configuration). We put a lot of work in the past to make our CI faster, so it's a no-go to add a job that takes much longer than the rest (21m30s on M1 with 10 cores). We need to determine if it's possible to improve it.
- There is a lot of `S` at the beginning, then it freezes for significant amount of time, then it runs further (why?).
- Mutating `src/Runner/Runner.php` causes some fixture files to be modified, which causes regular test failures and may lead to committing changes that should not be committed.

CC: @maks-rafalko, any suggestion are welcome 😃.