### PR TITLE
feat: Add `array_indentation` to `PER-CS2.0` ruleset

### DIFF
--- a/doc/ruleSets/PER-CS2.0.rst
+++ b/doc/ruleSets/PER-CS2.0.rst
@@ -8,6 +8,7 @@ Rules
 -----
 
 - `@PER-CS1.0 <./PER-CS1.0.rst>`_
+- `array_indentation <./../rules/whitespace/array_indentation.rst>`_
 - `cast_spaces <./../rules/cast_notation/cast_spaces.rst>`_
 - `concat_space <./../rules/operator/concat_space.rst>`_ with config:
 

--- a/doc/ruleSets/PhpCsFixer.rst
+++ b/doc/ruleSets/PhpCsFixer.rst
@@ -9,7 +9,6 @@ Rules
 
 - `@PER-CS <./PER-CS.rst>`_
 - `@Symfony <./Symfony.rst>`_
-- `array_indentation <./../rules/whitespace/array_indentation.rst>`_
 - `blank_line_before_statement <./../rules/whitespace/blank_line_before_statement.rst>`_ with config:
 
   ``['statements' => ['break', 'case', 'continue', 'declare', 'default', 'exit', 'goto', 'include', 'include_once', 'phpdoc', 'require', 'require_once', 'return', 'switch', 'throw', 'try', 'yield', 'yield_from']]``

--- a/doc/rules/whitespace/array_indentation.rst
+++ b/doc/rules/whitespace/array_indentation.rst
@@ -27,9 +27,13 @@ Example #1
 Rule sets
 ---------
 
-The rule is part of the following rule set:
+The rule is part of the following rule sets:
 
+- `@PER <./../../ruleSets/PER.rst>`_
+- `@PER-CS <./../../ruleSets/PER-CS.rst>`_
+- `@PER-CS2.0 <./../../ruleSets/PER-CS2.0.rst>`_
 - `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
+- `@Symfony <./../../ruleSets/Symfony.rst>`_
 
 References
 ----------

--- a/src/RuleSet/Sets/PERCS2x0Set.php
+++ b/src/RuleSet/Sets/PERCS2x0Set.php
@@ -34,6 +34,7 @@ final class PERCS2x0Set extends AbstractRuleSetDescription
     {
         return [
             '@PER-CS1.0' => true,
+            'array_indentation' => true,
             'cast_spaces' => true,
             'concat_space' => ['spacing' => 'one'],
             'function_declaration' => [

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -26,7 +26,6 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
         return [
             '@PER-CS' => true,
             '@Symfony' => true,
-            'array_indentation' => true,
             'blank_line_before_statement' => [
                 'statements' => [
                     'break',

--- a/tests/Fixtures/Integration/set/@PER-CS2.0.test-in.php
+++ b/tests/Fixtures/Integration/set/@PER-CS2.0.test-in.php
@@ -43,4 +43,8 @@ $c = true  ? (INT) '1'  :  2;
 
 $fn = fn ($a) => $a;
 
+$array = [
+'foo' => 'bar',
+];
+
 ?>

--- a/tests/Fixtures/Integration/set/@PER-CS2.0.test-in.php
+++ b/tests/Fixtures/Integration/set/@PER-CS2.0.test-in.php
@@ -43,8 +43,10 @@ $c = true  ? (INT) '1'  :  2;
 
 $fn = fn ($a) => $a;
 
-$array = [
+$arrayNotMultiline = ['foo' => 'bar', 'foo2' => 'bar'];
+$arrayMultiline = [
 'foo' => 'bar',
+'foo2' => 'bar',
 ];
 
 ?>

--- a/tests/Fixtures/Integration/set/@PER-CS2.0.test-out.php
+++ b/tests/Fixtures/Integration/set/@PER-CS2.0.test-out.php
@@ -51,6 +51,8 @@ $c = true ? (int) '1' : 2;
 
 $fn = fn($a) => $a;
 
-$array = [
+$arrayNotMultiline = ['foo' => 'bar', 'foo2' => 'bar'];
+$arrayMultiline = [
     'foo' => 'bar',
+    'foo2' => 'bar',
 ];

--- a/tests/Fixtures/Integration/set/@PER-CS2.0.test-out.php
+++ b/tests/Fixtures/Integration/set/@PER-CS2.0.test-out.php
@@ -50,3 +50,7 @@ $b = (bool) 1;
 $c = true ? (int) '1' : 2;
 
 $fn = fn($a) => $a;
+
+$array = [
+    'foo' => 'bar',
+];


### PR DESCRIPTION
See https://www.php-fig.org/per/coding-style/#11-arrays

> Array declarations MAY be split across multiple lines, where each subsequent line is indented once.

Closes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7846