### PR TITLE
fix: StatementIndentationFixer - do not crash on ternary operator in class property

### DIFF
--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -230,7 +230,7 @@ if ($foo) {
                 } elseif ($token->equals(':')) {
                     if (isset($caseBlockStarts[$index])) {
                         [$endIndex, $endIndexInclusive] = $this->findCaseBlockEnd($tokens, $index);
-                    } else {
+                    } elseif ($this->alternativeSyntaxAnalyzer->belongsToAlternativeSyntax($tokens, $index)) {
                         $endIndex = $this->alternativeSyntaxAnalyzer->findAlternativeSyntaxBlockEnd($tokens, $alternativeBlockStarts[$index]);
                     }
                 } elseif ($token->isGivenKind(CT::T_DESTRUCTURING_SQUARE_BRACE_OPEN)) {

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -1464,6 +1464,16 @@ $foo = [
     1,
 ];',
         ];
+
+        yield 'ternary operator in property' => [
+            <<<'PHP'
+                <?php
+                class Foo
+                {
+                    public int $bar = BAZ ? -1 : 1;
+                }
+                PHP
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7896