### PR TITLE
fix: `PhpCsFixer\Tokenizer\Tokens::setSize` return type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,121 +21,121 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - operating-system: 'ubuntu-20.04'
-            php-version: '7.4'
-            job-description: 'Fixer with lowest deps'
-            run-fixer: 'yes'
-            composer-flags: '--prefer-lowest' # should be checked on the lowest supported PHP version
-            execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '7.4'
-            job-description: 'tests with lowest deps'
-            run-tests: 'yes'
-            composer-flags: '--prefer-lowest' # should be checked on the lowest supported PHP version
-            execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '8.0'
-            job-description: 'Fixer'
-            run-fixer: 'yes'
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '8.0'
-            job-description: 'tests'
-            run-tests: 'yes'
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '8.1'
-            job-description: 'Fixer with Symfony ^6'
-            run-fixer: 'yes'
-            execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '8.1'
-            job-description: 'tests with Symfony ^6'
-            run-tests: 'yes'
-            execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '8.2'
-            job-description: 'Fixer'
-            run-fixer: 'yes'
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '8.2'
-            job-description: 'tests'
-            run-tests: 'yes'
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '8.3'
-            job-description: 'Fixer'
-            run-fixer: 'yes'
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '8.3'
-            job-description: 'tests'
-            run-tests: 'yes'
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '8.3'
-            job-description: 'Fixer with migration rules'
-            run-fixer: 'yes'
-            run-migration-rules: 'yes' # should be checked on the highest supported PHP version
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '8.3'
-            job-description: 'tests with migration rules'
-            run-tests: 'yes'
-            run-migration-rules: 'yes' # should be checked on the highest supported PHP version
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '8.3'
-            job-description: 'Fixer with Symfony ^7'
-            run-fixer: 'yes'
-            execute-flex-with-symfony-version: '^7' # explicit check for Symfony 7.x compatibility
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '8.3'
-            job-description: 'tests with Symfony ^7'
-            run-tests: 'yes'
-            execute-flex-with-symfony-version: '^7' # explicit check for Symfony 7.x compatibility
-
-          - operating-system: 'ubuntu-20.04'
-            php-version: '8.3'
-            job-description: 'code coverage'
-            run-tests: 'yes'
-            collect-code-coverage: 'yes'
-
-          - operating-system: 'windows-latest'
-            php-version: '8.3'
-            job-description: 'Fixer on Windows'
-            run-fixer: 'yes'
-            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional
-
-          - operating-system: 'windows-latest'
-            php-version: '8.3'
-            job-description: 'tests on Windows'
-            run-tests: 'yes'
-            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional systems
-
-          - operating-system: 'macos-latest'
-            php-version: '8.3'
-            job-description: 'Fixer on macOS'
-            run-fixer: 'yes'
-            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional systems
-
-          - operating-system: 'macos-latest'
-            php-version: '8.3'
-            job-description: 'tests on macOS'
-            run-tests: 'yes'
-            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional
-
-          - operating-system: 'ubuntu-22.04'
-            php-version: '8.4'
-            job-description: 'Fixer'
-            run-fixer: 'yes'
-            PHP_CS_FIXER_IGNORE_ENV: 1
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '7.4'
+#            job-description: 'Fixer with lowest deps'
+#            run-fixer: 'yes'
+#            composer-flags: '--prefer-lowest' # should be checked on the lowest supported PHP version
+#            execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
+#
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '7.4'
+#            job-description: 'tests with lowest deps'
+#            run-tests: 'yes'
+#            composer-flags: '--prefer-lowest' # should be checked on the lowest supported PHP version
+#            execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
+#
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '8.0'
+#            job-description: 'Fixer'
+#            run-fixer: 'yes'
+#
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '8.0'
+#            job-description: 'tests'
+#            run-tests: 'yes'
+#
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '8.1'
+#            job-description: 'Fixer with Symfony ^6'
+#            run-fixer: 'yes'
+#            execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
+#
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '8.1'
+#            job-description: 'tests with Symfony ^6'
+#            run-tests: 'yes'
+#            execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
+#
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '8.2'
+#            job-description: 'Fixer'
+#            run-fixer: 'yes'
+#
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '8.2'
+#            job-description: 'tests'
+#            run-tests: 'yes'
+#
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '8.3'
+#            job-description: 'Fixer'
+#            run-fixer: 'yes'
+#
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '8.3'
+#            job-description: 'tests'
+#            run-tests: 'yes'
+#
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '8.3'
+#            job-description: 'Fixer with migration rules'
+#            run-fixer: 'yes'
+#            run-migration-rules: 'yes' # should be checked on the highest supported PHP version
+#
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '8.3'
+#            job-description: 'tests with migration rules'
+#            run-tests: 'yes'
+#            run-migration-rules: 'yes' # should be checked on the highest supported PHP version
+#
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '8.3'
+#            job-description: 'Fixer with Symfony ^7'
+#            run-fixer: 'yes'
+#            execute-flex-with-symfony-version: '^7' # explicit check for Symfony 7.x compatibility
+#
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '8.3'
+#            job-description: 'tests with Symfony ^7'
+#            run-tests: 'yes'
+#            execute-flex-with-symfony-version: '^7' # explicit check for Symfony 7.x compatibility
+#
+#          - operating-system: 'ubuntu-20.04'
+#            php-version: '8.3'
+#            job-description: 'code coverage'
+#            run-tests: 'yes'
+#            collect-code-coverage: 'yes'
+#
+#          - operating-system: 'windows-latest'
+#            php-version: '8.3'
+#            job-description: 'Fixer on Windows'
+#            run-fixer: 'yes'
+#            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional
+#
+#          - operating-system: 'windows-latest'
+#            php-version: '8.3'
+#            job-description: 'tests on Windows'
+#            run-tests: 'yes'
+#            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional systems
+#
+#          - operating-system: 'macos-latest'
+#            php-version: '8.3'
+#            job-description: 'Fixer on macOS'
+#            run-fixer: 'yes'
+#            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional systems
+#
+#          - operating-system: 'macos-latest'
+#            php-version: '8.3'
+#            job-description: 'tests on macOS'
+#            run-tests: 'yes'
+#            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional
+#
+#          - operating-system: 'ubuntu-22.04'
+#            php-version: '8.4'
+#            job-description: 'Fixer'
+#            run-fixer: 'yes'
+#            PHP_CS_FIXER_IGNORE_ENV: 1
 
           - operating-system: 'ubuntu-22.04'
             php-version: '8.4'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,121 +21,121 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '7.4'
-#            job-description: 'Fixer with lowest deps'
-#            run-fixer: 'yes'
-#            composer-flags: '--prefer-lowest' # should be checked on the lowest supported PHP version
-#            execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
-#
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '7.4'
-#            job-description: 'tests with lowest deps'
-#            run-tests: 'yes'
-#            composer-flags: '--prefer-lowest' # should be checked on the lowest supported PHP version
-#            execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
-#
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '8.0'
-#            job-description: 'Fixer'
-#            run-fixer: 'yes'
-#
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '8.0'
-#            job-description: 'tests'
-#            run-tests: 'yes'
-#
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '8.1'
-#            job-description: 'Fixer with Symfony ^6'
-#            run-fixer: 'yes'
-#            execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
-#
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '8.1'
-#            job-description: 'tests with Symfony ^6'
-#            run-tests: 'yes'
-#            execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
-#
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '8.2'
-#            job-description: 'Fixer'
-#            run-fixer: 'yes'
-#
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '8.2'
-#            job-description: 'tests'
-#            run-tests: 'yes'
-#
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '8.3'
-#            job-description: 'Fixer'
-#            run-fixer: 'yes'
-#
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '8.3'
-#            job-description: 'tests'
-#            run-tests: 'yes'
-#
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '8.3'
-#            job-description: 'Fixer with migration rules'
-#            run-fixer: 'yes'
-#            run-migration-rules: 'yes' # should be checked on the highest supported PHP version
-#
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '8.3'
-#            job-description: 'tests with migration rules'
-#            run-tests: 'yes'
-#            run-migration-rules: 'yes' # should be checked on the highest supported PHP version
-#
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '8.3'
-#            job-description: 'Fixer with Symfony ^7'
-#            run-fixer: 'yes'
-#            execute-flex-with-symfony-version: '^7' # explicit check for Symfony 7.x compatibility
-#
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '8.3'
-#            job-description: 'tests with Symfony ^7'
-#            run-tests: 'yes'
-#            execute-flex-with-symfony-version: '^7' # explicit check for Symfony 7.x compatibility
-#
-#          - operating-system: 'ubuntu-20.04'
-#            php-version: '8.3'
-#            job-description: 'code coverage'
-#            run-tests: 'yes'
-#            collect-code-coverage: 'yes'
-#
-#          - operating-system: 'windows-latest'
-#            php-version: '8.3'
-#            job-description: 'Fixer on Windows'
-#            run-fixer: 'yes'
-#            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional
-#
-#          - operating-system: 'windows-latest'
-#            php-version: '8.3'
-#            job-description: 'tests on Windows'
-#            run-tests: 'yes'
-#            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional systems
-#
-#          - operating-system: 'macos-latest'
-#            php-version: '8.3'
-#            job-description: 'Fixer on macOS'
-#            run-fixer: 'yes'
-#            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional systems
-#
-#          - operating-system: 'macos-latest'
-#            php-version: '8.3'
-#            job-description: 'tests on macOS'
-#            run-tests: 'yes'
-#            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional
-#
-#          - operating-system: 'ubuntu-22.04'
-#            php-version: '8.4'
-#            job-description: 'Fixer'
-#            run-fixer: 'yes'
-#            PHP_CS_FIXER_IGNORE_ENV: 1
+          - operating-system: 'ubuntu-20.04'
+            php-version: '7.4'
+            job-description: 'Fixer with lowest deps'
+            run-fixer: 'yes'
+            composer-flags: '--prefer-lowest' # should be checked on the lowest supported PHP version
+            execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '7.4'
+            job-description: 'tests with lowest deps'
+            run-tests: 'yes'
+            composer-flags: '--prefer-lowest' # should be checked on the lowest supported PHP version
+            execute-flex-with-symfony-version: '^5' # explicit check for Symfony 5.x compatibility
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.0'
+            job-description: 'Fixer'
+            run-fixer: 'yes'
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.0'
+            job-description: 'tests'
+            run-tests: 'yes'
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.1'
+            job-description: 'Fixer with Symfony ^6'
+            run-fixer: 'yes'
+            execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.1'
+            job-description: 'tests with Symfony ^6'
+            run-tests: 'yes'
+            execute-flex-with-symfony-version: '^6' # explicit check for Symfony 6.x compatibility
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.2'
+            job-description: 'Fixer'
+            run-fixer: 'yes'
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.2'
+            job-description: 'tests'
+            run-tests: 'yes'
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.3'
+            job-description: 'Fixer'
+            run-fixer: 'yes'
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.3'
+            job-description: 'tests'
+            run-tests: 'yes'
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.3'
+            job-description: 'Fixer with migration rules'
+            run-fixer: 'yes'
+            run-migration-rules: 'yes' # should be checked on the highest supported PHP version
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.3'
+            job-description: 'tests with migration rules'
+            run-tests: 'yes'
+            run-migration-rules: 'yes' # should be checked on the highest supported PHP version
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.3'
+            job-description: 'Fixer with Symfony ^7'
+            run-fixer: 'yes'
+            execute-flex-with-symfony-version: '^7' # explicit check for Symfony 7.x compatibility
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.3'
+            job-description: 'tests with Symfony ^7'
+            run-tests: 'yes'
+            execute-flex-with-symfony-version: '^7' # explicit check for Symfony 7.x compatibility
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.3'
+            job-description: 'code coverage'
+            run-tests: 'yes'
+            collect-code-coverage: 'yes'
+
+          - operating-system: 'windows-latest'
+            php-version: '8.3'
+            job-description: 'Fixer on Windows'
+            run-fixer: 'yes'
+            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional
+
+          - operating-system: 'windows-latest'
+            php-version: '8.3'
+            job-description: 'tests on Windows'
+            run-tests: 'yes'
+            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional systems
+
+          - operating-system: 'macos-latest'
+            php-version: '8.3'
+            job-description: 'Fixer on macOS'
+            run-fixer: 'yes'
+            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional systems
+
+          - operating-system: 'macos-latest'
+            php-version: '8.3'
+            job-description: 'tests on macOS'
+            run-tests: 'yes'
+            FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional
+
+          - operating-system: 'ubuntu-22.04'
+            php-version: '8.4'
+            job-description: 'Fixer'
+            run-fixer: 'yes'
+            PHP_CS_FIXER_IGNORE_ENV: 1
 
           - operating-system: 'ubuntu-22.04'
             php-version: '8.4'

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -287,6 +287,7 @@ class Tokens extends \SplFixedArray
      *
      * @param int $size
      */
+    #[\ReturnTypeWillChange]
     public function setSize($size): bool
     {
         if ($this->getSize() !== $size) {


### PR DESCRIPTION
This time new error was:

> Return type of PhpCsFixer\Tokenizer\Tokens::setSize($size): bool should either be compatible with SplFixedArray::setSize(int $size): true, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice