### PR TITLE
fix: Add initial in-statements indent support

### DIFF
--- a/src/Fixer/ClassNotation/FinalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalClassFixer.php
@@ -36,10 +36,10 @@ class MyApp {}
                 ),
             ],
             'No exception and no configuration are intentional. Beside Doctrine entities and of course abstract classes, there is no single reason not to declare all classes final. '
-            .'If you want to subclass a class, mark the parent class as abstract and create two child classes, one empty if necessary: you\'ll gain much more fine grained type-hinting. '
-            .'If you need to mock a standalone class, create an interface, or maybe it\'s a value-object that shouldn\'t be mocked at all. '
-            .'If you need to extend a standalone class, create an interface and use the Composite pattern. '
-            .'If you aren\'t ready yet for serious OOP, go with FinalInternalClassFixer, it\'s fine.',
+                .'If you want to subclass a class, mark the parent class as abstract and create two child classes, one empty if necessary: you\'ll gain much more fine grained type-hinting. '
+                .'If you need to mock a standalone class, create an interface, or maybe it\'s a value-object that shouldn\'t be mocked at all. '
+                .'If you need to extend a standalone class, create an interface and use the Composite pattern. '
+                .'If you aren\'t ready yet for serious OOP, go with FinalInternalClassFixer, it\'s fine.',
             'Risky when subclassing non-abstract classes.'
         );
     }

--- a/src/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixer.php
@@ -64,7 +64,7 @@ abstract class AbstractMachine
                 ),
             ],
             'Enforce API encapsulation in an inheritance architecture. '
-            .'If you want to override a method, use the Template method pattern.',
+                .'If you want to override a method, use the Template method pattern.',
             'Risky when overriding `public` methods of `abstract` classes.'
         );
     }

--- a/src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+++ b/src/Fixer/ClassNotation/OrderedInterfacesFixer.php
@@ -178,8 +178,8 @@ final class OrderedInterfacesFixer extends AbstractFixer implements Configurable
                     ? \strlen($first['normalized']) - \strlen($second['normalized'])
                     : (
                         true === $this->configuration['case_sensitive']
-                        ? $first['normalized'] <=> $second['normalized']
-                        : strcasecmp($first['normalized'], $second['normalized'])
+                            ? $first['normalized'] <=> $second['normalized']
+                            : strcasecmp($first['normalized'], $second['normalized'])
                     );
 
                 if (self::DIRECTION_DESCEND === $this->configuration[self::OPTION_DIRECTION]) {

--- a/src/Fixer/FunctionNotation/VoidReturnFixer.php
+++ b/src/Fixer/FunctionNotation/VoidReturnFixer.php
@@ -176,7 +176,7 @@ final class VoidReturnFixer extends AbstractFixer
             if (
                 // skip anonymous classes
                 ($tokens[$i]->isGivenKind(T_CLASS) && $tokensAnalyzer->isAnonymousClass($i))
-                 // skip lambda functions
+                // skip lambda functions
                 || ($tokens[$i]->isGivenKind(T_FUNCTION) && $tokensAnalyzer->isLambda($i))
             ) {
                 $i = $tokens->getNextTokenOfKind($i, ['{']);

--- a/src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+++ b/src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
@@ -34,9 +34,9 @@ final class NoUnsetOnPropertyFixer extends AbstractFixer
             [new CodeSample("<?php\nunset(\$this->a);\n")],
             null,
             'Risky when relying on attributes to be removed using `unset` rather than be set to `null`.'.
-            ' Changing variables to `null` instead of unsetting means these still show up when looping over class variables'.
-            ' and reference properties remain unbroken.'.
-            ' With PHP 7.4, this rule might introduce `null` assignments to properties whose type declaration does not allow it.'
+                ' Changing variables to `null` instead of unsetting means these still show up when looping over class variables'.
+                ' and reference properties remain unbroken.'.
+                ' With PHP 7.4, this rule might introduce `null` assignments to properties whose type declaration does not allow it.'
         );
     }
 

--- a/src/Fixer/PhpUnit/PhpUnitDataProviderStaticFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDataProviderStaticFixer.php
@@ -93,8 +93,8 @@ class FooTest extends TestCase {
             (new FixerOptionBuilder(
                 'force',
                 'Whether to make the data providers static even if they have a dynamic class call'
-                .' (may introduce fatal error "using $this when not in object context",'
-                .' and you may have to adjust the code manually by converting dynamic calls to static ones).'
+                    .' (may introduce fatal error "using $this when not in object context",'
+                    .' and you may have to adjust the code manually by converting dynamic calls to static ones).'
             ))
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)

--- a/src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
@@ -68,9 +68,9 @@ final class MyTest extends \PHPUnit_Framework_TestCase
                 new CodeSample($codeSample, ['target' => PhpUnitTargetVersion::VERSION_4_8]),
             ],
             "PHPUnit v6 has finally fully switched to namespaces.\n"
-            ."You could start preparing the upgrade by switching from non-namespaced TestCase to namespaced one.\n"
-            .'Forward compatibility layer (`\PHPUnit\Framework\TestCase` class) was backported to PHPUnit v4.8.35 and PHPUnit v5.4.0.'."\n"
-            .'Extended forward compatibility layer (`PHPUnit\Framework\Assert`, `PHPUnit\Framework\BaseTestListener`, `PHPUnit\Framework\TestListener` classes) was introduced in v5.7.0.'."\n",
+                ."You could start preparing the upgrade by switching from non-namespaced TestCase to namespaced one.\n"
+                .'Forward compatibility layer (`\PHPUnit\Framework\TestCase` class) was backported to PHPUnit v4.8.35 and PHPUnit v5.4.0.'."\n"
+                .'Extended forward compatibility layer (`PHPUnit\Framework\Assert`, `PHPUnit\Framework\BaseTestListener`, `PHPUnit\Framework\TestListener` classes) was introduced in v5.7.0.'."\n",
             'Risky when PHPUnit classes are overridden or not accessible, or when project has PHPUnit incompatibilities.'
         );
     }

--- a/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
@@ -52,7 +52,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             ],
             null,
             'This fixer may change functions named `setUp()` or `tearDown()` outside of PHPUnit tests, '.
-            'when a class is wrongly seen as a PHPUnit test.'
+                'when a class is wrongly seen as a PHPUnit test.'
         );
     }
 

--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -60,7 +60,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
             ],
             null,
             'This fixer may change the name of your tests, and could cause incompatibility with'.
-            ' abstract classes or interfaces.'
+                ' abstract classes or interfaces.'
         );
     }
 

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -373,8 +373,8 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
                         .$item['var']
                         .(
                             '' !== $item['desc']
-                            ? $this->getIndent($varMax - \strlen($item['var']) + $spacingForTag, $spacingForTag).$item['desc']
-                            : ''
+                                ? $this->getIndent($varMax - \strlen($item['var']) + $spacingForTag, $spacingForTag).$item['desc']
+                                : ''
                         );
                 } elseif ('' !== $item['desc']) {
                     $line .= $this->getIndent($hintMax - \strlen($item['hint']) + $spacingForTag, $spacingForTag).$item['desc'];

--- a/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
@@ -154,13 +154,13 @@ final class PhpdocSeparationFixer extends AbstractFixer implements ConfigurableF
                         if ($groupIndex === $tags[$member]) {
                             throw new InvalidOptionsException(
                                 'The option "groups" value is invalid. '.
-                                'The "'.$member.'" tag is specified more than once.'
+                                    'The "'.$member.'" tag is specified more than once.'
                             );
                         }
 
                         throw new InvalidOptionsException(
                             'The option "groups" value is invalid. '.
-                            'The "'.$member.'" tag belongs to more than one group.'
+                                'The "'.$member.'" tag belongs to more than one group.'
                         );
                     }
                     $tags[$member] = $groupIndex;

--- a/src/Fixer/StringNotation/EscapeImplicitBackslashesFixer.php
+++ b/src/Fixer/StringNotation/EscapeImplicitBackslashesFixer.php
@@ -70,12 +70,12 @@ final class EscapeImplicitBackslashesFixer extends AbstractProxyFixer implements
                 ),
             ],
             'In PHP double-quoted strings and heredocs some chars like `n`, `$` or `u` have special meanings if preceded by a backslash '
-            .'(and some are special only if followed by other special chars), while a backslash preceding other chars are interpreted like a plain '
-            .'backslash. The precise list of those special chars is hard to remember and to identify quickly: this fixer escapes backslashes '
-            ."that do not start a special interpretation with the char after them.\n"
-            .'It is possible to fix also single-quoted strings: in this case there is no special chars apart from single-quote and backslash '
-            .'itself, so the fixer simply ensure that all backslashes are escaped. Both single and double backslashes are allowed in single-quoted '
-            .'strings, so the purpose in this context is mainly to have a uniformed way to have them written all over the codebase.'
+                .'(and some are special only if followed by other special chars), while a backslash preceding other chars are interpreted like a plain '
+                .'backslash. The precise list of those special chars is hard to remember and to identify quickly: this fixer escapes backslashes '
+                ."that do not start a special interpretation with the char after them.\n"
+                .'It is possible to fix also single-quoted strings: in this case there is no special chars apart from single-quote and backslash '
+                .'itself, so the fixer simply ensure that all backslashes are escaped. Both single and double backslashes are allowed in single-quoted '
+                .'strings, so the purpose in this context is mainly to have a uniformed way to have them written all over the codebase.'
         );
     }
 

--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -45,7 +45,7 @@ final class ExplicitStringVariableFixer extends AbstractFixer
                 ."\n".'- PHP manual marks `"$var"` syntax as implicit and `"${var}"` syntax as explicit: explicit code should always be preferred.'
                 ."\n".'- Explicit syntax allows word concatenation inside strings, e.g. `"${var}IsAVar"`, implicit doesn\'t.'
                 ."\n".'- Explicit syntax is easier to detect for IDE/editors and therefore has colors/highlight with higher contrast, which is easier to read.'
-            ."\n".'Backtick operator is skipped because it is harder to handle; you can use `backtick_to_shell_exec` fixer to normalize backticks to strings.'
+                ."\n".'Backtick operator is skipped because it is harder to handle; you can use `backtick_to_shell_exec` fixer to normalize backticks to strings.'
         );
     }
 

--- a/src/Fixer/StringNotation/StringImplicitBackslashesFixer.php
+++ b/src/Fixer/StringNotation/StringImplicitBackslashesFixer.php
@@ -65,12 +65,12 @@ final class StringImplicitBackslashesFixer extends AbstractFixer implements Conf
                 ),
             ],
             'In PHP double-quoted strings and heredocs some chars like `n`, `$` or `u` have special meanings if preceded by a backslash '
-            .'(and some are special only if followed by other special chars), while a backslash preceding other chars are interpreted like a plain '
-            .'backslash. The precise list of those special chars is hard to remember and to identify quickly: this fixer escapes backslashes '
-            ."that do not start a special interpretation with the char after them.\n"
-            .'It is possible to fix also single-quoted strings: in this case there is no special chars apart from single-quote and backslash '
-            .'itself, so the fixer simply ensure that all backslashes are escaped. Both single and double backslashes are allowed in single-quoted '
-            .'strings, so the purpose in this context is mainly to have a uniformed way to have them written all over the codebase.'
+                .'(and some are special only if followed by other special chars), while a backslash preceding other chars are interpreted like a plain '
+                .'backslash. The precise list of those special chars is hard to remember and to identify quickly: this fixer escapes backslashes '
+                ."that do not start a special interpretation with the char after them.\n"
+                .'It is possible to fix also single-quoted strings: in this case there is no special chars apart from single-quote and backslash '
+                .'itself, so the fixer simply ensure that all backslashes are escaped. Both single and double backslashes are allowed in single-quoted '
+                .'strings, so the purpose in this context is mainly to have a uniformed way to have them written all over the codebase.'
         );
     }
 

--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -136,6 +136,8 @@ if ($foo) {
             T_CASE,
             T_DEFAULT,
             T_TRY,
+            T_CATCH,
+            T_FINALLY,
             T_CLASS,
             T_INTERFACE,
             T_TRAIT,
@@ -143,6 +145,10 @@ if ($foo) {
             T_IMPLEMENTS,
             T_CONST,
         ];
+        if (\defined('T_ENUM')) { // @TODO: drop condition when PHP 8.1+ is required
+            $blockSignatureFirstTokens[] = T_ENUM;
+        }
+
         $controlStructurePossibiblyWithoutBracesTokens = [
             T_IF,
             T_ELSE,
@@ -156,7 +162,12 @@ if ($foo) {
             $blockSignatureFirstTokens[] = T_MATCH;
         }
 
-        $blockFirstTokens = ['{', [CT::T_DESTRUCTURING_SQUARE_BRACE_OPEN], [CT::T_USE_TRAIT], [CT::T_GROUP_IMPORT_BRACE_OPEN]];
+        $blockFirstTokens = [
+            '{',
+            [CT::T_DESTRUCTURING_SQUARE_BRACE_OPEN],
+            [CT::T_USE_TRAIT],
+            [CT::T_GROUP_IMPORT_BRACE_OPEN],
+        ];
         if (\defined('T_ATTRIBUTE')) { // @TODO: drop condition when PHP 8.0+ is required
             $blockFirstTokens[] = [T_ATTRIBUTE];
         }
@@ -174,13 +185,15 @@ if ($foo) {
 
         /**
          * @var list<array{
-         *     type: 'block'|'block_signature'|'statement',
+         *     type: 'block'|'block_signature'|'statement'|'array'|'array_access',
          *     skip: bool,
          *     end_index: int,
          *     end_index_inclusive: bool,
          *     initial_indent: string,
+         *     base_indent: string,
          *     new_indent?: string,
          *     is_indented_block: bool,
+         *     statement_inner_indent: bool,
          * }> $scopes
          */
         $scopes = [
@@ -190,7 +203,9 @@ if ($foo) {
                 'end_index' => $endIndex,
                 'end_index_inclusive' => true,
                 'initial_indent' => $lastIndent,
+                'base_indent' => $lastIndent,
                 'is_indented_block' => false,
+                'statement_inner_indent' => true,
             ],
         ];
 
@@ -204,13 +219,17 @@ if ($foo) {
             $currentScope = \count($scopes) - 1;
 
             if (isset($noBracesBlockStarts[$index])) {
+                $currentIndent = $this->getLineIndentationWithBracesCompatibility($tokens, $index, $lastIndent);
+
                 $scopes[] = [
                     'type' => 'block',
                     'skip' => false,
                     'end_index' => $this->findStatementEndIndex($tokens, $index, \count($tokens) - 1),
                     'end_index_inclusive' => true,
-                    'initial_indent' => $this->getLineIndentationWithBracesCompatibility($tokens, $index, $lastIndent),
+                    'initial_indent' => $currentIndent,
+                    'base_indent' => $currentIndent,
                     'is_indented_block' => true,
+                    'statement_inner_indent' => true,
                 ];
                 ++$currentScope;
             }
@@ -262,13 +281,27 @@ if ($foo) {
                     }
                 }
 
+                $innerIndent = true;
+                if ($token->equals('(')) {
+                    $prevToken = $tokens[$tokens->getPrevMeaningfulToken($index)];
+
+                    if (
+                        !$prevToken->isGivenKind([T_ARRAY, T_STRING, T_VARIABLE, T_FN, T_FUNCTION, T_CLASS, CT::T_BRACE_CLASS_INSTANTIATION_CLOSE])
+                        && !$prevToken->equals(')')
+                    ) {
+                        $innerIndent = false;
+                    }
+                }
+
                 $scopes[] = [
                     'type' => 'block',
                     'skip' => $skip,
                     'end_index' => $endIndex,
                     'end_index_inclusive' => $endIndexInclusive,
                     'initial_indent' => $initialIndent,
+                    'base_indent' => $initialIndent,
                     'is_indented_block' => true,
+                    'statement_inner_indent' => $innerIndent,
                 ];
                 ++$currentScope;
 
@@ -281,20 +314,48 @@ if ($foo) {
                 continue;
             }
 
+            while ($index >= $scopes[$currentScope]['end_index']) {
+                array_pop($scopes);
+
+                if ([] === $scopes) {
+                    return;
+                }
+
+                --$currentScope;
+            }
+
             if (
                 $token->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN)
-                || ($token->equals('(') && $tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind(T_ARRAY))
+                || $token->equals('(')
             ) {
                 $blockType = $token->equals('(') ? Tokens::BLOCK_TYPE_PARENTHESIS_BRACE : Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE;
 
                 $scopes[] = [
-                    'type' => 'statement',
-                    'skip' => true,
+                    'type' => 'array',
+                    'skip' => false,
                     'end_index' => $tokens->findBlockEnd($blockType, $index),
                     'end_index_inclusive' => true,
                     'initial_indent' => $previousLineInitialIndent,
+                    'base_indent' => $previousLineInitialIndent,
                     'new_indent' => $previousLineNewIndent,
-                    'is_indented_block' => false,
+                    'is_indented_block' => true,
+                    'statement_inner_indent' => true,
+                ];
+
+                continue;
+            }
+
+            if ($token->equals('[')) {
+                $scopes[] = [
+                    'type' => 'array_access',
+                    'skip' => false,
+                    'end_index' => $tokens->findBlockEnd(Tokens::BLOCK_TYPE_INDEX_SQUARE_BRACE, $index),
+                    'end_index_inclusive' => true,
+                    'initial_indent' => $previousLineInitialIndent,
+                    'base_indent' => $previousLineInitialIndent,
+                    'new_indent' => $previousLineNewIndent,
+                    'is_indented_block' => true,
+                    'statement_inner_indent' => true,
                 ];
 
                 continue;
@@ -349,13 +410,17 @@ if ($foo) {
                     }
                 }
 
+                $currentIndent = $this->getLineIndentationWithBracesCompatibility($tokens, $index, $lastIndent);
+
                 $scopes[] = [
                     'type' => 'block_signature',
                     'skip' => false,
                     'end_index' => $endIndex,
                     'end_index_inclusive' => true,
-                    'initial_indent' => $this->getLineIndentationWithBracesCompatibility($tokens, $index, $lastIndent),
+                    'initial_indent' => $currentIndent,
+                    'base_indent' => $currentIndent,
                     'is_indented_block' => $isPropertyStart || $token->isGivenKind([T_EXTENDS, T_IMPLEMENTS, T_CONST]),
+                    'statement_inner_indent' => true,
                 ];
 
                 continue;
@@ -376,16 +441,38 @@ if ($foo) {
                     }
                 }
 
+                $currentIndent = $this->getLineIndentationWithBracesCompatibility($tokens, $index, $lastIndent);
+
                 $scopes[] = [
                     'type' => 'block_signature',
                     'skip' => false,
                     'end_index' => $endIndex,
                     'end_index_inclusive' => true,
-                    'initial_indent' => $this->getLineIndentationWithBracesCompatibility($tokens, $index, $lastIndent),
+                    'initial_indent' => $currentIndent,
+                    'base_indent' => $currentIndent,
                     'is_indented_block' => false,
+                    'statement_inner_indent' => true,
                 ];
 
                 continue;
+            }
+
+            $nextToken = $tokens->getNextMeaningfulToken($index);
+            if (
+                null !== $nextToken
+                && $tokens[$nextToken]->equals('?')
+            ) {
+                $scopes[] = [
+                    'type' => 'statement',
+                    'skip' => false,
+                    'end_index' => $this->findStatementEndIndex($tokens, $index, $scopes[$currentScope]['end_index']),
+                    'end_index_inclusive' => true,
+                    'initial_indent' => $previousLineInitialIndent,
+                    'new_indent' => $previousLineNewIndent,
+                    'base_indent' => $this->getLineIndentationWithBracesCompatibility($tokens, $index, $lastIndent),
+                    'is_indented_block' => true,
+                    'statement_inner_indent' => true,
+                ];
             }
 
             if (
@@ -413,7 +500,10 @@ if ($foo) {
                     continue;
                 }
 
-                if ('block' === $scopes[$currentScope]['type'] || 'block_signature' === $scopes[$currentScope]['type']) {
+                if (
+                    'array' !== $scopes[$currentScope]['type']
+                    && (null === $nextToken || !$nextToken->isGivenKind(T_OBJECT_OPERATOR))
+                ) {
                     $indent = false;
 
                     if ($scopes[$currentScope]['is_indented_block']) {
@@ -464,9 +554,11 @@ if ($foo) {
                                     $nextIndex = $tokens->getNextMeaningfulToken($firstNonWhitespaceTokenIndex);
                                     $nextNextIndex = $tokens->getNextMeaningfulToken($nextIndex);
 
-                                    if (null !== $nextNextIndex && $tokens[$nextNextIndex]->isGivenKind([T_ELSE, T_ELSEIF])) {
-                                        $indent = true !== $this->configuration['stick_comment_to_next_continuous_control_statement'];
-                                    } else {
+                                    if (
+                                        null === $nextNextIndex
+                                        || !$tokens[$nextNextIndex]->isGivenKind([T_ELSE, T_ELSEIF])
+                                        || false === $this->configuration['stick_comment_to_next_continuous_control_statement']
+                                    ) {
                                         $indent = true;
                                     }
                                 }
@@ -481,7 +573,20 @@ if ($foo) {
                     if ($scopes[$currentScope]['skip']) {
                         $whitespaces = $previousLineInitialIndent;
                     } else {
-                        $whitespaces = $scopes[$currentScope]['initial_indent'].($indent ? $this->whitespacesConfig->getIndent() : '');
+                        $baseIndent = $scopes[$currentScope]['base_indent'];
+
+                        if ('statement' === $scopes[$currentScope]['type'] && !$scopes[$currentScope]['statement_inner_indent']) {
+                            $indent = false;
+                        }
+
+                        $whitespaces = $baseIndent.($indent ? $this->whitespacesConfig->getIndent() : '');
+
+                        if ('statement' === $scopes[$currentScope]['type']) {
+                            $minimumIndent = $scopes[$currentScope - 1]['base_indent'].$this->whitespacesConfig->getIndent();
+                            if (\strlen($minimumIndent) > \strlen($whitespaces)) {
+                                $whitespaces = $minimumIndent;
+                            }
+                        }
                     }
 
                     $content = Preg::replace(
@@ -531,21 +636,11 @@ if ($foo) {
                 $lastIndent = $this->extractIndent($this->computeNewLineContent($tokens, $index));
             }
 
-            while ($index >= $scopes[$currentScope]['end_index']) {
-                array_pop($scopes);
-
-                if ([] === $scopes) {
-                    return;
-                }
-
-                --$currentScope;
-            }
-
             if ($token->isComment() || $token->equalsAny([';', ',', '}', [T_OPEN_TAG], [T_CLOSE_TAG], [CT::T_ATTRIBUTE_CLOSE]])) {
                 continue;
             }
 
-            if ('statement' !== $scopes[$currentScope]['type'] && 'block_signature' !== $scopes[$currentScope]['type']) {
+            if (0 !== $index && 'block' === $scopes[$currentScope]['type']) {
                 $endIndex = $this->findStatementEndIndex($tokens, $index, $scopes[$currentScope]['end_index']);
 
                 if ($endIndex === $index) {
@@ -559,7 +654,9 @@ if ($foo) {
                     'end_index_inclusive' => false,
                     'initial_indent' => $previousLineInitialIndent,
                     'new_indent' => $previousLineNewIndent,
+                    'base_indent' => $this->getLineIndentationWithBracesCompatibility($tokens, $index, $lastIndent),
                     'is_indented_block' => true,
+                    'statement_inner_indent' => $scopes[$currentScope]['statement_inner_indent'] && !$token->isGivenKind(T_INLINE_HTML),
                 ];
             }
         }

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -436,7 +436,7 @@ $/s',
         ]);
 
         $expected =
-"Description of the `Vendor/describe_fixture` rule.
+            "Description of the `Vendor/describe_fixture` rule.
 
 Fixture for describe command.
 

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -36,7 +36,7 @@ final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
     public static function provideFixCases(): iterable
     {
         yield // Do not fix cases.
-        ['<?php $x = isset($a) ? $a[1] : null;'];
+            ['<?php $x = isset($a) ? $a[1] : null;'];
 
         yield ['<?php $x = isset($a) and $a ? $a : "";'];
 

--- a/tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
@@ -423,8 +423,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
 
     public static function provideWithWhitespacesConfigCases(): iterable
     {
-        $expectedTemplate =
-'
+        $expectedTemplate = '
         function testFnc%d()
         {
             aaa();
@@ -434,8 +433,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             zzz();
         }
 ';
-        $inputTemplate =
-'
+        $inputTemplate = '
         function testFnc%d()
         {
             aaa();

--- a/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
@@ -656,7 +656,7 @@ final class PhpdocSeparationFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage(
             'The option "groups" value is invalid. '.
-            'The "param" tag belongs to more than one group.'
+                'The "param" tag belongs to more than one group.'
         );
 
         $this->fixer->configure(['groups' => [['param', 'return'], ['param', 'throws']]]);
@@ -667,7 +667,7 @@ final class PhpdocSeparationFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage(
             'The option "groups" value is invalid. '.
-            'The "param" tag is specified more than once.'
+                'The "param" tag is specified more than once.'
         );
 
         $this->fixer->configure(['groups' => [['param', 'return', 'param', 'throws']]]);

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -589,8 +589,8 @@ foo(
             '<?php
 if (true) {
     $foo =
-         $a
-             && $b
+        $a
+        && $b
     ;
 }',
             '<?php
@@ -605,7 +605,7 @@ if (true) {
         yield 'multiline control structure conditions' => [
             '<?php
 if ($a
-       && $b) {
+    && $b) {
     foo();
 }',
             '<?php
@@ -1473,6 +1473,212 @@ $foo = [
                     public int $bar = BAZ ? -1 : 1;
                 }
                 PHP
+        ];
+
+        yield 'multiline if condition' => [
+            '<?php
+if (
+    true
+    || false
+) {
+}',
+            '<?php
+if (
+ true
+      || false
+) {
+}',
+        ];
+
+        yield 'multiline return' => [
+            '<?php
+if (true) {
+    return
+        $a
+        && $b
+    ;
+}',
+            '<?php
+if (true) {
+  return
+          $a
+           && $b
+   ;
+}',
+        ];
+
+        yield 'multiline continue' => [
+            '<?php
+while (true) {
+    continue
+        1
+    ;
+}',
+            '<?php
+while (true) {
+   continue
+           1
+  ;
+}',
+        ];
+
+        yield 'multiline break' => [
+            '<?php
+while (true) {
+    break
+        1
+    ;
+}',
+            '<?php
+while (true) {
+   break
+           1
+  ;
+}',
+        ];
+
+        yield 'multiline throw' => [
+            '<?php
+if (true) {
+    throw
+        new \Exception()
+    ;
+}',
+            '<?php
+if (true) {
+      throw
+     new \Exception()
+   ;
+}',
+        ];
+
+        yield 'multiline yield' => [
+            '<?php
+function foo() {
+    yield
+        1
+    ;
+}',
+            '<?php
+function foo() {
+      yield
+     1
+   ;
+}',
+        ];
+
+        yield 'multiline ternary' => [
+            '<?php
+if (true) {
+    $foo
+        ? bar()
+        : baz()
+    ;
+}',
+            '<?php
+if (true) {
+      $foo
+    ? bar()
+   : baz()
+  ;
+}',
+        ];
+
+        yield 'strict types in file with shebang' => [
+            '#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);',
+            '#!/usr/bin/env php
+<?php
+
+  declare(strict_types=1);',
+        ];
+
+        yield 'expression in parentheses' => [
+            '<?php
+(
+    1
+    + 2
+);',
+            '<?php
+(
+  1
+   + 2
+);',
+        ];
+
+        yield 'multiline array index write access' => [
+            '<?php
+$a[
+    1
+] = 2;',
+            '<?php
+$a[
+  1
+] = 2;',
+        ];
+
+        yield 'multiline array index read access' => [
+            '<?php
+$a[
+    1
+];',
+            '<?php
+$a[
+  1
+];',
+        ];
+
+        yield 'ternary in parentheses with operators at beginning of lines' => [
+            '<?php
+(
+    $foo
+        ? 1
+        : 2
+);',
+            '<?php
+(
+ $foo
+  ? 1
+   : 2
+);',
+        ];
+
+        yield 'ternary in parentheses with operators at end of lines' => [
+            '<?php
+(
+    $foo ?
+        1 :
+        2
+);',
+            '<?php
+(
+ $foo ?
+  1 :
+   2
+);',
+        ];
+
+        yield 'ternary after expression in parentheses' => [
+            '<?php
+$a = (true)
+    ? 1
+    : 2;
+',
+        ];
+
+        yield 'try catch finally with opening braces on their own line' => [
+            '<?php
+try
+{
+}
+catch (Exception $e)
+{
+}
+finally
+{
+}',
         ];
     }
 

--- a/tests/Fixtures/Integration/misc/anonymous_class_with_phpdoc.test
+++ b/tests/Fixtures/Integration/misc/anonymous_class_with_phpdoc.test
@@ -6,23 +6,23 @@ Integration of fixers: Anonymous class /w PHPDoc and attributes on separate line
 <?php
 
 $a = new
-/** @property string $x */
-class() {};
+    /** @property string $x */
+    class() {};
 
 $b = new
-#[X]
-class() {};
+    #[X]
+    class() {};
 
 $c = new
-/** @property string $x */
-#[X] #[Y\Z]
-class() {};
+    /** @property string $x */
+    #[X] #[Y\Z]
+    class() {};
 
 class Z {}
 
 $d = new
-#[X] // comment
-class() {};
+    #[X] // comment
+    class() {};
 
 --INPUT--
 <?php

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -65,8 +65,8 @@ final class IntegrationTest extends AbstractIntegrationTestCase
                 ], true)) {
                     self::markTestIncomplete(sprintf(
                         'Integration test `%s` was defined as explicit priority test, but no priority conflict was detected.'
-                        ."\n".'Either integration test needs to be extended or moved from `priority` to `misc`.'
-                        ."\n".'But don\'t do it blindly - it deserves investigation!',
+                            ."\n".'Either integration test needs to be extended or moved from `priority` to `misc`.'
+                            ."\n".'But don\'t do it blindly - it deserves investigation!',
                         $case->getFileName()
                     ));
                 }

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -2358,45 +2358,45 @@ class TestClass {
     public function testIsWhilePartOfDoWhile(): void
     {
         $source =
-<<<'SRC'
-    <?php
-    // `not do`
-    while(false) {
-    }
-    while (false);
-    while (false)?>
-    <?php
+            <<<'SRC'
+                <?php
+                // `not do`
+                while(false) {
+                }
+                while (false);
+                while (false)?>
+                <?php
 
-    if(false){
-    }while(false);
+                if(false){
+                }while(false);
 
-    if(false){
-    }while(false)?><?php
-    while(false){}while(false){}
+                if(false){
+                }while(false)?><?php
+                while(false){}while(false){}
 
-    while ($i <= 10):
-        echo $i;
-        $i++;
-    endwhile;
+                while ($i <= 10):
+                    echo $i;
+                    $i++;
+                endwhile;
 
-    ?>
-    <?php while(false): ?>
+                ?>
+                <?php while(false): ?>
 
-    <?php endwhile ?>
+                <?php endwhile ?>
 
-    <?php
-    // `do`
-    do{
-    } while(false);
+                <?php
+                // `do`
+                do{
+                } while(false);
 
-    do{
-    } while(false)?>
-    <?php
-    if (false){}do{}while(false);
+                do{
+                } while(false)?>
+                <?php
+                if (false){}do{}while(false);
 
-    // `not do`, `do`
-    if(false){}while(false){}do{}while(false);
-    SRC;
+                // `not do`, `do`
+                if(false){}while(false){}do{}while(false);
+                SRC;
 
         $expected = [
             3 => false,


### PR DESCRIPTION
Fixes #7884.

⚠️ This is a big change for `statement_indentation`: previously, statements (which here means anything that isn't a block or an array) were not fixed but adjusted as a whole, meaning that instead of forcing the indentation level on each line of a given statement, only the first line was fixed, and subsequent lines were changed with the same delta.

For example, in the following snippet, line 3 is indented with one more space than line 2. Line 2 was fixed by adding two spaces, so line 3 was adjusted with 2 more spaces as well.

```diff
 if (
-  true
-   || false) {}
+    true
+     || false) {}
```

This behavior was intended because actually fixing statements that span multiple lines was quite difficult. However, this leads to unexpected results, so I would consider this a bugfix rather than an enhancement.

⚠️ These changes might also introduce a lot of new bugs because there are likely a lot of possible situations and only very few covered in tests. I didn't try running the rule on other projects for now.

Also, currently, new indentation behavior might be more opinionated than before: it adds an extra level of indentation in multiline statements unless they are in a control structure condition or wrapped in parentheses:
```diff
 if (
-$foo
-.$bar
+    $foo
+    .$bar
 ) {}

 $a = (
-$foo
-.$bar
+    $foo
+    .$bar
 );

 foo(
-$foo
-.$bar,
-true,
+    $foo
+        .$bar,
+    true,
 );
```

We might want to make all these changes opt-in with an option, which would prevent maybe unwanted changes in users codebases but few people might notice the new option and enable it.