### PR TITLE
DX: reduce `array_filter` function usages

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -832,10 +832,10 @@ final class ConfigurationResolver
 
         $isIntersectionPathMode = self::PATH_MODE_INTERSECTION === $this->options['path-mode'];
 
-        $paths = array_filter(array_map(
+        $paths = array_map(
             static fn (string $path) => realpath($path),
             $this->getPath()
-        ));
+        );
 
         if (0 === \count($paths)) {
             if ($isIntersectionPathMode) {

--- a/src/Documentation/RuleSetDocumentationGenerator.php
+++ b/src/Documentation/RuleSetDocumentationGenerator.php
@@ -87,11 +87,11 @@ final class RuleSetDocumentationGenerator
             $warningsHeaderLine = str_repeat('-', \strlen($warningsHeader));
             $doc .= "\n\n".implode(
                 "\n",
-                array_filter([
+                [
                     $warningsHeader,
                     $warningsHeaderLine,
                     ...$warnings,
-                ])
+                ]
             );
         }
 

--- a/src/Fixer/Import/GlobalNamespaceImportFixer.php
+++ b/src/Fixer/Import/GlobalNamespaceImportFixer.php
@@ -146,8 +146,6 @@ if (count($x)) {
             $this->fullyQualifyClasses($tokens, $useDeclarations);
         }
 
-        $newImports = array_filter($newImports);
-
         if (\count($newImports) > 0) {
             if (\count($useDeclarations) > 0) {
                 $useDeclaration = end($useDeclarations);

--- a/src/Fixer/Import/GroupImportFixer.php
+++ b/src/Fixer/Import/GroupImportFixer.php
@@ -143,7 +143,7 @@ final class GroupImportFixer extends AbstractFixer
                     $tokens,
                     $insertIndex,
                     $useDeclaration,
-                    $this->getNamespaceNameWithSlash($currentUseDeclaration)
+                    rtrim($this->getNamespaceNameWithSlash($currentUseDeclaration), '\\')
                 );
             } else {
                 $newTokens = [
@@ -225,7 +225,7 @@ final class GroupImportFixer extends AbstractFixer
             $newTokens[] = new Token([T_WHITESPACE, ' ']);
         }
 
-        $namespaceParts = array_filter(explode('\\', $currentNamespace));
+        $namespaceParts = explode('\\', $currentNamespace);
 
         foreach ($namespaceParts as $part) {
             $newTokens[] = new Token([T_STRING, $part]);


### PR DESCRIPTION
According to the tests, the first three are not needed, and the last one could be handled better.

(if it causes any bug I will happily add a test case and restore the change)

([spoiler](https://github.com/phpstan/phpstan-strict-rules/pull/239))