### PR TITLE
DX: update actions producing warnings

### DIFF
--- a/.github/composite-actions/install-composer-deps/action.yml
+++ b/.github/composite-actions/install-composer-deps/action.yml
@@ -35,7 +35,7 @@ runs:
         echo "PHP_VERSION_ID=$(php -r 'echo PHP_VERSION_ID;')" >> $GITHUB_ENV
 
     - name: Cache Composer dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.COMPOSER_CACHE_DIR }}
         key: Composer-${{ runner.os }}-${{ env.COMPOSER_CACHE_PHP }}-${{ hashFiles('**/composer.json') }}-${{ hashFiles('**/composer.lock') }}
@@ -45,7 +45,7 @@ runs:
           Composer-${{ runner.os }}-
 
     - name: Install dependencies
-      uses: nick-invision/retry@v2
+      uses: nick-invision/retry@v3
       with:
         timeout_minutes: 5
         max_attempts: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
           php: ${{ matrix.php-version }}
 
       - name: Cache dev-tools
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dev-tools/bin/
           key: Build-${{ hashFiles('dev-tools/build.sh') }}

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -42,13 +42,13 @@ jobs:
         run: rm ./dev-tools/composer.lock
 
       - name: Cache dev-tools
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: dev-tools/bin/
           key: DevTools-${{ hashFiles('dev-tools/install.sh') }}
 
       - name: Install dev-tools
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 5

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-sphinx-lint


### PR DESCRIPTION
There are a lot of warnings like these:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3, nick-invision/retry@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
