### PR TITLE
DX: update actions producing warnings

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Docker Compose build
         run: docker compose build --no-cache --pull php-${{ matrix.php-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3


### PR DESCRIPTION
I have missed them in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7925 because they are not run on PR, only on the main branch/tag.