### PR TITLE
CI: no need to trigger enable auto-merge when self-approve

### DIFF
--- a/.github/workflows/self-approval.yml
+++ b/.github/workflows/self-approval.yml
@@ -38,4 +38,3 @@ jobs:
         run: |
           echo self-approving
           gh pr review --approve "$PR_URL"
-          gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
as everyone needed have the powers to click `enable auto-merge`

@kubawerlos , please approve this PR if you can merge https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7928 without anyone else touching that PR. 

(everyone else, please skip those 2 PRs)