### PR TITLE
test: Ignore PHP version related mutations

### DIFF
--- a/infection.json5.dist
+++ b/infection.json5.dist
@@ -7,6 +7,12 @@
         ]
     },
     "mutators": {
+        "global-ignoreSourceCodeByRegex": [
+            // Don't touch version-specific code examples in rules
+            ".*new VersionSpecification\\(.*",
+            // Don't touch conditions based on PHP version as these are crucial for tool to work properly
+            ".*\\\\PHP_VERSION_ID.*",
+        ],
         "@default": true,
         "Throw_": {
             "ignore": [


### PR DESCRIPTION
Discussed with @maks-rafalko, it does not make sense to mutate code related to PHP versions, as it will always produce escape mutants, because these conditions are there for a reason 😉.

Tested locally with:

```
composer infection -- --filter=src/Fixer/Alias/MbStrFunctionsFixer.php --map-source-class-to-test
composer infection -- --filter=src/Fixer/Basic/OctalNotationFixer.php --map-source-class-to-test
```

Code containing `VersionSpecification` or `PHP_VERSION_ID` is not mutated.