### PR TITLE
chore: Properly determine self-approval trigger commit

### DIFF
--- a/.github/workflows/self-approval.yml
+++ b/.github/workflows/self-approval.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.after }}
+          ref: ${{ github.head_ref }}
       - name: Determine whether PR should be automatically approved
         id: marker
         run: |
-          msg=$(git show -s --format=%s ${{ github.event.after }})
+          msg=$(git show -s --format=%s ${{ github.head_ref }})
           echo $msg
           indicator=$([[ $msg == $MARKER ]] && echo yes || echo no)
           echo $indicator

--- a/.github/workflows/self-approval.yml
+++ b/.github/workflows/self-approval.yml
@@ -33,8 +33,8 @@ jobs:
           indicator=$([[ $msg == $MARKER ]] && echo yes || echo no)
           echo $indicator
           echo "indicator_value=${indicator}" >> "$GITHUB_OUTPUT"
-      - name: Approve and enable auto-merge
+      - name: Approve pull request
         if: steps.marker.outputs.indicator_value == 'yes'
         run: |
-          echo self-approving
           gh pr review --approve "$PR_URL"
+          echo "Approval from GH Bot - PR is now mergeable, use it wisely!"


### PR DESCRIPTION
As you can see [here](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/actions/runs/8645246725/job/23702016568?pr=7935#step:3:13) commit message for self-approval is determined improperly when PR is created. Workflow takes last commit from `master`, and it does not trigger the Bot.

> To run a job based on the pull request's head branch name (as opposed to the pull request's base branch name), use the `github.head_ref` context in a conditional."

[Source](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request_target-workflow-based-on-the-head-or-base-branch-of-a-pull-request)