### PR TITLE
fix: Remove Infection during Docker release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ COPY --from=composer/composer:2-bin /composer /usr/local/bin/composer
 FROM base-dev as vendor
 COPY composer.json /fixer/composer.json
 WORKDIR /fixer
-RUN composer install --prefer-dist --no-dev --optimize-autoloader --no-scripts
+RUN composer remove --dev infection/infection --no-update \
+    && composer install --prefer-dist --no-dev --optimize-autoloader --no-scripts
 
 FROM base as dist
 


### PR DESCRIPTION
It's causing failures during Docker build:

```
 => [dist 4/6] COPY php-cs-fixer /fixer/php-cs-fixer                                                                                                                                                                                0.0s
------
 > [vendor 3/3] RUN composer install --prefer-dist --no-dev --optimize-autoloader --no-scripts:
[...]
1.875 Updating dependencies
1.886 Your requirements could not be resolved to an installable set of packages.
1.886 
1.886   Problem 1
1.886     - Root composer.json requires infection/infection ^0.27.11 -> satisfiable by infection/infection[0.27.11].
1.886     - infection/infection 0.27.11 requires php ^8.1 -> your php version (7.4.33) does not satisfy that requirement.
1.886 
1.886 Running update with --no-dev does not mean require-dev is ignored, it just means the packages will not be installed. If dev requirements are blocking the update you have to resolve those problems.
------
Dockerfile:28
--------------------
  26 |     COPY composer.json /fixer/composer.json
  27 |     WORKDIR /fixer
  28 | >>> RUN composer install --prefer-dist --no-dev --optimize-autoloader --no-scripts
  29 |     
  30 |     FROM base as dist
--------------------
ERROR: failed to solve: process "/bin/sh -c composer install --prefer-dist --no-dev --optimize-autoloader --no-scripts" did not complete successfully: exit code: 2
```