### PR TITLE
chore: Revert ref for self-approval Git checkout

### DIFF
--- a/.github/workflows/self-approval.yml
+++ b/.github/workflows/self-approval.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.after }}
       - name: Determine whether PR should be automatically approved
         id: marker
         run: |
-          msg=$(git show -s --format=%s ${{ github.head_ref }})
+          msg=$(git show -s --format=%s ${{ github.event.after }})
           echo $msg
           indicator=$([[ $msg == $MARKER ]] && echo yes || echo no)
           echo $indicator


### PR DESCRIPTION
Partially reverts #7936

It does not work, because it tries to check out branch which is not present in the repository. I'll fiddle with it in my fork and will come back with verified solution. Sorry for the trouble.