### PR TITLE
feat: Add assertResponseStatusCodeSame to StaticMethodCallsFixer

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
@@ -199,6 +199,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixer extends AbstractPhpUnitFixer i
         'assertObjectNotHasAttribute' => true,
         'assertObjectNotHasProperty' => true,
         'assertRegExp' => true,
+        'assertResponseStatusCodeSame' => true,
         'assertSame' => true,
         'assertSameSize' => true,
         'assertStringContainsString' => true,


### PR DESCRIPTION
Add assertResponseStatusCodeSame to PhpUnitTestCaseStaticMethodCallsFixerTest.php.
Referencing Feature Request:
#7922 

The change is already covered by test for this file imho.