### PR TITLE
fix: `PhpUnitMethodCasingFixer` - do not double underscore

### DIFF
--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -57,6 +57,17 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
 
             yield $key.' to snake case' => [$snakeCase, $camelCase, ['case' => 'snake_case']];
         }
+
+        yield 'mixed case to camel case' => [
+            '<?php class MyTest extends TestCase { function testShouldNotFooWhenBar() {} }',
+            '<?php class MyTest extends TestCase { function test_should_notFoo_When_Bar() {} }',
+        ];
+
+        yield 'mixed case to snake case' => [
+            '<?php class MyTest extends TestCase { function test_should_not_foo__when__bar() {} }',
+            '<?php class MyTest extends TestCase { function test_should_notFoo_When_Bar() {} }',
+            ['case' => 'snake_case'],
+        ];
     }
 
     /**

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -125,6 +125,11 @@ final class UtilsTest extends TestCase
             'voyage_éclair',
             'VoyageÉclair',
         ];
+
+        yield [
+            'i_want_to_fully_be__a__snake',
+            'i_wantTo_fully_be_A_Snake',
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7945