### PR TITLE
fix: `FullyQualifiedStrictTypesFixer` - do not add imports before PHP opening tag

### DIFF
--- a/src/Tokenizer/Analyzer/NamespacesAnalyzer.php
+++ b/src/Tokenizer/Analyzer/NamespacesAnalyzer.php
@@ -65,7 +65,14 @@ final class NamespacesAnalyzer
         }
 
         if (0 === \count($namespaces) && $tokens->isTokenKindFound(T_OPEN_TAG)) {
-            $namespaces[] = new NamespaceAnalysis('', '', 0, 0, 0, \count($tokens) - 1);
+            $namespaces[] = new NamespaceAnalysis(
+                '',
+                '',
+                $openTagIndex = $tokens[0]->isGivenKind(T_INLINE_HTML) ? 1 : 0,
+                $openTagIndex,
+                $openTagIndex,
+                \count($tokens) - 1,
+            );
         }
 
         return $namespaces;

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -2604,6 +2604,22 @@ use Foo\Bar;
  */
 function foo($a) {}',
         ];
+
+        yield 'with shebang' => [
+            <<<'PHP'
+                #!/usr/bin/env php
+                <?php
+
+                use Bar\Baz;
+                $foo = new Baz();
+                PHP,
+            <<<'PHP'
+                #!/usr/bin/env php
+                <?php
+                $foo = new Bar\Baz();
+                PHP,
+            ['import_symbols' => true],
+        ];
     }
 
     /**

--- a/tests/Tokenizer/Analyzer/NamespacesAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/NamespacesAnalyzerTest.php
@@ -88,9 +88,26 @@ final class NamespacesAnalyzerTest extends TestCase
         ]];
 
         yield [
-            'there is no namespace if there is no PHP code',
+            <<<'PHP'
+                #!/usr/bin/php
+                <?php
+                return true;
+                PHP,
             [
+                new NamespaceAnalysis(
+                    '',
+                    '',
+                    1,
+                    1,
+                    1,
+                    5
+                ),
             ],
+        ];
+
+        yield [
+            'there is no namespace if there is no PHP code',
+            [],
         ];
     }
 


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7950