### PR TITLE
fix: Faster StatementIndentationFixer

### DIFF
--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -237,24 +237,24 @@ if ($foo) {
             ) {
                 $endIndexInclusive = true;
 
-                if ($token->isGivenKind([T_EXTENDS, T_IMPLEMENTS])) {
-                    $endIndex = $tokens->getNextTokenOfKind($index, ['{']);
-                } elseif ($token->isGivenKind(CT::T_USE_TRAIT)) {
-                    $endIndex = $tokens->getNextTokenOfKind($index, [';']);
+                if ($token->equals('{')) {
+                    $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
+                } elseif ($token->equals('(')) {
+                    $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
                 } elseif ($token->equals(':')) {
                     if (isset($caseBlockStarts[$index])) {
                         [$endIndex, $endIndexInclusive] = $this->findCaseBlockEnd($tokens, $index);
                     } elseif ($this->alternativeSyntaxAnalyzer->belongsToAlternativeSyntax($tokens, $index)) {
                         $endIndex = $this->alternativeSyntaxAnalyzer->findAlternativeSyntaxBlockEnd($tokens, $alternativeBlockStarts[$index]);
                     }
+                } elseif ($token->isGivenKind([T_EXTENDS, T_IMPLEMENTS])) {
+                    $endIndex = $tokens->getNextTokenOfKind($index, ['{']);
+                } elseif ($token->isGivenKind(CT::T_USE_TRAIT)) {
+                    $endIndex = $tokens->getNextTokenOfKind($index, [';']);
                 } elseif ($token->isGivenKind(CT::T_DESTRUCTURING_SQUARE_BRACE_OPEN)) {
                     $endIndex = $tokens->getNextTokenOfKind($index, [[CT::T_DESTRUCTURING_SQUARE_BRACE_CLOSE]]);
                 } elseif ($token->isGivenKind(CT::T_GROUP_IMPORT_BRACE_OPEN)) {
                     $endIndex = $tokens->getNextTokenOfKind($index, [[CT::T_GROUP_IMPORT_BRACE_CLOSE]]);
-                } elseif ($token->equals('{')) {
-                    $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
-                } elseif ($token->equals('(')) {
-                    $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
                 } else {
                     $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ATTRIBUTE, $index);
                 }


### PR DESCRIPTION
when re-ordering the conditions we highly reduce the number of function calls happening in a regular code base.

As PHP (tested on 8.2.12) is pretty fast, the change itself does not yield much improvements regarding runtime.

As soon as php-extensions like xdebug, blackfire or other dev-tools which incur a perf penalty on function calls are in the game we see improvements though.

running php-cs-fixer on one of our closed source projects before this PR and a php.ini like
```
zend_extension=xdebug
xdebug.mode=debug
xdebug.start_with_request=yes
```
makes a big difference though (so xdebug is just loaded).

3 runs before this PR: `1m5s, 1m11s, 1m8s`
3 runs after this PR: `44s, 41s, 45s`

I think people having xdebug loaded while daily work while running a dev tool like php-cs-fixer is not unusal.

---

additionally by removing function calls we improve php-cs-fixer beeing profiled, because xdebug and blackfire currently are not able to yield useful results, as there are so many function calls happening, that the function call overhead by the profiler is more visible then the actual php-cs-fixer workload.

after this PR, as we have less function calls, profiles get a bit more precise. tbh we should do a few more optimizations to bring the tooling into a state where it can be helpful for us.