### PR TITLE
fix: Remove unnecessary method-proxying calls

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -589,7 +589,7 @@ class Tokens extends \SplFixedArray
      */
     public function getNextNonWhitespace(int $index, ?string $whitespaces = null): ?int
     {
-        return $this->getNonWhitespaceSibling($index, 1, $whitespaces);
+        return $this->getNonWhitespaceSibling($index, self::DIRECTION_NEXT, $whitespaces);
     }
 
     /**
@@ -603,7 +603,7 @@ class Tokens extends \SplFixedArray
      */
     public function getNextTokenOfKind(int $index, array $tokens = [], bool $caseSensitive = true): ?int
     {
-        return $this->getTokenOfKindSibling($index, 1, $tokens, $caseSensitive);
+        return $this->getTokenOfKindSibling($index, self::DIRECTION_NEXT, $tokens, $caseSensitive);
     }
 
     /**
@@ -637,7 +637,7 @@ class Tokens extends \SplFixedArray
      */
     public function getPrevNonWhitespace(int $index, ?string $whitespaces = null): ?int
     {
-        return $this->getNonWhitespaceSibling($index, -1, $whitespaces);
+        return $this->getNonWhitespaceSibling($index, self::DIRECTION_PREV, $whitespaces);
     }
 
     /**
@@ -650,7 +650,7 @@ class Tokens extends \SplFixedArray
      */
     public function getPrevTokenOfKind(int $index, array $tokens = [], bool $caseSensitive = true): ?int
     {
-        return $this->getTokenOfKindSibling($index, -1, $tokens, $caseSensitive);
+        return $this->getTokenOfKindSibling($index, self::DIRECTION_PREV, $tokens, $caseSensitive);
     }
 
     /**
@@ -1033,7 +1033,7 @@ class Tokens extends \SplFixedArray
      */
     public function removeLeadingWhitespace(int $index, ?string $whitespaces = null): void
     {
-        $this->removeWhitespaceSafely($index, -1, $whitespaces);
+        $this->removeWhitespaceSafely($index, self::DIRECTION_PREV, $whitespaces);
     }
 
     /**
@@ -1041,7 +1041,7 @@ class Tokens extends \SplFixedArray
      */
     public function removeTrailingWhitespace(int $index, ?string $whitespaces = null): void
     {
-        $this->removeWhitespaceSafely($index, 1, $whitespaces);
+        $this->removeWhitespaceSafely($index, self::DIRECTION_NEXT, $whitespaces);
     }
 
     /**
@@ -1218,7 +1218,7 @@ class Tokens extends \SplFixedArray
             return;
         }
 
-        $prevIndex = $this->getNonEmptySibling($index, -1);
+        $prevIndex = $this->getNonEmptySibling($index, self::DIRECTION_PREV);
 
         if ($this[$prevIndex]->isWhitespace()) {
             $this[$prevIndex] = new Token([T_WHITESPACE, $this[$prevIndex]->getContent().$this[$nextIndex]->getContent()]);

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -51,6 +51,10 @@ class Tokens extends \SplFixedArray
     public const BLOCK_TYPE_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS = 12;
     public const BLOCK_TYPE_DYNAMIC_CLASS_CONSTANT_FETCH_CURLY_BRACE = 13;
 
+    private const NON_MEANINGFUL_TOKENS = [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT];
+    private const DIRECTION_PREV = -1;
+    private const DIRECTION_NEXT = 1;
+
     /**
      * Static class cache.
      *
@@ -717,10 +721,10 @@ class Tokens extends \SplFixedArray
      */
     public function getMeaningfulTokenSibling(int $index, int $direction): ?int
     {
-        return $this->getTokenNotOfKindsSibling(
+        return $this->getTokenNotOfKind(
             $index,
             $direction,
-            [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT]
+            fn (int $index): bool => $this[$index]->isGivenKind(self::NON_MEANINGFUL_TOKENS),
         );
     }
 
@@ -751,7 +755,11 @@ class Tokens extends \SplFixedArray
      */
     public function getNextMeaningfulToken(int $index): ?int
     {
-        return $this->getMeaningfulTokenSibling($index, 1);
+        return $this->getTokenNotOfKind(
+            $index,
+            self::DIRECTION_NEXT,
+            fn (int $index): bool => $this[$index]->isGivenKind(self::NON_MEANINGFUL_TOKENS),
+        );
     }
 
     /**
@@ -761,7 +769,11 @@ class Tokens extends \SplFixedArray
      */
     public function getPrevMeaningfulToken(int $index): ?int
     {
-        return $this->getMeaningfulTokenSibling($index, -1);
+        return $this->getTokenNotOfKind(
+            $index,
+            self::DIRECTION_PREV,
+            fn (int $index): bool => $this[$index]->isGivenKind(self::NON_MEANINGFUL_TOKENS),
+        );
     }
 
     /**


### PR DESCRIPTION
similar as https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7957 this PR is trying to remove unnecessary layers of indirection, which create a huge amount of function calls (millions).

see blackfire profile before this PR:

![grafik](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/120441/598e71cf-8743-4830-8374-d0e0ed3001bc)

see profile comparison before/after PR:

![grafik](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/120441/47238318-6974-454e-ac68-8bb9b23455d4)

---

you can see here that a few fixers need to call 

`getPrevMeaningfulToken` -> `getMeaningfulTokenSibling`  -> `getTOkenNotOfSibling` -> `getTokenNotOfKind`.

each of these method calls in between are just stacking up a new function call without any other additional logic.
