### PR TITLE
feat: Add `single_line_empty_body` config `only_for_constructors`

### DIFF
--- a/doc/rules/basic/single_line_empty_body.rst
+++ b/doc/rules/basic/single_line_empty_body.rst
@@ -6,11 +6,25 @@ Empty body of class, interface, trait, enum or function must be abbreviated as
 ``{}`` and placed on the same line as the previous symbol, separated by a single
 space.
 
+Configuration
+-------------
+
+``only_for_constructors``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whether to ONLY fold __construct() methods, nothing else.
+
+Allowed types: ``bool``
+
+Default value: ``false``
+
 Examples
 --------
 
 Example #1
 ~~~~~~~~~~
+
+*Default* configuration.
 
 .. code-block:: diff
 
@@ -22,6 +36,28 @@ Example #1
    -{
    -}
    +) {}
+
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['only_for_constructors' => true]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    class Foo
+    {
+   -    public function __construct()
+   -    {
+   -    }
+   +    public function __construct() {}
+
+        public function foo()
+        {
+        }
+    }
 
 Rule sets
 ---------

--- a/src/Fixer/Basic/SingleLineEmptyBodyFixer.php
+++ b/src/Fixer/Basic/SingleLineEmptyBodyFixer.php
@@ -15,13 +15,13 @@ declare(strict_types=1);
 namespace PhpCsFixer\Fixer\Basic;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -78,7 +78,7 @@ final class SingleLineEmptyBodyFixer extends AbstractFixer implements Configurab
 
             if (true === $this->configuration['only_for_constructors']) {
                 $funcNameIndex = $tokens->getNextNonWhitespace($index);
-                if ($tokens[$funcNameIndex]->getContent() !== '__construct') {
+                if ('__construct' !== $tokens[$funcNameIndex]->getContent()) {
                     continue;
                 }
             }

--- a/src/Fixer/Basic/SingleLineEmptyBodyFixer.php
+++ b/src/Fixer/Basic/SingleLineEmptyBodyFixer.php
@@ -31,12 +31,29 @@ final class SingleLineEmptyBodyFixer extends AbstractFixer implements Configurab
     {
         return new FixerDefinition(
             'Empty body of class, interface, trait, enum or function must be abbreviated as `{}` and placed on the same line as the previous symbol, separated by a single space.',
-            [new CodeSample('<?php function foo(
+            [
+                new CodeSample('<?php function foo(
     int $x
 )
 {
 }
-')],
+'
+                ),
+                new CodeSample('<?php
+class Foo
+{
+    public function __construct()
+    {
+    }
+
+    public function foo()
+    {
+    }
+}
+',
+                    ['only_for_constructors' => true]
+                )
+            ],
         );
     }
 


### PR DESCRIPTION
Don't fold **anything**, except a class' `__construct()`, because that looks better with PHP 8's property promotion.

I have plenty of empty methods that are overridden in children, or that **are** overrides of parents. I don't want to fold those, because that looks weird:

```php
protected function applyConfig(int $priority, array $config, TreeAwareConfigContainer $parent): void {}
```

_(where are the brackets?? am I in an interface?? help!!)_

But empty PHP 8 constructors look weird if they're NOT folded:

```php
public function __construct(
	protected string $name,
)
{

}
```

or

```php
public function __construct(
	protected string $name,
) {
}
```

etc.

----

If the general idea is acceptable, it could be configured differently, with a `context` config option or something. Default is everything:

```php
[
	'contexts' => ['class', 'interface', 'trait', 'enum', 'method', 'constructor', 'function'], // more?
],
```