### PR TITLE
feat: Add `statement_indentation` config `not_for_comments`

### DIFF
--- a/doc/rules/whitespace/statement_indentation.rst
+++ b/doc/rules/whitespace/statement_indentation.rst
@@ -7,6 +7,15 @@ Each statement must be indented.
 Configuration
 -------------
 
+``not_for_comments``
+~~~~~~~~~~~~~~~~~~~~
+
+Leave commented lines alone.
+
+Allowed types: ``bool``
+
+Default value: ``false``
+
 ``stick_comment_to_next_continuous_control_statement``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -83,6 +92,25 @@ With configuration: ``['stick_comment_to_next_continuous_control_statement' => t
         $aaa = 1;
    -        // this is treated as comment of `elseif(3)` block, as it is a comment in the final block
    +    // this is treated as comment of `elseif(3)` block, as it is a comment in the final block
+    }
+
+Example #4
+~~~~~~~~~~
+
+With configuration: ``['not_for_comments' => true]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    if ($foo) {
+    // Comment stays where it is
+   -echo "foo"; // Code is indented
+   +    echo "foo"; // Code is indented
+            // Comment stays where it is
+    } else {
+        $aaa = 1;
     }
 
 Rule sets

--- a/doc/rules/whitespace/statement_indentation.rst
+++ b/doc/rules/whitespace/statement_indentation.rst
@@ -7,10 +7,10 @@ Each statement must be indented.
 Configuration
 -------------
 
-``not_for_comments``
-~~~~~~~~~~~~~~~~~~~~
+``allow_zero_indented_comments``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Leave commented lines alone.
+Leave lines that start with a // comment alone.
 
 Allowed types: ``bool``
 
@@ -97,7 +97,7 @@ With configuration: ``['stick_comment_to_next_continuous_control_statement' => t
 Example #4
 ~~~~~~~~~~
 
-With configuration: ``['not_for_comments' => true]``.
+With configuration: ``['allow_zero_indented_comments' => true]``.
 
 .. code-block:: diff
 
@@ -105,10 +105,11 @@ With configuration: ``['not_for_comments' => true]``.
    +++ New
     <?php
     if ($foo) {
-    // Comment stays where it is
-   -echo "foo"; // Code is indented
-   +    echo "foo"; // Code is indented
-            // Comment stays where it is
+    // This comment will stay where it is
+   -echo "foo"; // This code will be indented
+   -        // This comment will be indented properly
+   +    echo "foo"; // This code will be indented
+   +    // This comment will be indented properly
     } else {
         $aaa = 1;
     }

--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -116,6 +116,10 @@ if ($foo) {
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)
                 ->getOption(),
+            (new FixerOptionBuilder('not_for_comments', 'Leave commented lines alone.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(false)
+                ->getOption(),
         ]);
     }
 
@@ -434,6 +438,13 @@ if ($foo) {
                                 $nextNewlineIndex = $searchIndex;
 
                                 break;
+                            }
+                        }
+
+                        if (true === $this->configuration['not_for_comments']) {
+                            $lineIsCommented = $tokens[$firstNonWhitespaceTokenIndex]->isGivenKind([T_COMMENT]);
+                            if ($lineIsCommented) {
+                                continue;
                             }
                         }
 

--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -92,14 +92,14 @@ if ($foo) {
                 new CodeSample(
                     '<?php
 if ($foo) {
-// Comment stays where it is
-echo "foo"; // Code is indented
-        // Comment stays where it is
+// This comment will stay where it is
+echo "foo"; // This code will be indented
+        // This comment will be indented properly
 } else {
     $aaa = 1;
 }
 ',
-                    ['not_for_comments' => true]
+                    ['allow_zero_indented_comments' => true]
                 ),
             ]
         );
@@ -128,7 +128,7 @@ echo "foo"; // Code is indented
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)
                 ->getOption(),
-            (new FixerOptionBuilder('not_for_comments', 'Leave commented lines alone.'))
+            (new FixerOptionBuilder('allow_zero_indented_comments', 'Leave lines that start with a // comment alone.'))
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)
                 ->getOption(),
@@ -453,9 +453,10 @@ echo "foo"; // Code is indented
                             }
                         }
 
-                        if (true === $this->configuration['not_for_comments']) {
+                        if (true === $this->configuration['allow_zero_indented_comments']) {
                             $lineIsCommented = $tokens[$firstNonWhitespaceTokenIndex]->isGivenKind([T_COMMENT]);
-                            if ($lineIsCommented) {
+                            $prevTokenEndsWithNewline = Preg::match('/\R$/', $tokens[$firstNonWhitespaceTokenIndex - 1]->getContent());
+                            if ($lineIsCommented && $prevTokenEndsWithNewline) {
                                 continue;
                             }
                         }

--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -89,6 +89,18 @@ if ($foo) {
 ',
                     ['stick_comment_to_next_continuous_control_statement' => true]
                 ),
+                new CodeSample(
+                    '<?php
+if ($foo) {
+// Comment stays where it is
+echo "foo"; // Code is indented
+        // Comment stays where it is
+} else {
+    $aaa = 1;
+}
+',
+                    ['not_for_comments' => true]
+                ),
             ]
         );
     }


### PR DESCRIPTION
New option to completely ignore `//` commented lines. I like my temporary comments to be very explicit, not neatly indented with the rest of the code. Real comments, I'll correctly indent myself, these temp comments, I'll put at the start of the line, or maybe more indented than the rest, whatever stands out.

E.g., while playing with phpstan:

```diff
 public function buildForm(): void {
 // \PHPStan\dumpType($this->model); // << Leave this one alone
-$this->platform = $this->requireData('platform'); // << Indent this one 1 level
+	$this->platform = $this->requireData('platform'); // << Indent this one 1 level
 	$this->required = $this->requireData('required');
 
 	$this->platform->buildKeyForm($this, $this->required);
}
```