### PR TITLE
fix: `PhpUnitAttributesFixer` - fix for `#[RequiresPhp]` exceeding its constructor parameters

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitAttributesFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitAttributesFixer.php
@@ -375,11 +375,13 @@ final class PhpUnitAttributesFixer extends AbstractPhpUnitFixer
                 new Token([T_WHITESPACE, ' ']),
                 self::createEscapedStringToken($method),
             ];
+        } elseif ('RequiresPhp' === $attributeName && isset($matches[3])) {
+            $attributeTokens = [self::createEscapedStringToken($matches[2].' '.$matches[3])];
         } else {
             $attributeTokens = [self::createEscapedStringToken($matches[2])];
         }
 
-        if (isset($matches[3])) {
+        if (isset($matches[3]) && 'RequiresPhp' !== $attributeName) {
             $attributeTokens[] = new Token(',');
             $attributeTokens[] = new Token([T_WHITESPACE, ' ']);
             $attributeTokens[] = self::createEscapedStringToken($matches[3]);

--- a/tests/Fixer/PhpUnit/PhpUnitAttributesFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitAttributesFixerTest.php
@@ -136,6 +136,27 @@ final class PhpUnitAttributesFixerTest extends AbstractFixerTestCase
                 PHP,
         ];
 
+        yield 'fix with > in operator' => [
+            <<<'PHP'
+                <?php
+                class FooTest extends \PHPUnit\Framework\TestCase {
+                    /**
+                     */
+                    #[\PHPUnit\Framework\Attributes\RequiresPhp('>= 8.1')]
+                    public function testFoo() { self::assertTrue(true); }
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                class FooTest extends \PHPUnit\Framework\TestCase {
+                    /**
+                     * @requires PHP >= 8.1
+                     */
+                    public function testFoo() { self::assertTrue(true); }
+                }
+                PHP,
+        ];
+
         yield 'fix with trailing spaces' => self::createCase(
             ['class'],
             '#[CoversClass(Foo::class)]',


### PR DESCRIPTION
If the annotation is:
```
/**
 * @requires PHP >= 8.1
 */
```

this will become:
```
#[\PHPUnit\Framework\Attributes\RequiresPhp('>=', '8.1')]
```

which is wrong since the attribute accepts only one parameter. Ref: https://docs.phpunit.de/en/10.5/attributes.html#requiresphp

During parsing, this will error and cause PHPUnit to crash.