### PR TITLE
DX: Prevent having deprecated fixers listed as successors of other deprecated fixers

### DIFF
--- a/doc/rules/basic/braces.rst
+++ b/doc/rules/basic/braces.rst
@@ -13,7 +13,7 @@ This rule is deprecated and will be removed in the next major version
 
 You should use ``single_space_around_construct``, ``control_structure_braces``,
 ``control_structure_continuation_position``, ``declare_parentheses``,
-``no_multiple_statements_per_line``, ``curly_braces_position``,
+``no_multiple_statements_per_line``, ``braces_position``,
 ``statement_indentation`` and ``no_extra_blank_lines`` instead.
 
 Configuration

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -51,9 +51,9 @@ final class BracesFixer extends AbstractProxyFixer implements ConfigurableFixerI
     public const LINE_SAME = 'same';
 
     /**
-     * @var null|CurlyBracesPositionFixer
+     * @var null|BracesPositionFixer
      */
-    private $curlyBracesPositionFixer;
+    private $bracesPositionFixer;
 
     /**
      * @var null|ControlStructureContinuationPositionFixer
@@ -156,7 +156,7 @@ class Foo
     {
         parent::configure($configuration);
 
-        $this->getCurlyBracesPositionFixer()->configure([
+        $this->getBracesPositionFixer()->configure([
             'control_structures_opening_brace' => $this->translatePositionOption($this->configuration['position_after_control_structures']),
             'functions_opening_brace' => $this->translatePositionOption($this->configuration['position_after_functions_and_oop_constructs']),
             'anonymous_functions_opening_brace' => $this->translatePositionOption($this->configuration['position_after_anonymous_constructs']),
@@ -217,7 +217,7 @@ class Foo
             $singleSpaceAroundConstructFixer,
             new ControlStructureBracesFixer(),
             $noExtraBlankLinesFixer,
-            $this->getCurlyBracesPositionFixer(),
+            $this->getBracesPositionFixer(),
             $this->getControlStructureContinuationPositionFixer(),
             new DeclareParenthesesFixer(),
             new NoMultipleStatementsPerLineFixer(),
@@ -225,13 +225,13 @@ class Foo
         ];
     }
 
-    private function getCurlyBracesPositionFixer(): CurlyBracesPositionFixer
+    private function getBracesPositionFixer(): BracesPositionFixer
     {
-        if (null === $this->curlyBracesPositionFixer) {
-            $this->curlyBracesPositionFixer = new CurlyBracesPositionFixer();
+        if (null === $this->bracesPositionFixer) {
+            $this->bracesPositionFixer = new BracesPositionFixer();
         }
 
-        return $this->curlyBracesPositionFixer;
+        return $this->bracesPositionFixer;
     }
 
     private function getControlStructureContinuationPositionFixer(): ControlStructureContinuationPositionFixer
@@ -246,7 +246,7 @@ class Foo
     private function translatePositionOption(string $option): string
     {
         return self::LINE_NEXT === $option
-            ? CurlyBracesPositionFixer::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END
-            : CurlyBracesPositionFixer::SAME_LINE;
+            ? BracesPositionFixer::NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END
+            : BracesPositionFixer::SAME_LINE;
     }
 }

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -85,11 +85,7 @@ final class RuleSetTest extends TestCase
      */
     public function testThatDefaultConfigIsNotPassed(string $setName, string $ruleName, $ruleConfig): void
     {
-        $factory = new FixerFactory();
-        $factory->registerBuiltInFixers();
-        $factory->useRuleSet(new RuleSet([$ruleName => true]));
-
-        $fixer = current($factory->getFixers());
+        $fixer = self::getFixerByName($ruleName);
 
         if (!$fixer instanceof ConfigurableFixerInterface || \is_bool($ruleConfig)) {
             $this->expectNotToPerformAssertions();
@@ -119,11 +115,7 @@ final class RuleSetTest extends TestCase
      */
     public function testThatThereIsNoDeprecatedFixerInRuleSet(string $setName, string $ruleName): void
     {
-        $factory = new FixerFactory();
-        $factory->registerBuiltInFixers();
-        $factory->useRuleSet(new RuleSet([$ruleName => true]));
-
-        $fixer = current($factory->getFixers());
+        $fixer = self::getFixerByName($ruleName);
 
         self::assertNotInstanceOf(DeprecatedFixerInterface::class, $fixer, sprintf('RuleSet "%s" contains deprecated rule "%s".', $setName, $ruleName));
     }

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -23,6 +23,7 @@ use PhpCsFixer\FixerFactory;
 use PhpCsFixer\RuleSet\RuleSet;
 use PhpCsFixer\RuleSet\RuleSetDescriptionInterface;
 use PhpCsFixer\RuleSet\RuleSets;
+use PhpCsFixer\Tests\Test\TestCaseUtils;
 use PhpCsFixer\Tests\TestCase;
 
 /**
@@ -85,7 +86,7 @@ final class RuleSetTest extends TestCase
      */
     public function testThatDefaultConfigIsNotPassed(string $setName, string $ruleName, $ruleConfig): void
     {
-        $fixer = self::getFixerByName($ruleName);
+        $fixer = TestCaseUtils::getFixerByName($ruleName);
 
         if (!$fixer instanceof ConfigurableFixerInterface || \is_bool($ruleConfig)) {
             $this->expectNotToPerformAssertions();
@@ -115,7 +116,7 @@ final class RuleSetTest extends TestCase
      */
     public function testThatThereIsNoDeprecatedFixerInRuleSet(string $setName, string $ruleName): void
     {
-        $fixer = self::getFixerByName($ruleName);
+        $fixer = TestCaseUtils::getFixerByName($ruleName);
 
         self::assertNotInstanceOf(DeprecatedFixerInterface::class, $fixer, sprintf('RuleSet "%s" contains deprecated rule "%s".', $setName, $ruleName));
     }

--- a/tests/RuleSet/RuleSetsTest.php
+++ b/tests/RuleSet/RuleSetsTest.php
@@ -18,6 +18,7 @@ use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTargetVersion;
 use PhpCsFixer\RuleSet\RuleSet;
 use PhpCsFixer\RuleSet\RuleSets;
+use PhpCsFixer\Tests\Test\TestCaseUtils;
 use PhpCsFixer\Tests\TestCase;
 
 /**
@@ -185,7 +186,7 @@ Integration of %s.
     {
         $maximumVersionForRuleset = preg_replace('/^@PHPUnit(\d+)(\d)Migration:risky$/', '$1.$2', $setName);
 
-        $fixer = self::getFixerByName($ruleName);
+        $fixer = TestCaseUtils::getFixerByName($ruleName);
 
         self::assertInstanceOf(ConfigurableFixerInterface::class, $fixer, sprintf('The fixer "%s" shall be configurable.', $fixer->getName()));
 
@@ -283,7 +284,7 @@ Integration of %s.
     private function getDefaultPHPUnitTargetOfRule(string $ruleName): ?string
     {
         $targetVersion = null;
-        $fixer = self::getFixerByName($ruleName);
+        $fixer = TestCaseUtils::getFixerByName($ruleName);
 
         if ($fixer instanceof ConfigurableFixerInterface) {
             foreach ($fixer->getConfigurationDefinition()->getOptions() as $option) {

--- a/tests/RuleSet/RuleSetsTest.php
+++ b/tests/RuleSet/RuleSetsTest.php
@@ -14,10 +14,8 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\RuleSet;
 
-use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTargetVersion;
-use PhpCsFixer\FixerFactory;
 use PhpCsFixer\RuleSet\RuleSet;
 use PhpCsFixer\RuleSet\RuleSets;
 use PhpCsFixer\Tests\TestCase;
@@ -298,26 +296,5 @@ Integration of %s.
         }
 
         return $targetVersion;
-    }
-
-    private static function getFixerByName(string $name): AbstractFixer
-    {
-        $factory = new FixerFactory();
-        $factory->registerBuiltInFixers();
-        $factory->useRuleSet(new RuleSet([$name => true]));
-
-        $fixers = $factory->getFixers();
-
-        if (0 === \count($fixers)) {
-            throw new \RuntimeException('FixerFactory unexpectedly returned empty array.');
-        }
-
-        $fixer = current($fixers);
-
-        if (!$fixer instanceof AbstractFixer) {
-            throw new \RuntimeException(sprintf('Fixer class for "%s" rule does not extend "%s".', $name, AbstractFixer::class));
-        }
-
-        return $fixer;
     }
 }

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -322,6 +322,27 @@ abstract class AbstractFixerTestCase extends TestCase
         }
     }
 
+    final public function testDeprecatedFixersDoNotHaveDeprecatedSuccessor(): void
+    {
+        if (!$this->fixer instanceof DeprecatedFixerInterface || [] === $this->fixer->getSuccessorsNames()) {
+            $this->addToAssertionCount(1);
+
+            return;
+        }
+
+        foreach ($this->fixer->getSuccessorsNames() as $successorName) {
+            self::assertNotInstanceOf(
+                DeprecatedFixerInterface::class,
+                self::getFixerByName($successorName),
+                sprintf(
+                    'Successor fixer `%s` for deprecated fixer `%s` is deprecated itself.',
+                    $successorName,
+                    $this->fixer->getName(),
+                )
+            );
+        }
+    }
+
     /**
      * Blur filter that find candidate fixer for performance optimization to use only `insertSlices` instead of multiple `insertAt` if there is no other collection manipulation.
      */

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -333,7 +333,7 @@ abstract class AbstractFixerTestCase extends TestCase
         foreach ($this->fixer->getSuccessorsNames() as $successorName) {
             self::assertNotInstanceOf(
                 DeprecatedFixerInterface::class,
-                self::getFixerByName($successorName),
+                TestCaseUtils::getFixerByName($successorName),
                 sprintf(
                     'Successor fixer `%s` for deprecated fixer `%s` is deprecated itself.',
                     $successorName,

--- a/tests/Test/TestCaseUtils.php
+++ b/tests/Test/TestCaseUtils.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Test;
 
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerFactory;
+
 /**
  * @internal
  */
@@ -37,5 +40,26 @@ final class TestCaseUtils
 
             yield $case;
         }
+    }
+
+    public static function getFixerByName(string $name): FixerInterface
+    {
+        static $fixers = null;
+
+        if (null === $fixers) {
+            $factory = new FixerFactory();
+            $factory->registerBuiltInFixers();
+
+            $fixers = [];
+            foreach ($factory->getFixers() as $fixer) {
+                $fixers[$fixer->getName()] = $fixer;
+            }
+        }
+
+        if (!\array_key_exists($name, $fixers)) {
+            throw new \InvalidArgumentException(sprintf('Fixer "%s" does not exist.', $name));
+        }
+
+        return $fixers[$name];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests;
 
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerFactory;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 /**
@@ -80,5 +82,22 @@ abstract class TestCase extends BaseTestCase
                 }
             );
         }
+    }
+
+    protected static function getFixerByName(string $name): FixerInterface
+    {
+        static $fixers = null;
+
+        if (null === $fixers) {
+            $factory = new FixerFactory();
+            $factory->registerBuiltInFixers();
+
+            $fixers = [];
+            foreach ($factory->getFixers() as $fixer) {
+                $fixers[$fixer->getName()] = $fixer;
+            }
+        }
+
+        return $fixers[$name];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -98,6 +98,10 @@ abstract class TestCase extends BaseTestCase
             }
         }
 
+        if (!\array_key_exists($name, $fixers)) {
+            throw new \InvalidArgumentException(sprintf('Fixer "%s" does not exist.', $name));
+        }
+
         return $fixers[$name];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests;
 
-use PhpCsFixer\Fixer\FixerInterface;
-use PhpCsFixer\FixerFactory;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 /**
@@ -82,26 +80,5 @@ abstract class TestCase extends BaseTestCase
                 }
             );
         }
-    }
-
-    protected static function getFixerByName(string $name): FixerInterface
-    {
-        static $fixers = null;
-
-        if (null === $fixers) {
-            $factory = new FixerFactory();
-            $factory->registerBuiltInFixers();
-
-            $fixers = [];
-            foreach ($factory->getFixers() as $fixer) {
-                $fixers[$fixer->getName()] = $fixer;
-            }
-        }
-
-        if (!\array_key_exists($name, $fixers)) {
-            throw new \InvalidArgumentException(sprintf('Fixer "%s" does not exist.', $name));
-        }
-
-        return $fixers[$name];
     }
 }


### PR DESCRIPTION
Revived #7960, credits to @kubawerlos.

In terms of [this discussion](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7960#discussion_r1572464719), I believe the point was valid but maybe not articulated correctly. As you can see, `AbstractFixerTestCase::testDeprecatedFixersDoNotHaveDeprecatedSuccessor()` iterates over the result of `DeprecatedFixerInterface::getSuccessorsNames()` and then calls `TestCaseUtils::getFixerByName()` (previously this method was a part of `TestCase`). The problem here is that `getSuccessorsNames()`'s return type is defined as `list<string>` and there is not any mechanism that would verify if successors are valid references to existing fixers. For example, when we do:

```php
public function getSuccessorsNames(): array
{
    return array_merge(array_keys($this->proxyFixers), ['foo']);
}
```

the docs are generated properly, Auto Review tests pass, everything looks OK, but then `testDeprecatedFixersDoNotHaveDeprecatedSuccessor()` fails with `TypeError: PhpCsFixer\Tests\Test\TestCaseUtils::getFixerByName(): Return value must be of type PhpCsFixer\Fixer\FixerInterface, null returned`.

<img width="1840" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/c2b1f07c-e607-4f90-aea1-a22538b60c37">

With the explicit check, as suggested in the original PR, it just looks better and is more descriptive:

<img width="1840" alt="image" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/600668/d88ea693-2592-479a-9b67-18302b0fe984">

PS. Maybe we should have auto-review test that would verify if defined successors are valid fixers? (should be done in separate PR, if needed)