### PR TITLE
fix: `TrailingCommaInMultilineFixer` - handle trailing comma in language constructs

### DIFF
--- a/src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php
+++ b/src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php
@@ -153,8 +153,9 @@ final class TrailingCommaInMultilineFixer extends AbstractFixer implements Confi
             if (
                 $fixParameters
                 && (
-                    $tokens[$prevIndex]->isGivenKind(T_STRING) && $tokens[$prevPrevIndex]->isGivenKind(T_FUNCTION)
-                    || $tokens[$prevIndex]->isGivenKind([T_FN, T_FUNCTION])
+                    $tokens[$prevIndex]->isGivenKind(T_STRING)
+                    && $tokens[$prevPrevIndex]->isGivenKind(T_FUNCTION)
+                    || $tokens[$prevIndex]->isGivenKind([T_FN, T_FUNCTION, T_ISSET, T_UNSET, T_LIST])
                 )
             ) {
                 $this->fixBlock($tokens, $index);

--- a/src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php
+++ b/src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php
@@ -153,9 +153,10 @@ final class TrailingCommaInMultilineFixer extends AbstractFixer implements Confi
             if (
                 $fixParameters
                 && (
-                    $tokens[$prevIndex]->isGivenKind(T_STRING)
-                    && $tokens[$prevPrevIndex]->isGivenKind(T_FUNCTION)
-                    || $tokens[$prevIndex]->isGivenKind([T_FN, T_FUNCTION, T_ISSET, T_UNSET, T_LIST])
+                    $tokens[$prevIndex]->isGivenKind(T_STRING) && (
+                        $tokens[$prevPrevIndex]->isGivenKind(T_FUNCTION)
+                        || $tokens[$prevIndex]->isGivenKind([T_FN, T_FUNCTION, T_ISSET, T_UNSET, T_LIST]
+                    )
                 )
             ) {
                 $this->fixBlock($tokens, $index);

--- a/src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php
+++ b/src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php
@@ -153,10 +153,9 @@ final class TrailingCommaInMultilineFixer extends AbstractFixer implements Confi
             if (
                 $fixParameters
                 && (
-                    $tokens[$prevIndex]->isGivenKind(T_STRING) && (
-                        $tokens[$prevPrevIndex]->isGivenKind(T_FUNCTION)
-                        || $tokens[$prevIndex]->isGivenKind([T_FN, T_FUNCTION, T_ISSET, T_UNSET, T_LIST]
-                    )
+                    $tokens[$prevIndex]->isGivenKind(T_STRING)
+                    && $tokens[$prevPrevIndex]->isGivenKind(T_FUNCTION)
+                    || $tokens[$prevIndex]->isGivenKind([T_FN, T_FUNCTION, T_ISSET, T_UNSET, T_LIST])
                 )
             ) {
                 $this->fixBlock($tokens, $index);

--- a/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
+++ b/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
@@ -674,6 +674,38 @@ $a
             ['elements' => [TrailingCommaInMultilineFixer::ELEMENTS_PARAMETERS]],
         ];
 
+        yield [
+            '<?php
+isset(
+    $a,
+    $b,
+);
+unset(
+    $a,
+    $b,
+);
+list(
+    $a,
+    $b,
+) = $foo;
+            ',
+            '<?php
+isset(
+    $a,
+    $b
+);
+unset(
+    $a,
+    $b
+);
+list(
+    $a,
+    $b
+) = $foo;
+            ',
+            ['elements' => [TrailingCommaInMultilineFixer::ELEMENTS_PARAMETERS]],
+        ];
+
         yield 'match' => [
             '<?php
 $m = match ($a) {

--- a/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
+++ b/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
@@ -674,7 +674,7 @@ $a
             ['elements' => [TrailingCommaInMultilineFixer::ELEMENTS_PARAMETERS]],
         ];
 
-        yield [
+        yield 'function-like language constructs' => [
             '<?php
 isset(
     $a,


### PR DESCRIPTION
Trailing comma was not added for "function-like" language constructs which accepts more then one parameter.

That is:
- `isset()`
- `unset()`
- `list()`

This change was supposed to happen, but did not, even though `['elements' => ['parameters']]` was enabled.

```diff
<?php

isset(
    $a,
-    $b
+    $b,
);
unset(
    $a,
-    $b
+    $b,

);
list(
    $a,
-    $b
+    $b,

) = $foo;

```