### PR TITLE
fix: `TrailingCommaInMultilineFixer` - language constructs should be covered by arguments, not parameters

### DIFF
--- a/src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php
+++ b/src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php
@@ -142,7 +142,7 @@ final class TrailingCommaInMultilineFixer extends AbstractFixer implements Confi
             $prevPrevIndex = $tokens->getPrevMeaningfulToken($prevIndex);
 
             if ($fixArguments
-                && $tokens[$prevIndex]->equalsAny([']', [T_CLASS], [T_STRING], [T_VARIABLE], [T_STATIC]])
+                && $tokens[$prevIndex]->equalsAny([']', [T_CLASS], [T_STRING], [T_VARIABLE], [T_STATIC], [T_ISSET], [T_UNSET], [T_LIST]])
                 && !$tokens[$prevPrevIndex]->isGivenKind(T_FUNCTION)
             ) {
                 $this->fixBlock($tokens, $index);
@@ -155,7 +155,7 @@ final class TrailingCommaInMultilineFixer extends AbstractFixer implements Confi
                 && (
                     $tokens[$prevIndex]->isGivenKind(T_STRING)
                     && $tokens[$prevPrevIndex]->isGivenKind(T_FUNCTION)
-                    || $tokens[$prevIndex]->isGivenKind([T_FN, T_FUNCTION, T_ISSET, T_UNSET, T_LIST])
+                    || $tokens[$prevIndex]->isGivenKind([T_FN, T_FUNCTION])
                 )
             ) {
                 $this->fixBlock($tokens, $index);

--- a/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
+++ b/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
@@ -530,6 +530,38 @@ $a
             ['elements' => [TrailingCommaInMultilineFixer::ELEMENTS_ARGUMENTS]],
         ];
 
+        yield 'function-like language constructs' => [
+            '<?php
+isset(
+    $a,
+    $b,
+);
+unset(
+    $a,
+    $b,
+);
+list(
+    $a,
+    $b,
+) = $foo;
+            ',
+            '<?php
+isset(
+    $a,
+    $b
+);
+unset(
+    $a,
+    $b
+);
+list(
+    $a,
+    $b
+) = $foo;
+            ',
+            ['elements' => [TrailingCommaInMultilineFixer::ELEMENTS_ARGUMENTS]],
+        ];
+
         yield [
             '<?php
                     array(
@@ -671,38 +703,6 @@ $a
                     $x,
                     $y
                 ) => $x + $y;',
-            ['elements' => [TrailingCommaInMultilineFixer::ELEMENTS_PARAMETERS]],
-        ];
-
-        yield 'function-like language constructs' => [
-            '<?php
-isset(
-    $a,
-    $b,
-);
-unset(
-    $a,
-    $b,
-);
-list(
-    $a,
-    $b,
-) = $foo;
-            ',
-            '<?php
-isset(
-    $a,
-    $b
-);
-unset(
-    $a,
-    $b
-);
-list(
-    $a,
-    $b
-) = $foo;
-            ',
             ['elements' => [TrailingCommaInMultilineFixer::ELEMENTS_PARAMETERS]],
         ];
 


### PR DESCRIPTION
Ref. https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7989#issuecomment-2098564656