### PR TITLE
fix: Better array shape in `PhpUnitDedicateAssertFixer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # PHP Coding Standards Fixer
 
-The PHP Coding Standards Fixer (PHP CS Fixer) tool fixes your code to follow standardz;
+The PHP Coding Standards Fixer (PHP CS Fixer) tool fixes your code to follow standards;
 whether you want to follow PHP coding standards as defined in the PSR-1, PSR-2, etc.,
 or other community driven ones like the Symfony one.
 You can **also** define your (team's) style through configuration.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # PHP Coding Standards Fixer
 
-The PHP Coding Standards Fixer (PHP CS Fixer) tool fixes your code to follow standards;
+The PHP Coding Standards Fixer (PHP CS Fixer) tool fixes your code to follow standardz;
 whether you want to follow PHP coding standards as defined in the PSR-1, PSR-2, etc.,
 or other community driven ones like the Symfony one.
 You can **also** define your (team's) style through configuration.

--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -567,16 +567,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in an if condition, bool\\|int\\|string given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$token of class PhpCsFixer\\\\Tokenizer\\\\Token constructor expects array\\{int, string\\}\\|string, array\\{[0-9]+, int\\|string\\|true\\} given\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#3 \\$length of function substr expects int\\|null, int\\<0, max\\>\\|false given\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php',

--- a/src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
@@ -34,7 +34,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 final class PhpUnitDedicateAssertFixer extends AbstractPhpUnitFixer implements ConfigurableFixerInterface
 {
     /**
-     * @var array<string, array<string, bool|int|string>|true>
+     * @var array<string, array{positive: string, negative: false|string, argument_count?: int, swap_arguments?: true}|true>
      */
     private static array $fixMap = [
         'array_key_exists' => [


### PR DESCRIPTION
CI now runs PHP 8.3.7 (not officially released, but has a tag at https://github.com/php/php-src) and the value of `T_STRING` changed, which fails CI (see 1st commit).