### PR TITLE
DX: Install PCov extension for local Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN if [ ! -z "$DOCKER_GROUP_ID" ] && [ ! getent group "${DOCKER_GROUP_ID}" > /d
     fi \
     && apk add git \
     && sync \
-    && install-php-extensions xdebug-${PHP_XDEBUG_VERSION} \
+    && install-php-extensions pcov xdebug-${PHP_XDEBUG_VERSION} \
     && curl --location --output /usr/local/bin/xdebug https://github.com/julienfalque/xdebug/releases/download/v2.0.0/xdebug \
     && chmod +x /usr/local/bin/xdebug
 


### PR DESCRIPTION
Without it, PHPUnit produces many `XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set` warnings when running tests in IDE.