### PR TITLE
DX: Fix Mess Detector violations

### DIFF
--- a/src/Console/Report/FixReport/XmlReporter.php
+++ b/src/Console/Report/FixReport/XmlReporter.php
@@ -126,9 +126,9 @@ final class XmlReporter implements ReporterInterface
 
     private function createAboutElement(\DOMDocument $dom, string $about): \DOMElement
     {
-        $XML = $dom->createElement('about');
-        $XML->setAttribute('value', $about);
+        $xml = $dom->createElement('about');
+        $xml->setAttribute('value', $about);
 
-        return $XML;
+        return $xml;
     }
 }

--- a/src/Tokenizer/Analyzer/AttributeAnalyzer.php
+++ b/src/Tokenizer/Analyzer/AttributeAnalyzer.php
@@ -110,7 +110,9 @@ final class AttributeAnalyzer
         }
 
         $startIndex = $index;
-        if ($tokens[$prevIndex = $tokens->getPrevMeaningfulToken($index)]->isGivenKind(CT::T_ATTRIBUTE_CLOSE)) {
+        $prevIndex = $tokens->getPrevMeaningfulToken($index);
+
+        if ($tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind(CT::T_ATTRIBUTE_CLOSE)) {
             // Include comments/PHPDoc if they are present
             $startIndex = $tokens->getNextNonWhitespace($prevIndex);
         }


### PR DESCRIPTION
When running `composer qa`, Mess Detector is executed for the whole codebase (in contrast to CI where it's run only for files included in the PR), and since Mess Detector was not working in CI for some time, we introduced some violations that now fail `qa` script.