### PR TITLE
fix: `native_constant_invocation` - array constants with native constant names

### DIFF
--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -379,7 +379,7 @@ final class TokensAnalyzer
             return false;
         }
 
-        while ($this->tokens[$prevIndex]->isGivenKind([CT::T_NAMESPACE_OPERATOR, T_NS_SEPARATOR, T_STRING])) {
+        while ($this->tokens[$prevIndex]->isGivenKind([CT::T_NAMESPACE_OPERATOR, T_NS_SEPARATOR, T_STRING, CT::T_ARRAY_TYPEHINT])) {
             $prevIndex = $this->tokens->getPrevMeaningfulToken($prevIndex);
         }
 

--- a/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+++ b/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
@@ -606,12 +606,14 @@ echo M_PI;
                 protected const string|int C2 = \PHP_EOL;
                 private const string|(A&B) C3 = BAR;
                 public const EnumA C4 = EnumA::FOO;
+                private const array CONNECTION_TIMEOUT = [\'foo\'];
             }',
             '<?php class Foo {
                 public const string C1 = PHP_EOL;
                 protected const string|int C2 = \PHP_EOL;
                 private const string|(A&B) C3 = \BAR;
                 public const EnumA C4 = EnumA::FOO;
+                private const array CONNECTION_TIMEOUT = [\'foo\'];
             }',
         ];
     }

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -1528,6 +1528,26 @@ abstract class Baz
     {
         yield [
             [3 => false, 11 => false, 13 => false, 17 => true],
+            '<?php class Foo { public const string FOO = BAR; }',
+        ];
+
+        yield [
+            [3 => false, 11 => false, 13 => false, 17 => true],
+            '<?php class Foo { public const int FOO = BAR; }',
+        ];
+
+        yield [
+            [3 => false, 11 => false, 13 => false, 17 => true],
+            '<?php class Foo { public const bool FOO = BAR; }',
+        ];
+
+        yield [
+            [3 => false, 13 => false, 18 => true],
+            '<?php class Foo { public const array FOO = [BAR]; }',
+        ];
+
+        yield [
+            [3 => false, 11 => false, 13 => false, 17 => true],
             '<?php class Foo { public const A FOO = BAR; }',
         ];
 


### PR DESCRIPTION
Currently the `native_constant_invocation` tries to do the following:

```diff
- private const array CONNECTION_TIMEOUT = ['foo'];
+ private const array \CONNECTION_TIMEOUT = ['foo'];
```