### PR TITLE
fix: Support named args in `ParallelConfigFactory::detect()`

### DIFF
--- a/src/Runner/Parallel/ParallelConfig.php
+++ b/src/Runner/Parallel/ParallelConfig.php
@@ -19,8 +19,8 @@ namespace PhpCsFixer\Runner\Parallel;
  */
 final class ParallelConfig
 {
-    private const DEFAULT_FILES_PER_PROCESS = 10;
-    private const DEFAULT_PROCESS_TIMEOUT = 120;
+    public const DEFAULT_FILES_PER_PROCESS = 10;
+    public const DEFAULT_PROCESS_TIMEOUT = 120;
 
     private int $filesPerProcess;
     private int $maxProcesses;

--- a/src/Runner/Parallel/ParallelConfig.php
+++ b/src/Runner/Parallel/ParallelConfig.php
@@ -19,7 +19,9 @@ namespace PhpCsFixer\Runner\Parallel;
  */
 final class ParallelConfig
 {
+    /** @internal */
     public const DEFAULT_FILES_PER_PROCESS = 10;
+    /** @internal */
     public const DEFAULT_PROCESS_TIMEOUT = 120;
 
     private int $filesPerProcess;

--- a/src/Runner/Parallel/ParallelConfig.php
+++ b/src/Runner/Parallel/ParallelConfig.php
@@ -21,6 +21,7 @@ final class ParallelConfig
 {
     /** @internal */
     public const DEFAULT_FILES_PER_PROCESS = 10;
+
     /** @internal */
     public const DEFAULT_PROCESS_TIMEOUT = 120;
 

--- a/src/Runner/Parallel/ParallelConfigFactory.php
+++ b/src/Runner/Parallel/ParallelConfigFactory.php
@@ -47,19 +47,10 @@ final class ParallelConfigFactory
             ]);
         }
 
-        $args = array_filter(
-            [
-                'maxProcesses' => self::$cpuDetector->getCount(),
-                'filesPerProcess' => $filesPerProcess,
-                'processTimeout' => $processTimeout,
-            ],
-            static fn ($value): bool => null !== $value
+        return new ParallelConfig(
+            self::$cpuDetector->getCount(),
+            $filesPerProcess ?? ParallelConfig::DEFAULT_FILES_PER_PROCESS,
+            $processTimeout ?? ParallelConfig::DEFAULT_PROCESS_TIMEOUT
         );
-
-        if (\PHP_VERSION_ID < 8_00_00) {
-            $args = array_values($args);
-        }
-
-        return new ParallelConfig(...$args);
     }
 }

--- a/src/Runner/Parallel/ParallelConfigFactory.php
+++ b/src/Runner/Parallel/ParallelConfigFactory.php
@@ -47,11 +47,19 @@ final class ParallelConfigFactory
             ]);
         }
 
-        return new ParallelConfig(
-            ...array_filter(
-                [self::$cpuDetector->getCount(), $filesPerProcess, $processTimeout],
-                static fn ($value): bool => null !== $value
-            )
+        $args = array_filter(
+            [
+                'maxProcesses' => self::$cpuDetector->getCount(),
+                'filesPerProcess' => $filesPerProcess,
+                'processTimeout' => $processTimeout,
+            ],
+            static fn ($value): bool => null !== $value
         );
+
+        if (\PHP_VERSION_ID < 8_00_00) {
+            $args = array_values($args);
+        }
+
+        return new ParallelConfig(...$args);
     }
 }

--- a/tests/Runner/Parallel/ParallelConfigFactoryTest.php
+++ b/tests/Runner/Parallel/ParallelConfigFactoryTest.php
@@ -61,4 +61,31 @@ final class ParallelConfigFactoryTest extends TestCase
         self::assertSame(22, $config->getFilesPerProcess());
         self::assertSame(2_200, $config->getProcessTimeout());
     }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testDetectConfigurationWithNamedArgs(): void
+    {
+        // First argument omitted, second one provided via named argument
+        $config1 = \call_user_func_array([ParallelConfigFactory::class, 'detect'], ['processTimeout' => 300]);
+
+        self::assertSame(10, $config1->getFilesPerProcess());
+        self::assertSame(300, $config1->getProcessTimeout());
+
+        // Flipped order of arguments using named arguments syntax
+        $config2 = \call_user_func_array([ParallelConfigFactory::class, 'detect'], [
+            'processTimeout' => 300,
+            'filesPerProcess' => 5,
+        ]);
+
+        self::assertSame(5, $config2->getFilesPerProcess());
+        self::assertSame(300, $config2->getProcessTimeout());
+
+        // Only first argument provided, but via named argument
+        $config3 = \call_user_func_array([ParallelConfigFactory::class, 'detect'], ['filesPerProcess' => 7]);
+
+        self::assertSame(7, $config3->getFilesPerProcess());
+        self::assertSame(120, $config3->getProcessTimeout());
+    }
 }

--- a/tests/Runner/Parallel/ParallelConfigFactoryTest.php
+++ b/tests/Runner/Parallel/ParallelConfigFactoryTest.php
@@ -62,6 +62,14 @@ final class ParallelConfigFactoryTest extends TestCase
         self::assertSame(2_200, $config->getProcessTimeout());
     }
 
+    public function testDetectConfigurationWithDefaultValue(): void
+    {
+        $config = ParallelConfigFactory::detect(null, 60);
+
+        self::assertSame(10, $config->getFilesPerProcess());
+        self::assertSame(60, $config->getProcessTimeout());
+    }
+
     /**
      * @requires PHP 8.0
      */

--- a/tests/Runner/Parallel/ParallelConfigFactoryTest.php
+++ b/tests/Runner/Parallel/ParallelConfigFactoryTest.php
@@ -16,6 +16,7 @@ namespace PhpCsFixer\Tests\Runner\Parallel;
 
 use Fidry\CpuCoreCounter\CpuCoreCounter;
 use Fidry\CpuCoreCounter\Finder\DummyCpuCoreFinder;
+use PhpCsFixer\Runner\Parallel\ParallelConfig;
 use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 use PhpCsFixer\Tests\TestCase;
 
@@ -48,8 +49,8 @@ final class ParallelConfigFactoryTest extends TestCase
         $config = ParallelConfigFactory::detect();
 
         self::assertSame(7, $config->getMaxProcesses());
-        self::assertSame(10, $config->getFilesPerProcess());
-        self::assertSame(120, $config->getProcessTimeout());
+        self::assertSame(ParallelConfig::DEFAULT_FILES_PER_PROCESS, $config->getFilesPerProcess());
+        self::assertSame(ParallelConfig::DEFAULT_PROCESS_TIMEOUT, $config->getProcessTimeout());
 
         $cpuDetector->setValue($parallelConfigFactoryReflection, null);
     }
@@ -66,7 +67,7 @@ final class ParallelConfigFactoryTest extends TestCase
     {
         $config = ParallelConfigFactory::detect(null, 60);
 
-        self::assertSame(10, $config->getFilesPerProcess());
+        self::assertSame(ParallelConfig::DEFAULT_FILES_PER_PROCESS, $config->getFilesPerProcess());
         self::assertSame(60, $config->getProcessTimeout());
     }
 
@@ -78,7 +79,7 @@ final class ParallelConfigFactoryTest extends TestCase
         // First argument omitted, second one provided via named argument
         $config1 = \call_user_func_array([ParallelConfigFactory::class, 'detect'], ['processTimeout' => 300]);
 
-        self::assertSame(10, $config1->getFilesPerProcess());
+        self::assertSame(ParallelConfig::DEFAULT_FILES_PER_PROCESS, $config1->getFilesPerProcess());
         self::assertSame(300, $config1->getProcessTimeout());
 
         // Flipped order of arguments using named arguments syntax
@@ -94,6 +95,6 @@ final class ParallelConfigFactoryTest extends TestCase
         $config3 = \call_user_func_array([ParallelConfigFactory::class, 'detect'], ['filesPerProcess' => 7]);
 
         self::assertSame(7, $config3->getFilesPerProcess());
-        self::assertSame(120, $config3->getProcessTimeout());
+        self::assertSame(ParallelConfig::DEFAULT_PROCESS_TIMEOUT, $config3->getProcessTimeout());
     }
 }


### PR DESCRIPTION
Fixes #8025