### PR TITLE
docs: fix deprecated string interpolation style

### DIFF
--- a/doc/rules/string_notation/explicit_string_variable.rst
+++ b/doc/rules/string_notation/explicit_string_variable.rst
@@ -11,10 +11,10 @@ Description
 The reasoning behind this rule is the following:
 - When there are two valid ways of doing the same thing, using both is
 confusing, there should be a coding standard to follow.
-- PHP manual marks ``"$var"`` syntax as implicit and ``"${var}"`` syntax as
+- PHP manual marks ``"$var"`` syntax as implicit and ``"{$var}"`` syntax as
 explicit: explicit code should always be preferred.
 - Explicit syntax allows word concatenation inside strings, e.g.
-``"${var}IsAVar"``, implicit doesn't.
+``"{$var}IsAVar"``, implicit doesn't.
 - Explicit syntax is easier to detect for IDE/editors and therefore has
 colors/highlight with higher contrast, which is easier to read.
 Backtick operator is skipped because it is harder to handle; you can use

--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -42,8 +42,8 @@ final class ExplicitStringVariableFixer extends AbstractFixer
             )],
             'The reasoning behind this rule is the following:'
                 ."\n".'- When there are two valid ways of doing the same thing, using both is confusing, there should be a coding standard to follow.'
-                ."\n".'- PHP manual marks `"$var"` syntax as implicit and `"${var}"` syntax as explicit: explicit code should always be preferred.'
-                ."\n".'- Explicit syntax allows word concatenation inside strings, e.g. `"${var}IsAVar"`, implicit doesn\'t.'
+                ."\n".'- PHP manual marks `"$var"` syntax as implicit and `"{$var}"` syntax as explicit: explicit code should always be preferred.'
+                ."\n".'- Explicit syntax allows word concatenation inside strings, e.g. `"{$var}IsAVar"`, implicit doesn\'t.'
                 ."\n".'- Explicit syntax is easier to detect for IDE/editors and therefore has colors/highlight with higher contrast, which is easier to read.'
             ."\n".'Backtick operator is skipped because it is harder to handle; you can use `backtick_to_shell_exec` fixer to normalize backticks to strings.'
         );


### PR DESCRIPTION
Since PHP 8.2 the use of `${var}` is deprecated. Instead, `{$var}` should be used.
The documentation/definition for the fixer`explicit_string_variable` was still using the deprecated string interpolation style.

See: https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dollar-brace-interpolation
