### PR TITLE
fix: `PhpUnitTestClassRequiresCoversFixer` - attribute detection when class is `readonly`

### DIFF
--- a/src/Fixer/AbstractPhpUnitFixer.php
+++ b/src/Fixer/AbstractPhpUnitFixer.php
@@ -153,13 +153,20 @@ abstract class AbstractPhpUnitFixer extends AbstractFixer
             return false;
         }
 
-        $attributeIndex = $tokens->getPrevMeaningfulToken($index);
-        if (!$tokens[$attributeIndex]->isGivenKind(CT::T_ATTRIBUTE_CLOSE)) {
+        $modifiers = [T_FINAL];
+        if (\defined('T_READONLY')) { // @TODO: drop condition when PHP 8.2+ is required
+            $modifiers[] = T_READONLY;
+        }
+
+        do {
+            $index = $tokens->getPrevMeaningfulToken($index);
+        } while ($tokens[$index]->isGivenKind($modifiers));
+        if (!$tokens[$index]->isGivenKind(CT::T_ATTRIBUTE_CLOSE)) {
             return false;
         }
-        $attributeIndex = $tokens->findBlockStart(Tokens::BLOCK_TYPE_ATTRIBUTE, $attributeIndex);
+        $index = $tokens->findBlockStart(Tokens::BLOCK_TYPE_ATTRIBUTE, $index);
 
-        foreach (AttributeAnalyzer::collect($tokens, $attributeIndex) as $attributeAnalysis) {
+        foreach (AttributeAnalyzer::collect($tokens, $index) as $attributeAnalysis) {
             foreach ($attributeAnalysis->getAttributes() as $attribute) {
                 if (\in_array(self::getFullyQualifiedName($tokens, $attribute['name']), $preventingAttributes, true)) {
                     return true;

--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -68,10 +68,6 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             return; // don't add `@covers` annotation for abstract base classes
         }
 
-        if (isset($modifiers['final'])) {
-            $classIndex = $tokens->getPrevMeaningfulToken($classIndex);
-        }
-
         $this->ensureIsDocBlockWithAnnotation(
             $tokens,
             $classIndex,

--- a/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
@@ -385,7 +385,7 @@ class FooTest extends \PHPUnit_Framework_TestCase {}
      *
      * @requires PHP 8.2
      */
-    public function testFix82(string $expected, ?string $input): void
+    public function testFix82(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -411,6 +411,22 @@ class FooTest extends \PHPUnit_Framework_TestCase {}
                     abstract readonly class FooTest extends \PHPUnit_Framework_TestCase {}
             ',
             null,
+        ];
+
+        yield 'with attribute on readonly class' => [
+            <<<'PHP'
+                <?php
+                #[PHPUnit\Framework\Attributes\CoversNothing]
+                readonly class FooTest extends \PHPUnit_Framework_TestCase {}
+                PHP,
+        ];
+
+        yield 'with attribute on final readonly class' => [
+            <<<'PHP'
+                <?php
+                #[PHPUnit\Framework\Attributes\CoversNothing]
+                final readonly class FooTest extends \PHPUnit_Framework_TestCase {}
+                PHP,
         ];
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8016