### PR TITLE
fix: handle PHP closing tag with `simplified_null_return` correctly

### DIFF
--- a/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+++ b/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
@@ -79,7 +79,7 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
      */
     private function clear(Tokens $tokens, int $index): void
     {
-        while (!$tokens[++$index]->equals(';')) {
+        while (!$tokens[++$index]->equalsAny([';', [T_CLOSE_TAG]])) {
             if ($this->shouldClearToken($tokens, $index)) {
                 $tokens->clearAt($index);
             }
@@ -96,13 +96,16 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
         }
 
         $content = '';
-        while (!$tokens[$index]->equals(';')) {
+        while (!$tokens[$index]->equalsAny([';', [T_CLOSE_TAG]])) {
             $index = $tokens->getNextMeaningfulToken($index);
             $content .= $tokens[$index]->getContent();
         }
 
+        $lastTokenContent = $tokens[$index]->getContent();
+        $content = substr($content, 0, -\strlen($lastTokenContent));
+
         $content = ltrim($content, '(');
-        $content = rtrim($content, ');');
+        $content = rtrim($content, ')');
 
         return 'null' === strtolower($content);
     }
@@ -137,13 +140,29 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
     /**
      * Should we clear the specific token?
      *
-     * If the token is a comment, or is whitespace that is immediately before a
-     * comment, then we'll leave it alone.
+     * We'll leave it alone if
+     * - token is a comment
+     * - token is whitespace that is immediately before a comment
+     * - token is whitespace that is immediately before the PHP close tag
      */
     private function shouldClearToken(Tokens $tokens, int $index): bool
     {
         $token = $tokens[$index];
 
-        return !$token->isComment() && !($token->isWhitespace() && $tokens[$index + 1]->isComment());
+        if ($token->isComment()) {
+            return false;
+        }
+
+        if ($token->isWhitespace()) {
+            if ($tokens[$index + 1]->isComment()) {
+                return false;
+            }
+
+            if ($tokens[$index + 1]->equals([T_CLOSE_TAG])) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+++ b/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
@@ -144,6 +144,7 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
      * - token is a comment
      * - token is whitespace that is immediately before a comment
      * - token is whitespace that is immediately before the PHP close tag
+     * - token is whitespace that is immediately after a comment and before a semicolon
      */
     private function shouldClearToken(Tokens $tokens, int $index): bool
     {
@@ -159,6 +160,10 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
             }
 
             if ($tokens[$index + 1]->equals([T_CLOSE_TAG])) {
+                return false;
+            }
+
+            if ($tokens[$index - 1]->isComment() && $tokens[$index + 1]->equals(';')) {
                 return false;
             }
         }

--- a/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+++ b/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
@@ -154,18 +154,16 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
             return false;
         }
 
-        if ($token->isWhitespace()) {
-            if ($tokens[$index + 1]->isComment()) {
-                return false;
-            }
+        if (!$token->isWhitespace()) {
+            return true;
+        }
 
-            if ($tokens[$index + 1]->equals([T_CLOSE_TAG])) {
-                return false;
-            }
-
-            if ($tokens[$index - 1]->isComment() && $tokens[$index + 1]->equals(';')) {
-                return false;
-            }
+        if (
+            $tokens[$index + 1]->isComment()
+            || $tokens[$index + 1]->equals([T_CLOSE_TAG])
+            || ($tokens[$index - 1]->isComment() && $tokens[$index + 1]->equals(';'))
+        ) {
+            return false;
         }
 
         return true;

--- a/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
+++ b/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
@@ -92,6 +92,34 @@ final class SimplifiedNullReturnFixerTest extends AbstractFixerTestCase
         yield [
             '<?php function foo(): void { return; }',
         ];
+
+        yield ['<?php return ?>', '<?php return null ?>'];
+
+        yield ['<?php return [] ?>'];
+
+        yield [
+            '<?php
+                    return // hello
+                    ?>
+                ',
+            '<?php
+                    return null // hello
+                    ?>
+                ',
+        ];
+
+        yield [
+            '<?php
+                    return
+                    // hello
+                    ?>
+                ',
+            '<?php
+                    return null
+                    // hello
+                    ?>
+                ',
+        ];
     }
 
     /**

--- a/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
+++ b/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
@@ -120,6 +120,30 @@ final class SimplifiedNullReturnFixerTest extends AbstractFixerTestCase
                     ?>
                 ',
         ];
+
+        yield [
+            '<?php
+                    return // hello
+                    ;
+                ',
+            '<?php
+                    return null // hello
+                    ;
+                ',
+        ];
+
+        yield [
+            '<?php
+                    return
+                    // hello
+                    ;
+                ',
+            '<?php
+                    return null
+                    // hello
+                    ;
+                ',
+        ];
     }
 
     /**


### PR DESCRIPTION
This PR fixes a `TypeError: Illegal offset type` error when running the `SimplifiedNullReturnFixer` on files that end with a `return` statement followed by the PHP close tag `?>`, but omit the last semicolon, like so:
```PHP
<?php
return []
?>
```

The issue is described in detail here:
- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8037

## Note:
This PR also fixes an issue with the same fixer, that would incorrectly replace
```PHP
return null
// hello
;

```
with
```PHP
return // hello;
```
