### PR TITLE
fix: clear `Tokens::$blockStartCache` and `Tokens::$blockEndCache` when calling `Tokens::setCode`

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -1056,6 +1056,9 @@ class Tokens extends \SplFixedArray
             $this[$index] = new Token($token);
         }
 
+        $this->blockStartCache = [];
+        $this->blockEndCache = [];
+
         $this->applyTransformers();
 
         $this->foundTokenKinds = [];

--- a/tests/Fixtures/Integration/misc/trailing_comma_in_multiline,binary_operator_spaces.test
+++ b/tests/Fixtures/Integration/misc/trailing_comma_in_multiline,binary_operator_spaces.test
@@ -1,0 +1,15 @@
+--TEST--
+Integration of fixers: trailing_comma_in_multiline,binary_operator_spaces.
+--RULESET--
+{"trailing_comma_in_multiline": true, "binary_operator_spaces": {"default" : "align_single_space_minimal"}}
+--EXPECT--
+<?php $a = [
+    'key1'  => 'x',
+    'key11' => 'y',
+];
+
+--INPUT--
+<?php $a = [
+    'key1' => 'x',
+    'key11'=> 'y',
+];


### PR DESCRIPTION
Awful title, but still less awful than debugging this.