### PR TITLE
fix: `PhpUnitTestClassRequiresCoversFixer` - do not add annotation when attribute with leading slash present

### DIFF
--- a/src/Fixer/AbstractPhpUnitFixer.php
+++ b/src/Fixer/AbstractPhpUnitFixer.php
@@ -168,7 +168,7 @@ abstract class AbstractPhpUnitFixer extends AbstractFixer
 
         foreach (AttributeAnalyzer::collect($tokens, $index) as $attributeAnalysis) {
             foreach ($attributeAnalysis->getAttributes() as $attribute) {
-                if (\in_array(self::getFullyQualifiedName($tokens, $attribute['name']), $preventingAttributes, true)) {
+                if (\in_array(ltrim(self::getFullyQualifiedName($tokens, $attribute['name']), '\\'), $preventingAttributes, true)) {
                     return true;
                 }
             }

--- a/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
@@ -314,6 +314,14 @@ class FooTest extends \PHPUnit_Framework_TestCase {}
                 PHP,
         ];
 
+        yield 'already with attribute CoversNothing with leading slash' => [
+            <<<'PHP'
+                <?php
+                #[\PHPUnit\Framework\Attributes\CoversNothing]
+                class FooTest extends \PHPUnit_Framework_TestCase {}
+                PHP,
+        ];
+
         yield 'already with imported attribute' => [
             <<<'PHP'
                 <?php


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8034