### PR TITLE
fix: Look up for PHPDoc's variable name by only chars allowed in the variables

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -55,6 +55,6 @@ parameters:
         -
             message: '#^Method PhpCsFixer\\Tests\\.+::provide.+Cases\(\) return type has no value type specified in iterable type iterable\.$#'
             path: tests
-            count: 1013
+            count: 1012
     tipsOfTheDay: false
     tmpDir: dev-tools/phpstan/cache

--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -171,14 +171,17 @@ final class Annotation
     }
 
     /**
-     * @return null|string
-     *
      * @internal
      */
-    public function getVariableName()
+    public function getVariableName(): ?string
     {
         $type = preg_quote($this->getTypesContent() ?? '', '/');
-        $regex = "/@{$this->tag->getName()}\\s+({$type}\\s*)?(&\\s*)?(\\.{3}\\s*)?(?<variable>\\$[a-zA-Z_]+[a-zA-Z0-9_]*)(?:.*|$)/";
+        $regex = sprintf(
+            '/@%s\s+(%s\s*)?(&\s*)?(\.{3}\s*)?(?<variable>\$%s)(?:.*|$)/',
+            $this->tag->getName(),
+            $type,
+            TypeExpression::REGEX_IDENTIFIER
+        );
 
         if (Preg::match($regex, $this->lines[0]->getContent(), $matches)) {
             return $matches['variable'];

--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -178,7 +178,7 @@ final class Annotation
     public function getVariableName()
     {
         $type = preg_quote($this->getTypesContent() ?? '', '/');
-        $regex = "/@{$this->tag->getName()}\\s+({$type}\\s*)?(&\\s*)?(\\.{3}\\s*)?(?<variable>\\$.+?)(?:[\\s*]|$)/";
+        $regex = "/@{$this->tag->getName()}\\s+({$type}\\s*)?(&\\s*)?(\\.{3}\\s*)?(?<variable>\\$[a-zA-Z_]+[a-zA-Z0-9_]*)(?:.*|$)/";
 
         if (Preg::match($regex, $this->lines[0]->getContent(), $matches)) {
             return $matches['variable'];

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -637,6 +637,9 @@ final class AnnotationTest extends TestCase
         self::assertSame($expectedVariableName, $annotation->getVariableName());
     }
 
+    /**
+     * @return iterable<array{string, null|string}>
+     */
     public static function provideGetVariableNameCases(): iterable
     {
         yield ['* @param int $foo', '$foo'];
@@ -677,6 +680,8 @@ final class AnnotationTest extends TestCase
 
         yield ['* @param int & ... $foo', '$foo'];
 
-        yield ['* @param int $foo=invalid description', '$foo'];
+        yield ['* @param ?int $foo=null invalid description', '$foo'];
+
+        yield ['* @param int $počet Special chars in variable name', '$počet'];
     }
 }

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -676,5 +676,7 @@ final class AnnotationTest extends TestCase
         yield ['* @param int & ...$foo', '$foo'];
 
         yield ['* @param int & ... $foo', '$foo'];
+
+        yield ['* @param int $foo=invalid description', '$foo'];
     }
 }

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -2608,6 +2608,17 @@ static fn ($foo): int => 1;',
                 EOD,
             ['allow_hidden_params' => true],
         ];
+
+        yield '@param without space between variable name and description' => [
+            <<<'EOD'
+                <?php
+                /**
+                 * @param int $bar Bar description
+                 * @param resource|null $baz=null Wrong baz description
+                 */
+                function foo($bar, $baz = null) {}
+                EOD,
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes #7294 not by enforcing proper fixers' priorities, but by providing fix for how `@param`'s variable name is determined. PHPDoc params with descriptions are not considered as superfluous, but in order to do that, we need to determine variable name properly. Since `=` is not a char allowed in the variable name, it shouldn't be taken into consideration as a part of variable name when PHPDoc's line is parsed.