### PR TITLE
feat: `SimpleToComplexStringVariableFixer` - support variable being an array

### DIFF
--- a/src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
+++ b/src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
@@ -73,38 +73,24 @@ final class SimpleToComplexStringVariableFixer extends AbstractFixer
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
         for ($index = \count($tokens) - 3; $index > 0; --$index) {
-            $token = $tokens[$index];
-
-            if (!$token->isGivenKind(T_DOLLAR_OPEN_CURLY_BRACES)) {
+            if (!$tokens[$index]->isGivenKind(T_DOLLAR_OPEN_CURLY_BRACES)) {
                 continue;
             }
-
             $varnameToken = $tokens[$index + 1];
 
             if (!$varnameToken->isGivenKind(T_STRING_VARNAME)) {
                 continue;
             }
 
-            $dollarCloseToken = $tokens[$index + 2];
+            $dollarCloseToken = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_COMPLEX_STRING_VARIABLE, $index);
 
-            if (!$dollarCloseToken->isGivenKind(CT::T_DOLLAR_CLOSE_CURLY_BRACES)) {
-                continue;
+            $prevTokenContent = $tokens[$index - 1]->getContent();
+            if (str_ends_with($prevTokenContent, '$') && !str_ends_with($prevTokenContent, '\$')) {
+                $tokens[$index - 1] = new Token([T_ENCAPSED_AND_WHITESPACE, substr($prevTokenContent, 0, -1).'\$']);
             }
-
-            $tokenOfStringBeforeToken = $tokens[$index - 1];
-            $stringContent = $tokenOfStringBeforeToken->getContent();
-
-            if (str_ends_with($stringContent, '$') && !str_ends_with($stringContent, '\$')) {
-                $newContent = substr($stringContent, 0, -1).'\$';
-                $tokenOfStringBeforeToken = new Token([T_ENCAPSED_AND_WHITESPACE, $newContent]);
-            }
-
-            $tokens->overrideRange($index - 1, $index + 2, [
-                $tokenOfStringBeforeToken,
-                new Token([T_CURLY_OPEN, '{']),
-                new Token([T_VARIABLE, '$'.$varnameToken->getContent()]),
-                new Token([CT::T_CURLY_CLOSE, '}']),
-            ]);
+            $tokens[$index] = new Token([T_CURLY_OPEN, '{']);
+            $tokens[$index + 1] = new Token([T_VARIABLE, '$'.$varnameToken->getContent()]);
+            $tokens[$dollarCloseToken] = new Token([CT::T_CURLY_CLOSE, '}']);
         }
     }
 }

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -50,6 +50,7 @@ class Tokens extends \SplFixedArray
     public const BLOCK_TYPE_ATTRIBUTE = 11;
     public const BLOCK_TYPE_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS = 12;
     public const BLOCK_TYPE_DYNAMIC_CLASS_CONSTANT_FETCH_CURLY_BRACE = 13;
+    public const BLOCK_TYPE_COMPLEX_STRING_VARIABLE = 14;
 
     /**
      * Static class cache.
@@ -273,6 +274,10 @@ class Tokens extends \SplFixedArray
                 self::BLOCK_TYPE_DYNAMIC_CLASS_CONSTANT_FETCH_CURLY_BRACE => [
                     'start' => [CT::T_DYNAMIC_CLASS_CONSTANT_FETCH_CURLY_BRACE_OPEN, '{'],
                     'end' => [CT::T_DYNAMIC_CLASS_CONSTANT_FETCH_CURLY_BRACE_CLOSE, '}'],
+                ],
+                self::BLOCK_TYPE_COMPLEX_STRING_VARIABLE => [
+                    'start' => [T_DOLLAR_OPEN_CURLY_BRACES, '${'],
+                    'end' => [CT::T_DOLLAR_CLOSE_CURLY_BRACES, '}'],
                 ],
             ];
 

--- a/tests/Fixer/StringNotation/SimpleToComplexStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/SimpleToComplexStringVariableFixerTest.php
@@ -130,5 +130,13 @@ final class SimpleToComplexStringVariableFixerTest extends AbstractFixerTestCase
                 echo 'Hello $${name}';
                 EXPECTED,
         ];
+
+        yield 'array elements' => [
+            <<<'PHP'
+                <?php
+                "Hello ${array[0]}!";
+                "Hello ${array['index']}!";
+                PHP,
+        ];
     }
 }

--- a/tests/Fixer/StringNotation/SimpleToComplexStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/SimpleToComplexStringVariableFixerTest.php
@@ -134,6 +134,11 @@ final class SimpleToComplexStringVariableFixerTest extends AbstractFixerTestCase
         yield 'array elements' => [
             <<<'PHP'
                 <?php
+                "Hello {$array[0]}!";
+                "Hello {$array['index']}!";
+                PHP,
+            <<<'PHP'
+                <?php
                 "Hello ${array[0]}!";
                 "Hello ${array['index']}!";
                 PHP,

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -747,6 +747,8 @@ final class TokensTest extends TestCase
         yield [10, '<?php use a\{ClassA, ClassB};', Tokens::BLOCK_TYPE_GROUP_IMPORT_BRACE, 5];
 
         yield [3, '<?php [$a] = $array;', Tokens::BLOCK_TYPE_DESTRUCTURING_SQUARE_BRACE, 1];
+
+        yield [8, '<?php "start__${array[key]}__end";', Tokens::BLOCK_TYPE_COMPLEX_STRING_VARIABLE, 3];
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8063