### PR TITLE
docs: Make wording in `final_class` docs less dismissive

### DIFF
--- a/doc/rules/class_notation/final_class.rst
+++ b/doc/rules/class_notation/final_class.rst
@@ -14,8 +14,8 @@ create two child classes, one empty if necessary: you'll gain much more fine
 grained type-hinting. If you need to mock a standalone class, create an
 interface, or maybe it's a value-object that shouldn't be mocked at all. If you
 need to extend a standalone class, create an interface and use the Composite
-pattern. If you aren't ready yet for serious OOP, go with
-FinalInternalClassFixer, it's fine.
+pattern. If these rules are too strict for you, you can use
+``FinalInternalClassFixer`` instead.
 
 Warning
 -------

--- a/src/Fixer/ClassNotation/FinalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalClassFixer.php
@@ -39,7 +39,7 @@ class MyApp {}
             .'If you want to subclass a class, mark the parent class as abstract and create two child classes, one empty if necessary: you\'ll gain much more fine grained type-hinting. '
             .'If you need to mock a standalone class, create an interface, or maybe it\'s a value-object that shouldn\'t be mocked at all. '
             .'If you need to extend a standalone class, create an interface and use the Composite pattern. '
-            .'If you aren\'t ready yet for serious OOP, go with FinalInternalClassFixer, it\'s fine.',
+            .'If these rules are too strict for you, you can use `FinalInternalClassFixer` instead.',
             'Risky when subclassing non-abstract classes.'
         );
     }


### PR DESCRIPTION
The previous wording was pretty harsh and way too dismissive.