### PR TITLE
fix: Update `PhpUnitTestCaseStaticMethodCallsFixer::STATIC_METHODS`

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
@@ -196,6 +196,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixer extends AbstractPhpUnitFixer i
         'assertObjectEquals' => true,
         'assertObjectHasAttribute' => true,
         'assertObjectHasProperty' => true,
+        'assertObjectNotEquals' => true,
         'assertObjectNotHasAttribute' => true,
         'assertObjectNotHasProperty' => true,
         'assertRegExp' => true,

--- a/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
@@ -17,6 +17,7 @@ namespace PhpCsFixer\Tests\Fixer\PhpUnit;
 use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestCaseStaticMethodCallsFixer;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+use PhpCsFixer\Utils;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -42,7 +43,13 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
             }
         }
 
-        self::assertSame([], $missingMethods, sprintf('The following static methods from "%s" are missing from "%s::$staticMethods"', TestCase::class, PhpUnitTestCaseStaticMethodCallsFixer::class));
+        self::assertSame([], $missingMethods, sprintf(
+            'The following static methods from "%s" are missing from "%s::$staticMethods": %s',
+            TestCase::class,
+            PhpUnitTestCaseStaticMethodCallsFixer::class,
+            // `Utils::naturalLanguageJoin` does not accept empty array, so let's use it only if there's an actual difference.
+            [] === $missingMethods ? '' : Utils::naturalLanguageJoin($missingMethods)
+        ));
     }
 
     public function testWrongConfigTypeForMethodsKey(): void


### PR DESCRIPTION
[PHPUnit 11.2 introduced new assert method](https://github.com/sebastianbergmann/phpunit/releases/tag/11.2.0), and it causes [failures on our side](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/actions/runs/9444673934/job/26010697755?pr=7965#step:9:2522).

Additionally, when running test in IDE there is possibility to see the difference between expected and actual value, but in CI the error message looks incomplete (maybe ParaUnit issue). That's why I added list of missing methods to assert's error message, so it's explicitly printed in the CI output.