### PR TITLE
fix: Better way of walking types in `TypeExpression`

### DIFF
--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -271,20 +271,26 @@ final class TypeExpression
      */
     public function walkTypes(\Closure $callback): void
     {
-        foreach (array_reverse($this->innerTypeExpressions) as [
-            'start_index' => $startIndex,
+        $startIndexOffset = 0;
+
+        foreach ($this->innerTypeExpressions as $k => [
+            'start_index' => $startIndexOrig,
             'expression' => $inner,
         ]) {
-            $initialValueLength = \strlen($inner->toString());
+            $this->innerTypeExpressions[$k]['start_index'] += $startIndexOffset;
+
+            $innerLengthOrig = \strlen($inner->toString());
 
             $inner->walkTypes($callback);
 
             $this->value = substr_replace(
                 $this->value,
                 $inner->toString(),
-                $startIndex,
-                $initialValueLength
+                $startIndexOrig + $startIndexOffset,
+                $innerLengthOrig
             );
+
+            $startIndexOffset += \strlen($inner->toString()) - $innerLengthOrig;
         }
 
         $callback($this);

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -275,7 +275,7 @@ final class TypeExpression
 
         $startIndexOffset = 0;
 
-        foreach ($this->innerTypeExpressions as $k => [
+        foreach ($this->innerTypeExpressions as [
             'start_index' => $startIndexOrig,
             'expression' => $inner,
         ]) {

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -271,15 +271,14 @@ final class TypeExpression
      */
     public function walkTypes(\Closure $callback): void
     {
+        $innerValueOrig = $this->value;
+
         $startIndexOffset = 0;
 
         foreach ($this->innerTypeExpressions as $k => [
             'start_index' => $startIndexOrig,
             'expression' => $inner,
         ]) {
-            // @phpstan-ignore-next-line https://github.com/phpstan/phpstan/issues/11171
-            $this->innerTypeExpressions[$k]['start_index'] += $startIndexOffset;
-
             $innerLengthOrig = \strlen($inner->toString());
 
             $inner->walkTypes($callback);
@@ -295,6 +294,14 @@ final class TypeExpression
         }
 
         $callback($this);
+
+        if ($this->value !== $innerValueOrig) {
+            $this->isUnionType = false;
+            $this->typesGlue = '|';
+            $this->innerTypeExpressions = [];
+
+            $this->parse();
+        }
     }
 
     /**

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -393,7 +393,9 @@ final class TypeExpression
             $consumedValueLength = \strlen($matches[0][0]);
             $index += $consumedValueLength;
 
-            if (\strlen($this->value) === $index) {
+            if (\strlen($this->value) <= $index) {
+                \assert(\strlen($this->value) === $index);
+
                 return;
             }
         }

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -277,6 +277,7 @@ final class TypeExpression
             'start_index' => $startIndexOrig,
             'expression' => $inner,
         ]) {
+            // @phpstan-ignore-next-line https://github.com/phpstan/phpstan/issues/11171
             $this->innerTypeExpressions[$k]['start_index'] += $startIndexOffset;
 
             $innerLengthOrig = \strlen($inner->toString());

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -651,12 +651,12 @@ final class TypeExpressionTest extends TestCase
 
     public function testWalkTypes(): void
     {
-        $typeExpression = new TypeExpression('Foo|Bar|Baz', null, []);
+        $typeExpression = new TypeExpression('Foo|Bar|($v is \Closure(X, Y): Z ? U : (V&W))', null, []);
 
         $addLeadingSlashFx = static function (TypeExpression $type): void {
             \Closure::bind(static function () use ($type): void {
                 $value = $type->toString();
-                if (!str_starts_with($value, '\\')) {
+                if (!str_starts_with($value, '\\') && !str_starts_with($value, '(')) {
                     $value = '\\'.$value;
                 }
                 $type->value = $value;
@@ -674,19 +674,19 @@ final class TypeExpressionTest extends TestCase
         };
 
         $typeExpression->walkTypes($addLeadingSlashFx);
-        self::assertSame('\Foo|\Bar|\Baz', $typeExpression->toString());
+        self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
 
         $typeExpression->walkTypes($addLeadingSlashFx);
-        self::assertSame('\Foo|\Bar|\Baz', $typeExpression->toString());
+        self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
 
         $typeExpression->walkTypes($removeLeadingSlashFx);
-        self::assertSame('Foo|Bar|Baz', $typeExpression->toString());
+        self::assertSame('Foo|Bar|($v is Closure(X, Y): Z ? U : (V&W))', $typeExpression->toString());
 
         $typeExpression->walkTypes($removeLeadingSlashFx);
-        self::assertSame('Foo|Bar|Baz', $typeExpression->toString());
+        self::assertSame('Foo|Bar|($v is Closure(X, Y): Z ? U : (V&W))', $typeExpression->toString());
 
         $typeExpression->walkTypes($addLeadingSlashFx);
-        self::assertSame('\Foo|\Bar|\Baz', $typeExpression->toString());
+        self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
     }
 
     /**

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -653,7 +653,7 @@ final class TypeExpressionTest extends TestCase
     {
         $typeExpression = new TypeExpression('Foo|Bar|($v is \Closure(X, Y): Z ? U : (V&W))', null, []);
 
-        $addLeadingSlashFx = static function (TypeExpression $type): void {
+        $addLeadingSlash = static function (TypeExpression $type): void {
             \Closure::bind(static function () use ($type): void {
                 $value = $type->toString();
                 if (!str_starts_with($value, '\\') && !str_starts_with($value, '(')) {
@@ -663,7 +663,7 @@ final class TypeExpressionTest extends TestCase
             }, null, TypeExpression::class)();
         };
 
-        $removeLeadingSlashFx = static function (TypeExpression $type): void {
+        $removeLeadingSlash = static function (TypeExpression $type): void {
             \Closure::bind(static function () use ($type): void {
                 $value = $type->toString();
                 if (str_starts_with($value, '\\')) {
@@ -673,19 +673,19 @@ final class TypeExpressionTest extends TestCase
             }, null, TypeExpression::class)();
         };
 
-        $typeExpression->walkTypes($addLeadingSlashFx);
+        $typeExpression->walkTypes($addLeadingSlash);
         self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
 
-        $typeExpression->walkTypes($addLeadingSlashFx);
+        $typeExpression->walkTypes($addLeadingSlash);
         self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
 
-        $typeExpression->walkTypes($removeLeadingSlashFx);
+        $typeExpression->walkTypes($removeLeadingSlash);
         self::assertSame('Foo|Bar|($v is Closure(X, Y): Z ? U : (V&W))', $typeExpression->toString());
 
-        $typeExpression->walkTypes($removeLeadingSlashFx);
+        $typeExpression->walkTypes($removeLeadingSlash);
         self::assertSame('Foo|Bar|($v is Closure(X, Y): Z ? U : (V&W))', $typeExpression->toString());
 
-        $typeExpression->walkTypes($addLeadingSlashFx);
+        $typeExpression->walkTypes($addLeadingSlash);
         self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
     }
 

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -663,7 +663,9 @@ final class TypeExpressionTest extends TestCase
         };
 
         $typeExpression->walkTypes($addLeadingSlash);
+        self::assertSame('\Foo|\Bar|\Baz', $typeExpression->toString());
 
+        $typeExpression->walkTypes($addLeadingSlash);
         self::assertSame('\Foo|\Bar|\Baz', $typeExpression->toString());
     }
 


### PR DESCRIPTION
Previously the indexes were not updated at all.

`array_reverse` was more like a hack, the walk order should be not reversed. We should simply do DFS walk.