### PR TITLE
feat: Impl. TypeExpression::mapTypes()

### DIFF
--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -3429,18 +3429,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
-	'message' => '#^Offset 347 might not exist on array\\<int, array\\<int\\<0, max\\>, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\>\\.$#',
-	'count' => 2,
-	'path' => __DIR__ . '/../../tests/Tokenizer/TokensTest.php',
-];
-$ignoreErrors[] = [
-	// identifier: offsetAccess.notFound
-	'message' => '#^Offset 369 might not exist on array\\<int, array\\<int\\<0, max\\>, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\>\\.$#',
-	'count' => 2,
-	'path' => __DIR__ . '/../../tests/Tokenizer/TokensTest.php',
-];
-$ignoreErrors[] = [
-	// identifier: offsetAccess.notFound
 	'message' => '#^Offset int might not exist on array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\.$#',
 	'count' => 2,
 	'path' => __DIR__ . '/../../tests/Tokenizer/TokensTest.php',

--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -477,6 +477,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
+	'message' => '#^Offset \'glue\' might not exist on non\\-empty\\-array\\<array\\{string, int\\<\\-1, max\\>\\}\\>\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/DocBlock/TypeExpression.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAccess.notFound
 	'message' => '#^Offset \'nullable\' might not exist on non\\-empty\\-array\\<array\\{string, int\\<\\-1, max\\>\\}\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/DocBlock/TypeExpression.php',
@@ -3418,6 +3424,18 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
 	'message' => '#^Offset 3 might not exist on non\\-empty\\-array\\<int\\<0, 3\\>, array\\{tokens\\: non\\-empty\\-list\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>, content\\: literal\\-string&non\\-falsy\\-string\\}\\>\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../tests/Tokenizer/TokensTest.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAccess.notFound
+	'message' => '#^Offset 347 might not exist on array\\<int, array\\<int\\<0, max\\>, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\>\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../tests/Tokenizer/TokensTest.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAccess.notFound
+	'message' => '#^Offset 369 might not exist on array\\<int, array\\<int\\<0, max\\>, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\>\\.$#',
 	'count' => 2,
 	'path' => __DIR__ . '/../../tests/Tokenizer/TokensTest.php',
 ];

--- a/src/AbstractPhpdocTypesFixer.php
+++ b/src/AbstractPhpdocTypesFixer.php
@@ -104,15 +104,14 @@ abstract class AbstractPhpdocTypesFixer extends AbstractFixer
             function (string $type): string {
                 $typeExpression = new TypeExpression($type, null, []);
 
-                $typeExpression->walkTypes(function (TypeExpression $type): void {
+                $typeExpression = $typeExpression->mapTypes(function (TypeExpression $type) {
                     if (!$type->isUnionType()) {
                         $value = $this->normalize($type->toString());
 
-                        // TODO TypeExpression should be immutable and walkTypes method should be changed to mapTypes method
-                        \Closure::bind(static function () use ($type, $value): void {
-                            $type->value = $value;
-                        }, null, TypeExpression::class)();
+                        return new TypeExpression($value, null, []);
                     }
+
+                    return $type;
                 });
 
                 return $typeExpression->toString();

--- a/src/AbstractPhpdocTypesFixer.php
+++ b/src/AbstractPhpdocTypesFixer.php
@@ -104,7 +104,7 @@ abstract class AbstractPhpdocTypesFixer extends AbstractFixer
             function (string $type): string {
                 $typeExpression = new TypeExpression($type, null, []);
 
-                $typeExpression = $typeExpression->mapTypes(function (TypeExpression $type) {
+                $newTypeExpression = $typeExpression->mapTypes(function (TypeExpression $type) {
                     if (!$type->isUnionType()) {
                         $value = $this->normalize($type->toString());
 
@@ -114,7 +114,7 @@ abstract class AbstractPhpdocTypesFixer extends AbstractFixer
                     return $type;
                 });
 
-                return $typeExpression->toString();
+                return $newTypeExpression->toString();
             },
             $types
         );

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -329,6 +329,8 @@ final class TypeExpression
      */
     public function sortTypes(\Closure $compareCallback): void
     {
+        // TODO make this class immutable and change walkTypes to mapTypes
+
         $this->walkTypes(static function (self $type) use ($compareCallback): void {
             if ($type->isUnionType) {
                 $type->innerTypeExpressions = Utils::stableSort(

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -302,7 +302,7 @@ final class TypeExpression
      */
     public function walkTypes(\Closure $callback): void
     {
-        $type = $this->mapTypes(static function (self $type) use ($callback) {
+        $this->mapTypes(static function (self $type) use ($callback) {
             $valueOrig = $type->value;
             $callback($type);
             \assert($type->value === $valueOrig);

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -302,15 +302,13 @@ final class TypeExpression
      */
     public function walkTypes(\Closure $callback): void
     {
-        $innerValueOrig = $this->value;
-
         $type = $this->mapTypes(static function (self $type) use ($callback) {
+            $valueOrig = $type->value;
             $callback($type);
+            \assert($type->value === $valueOrig);
 
             return $type;
         });
-
-        \assert($type->value === $innerValueOrig);
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -187,12 +187,12 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements ConfigurableF
      */
     private function sortTypes(TypeExpression $typeExpression): array
     {
-        $normalizeType = static fn (string $type): string => Preg::replace('/^\(*\??\\\?/', '', $type);
+        $normalizeTypeFx = static fn (string $type): string => Preg::replace('/^\(*\??\\\?/', '', $type);
 
-        $typeExpression->sortTypes(
-            function (TypeExpression $a, TypeExpression $b) use ($normalizeType): int {
-                $a = $normalizeType($a->toString());
-                $b = $normalizeType($b->toString());
+        $res = $typeExpression->sortTypes(
+            function (TypeExpression $a, TypeExpression $b) use ($normalizeTypeFx): int {
+                $a = $normalizeTypeFx($a->toString());
+                $b = $normalizeTypeFx($b->toString());
                 $lowerCaseA = strtolower($a);
                 $lowerCaseB = strtolower($b);
 
@@ -213,6 +213,6 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements ConfigurableF
             }
         );
 
-        return $typeExpression->getTypes();
+        return $res->getTypes();
     }
 }

--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -189,7 +189,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements ConfigurableF
     {
         $normalizeType = static fn (string $type): string => Preg::replace('/^\(*\??\\\?/', '', $type);
 
-        $res = $typeExpression->sortTypes(
+        $sortedTypeExpression = $typeExpression->sortTypes(
             function (TypeExpression $a, TypeExpression $b) use ($normalizeType): int {
                 $a = $normalizeType($a->toString());
                 $b = $normalizeType($b->toString());
@@ -213,6 +213,6 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements ConfigurableF
             }
         );
 
-        return $res->getTypes();
+        return $sortedTypeExpression->getTypes();
     }
 }

--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -187,12 +187,12 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements ConfigurableF
      */
     private function sortTypes(TypeExpression $typeExpression): array
     {
-        $normalizeTypeFx = static fn (string $type): string => Preg::replace('/^\(*\??\\\?/', '', $type);
+        $normalizeType = static fn (string $type): string => Preg::replace('/^\(*\??\\\?/', '', $type);
 
         $res = $typeExpression->sortTypes(
-            function (TypeExpression $a, TypeExpression $b) use ($normalizeTypeFx): int {
-                $a = $normalizeTypeFx($a->toString());
-                $b = $normalizeTypeFx($b->toString());
+            function (TypeExpression $a, TypeExpression $b) use ($normalizeType): int {
+                $a = $normalizeType($a->toString());
+                $b = $normalizeType($b->toString());
                 $lowerCaseA = strtolower($a);
                 $lowerCaseB = strtolower($b);
 

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -675,6 +675,32 @@ final class TypeExpressionTest extends TestCase
             return $type;
         };
 
+        $callLog = [];
+        $typeExpression->mapTypes(static function (TypeExpression $type) use (&$callLog) {
+            $callLog[] = $type->toString();
+
+            if ('Y' === $type->toString()) {
+                return new TypeExpression('_y_', null, []);
+            }
+
+            return $type;
+        });
+        self::assertSame([
+            'Foo',
+            'Bar',
+            'X',
+            'Y',
+            'Z',
+            '\Closure(X, _y_): Z',
+            'U',
+            'V',
+            'W',
+            'V&W',
+            '(V&W)',
+            '($v is \Closure(X, _y_): Z ? U : (V&W))',
+            'Foo|Bar|($v is \Closure(X, _y_): Z ? U : (V&W))',
+        ], $callLog);
+
         $typeExpression = $typeExpression->mapTypes($addLeadingSlashFx);
         self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
 
@@ -714,6 +740,26 @@ final class TypeExpressionTest extends TestCase
                 $type->value = $value;
             }, null, TypeExpression::class)();
         };
+
+        $callLog = [];
+        $typeExpression->walkTypes(static function (TypeExpression $type) use (&$callLog): void {
+            $callLog[] = $type->toString();
+        });
+        self::assertSame([
+            'Foo',
+            'Bar',
+            'X',
+            'Y',
+            'Z',
+            '\Closure(X, Y): Z',
+            'U',
+            'V',
+            'W',
+            'V&W',
+            '(V&W)',
+            '($v is \Closure(X, Y): Z ? U : (V&W))',
+            'Foo|Bar|($v is \Closure(X, Y): Z ? U : (V&W))',
+        ], $callLog);
 
         $typeExpression->walkTypes($addLeadingSlashFx);
         self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -657,7 +657,7 @@ final class TypeExpressionTest extends TestCase
     {
         $typeExpression = new TypeExpression('Foo|Bar|($v is \Closure(X, Y): Z ? U : (V&W))', null, []);
 
-        $addLeadingSlashFx = static function (TypeExpression $type) {
+        $addLeadingSlash = static function (TypeExpression $type) {
             $value = $type->toString();
             if (!str_starts_with($value, '\\') && !str_starts_with($value, '(')) {
                 return new TypeExpression('\\'.$value, null, []);
@@ -666,7 +666,7 @@ final class TypeExpressionTest extends TestCase
             return $type;
         };
 
-        $removeLeadingSlashFx = static function (TypeExpression $type) {
+        $removeLeadingSlash = static function (TypeExpression $type) {
             $value = $type->toString();
             if (str_starts_with($value, '\\')) {
                 return new TypeExpression(substr($value, 1), null, []);
@@ -701,19 +701,19 @@ final class TypeExpressionTest extends TestCase
             'Foo|Bar|($v is \Closure(X, _y_): Z ? U : (V&W))',
         ], $callLog);
 
-        $typeExpression = $typeExpression->mapTypes($addLeadingSlashFx);
+        $typeExpression = $typeExpression->mapTypes($addLeadingSlash);
         self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
 
-        $typeExpression = $typeExpression->mapTypes($addLeadingSlashFx);
+        $typeExpression = $typeExpression->mapTypes($addLeadingSlash);
         self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
 
-        $typeExpression = $typeExpression->mapTypes($removeLeadingSlashFx);
+        $typeExpression = $typeExpression->mapTypes($removeLeadingSlash);
         self::assertSame('Foo|Bar|($v is Closure(X, Y): Z ? U : (V&W))', $typeExpression->toString());
 
-        $typeExpression = $typeExpression->mapTypes($removeLeadingSlashFx);
+        $typeExpression = $typeExpression->mapTypes($removeLeadingSlash);
         self::assertSame('Foo|Bar|($v is Closure(X, Y): Z ? U : (V&W))', $typeExpression->toString());
 
-        $typeExpression = $typeExpression->mapTypes($addLeadingSlashFx);
+        $typeExpression = $typeExpression->mapTypes($addLeadingSlash);
         self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
     }
 

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -657,7 +657,7 @@ final class TypeExpressionTest extends TestCase
     {
         $typeExpression = new TypeExpression('Foo|Bar|($v is \Closure(X, Y): Z ? U : (V&W))', null, []);
 
-        $addLeadingSlash = static function (TypeExpression $type): void {
+        $addLeadingSlashFx = static function (TypeExpression $type): void {
             \Closure::bind(static function () use ($type): void {
                 $value = $type->toString();
                 if (!str_starts_with($value, '\\') && !str_starts_with($value, '(')) {
@@ -667,7 +667,7 @@ final class TypeExpressionTest extends TestCase
             }, null, TypeExpression::class)();
         };
 
-        $removeLeadingSlash = static function (TypeExpression $type): void {
+        $removeLeadingSlashFx = static function (TypeExpression $type): void {
             \Closure::bind(static function () use ($type): void {
                 $value = $type->toString();
                 if (str_starts_with($value, '\\')) {
@@ -677,19 +677,19 @@ final class TypeExpressionTest extends TestCase
             }, null, TypeExpression::class)();
         };
 
-        $typeExpression->walkTypes($addLeadingSlash);
+        $typeExpression->walkTypes($addLeadingSlashFx);
         self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
 
-        $typeExpression->walkTypes($addLeadingSlash);
+        $typeExpression->walkTypes($addLeadingSlashFx);
         self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
 
-        $typeExpression->walkTypes($removeLeadingSlash);
+        $typeExpression->walkTypes($removeLeadingSlashFx);
         self::assertSame('Foo|Bar|($v is Closure(X, Y): Z ? U : (V&W))', $typeExpression->toString());
 
-        $typeExpression->walkTypes($removeLeadingSlash);
+        $typeExpression->walkTypes($removeLeadingSlashFx);
         self::assertSame('Foo|Bar|($v is Closure(X, Y): Z ? U : (V&W))', $typeExpression->toString());
 
-        $typeExpression->walkTypes($addLeadingSlash);
+        $typeExpression->walkTypes($addLeadingSlashFx);
         self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
     }
 

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -702,18 +702,23 @@ final class TypeExpressionTest extends TestCase
         ], $callLog);
 
         $typeExpression = $typeExpression->mapTypes($addLeadingSlash);
+        $this->checkInnerTypeExpressionsStartIndex($typeExpression);
         self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
 
         $typeExpression = $typeExpression->mapTypes($addLeadingSlash);
+        $this->checkInnerTypeExpressionsStartIndex($typeExpression);
         self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
 
         $typeExpression = $typeExpression->mapTypes($removeLeadingSlash);
+        $this->checkInnerTypeExpressionsStartIndex($typeExpression);
         self::assertSame('Foo|Bar|($v is Closure(X, Y): Z ? U : (V&W))', $typeExpression->toString());
 
         $typeExpression = $typeExpression->mapTypes($removeLeadingSlash);
+        $this->checkInnerTypeExpressionsStartIndex($typeExpression);
         self::assertSame('Foo|Bar|($v is Closure(X, Y): Z ? U : (V&W))', $typeExpression->toString());
 
         $typeExpression = $typeExpression->mapTypes($addLeadingSlash);
+        $this->checkInnerTypeExpressionsStartIndex($typeExpression);
         self::assertSame('\Foo|\Bar|($v is \Closure(\X, \Y): \Z ? \U : (\V&\W))', $typeExpression->toString());
     }
 


### PR DESCRIPTION
`TypeExpression` in `TypeExpression::walkTypes()` should not be mutated as whole `TypeExpression` public API is immutable.

needed for #8085