### PR TITLE
feat(Docker): Multi-arch build (support for `arm64`)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -64,6 +70,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: Dockerfile
           target: dist
           build-args: |


### PR DESCRIPTION
Following #8078 discussion I prepared multi-arch Docker build. I've tested it on my fork ([workflow run](https://github.com/Wirone/PHP-CS-Fixer/actions/runs/9486484068), [registry image with multiple architectures](https://github.com/wirone/PHP-CS-Fixer/pkgs/container/php-cs-fixer/229156843?tag=2-php8.3)). The warning about unmatched was there before on `arm64`:

```
$ docker run -it --rm --entrypoint="" ghcr.io/php-cs-fixer/php-cs-fixer:3-php8.3 sh

Unable to find image 'ghcr.io/php-cs-fixer/php-cs-fixer:3-php8.3' locally
3-php8.3: Pulling from php-cs-fixer/php-cs-fixer
(...)
Digest: sha256:4c0f3a0744ca4efcecd5024130a2ae1dfeeff3e8864ad5d780536926b14dca8b
Status: Downloaded newer image for ghcr.io/php-cs-fixer/php-cs-fixer:3-php8.3
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
/code # exit
```

and is not there anymore after build from this branch:

```
$ docker run -it --rm --entrypoint="" ghcr.io/wirone/php-cs-fixer:2-php8.2 sh

Unable to find image 'ghcr.io/wirone/php-cs-fixer:2-php8.2' locally
2-php8.2: Pulling from wirone/php-cs-fixer
(...)
Digest: sha256:b98cc3c0a8eabe16f44aa406c866fc2172fc0ab5b2c6c399b938902d4e9d32f4
Status: Downloaded newer image for ghcr.io/wirone/php-cs-fixer:2-php8.2
/code # exit
```

`arm64` images will be available from the next release.