### PR TITLE
chore: fix example issue reported by reportPossiblyNonexistentGeneralArrayOffset from PHPStan

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocScalarFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocScalarFixer.php
@@ -45,9 +45,8 @@ final class PhpdocScalarFixer extends AbstractPhpdocTypesFixer implements Config
     /**
      * The types to fix.
      *
-     * @var array<string, string>
      */
-    private static array $types = [
+    private const TYPES_MAP = [
         'boolean' => 'bool',
         'callback' => 'callable',
         'double' => 'float',
@@ -114,7 +113,7 @@ function sample($a, $b, $c)
 
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
-        $types = array_keys(self::$types);
+        $types = array_keys(self::TYPES_MAP);
 
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('types', 'A list of types to fix.'))
@@ -133,7 +132,7 @@ function sample($a, $b, $c)
         }
 
         if (\in_array($type, $this->configuration['types'], true)) {
-            $type = self::$types[$type];
+            $type = self::TYPES_MAP[$type];
         }
 
         return $type.$suffix;

--- a/src/Fixer/Phpdoc/PhpdocScalarFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocScalarFixer.php
@@ -44,7 +44,6 @@ final class PhpdocScalarFixer extends AbstractPhpdocTypesFixer implements Config
 
     /**
      * The types to fix.
-     *
      */
     private const TYPES_MAP = [
         'boolean' => 'bool',


### PR DESCRIPTION
inspired by discussion: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8011


example fix of reportPossiblyNonexistentGeneralArrayOffset - reported issue:
> Offset 'boolean'|'callback'|'double'|'integer'|'real'|'str' might not exist on array<string, string>.