### PR TITLE
fix: `NullableTypeDeclarationFixer` - don't convert standalone `null` into nullable union type

### DIFF
--- a/src/Fixer/LanguageConstruct/NullableTypeDeclarationFixer.php
+++ b/src/Fixer/LanguageConstruct/NullableTypeDeclarationFixer.php
@@ -183,11 +183,11 @@ class ValueObject
 
     private function isTypeNormalizable(TypeAnalysis $typeAnalysis): bool
     {
-        if (!$typeAnalysis->isNullable()) {
+        $type = $typeAnalysis->getName();
+
+        if ('null' === $type || !$typeAnalysis->isNullable()) {
             return false;
         }
-
-        $type = $typeAnalysis->getName();
 
         if (str_contains($type, '&')) {
             return false; // skip DNF types

--- a/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
@@ -274,5 +274,21 @@ class Infinite
 }
 ',
         ];
+
+        yield 'standalone null' => [
+            '<?php
+class Foo
+{
+    public function bar(null|array $config = null): null {}
+}
+',
+            '<?php
+class Foo
+{
+    public function bar(?array $config = null): null {}
+}
+',
+            ['syntax' => 'union'],
+        ];
     }
 }


### PR DESCRIPTION
### Fix for Incorrect Null Handling in NullableTypeDeclarationFixer

**Problem:**
Currently, when the union configuration is used in `NullableTypeDeclarationFixer` to process a standalone `null`, it leads to an incorrect transformation resulting in `null|null`. This PR addresses and resolves this issue.

**Solution:**
- Updated logic to ensure that a standalone `null` does not erroneously convert to `null|null`.

**Testing:**
- Added unit tests to confirm the fix.
- Verified that all existing tests pass without being impacted by the changes.

**Impact:**
This fix ensures that the `NullableTypeDeclarationFixer` handles nullable type declarations correctly, maintaining the expected behavior and avoiding redundant `null` entries.

Please review the implementation and let me know if there are any further adjustments needed.