### PR TITLE
Recurrence bug of standalone null type will be fixed to multiple null

### DIFF
--- a/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
@@ -274,5 +274,21 @@ class Infinite
 }
 ',
         ];
+
+        yield 'standalone null' => [
+            '<?php
+class Foo
+{
+    public function bar(null|array $config = null): null {}
+}
+',
+            '<?php
+class Foo
+{
+    public function bar(?array $config = null): null {}
+}
+',
+            ['syntax' => 'union'],
+        ];
     }
 }


### PR DESCRIPTION
Test case 
```php
yield 'standalone null' => [
            '<?php
class Foo
{
    public function bar(null|array $config = null): null {}
}
',
            '<?php
class Foo
{
    public function bar(?array $config = null): null {}
}
',
            ['syntax' => 'union'],
        ];
    }
```
Expected
```
'<?php
class Foo
{
    public function bar(null|array $config = null): null {}
}
'
```
Actual
```
'<?php
class Foo
{
    public function bar(null|array $config = null): null|null {}
}
'
```