### PR TITLE
fix: Fix for ClassKeywordFixer applyFix method

### DIFF
--- a/doc/rules/language_construct/class_keyword.rst
+++ b/doc/rules/language_construct/class_keyword.rst
@@ -43,8 +43,10 @@ Example #1
 
    -$foo = 'PhpCsFixer\Tokenizer\Tokens';
    -$bar = "\PhpCsFixer\Tokenizer\Tokens";
+   -$baz = "\Error";
    +$foo = \PhpCsFixer\Tokenizer\Tokens::class;
    +$bar = \PhpCsFixer\Tokenizer\Tokens::class;
+   +$baz = \Error::class;
 References
 ----------
 

--- a/doc/rules/language_construct/class_keyword.rst
+++ b/doc/rules/language_construct/class_keyword.rst
@@ -43,10 +43,8 @@ Example #1
 
    -$foo = 'PhpCsFixer\Tokenizer\Tokens';
    -$bar = "\PhpCsFixer\Tokenizer\Tokens";
-   -$baz = "\Error";
    +$foo = \PhpCsFixer\Tokenizer\Tokens::class;
    +$bar = \PhpCsFixer\Tokenizer\Tokens::class;
-   +$baz = \Error::class;
 References
 ----------
 

--- a/src/Fixer/LanguageConstruct/ClassKeywordFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordFixer.php
@@ -69,7 +69,7 @@ $bar = "\PhpCsFixer\Tokenizer\Tokens";
         for ($index = $tokens->count() - 1; $index >= 0; --$index) {
             $token = $tokens[$index];
 
-            if ($token->isGivenKind(T_CONSTANT_ENCAPSED_STRING)) {
+            if ($token->isGivenKind(T_CONSTANT_ENCAPSED_STRING) && str_contains($token->getContent(), '\\')) {
                 $name = substr($token->getContent(), 1, -1);
                 $name = ltrim($name, '\\');
                 $name = str_replace('\\\\', '\\', $name);

--- a/tests/Fixer/LanguageConstruct/ClassKeywordFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ClassKeywordFixerTest.php
@@ -44,12 +44,16 @@ final class ClassKeywordFixerTest extends AbstractFixerTestCase
                 echo \'Foo\Bar\Baz\';
                 echo \PhpCsFixer\FixerDefinition\CodeSample::class;
                 echo \PhpCsFixer\FixerDefinition\CodeSample::class;
+                echo "Error";
+                echo \Error::class;
                 ',
             '<?php
                 echo "PhpCsFixer\FixerDefinition\CodeSample";
                 echo \'Foo\Bar\Baz\';
                 echo \'PhpCsFixer\FixerDefinition\CodeSample\';
                 echo \'\PhpCsFixer\FixerDefinition\CodeSample\';
+                echo "Error";
+                echo "\Error";
                 ',
         ];
     }


### PR DESCRIPTION
### Fix for ClassKeywordFixer applyFix method

**Problem**
Main problem is described [here](https://github.com/blumilksoftware/codestyle/issues/112) but I will describe him shortly. When we have code like this:

```php
        if (in_array($response->status(), $this->handleByInertia, true)) {
            return Inertia::render("Error", [
                "status" => $response->status(),
            ])
                ->toResponse($request)
                ->setStatusCode($response->status());
        }
```

`ClassKeywordFixer` wanna fix that into:

```php
        if (in_array($response->status(), $this->handleByInertia, true)) {
            return Inertia::render(\Error::class, [
                "status" => $response->status(),
            ])
                ->toResponse($request)
                ->setStatusCode($response->status());
        }
```

And this makes no sense at all. Other example:

```php
            ["name" => "Redis"],
```
into:
```php
            ["name" => \Redis::class],
```

**Solution**
- Updated `applyFix` method in `ClassKeywordFixer` for additional condition when fixer checking token type.

**Testing**
- Added two more cases in `ClassKeywordFixer` test.

Please review the implementation and let me know if there are any further adjustments needed.