### PR TITLE
fix: `NullableTypeDeclarationFixer` - don't convert standalone `NULL` into nullable union type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
+        run: vendor/bin/paraunit run --testsuite unit,integration
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/phpunit tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/src/Fixer/LanguageConstruct/NullableTypeDeclarationFixer.php
+++ b/src/Fixer/LanguageConstruct/NullableTypeDeclarationFixer.php
@@ -185,7 +185,7 @@ class ValueObject
     {
         $type = $typeAnalysis->getName();
 
-        if ('null' === $type || !$typeAnalysis->isNullable()) {
+        if ('null' === strtolower($type) || !$typeAnalysis->isNullable()) {
             return false;
         }
 

--- a/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
@@ -280,12 +280,14 @@ class Infinite
 class Foo
 {
     public function bar(null|array $config = null): null {}
+    public function baz(null|array $config = NULL): NULL {}
 }
 ',
             '<?php
 class Foo
 {
     public function bar(?array $config = null): null {}
+    public function baz(?array $config = NULL): NULL {}
 }
 ',
             ['syntax' => 'union'],


### PR DESCRIPTION
Follow up to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8098