### PR TITLE
feat: set new_with_parentheses for anonymous_class to false in PER-CS2.0

### DIFF
--- a/doc/ruleSets/PER-CS2.0.rst
+++ b/doc/ruleSets/PER-CS2.0.rst
@@ -19,6 +19,10 @@ Rules
   ``['closure_fn_spacing' => 'none']``
 
 - `method_argument_space <./../rules/function_notation/method_argument_space.rst>`_
+- `new_with_parentheses <./../rules/operator/new_with_parentheses.rst>`_ with config:
+
+  ``['anonymous_class' => false]``
+
 - `single_line_empty_body <./../rules/basic/single_line_empty_body.rst>`_
 - `trailing_comma_in_multiline <./../rules/control_structure/trailing_comma_in_multiline.rst>`_ with config:
 

--- a/doc/rules/operator/new_with_parentheses.rst
+++ b/doc/rules/operator/new_with_parentheses.rst
@@ -78,13 +78,28 @@ Rule sets
 
 The rule is part of the following rule sets:
 
-- `@PER <./../../ruleSets/PER.rst>`_
-- `@PER-CS <./../../ruleSets/PER-CS.rst>`_
+- `@PER <./../../ruleSets/PER.rst>`_ with config:
+
+  ``['anonymous_class' => false]``
+
+- `@PER-CS <./../../ruleSets/PER-CS.rst>`_ with config:
+
+  ``['anonymous_class' => false]``
+
 - `@PER-CS1.0 <./../../ruleSets/PER-CS1.0.rst>`_
-- `@PER-CS2.0 <./../../ruleSets/PER-CS2.0.rst>`_
+- `@PER-CS2.0 <./../../ruleSets/PER-CS2.0.rst>`_ with config:
+
+  ``['anonymous_class' => false]``
+
 - `@PSR12 <./../../ruleSets/PSR12.rst>`_
-- `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
-- `@Symfony <./../../ruleSets/Symfony.rst>`_
+- `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ with config:
+
+  ``['anonymous_class' => false]``
+
+- `@Symfony <./../../ruleSets/Symfony.rst>`_ with config:
+
+  ``['anonymous_class' => false]``
+
 
 References
 ----------

--- a/src/Fixer/Internal/ConfigurableFixerTemplateFixer.php
+++ b/src/Fixer/Internal/ConfigurableFixerTemplateFixer.php
@@ -498,7 +498,7 @@ final class ConfigurableFixerTemplateFixer extends AbstractFixer implements Inte
         }
 
         if (AbstractPhpdocToTypeDeclarationFixer::class === $className) {
-            return new class() extends AbstractPhpdocToTypeDeclarationFixer {
+            return new class extends AbstractPhpdocToTypeDeclarationFixer {
                 protected function isSkippedType(string $type): bool
                 {
                     throw new \LogicException('Not implemented.');
@@ -525,7 +525,7 @@ final class ConfigurableFixerTemplateFixer extends AbstractFixer implements Inte
                 }
             };
         } elseif (AbstractDoctrineAnnotationFixer::class === $className) {
-            return new class() extends AbstractPhpdocToTypeDeclarationFixer {
+            return new class extends AbstractPhpdocToTypeDeclarationFixer {
                 protected function isSkippedType(string $type): bool
                 {
                     throw new \LogicException('Not implemented.');

--- a/src/RuleSet/Sets/PERCS2x0Set.php
+++ b/src/RuleSet/Sets/PERCS2x0Set.php
@@ -41,6 +41,9 @@ final class PERCS2x0Set extends AbstractRuleSetDescription
                 'closure_fn_spacing' => 'none',
             ],
             'method_argument_space' => true,
+            'new_with_parentheses' => [
+                'anonymous_class' => false,
+            ],
             'single_line_empty_body' => true,
             'trailing_comma_in_multiline' => [
                 'after_heredoc' => true,

--- a/tests/AbstractFixerTest.php
+++ b/tests/AbstractFixerTest.php
@@ -67,7 +67,7 @@ final class AbstractFixerTest extends TestCase
 
     private function createWhitespacesAwareFixerDouble(): WhitespacesAwareFixerInterface
     {
-        return new class() extends AbstractFixer implements WhitespacesAwareFixerInterface {
+        return new class extends AbstractFixer implements WhitespacesAwareFixerInterface {
             public function getDefinition(): FixerDefinitionInterface
             {
                 throw new \BadMethodCallException('Not implemented.');
@@ -87,7 +87,7 @@ final class AbstractFixerTest extends TestCase
 
     private function createUnconfigurableFixerDouble(): AbstractFixer
     {
-        return new class() extends AbstractFixer {
+        return new class extends AbstractFixer {
             public function getDefinition(): FixerDefinitionInterface
             {
                 throw new \LogicException('Not implemented.');

--- a/tests/AbstractFunctionReferenceFixerTest.php
+++ b/tests/AbstractFunctionReferenceFixerTest.php
@@ -126,7 +126,7 @@ final class AbstractFunctionReferenceFixerTest extends TestCase
 
     private function createAbstractFunctionReferenceFixerDouble(): AbstractFunctionReferenceFixer
     {
-        return new class() extends AbstractFunctionReferenceFixer {
+        return new class extends AbstractFunctionReferenceFixer {
             public function getDefinition(): FixerDefinitionInterface
             {
                 throw new \BadMethodCallException('Not implemented.');

--- a/tests/AbstractProxyFixerTest.php
+++ b/tests/AbstractProxyFixerTest.php
@@ -197,7 +197,7 @@ final class AbstractProxyFixerTest extends TestCase
 
     private function createWhitespacesAwareFixerDouble(): WhitespacesAwareFixerInterface
     {
-        return new class() implements WhitespacesAwareFixerInterface {
+        return new class implements WhitespacesAwareFixerInterface {
             /** @phpstan-ignore-next-line to not complain that property is never read */
             private WhitespacesFixerConfig $whitespacesConfig;
 

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -205,7 +205,7 @@ final class CacheTest extends TestCase
 
     private function createSignatureDouble(): SignatureInterface
     {
-        return new class() implements SignatureInterface {
+        return new class implements SignatureInterface {
             public function getPhpVersion(): string
             {
                 return '7.1.0';

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -358,7 +358,7 @@ $/s',
         $this->expectDeprecation('Rule set "@PER" is deprecated. Use "@PER-CS" instead.');
         $this->expectDeprecation('Rule set "@PER:risky" is deprecated. Use "@PER-CS:risky" instead.');
 
-        $fixer = new class() implements FixerInterface {
+        $fixer = new class implements FixerInterface {
             public function isCandidate(Tokens $tokens): bool
             {
                 throw new \LogicException('Not implemented.');
@@ -510,7 +510,7 @@ Fixing examples:
 
     private static function createConfigurableDeprecatedFixerDouble(): FixerInterface
     {
-        return new class() implements ConfigurableFixerInterface, DeprecatedFixerInterface {
+        return new class implements ConfigurableFixerInterface, DeprecatedFixerInterface {
             /** @var array<string, mixed> */
             private array $configuration;
 

--- a/tests/Console/Command/DocumentationCommandTest.php
+++ b/tests/Console/Command/DocumentationCommandTest.php
@@ -57,7 +57,7 @@ final class DocumentationCommandTest extends TestCase
 
     private function createFilesystemDouble(): Filesystem
     {
-        return new class() extends Filesystem {
+        return new class extends Filesystem {
             public function dumpFile(string $filename, $content): void {}
 
             /** @phpstan-ignore-next-line */

--- a/tests/Console/Command/SelfUpdateCommandTest.php
+++ b/tests/Console/Command/SelfUpdateCommandTest.php
@@ -515,7 +515,7 @@ final class SelfUpdateCommandTest extends TestCase
             public function compareVersions(string $versionA, string $versionB): int
             {
                 return (new NewVersionChecker(
-                    new class() implements GithubClientInterface {
+                    new class implements GithubClientInterface {
                         public function getTags(): array
                         {
                             throw new \LogicException('Not implemented.');
@@ -528,7 +528,7 @@ final class SelfUpdateCommandTest extends TestCase
 
     private function createPharCheckerDouble(): PharCheckerInterface
     {
-        return new class() implements PharCheckerInterface {
+        return new class implements PharCheckerInterface {
             public function checkFileValidity(string $filename): ?string
             {
                 return null;

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1423,7 +1423,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
 
     private function createDeprecatedFixerDouble(): DeprecatedFixerInterface
     {
-        return new class() extends AbstractFixer implements DeprecatedFixerInterface, ConfigurableFixerInterface {
+        return new class extends AbstractFixer implements DeprecatedFixerInterface, ConfigurableFixerInterface {
             /** @use ConfigurableFixerTrait<array<string, mixed>, array<string, mixed>> */
             use ConfigurableFixerTrait;
 
@@ -1460,7 +1460,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
 
     private function createToolInfoDouble(): ToolInfoInterface
     {
-        return new class() implements ToolInfoInterface {
+        return new class implements ToolInfoInterface {
             public function getComposerInstallationDetails(): array
             {
                 throw new \BadMethodCallException();

--- a/tests/Console/SelfUpdate/NewVersionCheckerTest.php
+++ b/tests/Console/SelfUpdate/NewVersionCheckerTest.php
@@ -101,7 +101,7 @@ final class NewVersionCheckerTest extends TestCase
 
     private function createGithubClientDouble(): GithubClientInterface
     {
-        return new class() implements GithubClientInterface {
+        return new class implements GithubClientInterface {
             public function getTags(): array
             {
                 return [

--- a/tests/FileReaderTest.php
+++ b/tests/FileReaderTest.php
@@ -82,7 +82,7 @@ final class FileReaderTest extends TestCase
 
     private function createStdinStreamDouble(): object
     {
-        return new class() {
+        return new class {
             /**
              * @var resource
              */

--- a/tests/FixerDefinition/FixerDefinitionTest.php
+++ b/tests/FixerDefinition/FixerDefinitionTest.php
@@ -68,7 +68,7 @@ final class FixerDefinitionTest extends TestCase
 
     private function createCodeSampleDouble(): CodeSampleInterface
     {
-        return new class() implements CodeSampleInterface {
+        return new class implements CodeSampleInterface {
             public function getCode(): string
             {
                 throw new \LogicException('Not implemented.');

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -226,7 +226,7 @@ final class FixerFactoryTest extends TestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage('Configuration must be an array and may not be empty.');
 
-        $testRuleSet = new class() implements RuleSetInterface {
+        $testRuleSet = new class implements RuleSetInterface {
             public function __construct(array $set = [])
             {
                 if ([] !== $set) {
@@ -441,7 +441,7 @@ final class FixerFactoryTest extends TestCase
     {
         $factory = new FixerFactory();
 
-        $fixer = new class() implements ConfigurableFixerInterface {
+        $fixer = new class implements ConfigurableFixerInterface {
             public function configure(array $configuration): void
             {
                 throw new \LogicException('Not implemented.');
@@ -514,7 +514,7 @@ final class FixerFactoryTest extends TestCase
 
     public function testConfigurableFixerIsConfigured(): void
     {
-        $fixer = new class() implements ConfigurableFixerInterface {
+        $fixer = new class implements ConfigurableFixerInterface {
             public function configure(array $configuration): void
             {
                 TestCase::assertSame(['bar' => 'baz'], $configuration);

--- a/tests/Fixtures/Integration/misc/PHP7_0.test
+++ b/tests/Fixtures/Integration/misc/PHP7_0.test
@@ -113,10 +113,10 @@ class Foo implements FooInterface
 }
 
 // anonymous class
-$message = (new class() {});
-$message = (new class() implements FooInterface {});
+$message = (new class {});
+$message = (new class implements FooInterface {});
 if (1) {
-    $message = (new class() extends Foo {
+    $message = (new class extends Foo {
         public function bar()
         {
             echo 1;

--- a/tests/Fixtures/Integration/misc/PHP8_0.test
+++ b/tests/Fixtures/Integration/misc/PHP8_0.test
@@ -44,7 +44,7 @@ class PostsController
     public function get($id): void {}
 }
 
-$object = new #[ExampleAttribute] class() {
+$object = new #[ExampleAttribute] class {
     #[ExampleAttribute]
     public function foo(#[ExampleAttribute] $bar): void {}
 };

--- a/tests/Fixtures/Integration/misc/PHP8_3.test
+++ b/tests/Fixtures/Integration/misc/PHP8_3.test
@@ -64,7 +64,7 @@ class Bar extends Foo
 }
 
 // https://www.php.net/manual/en/migration83.new-features.php#migration83.new-features.core.readonly-modifier-improvements
-$a = new readonly class() {};
+$a = new readonly class {};
 
 --INPUT--
 <?php

--- a/tests/Fixtures/Integration/misc/anonymous_class_with_phpdoc.test
+++ b/tests/Fixtures/Integration/misc/anonymous_class_with_phpdoc.test
@@ -7,22 +7,22 @@ Integration of fixers: Anonymous class /w PHPDoc and attributes on separate line
 
 $a = new
 /** @property string $x */
-class() {};
+class {};
 
 $b = new
 #[X]
-class() {};
+class {};
 
 $c = new
 /** @property string $x */
 #[X] #[Y\Z]
-class() {};
+class {};
 
 class Z {}
 
 $d = new
 #[X] // comment
-class() {};
+class {};
 
 --INPUT--
 <?php

--- a/tests/Fixtures/Integration/set/@PER-CS2.0.test-in.php
+++ b/tests/Fixtures/Integration/set/@PER-CS2.0.test-in.php
@@ -41,6 +41,12 @@ $a = new Foo;
 $b = (  boolean  )   1;
 $c = true  ? (INT) '1'  :  2;
 
+$anonymousClass = new class () {
+  public function test() {
+  // method body
+  }
+};
+
 $fn = fn ($a) => $a;
 
 $arrayNotMultiline = ['foo' => 'bar', 'foo2' => 'bar'];

--- a/tests/Fixtures/Integration/set/@PER-CS2.0.test-out.php
+++ b/tests/Fixtures/Integration/set/@PER-CS2.0.test-out.php
@@ -49,6 +49,13 @@ $a = new Foo();
 $b = (bool) 1;
 $c = true ? (int) '1' : 2;
 
+$anonymousClass = new class {
+    public function test()
+    {
+        // method body
+    }
+};
+
 $fn = fn($a) => $a;
 
 $arrayNotMultiline = ['foo' => 'bar', 'foo2' => 'bar'];

--- a/tests/Linter/CachingLinterTest.php
+++ b/tests/Linter/CachingLinterTest.php
@@ -156,7 +156,7 @@ final class CachingLinterTest extends TestCase
 
     private function createLintingResultDouble(): LintingResultInterface
     {
-        return new class() implements LintingResultInterface {
+        return new class implements LintingResultInterface {
             public function check(): void
             {
                 throw new \LogicException('Not implemented.');

--- a/tests/RuleSet/AbstractMigrationSetDescriptionTest.php
+++ b/tests/RuleSet/AbstractMigrationSetDescriptionTest.php
@@ -26,7 +26,7 @@ final class AbstractMigrationSetDescriptionTest extends TestCase
 {
     public function testGetDescriptionForPhpMigrationSet(): void
     {
-        $set = new class() extends AbstractMigrationSetDescription {
+        $set = new class extends AbstractMigrationSetDescription {
             public function getName(): string
             {
                 return '@PHP99MigrationSet';
@@ -43,7 +43,7 @@ final class AbstractMigrationSetDescriptionTest extends TestCase
 
     public function testGetDescriptionForPhpUnitMigrationSet(): void
     {
-        $set = new class() extends AbstractMigrationSetDescription {
+        $set = new class extends AbstractMigrationSetDescription {
             public function getName(): string
             {
                 return '@PHPUnit30Migration';
@@ -60,7 +60,7 @@ final class AbstractMigrationSetDescriptionTest extends TestCase
 
     public function testGetDescriptionForNoneMigrationSet(): void
     {
-        $set = new class() extends AbstractMigrationSetDescription {
+        $set = new class extends AbstractMigrationSetDescription {
             public function getName(): string
             {
                 return 'foo';

--- a/tests/Runner/FileCachingLintingFileIteratorTest.php
+++ b/tests/Runner/FileCachingLintingFileIteratorTest.php
@@ -48,7 +48,7 @@ final class FileCachingLintingFileIteratorTest extends TestCase
             new \SplFileInfo(__FILE__),
         ];
 
-        $lintingResult = new class() implements LintingResultInterface {
+        $lintingResult = new class implements LintingResultInterface {
             public function check(): void
             {
                 throw new \LogicException('Not implemented.');

--- a/tests/Runner/LintingFileIteratorTest.php
+++ b/tests/Runner/LintingFileIteratorTest.php
@@ -45,7 +45,7 @@ final class LintingFileIteratorTest extends TestCase
     {
         $file = new \SplFileInfo(__FILE__);
 
-        $lintingResult = new class() implements LintingResultInterface {
+        $lintingResult = new class implements LintingResultInterface {
             public function check(): void
             {
                 throw new \LogicException('Not implemented.');

--- a/tests/Runner/RunnerTest.php
+++ b/tests/Runner/RunnerTest.php
@@ -260,7 +260,7 @@ final class RunnerTest extends TestCase
 
     private function createDifferDouble(): DifferInterface
     {
-        return new class() implements DifferInterface {
+        return new class implements DifferInterface {
             public ?\SplFileInfo $passedFile = null;
 
             public function diff(string $old, string $new, ?\SplFileInfo $file = null): string
@@ -274,7 +274,7 @@ final class RunnerTest extends TestCase
 
     private function createLinterDouble(): LinterInterface
     {
-        return new class() implements LinterInterface {
+        return new class implements LinterInterface {
             public function isAsync(): bool
             {
                 return false;
@@ -282,14 +282,14 @@ final class RunnerTest extends TestCase
 
             public function lintFile(string $path): LintingResultInterface
             {
-                return new class() implements LintingResultInterface {
+                return new class implements LintingResultInterface {
                     public function check(): void {}
                 };
             }
 
             public function lintSource(string $source): LintingResultInterface
             {
-                return new class() implements LintingResultInterface {
+                return new class implements LintingResultInterface {
                     public function check(): void {}
                 };
             }


### PR DESCRIPTION
The spec for PER CS 2.0 states in [chapter 8](https://github.com/php-fig/per-coding-style/blob/2.0.0/spec.md#8-anonymous-classes) that anonymous classes without arguments must not have parentheses:

> If the anonymous class has no arguments, the () after class MUST be omitted. For example:
> ```php
> <?php
> 
> // Brace on the same line
> // No arguments
> $instance = new class extends \Foo implements \HandleableInterface {
>     // Class content
> };
> ```

The inheritance from PSR12 currently sets the `new_with_parentheses` to true for both named and anonymous classes
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/ed86702fbb853e68c7d0d7a371fe810c8eed4c9b/src/RuleSet/Sets/PSR12Set.php#L45