### PR TITLE
fix: Do not mangle non-whitespace token in `PhpdocIndentFixer`

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocIndentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocIndentFixer.php
@@ -103,7 +103,7 @@ class DocBlocks
                 if ('' !== $indent) {
                     $tokens->insertAt($index, new Token($indent));
                 }
-            } else if ('' !== $newPrevContent) {
+            } elseif ('' !== $newPrevContent) {
                 if ($prevToken->isArray()) {
                     $tokens[$prevIndex] = new Token([$prevToken->getId(), $newPrevContent]);
                 } else {

--- a/src/Fixer/Phpdoc/PhpdocIndentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocIndentFixer.php
@@ -63,7 +63,9 @@ class DocBlocks
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
-        foreach ($tokens as $index => $token) {
+        for ($index = $tokens->count() - 1; 0 <= $index; --$index) {
+            $token = $tokens[$index];
+
             if (!$token->isGivenKind(T_DOC_COMMENT)) {
                 continue;
             }
@@ -95,7 +97,13 @@ class DocBlocks
 
             $newPrevContent = $this->fixWhitespaceBeforeDocblock($prevToken->getContent(), $indent);
 
-            if ('' !== $newPrevContent) {
+            $tokens[$index] = new Token([T_DOC_COMMENT, $this->fixDocBlock($token->getContent(), $indent)]);
+
+            if (!$prevToken->isWhitespace()) {
+                if ('' !== $indent) {
+                    $tokens->insertAt($index, new Token($indent));
+                }
+            } else if ('' !== $newPrevContent) {
                 if ($prevToken->isArray()) {
                     $tokens[$prevIndex] = new Token([$prevToken->getId(), $newPrevContent]);
                 } else {
@@ -104,8 +112,6 @@ class DocBlocks
             } else {
                 $tokens->clearAt($prevIndex);
             }
-
-            $tokens[$index] = new Token([T_DOC_COMMENT, $this->fixDocBlock($token->getContent(), $indent)]);
         }
     }
 

--- a/src/Fixer/Phpdoc/PhpdocIndentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocIndentFixer.php
@@ -101,7 +101,7 @@ class DocBlocks
 
             if (!$prevToken->isWhitespace()) {
                 if ('' !== $indent) {
-                    $tokens->insertAt($index, new Token($indent));
+                    $tokens->insertAt($index, new Token([T_WHITESPACE, $indent]));
                 }
             } elseif ('' !== $newPrevContent) {
                 if ($prevToken->isArray()) {

--- a/tests/Fixer/Phpdoc/PhpdocIndentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocIndentFixerTest.php
@@ -412,5 +412,16 @@ class Dispatcher
 }
 ',
         ];
+
+        yield [
+            '<?php
+$foo->bar()    /** comment */
+    ->baz();
+',
+            '<?php
+$foo->bar()/** comment */
+    ->baz();
+',
+        ];
     }
 }

--- a/tests/Fixtures/Integration/misc/phpdoc_indent,no_spaces_after_function_name.test
+++ b/tests/Fixtures/Integration/misc/phpdoc_indent,no_spaces_after_function_name.test
@@ -1,0 +1,13 @@
+--TEST--
+Integration of fixers: phpdoc_indent,no_spaces_after_function_name
+--RULESET--
+{"phpdoc_indent": true, "no_spaces_after_function_name": true}
+--EXPECT--
+<?php
+$foo->bar()    /** comment */
+    ->baz();
+
+--INPUT--
+<?php
+$foo->bar()/** comment */
+    ->baz();


### PR DESCRIPTION
A colleague wrote this code:
```php
$foo->bar()/** @phpstan-ignore-next-line */
    ->baz();
```
`PhpdocIndentFixer` turns the `)` token into `)    `, causing a crash when another rule (in our case `NoSpacesAfterFunctionNameFixer`) can't find the closing parenthesis.

That output doesn't seem desirable to begin with but I've written a minimal fix to resolve only the crash.