### PR TITLE
chore: NewWithParenthesesFixer - create TODO to change the default configuration to match PER-CS2

### DIFF
--- a/src/Fixer/Operator/NewWithParenthesesFixer.php
+++ b/src/Fixer/Operator/NewWithParenthesesFixer.php
@@ -89,7 +89,7 @@ final class NewWithParenthesesFixer extends AbstractFixer implements Configurabl
                 ->getOption(),
             (new FixerOptionBuilder('anonymous_class', 'Whether anonymous classes should be followed by parentheses.'))
                 ->setAllowedTypes(['bool'])
-                ->setDefault(true)
+                ->setDefault(true) // @TODO 4.0: set to `false`
                 ->getOption(),
         ]);
     }


### PR DESCRIPTION


due to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8140#issue-2430430721