### PR TITLE
fix: `NoSuperfluousPhpdocTagsFixer` - fix "Undefined array key 0" error

### DIFF
--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -640,9 +640,7 @@ class Foo {
      */
     private function toComparableNames(array $types, ?string $namespace, ?string $currentSymbol, array $symbolShortNames): array
     {
-        \assert(0 !== \count($types));
-
-        if ('?' === $types[0][0]) {
+        if (isset($types[0][0]) && '?' === $types[0][0]) {
             $types = [
                 substr($types[0], 1),
                 'null',

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -2642,6 +2642,16 @@ static fn ($foo): int => 1;',
                 function foo($bar, $baz = null) {}
                 EOD,
         ];
+
+        yield 'splat operator with iterable' => [
+            <<<'PHP'
+                <?php
+                    /**
+                     * @param iterable<int> ...$x
+                     */
+                    function foo(...$x) {}
+                PHP,
+        ];
     }
 
     /**
@@ -2957,6 +2967,16 @@ class Foo {
      */
     public function doFoo(Bar|null $bar): ?Baz {}
 }',
+        ];
+
+        yield 'an attribute before parameter type' => [
+            <<<'PHP'
+                <?php
+                /**
+                 * @param list<int> $data
+                 */
+                function foo(#[AnAttribute] array $data) {}
+                PHP,
         ];
     }
 


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8149