### PR TITLE
feat: introduce NoWhitespaceInEmptyArrayFixer

### DIFF
--- a/doc/ruleSets/PhpCsFixer.rst
+++ b/doc/ruleSets/PhpCsFixer.rst
@@ -52,6 +52,7 @@ Rules
 
   ``['after_heredoc' => true]``
 
+- `no_whitespace_in_empty_array <./../rules/array_notation/no_whitespace_in_empty_array.rst>`_
 - `ordered_class_elements <./../rules/class_notation/ordered_class_elements.rst>`_
 - `ordered_types <./../rules/class_notation/ordered_types.rst>`_
 - `php_unit_internal_class <./../rules/php_unit/php_unit_internal_class.rst>`_

--- a/doc/rules/array_notation/no_whitespace_in_empty_array.rst
+++ b/doc/rules/array_notation/no_whitespace_in_empty_array.rst
@@ -19,6 +19,14 @@ Example #1
    -$foo = [
    -];
    +$foo = [];
+
+Rule sets
+---------
+
+The rule is part of the following rule set:
+
+- `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
+
 References
 ----------
 

--- a/doc/rules/array_notation/no_whitespace_in_empty_array.rst
+++ b/doc/rules/array_notation/no_whitespace_in_empty_array.rst
@@ -1,0 +1,28 @@
+=====================================
+Rule ``no_whitespace_in_empty_array``
+=====================================
+
+Empty arrays should not contain any whitespace.
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+
+   -$foo = [
+   -];
+   +$foo = [];
+References
+----------
+
+- Fixer class: `PhpCsFixer\\Fixer\\ArrayNotation\\NoWhitespaceInEmptyArrayFixer <./../../../src/Fixer/ArrayNotation/NoWhitespaceInEmptyArrayFixer.php>`_
+- Test class: `PhpCsFixer\\Tests\\Fixer\\ArrayNotation\\NoWhitespaceInEmptyArrayFixerTest <./../../../tests/Fixer/ArrayNotation/NoWhitespaceInEmptyArrayFixerTest.php>`_
+
+The test class defines officially supported behaviour. Each test case is a part of our backward compatibility promise.

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -54,6 +54,9 @@ Array Notation
 - `no_whitespace_before_comma_in_array <./array_notation/no_whitespace_before_comma_in_array.rst>`_
 
   In array declaration, there MUST NOT be a whitespace before each comma.
+- `no_whitespace_in_empty_array <./array_notation/no_whitespace_in_empty_array.rst>`_
+
+  Empty arrays should not contain any whitespace.
 - `normalize_index_brace <./array_notation/normalize_index_brace.rst>`_
 
   Array index should always be written by using square braces.

--- a/src/Fixer/ArrayNotation/ArraySyntaxFixer.php
+++ b/src/Fixer/ArrayNotation/ArraySyntaxFixer.php
@@ -70,7 +70,7 @@ final class ArraySyntaxFixer extends AbstractFixer implements ConfigurableFixerI
     /**
      * {@inheritdoc}
      *
-     * Must run before BinaryOperatorSpacesFixer, SingleSpaceAfterConstructFixer, SingleSpaceAroundConstructFixer, TernaryOperatorSpacesFixer.
+     * Must run before BinaryOperatorSpacesFixer, NoWhitespaceInEmptyArrayFixer, SingleSpaceAfterConstructFixer, SingleSpaceAroundConstructFixer, TernaryOperatorSpacesFixer.
      */
     public function getPriority(): int
     {

--- a/src/Fixer/ArrayNotation/NoWhitespaceInEmptyArrayFixer.php
+++ b/src/Fixer/ArrayNotation/NoWhitespaceInEmptyArrayFixer.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\ArrayNotation;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Jeremiasz Major <jrh.mjr@gmail.com>
+ */
+final class NoWhitespaceInEmptyArrayFixer extends AbstractFixer
+{
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Empty arrays should not contain any whitespace.',
+            [new CodeSample("<?php\n\n\$foo = [\n];\n")],
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(CT::T_ARRAY_SQUARE_BRACE_OPEN);
+    }
+
+    /**
+     * Must run after ArraySyntaxFixer, NoEmptyCommentFixer.
+     */
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        for ($index = \count($tokens) - 1; $index > 0; --$index) {
+            if (!$tokens[$index]->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_CLOSE)) {
+                continue;
+            }
+
+            if ($tokens->getPrevNonWhitespace($index) !== $index - 2) {
+                continue;
+            }
+
+            if (!$tokens[$index - 2]->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN)) {
+                continue;
+            }
+
+            $tokens->clearAt($index - 1);
+        }
+    }
+}

--- a/src/Fixer/ArrayNotation/NoWhitespaceInEmptyArrayFixer.php
+++ b/src/Fixer/ArrayNotation/NoWhitespaceInEmptyArrayFixer.php
@@ -40,6 +40,8 @@ final class NoWhitespaceInEmptyArrayFixer extends AbstractFixer
     }
 
     /**
+     * {@inheritdoc}
+     *
      * Must run after ArraySyntaxFixer, NoEmptyCommentFixer.
      */
     public function getPriority(): int

--- a/src/Fixer/Comment/NoEmptyCommentFixer.php
+++ b/src/Fixer/Comment/NoEmptyCommentFixer.php
@@ -32,7 +32,7 @@ final class NoEmptyCommentFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before NoExtraBlankLinesFixer, NoTrailingWhitespaceFixer, NoWhitespaceInBlankLineFixer.
+     * Must run before NoExtraBlankLinesFixer, NoTrailingWhitespaceFixer, NoWhitespaceInBlankLineFixer, NoWhitespaceInEmptyArrayFixer.
      * Must run after PhpdocToCommentFixer.
      */
     public function getPriority(): int

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -104,6 +104,7 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
             'no_useless_else' => true,
             'no_useless_return' => true,
             'no_whitespace_before_comma_in_array' => ['after_heredoc' => true],
+            'no_whitespace_in_empty_array' => true,
             'ordered_class_elements' => true,
             'ordered_types' => true,
             'php_unit_internal_class' => true,

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -344,6 +344,7 @@ final class FixerFactoryTest extends TestCase
             ],
             'array_syntax' => [
                 'binary_operator_spaces',
+                'no_whitespace_in_empty_array',
                 'single_space_after_construct',
                 'single_space_around_construct',
                 'ternary_operator_spaces',
@@ -587,6 +588,7 @@ final class FixerFactoryTest extends TestCase
                 'no_extra_blank_lines',
                 'no_trailing_whitespace',
                 'no_whitespace_in_blank_line',
+                'no_whitespace_in_empty_array',
             ],
             'no_empty_phpdoc' => [
                 'no_extra_blank_lines',

--- a/tests/Fixer/ArrayNotation/NoWhitespaceInEmptyArrayFixerTest.php
+++ b/tests/Fixer/ArrayNotation/NoWhitespaceInEmptyArrayFixerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\ArrayNotation;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Jeremiasz Major <jrh.mjr@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\ArrayNotation\NoWhitespaceInEmptyArrayFixer
+ *
+ * @extends AbstractFixerTestCase<\PhpCsFixer\Fixer\ArrayNotation\NoWhitespaceInEmptyArrayFixer>
+ */
+final class NoWhitespaceInEmptyArrayFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<array{0: string, 1?: string}>
+     */
+    public static function provideFixCases(): iterable
+    {
+        yield [
+            "<?php\n\n\$foo = [];\n",
+            "<?php\n\n\$foo = [\n];\n",
+        ];
+
+        yield [
+            "<?php\n\n\$foo = [];\n",
+            "<?php\n\n\$foo = [      ];\n",
+        ];
+
+        yield [
+            "<?php\n\n\$foo = [];\n",
+            "<?php\n\n\$foo = [\n\n];\n",
+        ];
+
+        yield [
+            "<?php\n\n\$foo = [\n    // foo\n];\n",
+        ];
+
+        yield [
+            "<?php\n\n\$foo = [];\n",
+            "<?php\n\n\$foo = [\n    \n];\n",
+        ];
+
+        yield [
+            "<?php\n\n\$foo = [ /* test */ ];\n",
+        ];
+
+        yield [
+            <<<'PHP'
+                <?php class Foo {
+                    private const Foo = [];
+                }
+                PHP,
+            <<<'PHP'
+                <?php class Foo {
+                    private const Foo = [
+                    ];
+                }
+                PHP,
+        ];
+
+        yield [
+            <<<'PHP'
+                <?php class Foo {
+                    public function bar(): void {
+                        $foo = [];
+                    }
+                }
+                PHP,
+            <<<'PHP'
+                <?php class Foo {
+                    public function bar(): void {
+                        $foo = [   ];
+                    }
+                }
+                PHP,
+        ];
+
+        yield [
+            <<<'PHP'
+                <?php class Foo {
+                    public array $ignore = [];
+                }
+                PHP,
+            <<<'PHP'
+                <?php class Foo {
+                    public array $ignore = [
+                    ];
+                }
+                PHP,
+        ];
+    }
+}

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAroundConstructFixerTest.php
@@ -3503,8 +3503,7 @@ $bar; }',
     public static function provideFixWithYieldFromCases(): iterable
     {
         $configFollowed = [
-            'constructs_contain_a_single_space' => [
-            ],
+            'constructs_contain_a_single_space' => [],
             'constructs_followed_by_a_single_space' => [
                 'yield_from',
             ],
@@ -3513,8 +3512,7 @@ $bar; }',
             'constructs_contain_a_single_space' => [
                 'yield_from',
             ],
-            'constructs_followed_by_a_single_space' => [
-            ],
+            'constructs_followed_by_a_single_space' => [],
         ];
         $configAll = [
             'constructs_contain_a_single_space' => [

--- a/tests/Fixtures/Integration/priority/array_syntax,no_whitespace_in_empty_array.test
+++ b/tests/Fixtures/Integration/priority/array_syntax,no_whitespace_in_empty_array.test
@@ -1,0 +1,15 @@
+--TEST--
+Integration of fixers: array_syntax,no_whitespace_in_empty_array.
+--RULESET--
+{"array_syntax": true, "no_whitespace_in_empty_array": true}
+--EXPECT--
+<?php
+
+$foo = [];
+
+--INPUT--
+<?php
+
+$foo = array(
+
+        );

--- a/tests/Fixtures/Integration/priority/no_empty_comment,no_whitespace_in_empty_array.test
+++ b/tests/Fixtures/Integration/priority/no_empty_comment,no_whitespace_in_empty_array.test
@@ -1,0 +1,15 @@
+--TEST--
+Integration of fixers: no_empty_comment,no_whitespace_in_empty_array.
+--RULESET--
+{"no_empty_comment": true, "no_whitespace_in_empty_array": true}
+--EXPECT--
+<?php
+
+$foo = [];
+
+--INPUT--
+<?php
+
+$foo = [
+    //
+];


### PR DESCRIPTION
This PR introduces fixer that will fix `[  \n  ]` to `[]`. I've also added it to `PhpCsFixer` set — ofc I can revert that if you don't like it. I've decided not to support `array()` notation, can also add that if necessary.