### PR TITLE
feat: Update the trailing comma rule in the Symfony set

### DIFF
--- a/doc/ruleSets/PhpCsFixer.rst
+++ b/doc/ruleSets/PhpCsFixer.rst
@@ -67,6 +67,7 @@ Rules
 - `single_line_comment_style <./../rules/comment/single_line_comment_style.rst>`_
 - `single_line_empty_body <./../rules/basic/single_line_empty_body.rst>`_
 - `string_implicit_backslashes <./../rules/string_notation/string_implicit_backslashes.rst>`_
+- `trailing_comma_in_multiline <./../rules/control_structure/trailing_comma_in_multiline.rst>`_
 - `whitespace_after_comma_in_array <./../rules/array_notation/whitespace_after_comma_in_array.rst>`_ with config:
 
   ``['ensure_single_space' => true]``

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -172,7 +172,10 @@ Rules
   ``['stick_comment_to_next_continuous_control_statement' => true]``
 
 - `switch_continue_to_break <./../rules/control_structure/switch_continue_to_break.rst>`_
-- `trailing_comma_in_multiline <./../rules/control_structure/trailing_comma_in_multiline.rst>`_
+- `trailing_comma_in_multiline <./../rules/control_structure/trailing_comma_in_multiline.rst>`_ with config:
+
+  ``['elements' => ['arrays', 'match', 'parameters']]``
+
 - `trim_array_spaces <./../rules/array_notation/trim_array_spaces.rst>`_
 - `type_declaration_spaces <./../rules/whitespace/type_declaration_spaces.rst>`_
 - `types_spaces <./../rules/whitespace/types_spaces.rst>`_

--- a/doc/rules/control_structure/trailing_comma_in_multiline.rst
+++ b/doc/rules/control_structure/trailing_comma_in_multiline.rst
@@ -144,7 +144,10 @@ The rule is part of the following rule sets:
   ``['after_heredoc' => true]``
 
 - `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
-- `@Symfony <./../../ruleSets/Symfony.rst>`_
+- `@Symfony <./../../ruleSets/Symfony.rst>`_ with config:
+
+  ``['elements' => ['arrays', 'match', 'parameters']]``
+
 
 References
 ----------

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -120,6 +120,7 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
             'single_line_empty_body' => true,
             'single_line_throw' => false,
             'string_implicit_backslashes' => true,
+            'trailing_comma_in_multiline' => true, // Overrides @symfony to keep support for PHP 7.4
             'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
         ];
     }

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -217,7 +217,9 @@ final class SymfonySet extends AbstractRuleSetDescription
                 'stick_comment_to_next_continuous_control_statement' => true,
             ],
             'switch_continue_to_break' => true,
-            'trailing_comma_in_multiline' => true,
+            'trailing_comma_in_multiline' => [
+                'elements' => ['arrays', 'match', 'parameters'],
+            ],
             'trim_array_spaces' => true,
             'type_declaration_spaces' => true,
             'types_spaces' => true,


### PR DESCRIPTION
This matches the configuration that is already applied in the symfony repository.