### PR TITLE
fix: `PhpUnitAttributesFixer` - fix priorities with `PhpUnitDataProvider(.+)Fixer`

### DIFF
--- a/src/Fixer/NamespaceNotation/CleanNamespaceFixer.php
+++ b/src/Fixer/NamespaceNotation/CleanNamespaceFixer.php
@@ -52,7 +52,7 @@ final class CleanNamespaceFixer extends AbstractFixer
      */
     public function getPriority(): int
     {
-        return 3;
+        return 10;
     }
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void

--- a/src/Fixer/PhpUnit/PhpUnitAttributesFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitAttributesFixer.php
@@ -98,6 +98,7 @@ final class PhpUnitAttributesFixer extends AbstractPhpUnitFixer implements Confi
      * {@inheritdoc}
      *
      * Must run before FullyQualifiedStrictTypesFixer, PhpdocSeparationFixer, PhpdocTrimConsecutiveBlankLineSeparationFixer, PhpdocTrimFixer.
+     * Must run after PhpUnitDataProviderNameFixer, PhpUnitDataProviderReturnTypeFixer, PhpUnitDataProviderStaticFixer.
      */
     public function getPriority(): int
     {

--- a/src/Fixer/PhpUnit/PhpUnitDataProviderNameFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDataProviderNameFixer.php
@@ -116,9 +116,14 @@ class FooTest extends TestCase {
         );
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * Must run before PhpUnitAttributesFixer.
+     */
     public function getPriority(): int
     {
-        return 0;
+        return 9;
     }
 
     public function isRisky(): bool

--- a/src/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixer.php
@@ -65,12 +65,12 @@ class FooTest extends TestCase {
     /**
      * {@inheritdoc}
      *
-     * Must run before ReturnToYieldFromFixer, ReturnTypeDeclarationFixer.
+     * Must run before PhpUnitAttributesFixer, ReturnToYieldFromFixer, ReturnTypeDeclarationFixer.
      * Must run after CleanNamespaceFixer.
      */
     public function getPriority(): int
     {
-        return 2;
+        return 9;
     }
 
     public function isRisky(): bool

--- a/src/Fixer/PhpUnit/PhpUnitDataProviderStaticFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDataProviderStaticFixer.php
@@ -95,6 +95,16 @@ class FooTest extends TestCase {
         );
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * Must run before PhpUnitAttributesFixer.
+     */
+    public function getPriority(): int
+    {
+        return 9;
+    }
+
     public function isRisky(): bool
     {
         return true;

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -740,9 +740,16 @@ final class FixerFactoryTest extends TestCase
             'php_unit_construct' => [
                 'php_unit_dedicate_assert',
             ],
+            'php_unit_data_provider_name' => [
+                'php_unit_attributes',
+            ],
             'php_unit_data_provider_return_type' => [
+                'php_unit_attributes',
                 'return_to_yield_from',
                 'return_type_declaration',
+            ],
+            'php_unit_data_provider_static' => [
+                'php_unit_attributes',
             ],
             'php_unit_dedicate_assert' => [
                 'no_unused_imports',

--- a/tests/Fixtures/Integration/misc/php_unit_attributes,php_unit_data_provider_name,php_unit_data_provider_return_type,php_unit_data_provider_static.test
+++ b/tests/Fixtures/Integration/misc/php_unit_attributes,php_unit_data_provider_name,php_unit_data_provider_return_type,php_unit_data_provider_static.test
@@ -1,0 +1,50 @@
+--TEST--
+Integration of fixers: php_unit_attributes,php_unit_data_provider_name,php_unit_data_provider_return_type,php_unit_data_provider_static.
+--RULESET--
+{
+    "php_unit_attributes": true,
+    "php_unit_data_provider_name": true,
+    "php_unit_data_provider_return_type": true,
+    "php_unit_data_provider_static": true
+}
+--REQUIREMENTS--
+{"php": 80000}
+--EXPECT--
+<?php
+
+namespace Foo;
+
+use PHPUnit\Framework\TestCase;
+
+class BarTest extends TestCase
+{
+    /**
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSomethingCases')]
+    public function testSomething(): void {}
+
+    public static function provideSomethingCases(): iterable
+    {
+        yield from range(1, 10);
+    }
+}
+
+--INPUT--
+<?php
+
+namespace Foo;
+
+use PHPUnit\Framework\TestCase;
+
+class BarTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function testSomething(): void {}
+
+    public function getData()
+    {
+        yield from range(1, 10);
+    }
+}

--- a/tests/Fixtures/Integration/priority/php_unit_data_provider_name,php_unit_attributes.test
+++ b/tests/Fixtures/Integration/priority/php_unit_data_provider_name,php_unit_attributes.test
@@ -1,0 +1,49 @@
+--TEST--
+Integration of fixers: php_unit_data_provider_name,php_unit_attributes.
+--RULESET--
+{"php_unit_data_provider_name": true, "php_unit_attributes": true}
+--REQUIREMENTS--
+{"php": 80000}
+--EXPECT--
+<?php
+
+namespace Foo;
+
+use PHPUnit\Framework\TestCase;
+
+class BarTest extends TestCase
+{
+    /**
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSomethingCases')]
+    public function testSomething()
+    {
+    }
+
+    public static function provideSomethingCases(): iterable
+    {
+        yield from range(1, 10);
+    }
+}
+
+--INPUT--
+<?php
+
+namespace Foo;
+
+use PHPUnit\Framework\TestCase;
+
+class BarTest extends TestCase
+{
+    /**
+     * @dataProvider getData
+     */
+    public function testSomething()
+    {
+    }
+
+    public static function getData(): iterable
+    {
+        yield from range(1, 10);
+    }
+}

--- a/tests/Fixtures/Integration/priority/php_unit_data_provider_return_type,php_unit_attributes.test
+++ b/tests/Fixtures/Integration/priority/php_unit_data_provider_return_type,php_unit_attributes.test
@@ -1,0 +1,39 @@
+--TEST--
+Integration of fixers: php_unit_data_provider_return_type,php_unit_attributes.
+--RULESET--
+{"php_unit_data_provider_return_type": true, "php_unit_attributes": true}
+--REQUIREMENTS--
+{"php": 80000}
+--EXPECT--
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class FooTest extends TestCase
+{
+    /**
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFooCases')]
+    public function testFoo() {}
+
+    public static function provideFooCases(): iterable {
+        return [[1], [2], [3]];
+    }
+}
+
+--INPUT--
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class FooTest extends TestCase
+{
+    /**
+     * @dataProvider provideFooCases
+     */
+    public function testFoo() {}
+
+    public static function provideFooCases() {
+        return [[1], [2], [3]];
+    }
+}

--- a/tests/Fixtures/Integration/priority/php_unit_data_provider_static,php_unit_attributes.test
+++ b/tests/Fixtures/Integration/priority/php_unit_data_provider_static,php_unit_attributes.test
@@ -1,0 +1,43 @@
+--TEST--
+Integration of fixers: php_unit_data_provider_static,php_unit_attributes.
+--RULESET--
+{"php_unit_data_provider_static": true, "php_unit_attributes": true}
+--REQUIREMENTS--
+{"php": 80000}
+--EXPECT--
+<?php
+
+namespace Foo;
+
+use PHPUnit\Framework\TestCase;
+
+class BarTest extends TestCase
+{
+    /**
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFooCases')]
+    public function testFoo() {}
+
+    public static function provideFooCases(): iterable {
+        yield from [[1], [2], [3]];
+    }
+}
+
+--INPUT--
+<?php
+
+namespace Foo;
+
+use PHPUnit\Framework\TestCase;
+
+class BarTest extends TestCase
+{
+    /**
+     * @dataProvider provideFooCases
+     */
+    public function testFoo() {}
+
+    public function provideFooCases(): iterable {
+        yield from [[1], [2], [3]];
+    }
+}


### PR DESCRIPTION
This fixes the priorities between `php_unit_attributes` and the 3 `php_unit_data_provider_*` fixers by running `php_unit_attributes` after them.

The 3 data provider fixers rely on `DataProviderAnalyser` which in turn relies on the `@dataProvider` PHPDoc to work. Early running `php_unit_attributes` on default config currently disables the 3 fixers' works.

Reproducer:
```php
<?php

namespace Foo;

use PHPUnit\Framework\TestCase;

class BarTest extends TestCase
{
    /**
     * @dataProvider getData
     */
    public function testSomething(): void {}

    public function getData()
    {
        yield from range(1, 10);
    }
}

```

PS: I cannot do the usual failing test first as FixerFactoryTest is quite intense in checking for the priority files and stuff.