### PR TITLE
feat: `DeclareStrictTypesFixer` on interfaces is superfluous

### DIFF
--- a/src/Fixer/Strict/DeclareStrictTypesFixer.php
+++ b/src/Fixer/Strict/DeclareStrictTypesFixer.php
@@ -53,7 +53,7 @@ final class DeclareStrictTypesFixer extends AbstractFixer implements Whitespaces
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isMonolithicPhp() && !$tokens->isTokenKindFound(T_OPEN_TAG_WITH_ECHO);
+        return $tokens->isMonolithicPhp() && !$tokens->isTokenKindFound(T_OPEN_TAG_WITH_ECHO) && !$tokens->isTokenKindFound(T_INTERFACE);
     }
 
     public function isRisky(): bool


### PR DESCRIPTION
Fix #8097 