### PR TITLE
fix: Ensure PHP binary path is used as a single CLI argument in parallel worker process

### DIFF
--- a/src/Runner/Parallel/ProcessFactory.php
+++ b/src/Runner/Parallel/ProcessFactory.php
@@ -61,7 +61,7 @@ final class ProcessFactory
             throw new ParallelisationException('Cannot find PHP executable.');
         }
 
-        $phpBinary = str_replace(" ", "\\ ", $phpBinary);
+        $phpBinary = str_replace(' ', '\\ ', $phpBinary);
 
         $mainScript = realpath(__DIR__.'/../../../php-cs-fixer');
         if (false === $mainScript

--- a/src/Runner/Parallel/ProcessFactory.php
+++ b/src/Runner/Parallel/ProcessFactory.php
@@ -56,11 +56,12 @@ final class ProcessFactory
     public function getCommandArgs(int $serverPort, ProcessIdentifier $identifier, RunnerConfig $runnerConfig): array
     {
         $phpBinary = (new PhpExecutableFinder())->find(false);
-        $phpBinary = str_replace(" ", "\\ ", $phpBinary);
 
         if (false === $phpBinary) {
             throw new ParallelisationException('Cannot find PHP executable.');
         }
+
+        $phpBinary = str_replace(" ", "\\ ", $phpBinary);
 
         $mainScript = realpath(__DIR__.'/../../../php-cs-fixer');
         if (false === $mainScript

--- a/src/Runner/Parallel/ProcessFactory.php
+++ b/src/Runner/Parallel/ProcessFactory.php
@@ -61,8 +61,6 @@ final class ProcessFactory
             throw new ParallelisationException('Cannot find PHP executable.');
         }
 
-        $phpBinary = str_replace(' ', '\ ', $phpBinary);
-
         $mainScript = realpath(__DIR__.'/../../../php-cs-fixer');
         if (false === $mainScript
             && isset($_SERVER['argv'][0])
@@ -76,7 +74,7 @@ final class ProcessFactory
         }
 
         $commandArgs = [
-            $phpBinary,
+            escapeshellarg($phpBinary),
             escapeshellarg($mainScript),
             'worker',
             '--port',

--- a/src/Runner/Parallel/ProcessFactory.php
+++ b/src/Runner/Parallel/ProcessFactory.php
@@ -56,6 +56,7 @@ final class ProcessFactory
     public function getCommandArgs(int $serverPort, ProcessIdentifier $identifier, RunnerConfig $runnerConfig): array
     {
         $phpBinary = (new PhpExecutableFinder())->find(false);
+        $phpBinary = str_replace(" ", "\\ ", $phpBinary);
 
         if (false === $phpBinary) {
             throw new ParallelisationException('Cannot find PHP executable.');

--- a/src/Runner/Parallel/ProcessFactory.php
+++ b/src/Runner/Parallel/ProcessFactory.php
@@ -61,7 +61,7 @@ final class ProcessFactory
             throw new ParallelisationException('Cannot find PHP executable.');
         }
 
-        $phpBinary = str_replace(' ', '\\ ', $phpBinary);
+        $phpBinary = str_replace(' ', '\ ', $phpBinary);
 
         $mainScript = realpath(__DIR__.'/../../../php-cs-fixer');
         if (false === $mainScript


### PR DESCRIPTION
Fixes: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8014

See: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8014#issuecomment-2305928410