### PR TITLE
CI: drop matrix for single-matrix-entry jobs of SCA and Deployment checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,16 +246,11 @@ jobs:
 
   deployment:
     needs: tests
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - operating-system: 'ubuntu-24.04'
-            php-version: '8.2'
-
     name: Deployment checks
 
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: 'ubuntu-24.04'
+    env:
+      php-version: '8.2'
 
     steps:
       - name: Checkout code
@@ -268,7 +263,7 @@ jobs:
         uses: ./.github/composite-actions/setup-php-with-composer-deps
         with:
           os: ${{ runner.os }}
-          php: ${{ matrix.php-version }}
+          php: ${{ env.php-version }}
 
       - name: Cache dev-tools
         uses: actions/cache@v4

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -12,18 +12,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        operating-system:
-          - ubuntu-24.04
-        php-version:
-          - 8.3
-
+  everything:
     name: Static Code Analysis
 
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: 'ubuntu-24.04'
+    env:
+      php-version: '8.3'
 
     steps:
       - name: Checkout code
@@ -40,7 +34,7 @@ jobs:
         uses: ./.github/composite-actions/setup-php-with-composer-deps
         with:
           os: ${{ runner.os }}
-          php: ${{ matrix.php-version }}
+          php: ${{ env.php-version }}
 
       ## We want to have a lock-file used on PR level, so contributors are not bothered by SCA complains unrelated to their changes,
       ## and same time we want to be aware that we are complying with bleeding edge of SCA tools as maintainers observing the push hook.

--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -2576,12 +2576,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../tests/AutoReview/CiConfigurationTest.php',
 ];
 $ignoreErrors[] = [
-	// identifier: offsetAccess.notFound
-	'message' => '#^Offset \'php\\-version\' might not exist on array\\<string, bool\\|float\\|int\\|string\\>\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../tests/AutoReview/CiConfigurationTest.php',
-];
-$ignoreErrors[] = [
 	// identifier: argument.type
 	'message' => '#^Parameter \\#1 \\$code of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:fromCode\\(\\) expects string, string\\|false given\\.$#',
 	'count' => 2,


### PR DESCRIPTION
Before:
> CI / Deployment checks (ubuntu-24.04, 8.2)
> Static Code Analysis / Static Code Analysis (ubuntu-24.04, 8.3)

After:
> CI / Deployment checks
> Static Code Analysis / Static Code Analysis

now, we can change execution env of those jobs without reconfiguring required jobs in repo _UI_ settings, again and again