### PR TITLE
CI: allow macos to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   tests:
+    continue-on-error: ${{ matrix.operating-system == 'macos-latest' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
frustrated of random macos failures, like in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8192

if someone knows how to make macos job stable, be my guest