### PR TITLE
DX: Make `TypeExpression` API more explicit about composite types

### DIFF
--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -543,7 +543,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: assign.propertyType
-	'message' => '#^Property PhpCsFixer\\\\DocBlock\\\\TypeExpression\\:\\:\\$typesGlue \\(\'&\'\\|\'\\|\'\\) does not accept non\\-empty\\-string\\.$#',
+	'message' => '#^Property PhpCsFixer\\\\DocBlock\\\\TypeExpression\\:\\:\\$typesGlue \\(\'&\'\\|\'\\|\'\\|null\\) does not accept non\\-empty\\-string\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/DocBlock/TypeExpression.php',
 ];

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -54,7 +54,7 @@ parameters:
         -
             message: '#^Method PhpCsFixer\\Tests\\.+::provide.+Cases\(\) return type has no value type specified in iterable type iterable\.$#'
             path: tests
-            count: 266
+            count: 265
     tipsOfTheDay: false
     tmpDir: dev-tools/phpstan/cache
 

--- a/src/AbstractPhpdocToTypeDeclarationFixer.php
+++ b/src/AbstractPhpdocToTypeDeclarationFixer.php
@@ -230,7 +230,7 @@ abstract class AbstractPhpdocToTypeDeclarationFixer extends AbstractFixer implem
             return null;
         }
 
-        if (!$typesExpression->isUnionType() || '|' !== $typesExpression->getTypesGlue()) {
+        if (!$typesExpression->isUnionType()) {
             return null;
         }
 

--- a/src/AbstractPhpdocTypesFixer.php
+++ b/src/AbstractPhpdocTypesFixer.php
@@ -91,7 +91,7 @@ abstract class AbstractPhpdocTypesFixer extends AbstractFixer
         }
 
         $newTypeExpression = $typeExpression->mapTypes(function (TypeExpression $type) {
-            if (!$type->isUnionType()) {
+            if (!$type->isCompositeType()) {
                 $value = $this->normalize($type->toString());
 
                 return new TypeExpression($value, null, []);

--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -215,7 +215,13 @@ final class Annotation
     public function setTypes(array $types): void
     {
         $origTypesContent = $this->getTypesContent();
-        $newTypesContent = implode($this->getTypeExpression()->getTypesGlue(), $types);
+        $newTypesContent = implode(
+            // Fallback to union type is provided for backward compatibility (previously glue was set to `|` by default even when type was not composite)
+            // @TODO Better handling for cases where type is fixed (original type is not composite, but was made composite during fix)
+            $this->getTypeExpression()->getTypesGlue() ?? '|',
+            $types
+        );
+
         if ($origTypesContent === $newTypesContent) {
             return;
         }


### PR DESCRIPTION
Method `isUnionType()` was misleading, because it was returning `true` also for intersection types. Since `TypeExpression` is marked as `@internal`, it's safe to refactor it and change the API.