### PR TITLE
chore: check for priority tests correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,8 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+#        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/phpunit tests/IntegrationTest.php
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,8 +199,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-#        run: vendor/bin/paraunit run --testsuite unit,integration
-        run: vendor/bin/phpunit tests/IntegrationTest.php
+        run: vendor/bin/paraunit run --testsuite unit,integration
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -61,6 +61,12 @@ final class IntegrationTest extends AbstractIntegrationTestCase
                     'priority'.\DIRECTORY_SEPARATOR.'backtick_to_shell_exec,escape_implicit_backslashes.test',
                     'priority'.\DIRECTORY_SEPARATOR.'backtick_to_shell_exec,string_implicit_backslashes.test',
                     'priority'.\DIRECTORY_SEPARATOR.'braces,indentation_type,no_break_comment.test',
+                    'priority'.\DIRECTORY_SEPARATOR.'fully_qualified_strict_types,no_superfluous_phpdoc_tags.test',
+                    'priority'.\DIRECTORY_SEPARATOR.'no_unused_imports,blank_line_after_namespace_2.test',
+                    'priority'.\DIRECTORY_SEPARATOR.'phpdoc_readonly_class_comment_to_keyword,phpdoc_align.test',
+                    'priority'.\DIRECTORY_SEPARATOR.'phpdoc_to_return_type,fully_qualified_strict_types.test',
+                    'priority'.\DIRECTORY_SEPARATOR.'single_import_per_statement,no_unused_imports.test',
+                    'priority'.\DIRECTORY_SEPARATOR.'single_space_around_construct,nullable_type_declaration.test',
                     'priority'.\DIRECTORY_SEPARATOR.'standardize_not_equals,binary_operator_spaces.test',
                 ], true)) {
                     self::markTestIncomplete(\sprintf(

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -329,7 +329,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
             $runner->fix();
             $fixedInputCodeWithReversedFixers = file_get_contents($tmpFile);
 
-            self::assertRevertedOrderFixing($case, $fixedInputCode, $fixedInputCodeWithReversedFixers);
+            static::assertRevertedOrderFixing($case, $fixedInputCode, $fixedInputCodeWithReversedFixers);
         }
     }
 


### PR DESCRIPTION
The assertion in child class (`IntegrationTest`) checks if tests run in reverse order are not making the same changes.

In this PR, not-anymore-priority-tests are added to the list of exceptions, to prevent having new ones being added (like in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8197 I was expecting that priority tests added in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8169 would became invalid, this is actually how I discovered the problem).