### PR TITLE
chore: remove from priority tests exceptions tests that are not actually exceptions

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -60,14 +60,12 @@ final class IntegrationTest extends AbstractIntegrationTestCase
                 if (\in_array($case->getFileName(), [
                     'priority'.\DIRECTORY_SEPARATOR.'backtick_to_shell_exec,escape_implicit_backslashes.test',
                     'priority'.\DIRECTORY_SEPARATOR.'backtick_to_shell_exec,string_implicit_backslashes.test',
-                    'priority'.\DIRECTORY_SEPARATOR.'braces,indentation_type,no_break_comment.test',
                     'priority'.\DIRECTORY_SEPARATOR.'fully_qualified_strict_types,no_superfluous_phpdoc_tags.test',
                     'priority'.\DIRECTORY_SEPARATOR.'no_unused_imports,blank_line_after_namespace_2.test',
                     'priority'.\DIRECTORY_SEPARATOR.'phpdoc_readonly_class_comment_to_keyword,phpdoc_align.test',
                     'priority'.\DIRECTORY_SEPARATOR.'phpdoc_to_return_type,fully_qualified_strict_types.test',
                     'priority'.\DIRECTORY_SEPARATOR.'single_import_per_statement,no_unused_imports.test',
                     'priority'.\DIRECTORY_SEPARATOR.'single_space_around_construct,nullable_type_declaration.test',
-                    'priority'.\DIRECTORY_SEPARATOR.'standardize_not_equals,binary_operator_spaces.test',
                 ], true)) {
                     self::markTestIncomplete(\sprintf(
                         'Integration test `%s` was defined as explicit priority test, but no priority conflict was detected.'


### PR DESCRIPTION
- `braces,indentation_type,no_break_comment.test` was moved to `misc` in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/5050
- `standardize_not_equals,binary_operator_spaces.test` is in fact priority test