### PR TITLE
chore: fix priority tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,8 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+#        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/phpunit tests/IntegrationTest.php
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -60,10 +60,7 @@ final class IntegrationTest extends AbstractIntegrationTestCase
                 if (\in_array($case->getFileName(), [
                     'priority'.\DIRECTORY_SEPARATOR.'backtick_to_shell_exec,escape_implicit_backslashes.test',
                     'priority'.\DIRECTORY_SEPARATOR.'backtick_to_shell_exec,string_implicit_backslashes.test',
-                    'priority'.\DIRECTORY_SEPARATOR.'fully_qualified_strict_types,no_superfluous_phpdoc_tags.test',
                     'priority'.\DIRECTORY_SEPARATOR.'no_unused_imports,blank_line_after_namespace_2.test',
-                    'priority'.\DIRECTORY_SEPARATOR.'phpdoc_readonly_class_comment_to_keyword,phpdoc_align.test',
-                    'priority'.\DIRECTORY_SEPARATOR.'phpdoc_to_return_type,fully_qualified_strict_types.test',
                     'priority'.\DIRECTORY_SEPARATOR.'single_import_per_statement,no_unused_imports.test',
                     'priority'.\DIRECTORY_SEPARATOR.'single_space_around_construct,nullable_type_declaration.test',
                 ], true)) {


### PR DESCRIPTION
These 3 were not priority tests.

For a test to be a priority test it must be that when the order is reversed, the result is different than in order according to priorities.