### PR TITLE
CI: Ensure `php-cs-fixer` PHP compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,21 @@ env:
   PHP_MIN: '7.4'
 
 jobs:
+  entrypoint-bc-promise:
+    name: Entrypoint BC promise
+    runs-on: 'ubuntu-24.04'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: ./.github/composite-actions/setup-php
+        with:
+          version: 5.6
+
+      - name: Verify `php-cs-fixer` can be run on unsupported runtimes
+        run: php -l php-cs-fixer
+
   tests:
     continue-on-error: ${{ matrix.operating-system == 'macos-latest' }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup PHP
         uses: ./.github/composite-actions/setup-php
         with:
-          version: 5.6
+          version: 7.0
 
       - name: Verify `php-cs-fixer` can be run on unsupported runtimes
         run: php -l php-cs-fixer

--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -19,8 +19,7 @@ set_error_handler(static function ($severity, $message, $file, $line) {
     }
 });
 
-// check environment requirements
-(function () {
+function checkRuntimeReqs() {
     if (\PHP_VERSION_ID === 80000) {
         fwrite(STDERR, "PHP CS Fixer is not able run on PHP 8.0.0 due to bug in PHP tokenizer (https://bugs.php.net/bug.php?id=80462).\n");
         fwrite(STDERR, "Update PHP version to unblock execution.\n");
@@ -54,10 +53,9 @@ set_error_handler(static function ($severity, $message, $file, $line) {
             }
         }
     }
-})();
+}
 
-// load dependencies
-(function () {
+function loadDependencies() {
     $require = true;
     if (class_exists('Phar')) {
         // Maybe this file is used as phar-stub? Let's try!
@@ -88,7 +86,11 @@ set_error_handler(static function ($severity, $message, $file, $line) {
 
         require_once $file;
     }
-})();
+}
+
+// Ensure proper runtime before running actual script
+checkRuntimeReqs();
+loadDependencies();
 
 use Composer\XdebugHandler\XdebugHandler;
 use PhpCsFixer\Console\Application;

--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -19,7 +19,8 @@ set_error_handler(static function ($severity, $message, $file, $line) {
     }
 });
 
-function checkRuntimeReqs() {
+// check environment requirements
+(function () {
     if (\PHP_VERSION_ID === 80000) {
         fwrite(STDERR, "PHP CS Fixer is not able run on PHP 8.0.0 due to bug in PHP tokenizer (https://bugs.php.net/bug.php?id=80462).\n");
         fwrite(STDERR, "Update PHP version to unblock execution.\n");
@@ -53,9 +54,10 @@ function checkRuntimeReqs() {
             }
         }
     }
-}
+})();
 
-function loadDependencies() {
+// load dependencies
+(function () {
     $require = true;
     if (class_exists('Phar')) {
         // Maybe this file is used as phar-stub? Let's try!
@@ -86,11 +88,7 @@ function loadDependencies() {
 
         require_once $file;
     }
-}
-
-// Ensure proper runtime before running actual script
-checkRuntimeReqs();
-loadDependencies();
+})();
 
 use Composer\XdebugHandler\XdebugHandler;
 use PhpCsFixer\Console\Application;


### PR DESCRIPTION
This PR fixes backward compatibility for `php-cs-fixer` entrypoint for PHP 5.6 that was unintentionally lost some time ago. Also it introduces CI job for ensuring BC promise is remained ([before](https://github.com/Wirone/PHP-CS-Fixer/actions/runs/11140891410/job/30960644542?pr=8235#step:4:11) vs [after](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/actions/runs/11140949332/job/30960839806?pr=8235#step:4:11)).