### PR TITLE
chore: Token::getContent() phpdoc return type

### DIFF
--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -2019,7 +2019,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
-	'message' => '#^Offset string might not exist on non\\-empty\\-array\\<string, callable\\(int\\)\\: void\\>\\.$#',
+	'message' => '#^Offset string might not exist on array\\<string, callable\\(int\\)\\: void\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/Whitespace/NoExtraBlankLinesFixer.php',
 ];

--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -2259,18 +2259,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: return.type
-	'message' => '#^Method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:getContent\\(\\) should return non\\-empty\\-string but returns string\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Tokenizer/Token.php',
-];
-$ignoreErrors[] = [
-	// identifier: return.type
-	'message' => '#^Method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:toJson\\(\\) should return string but returns string\\|false\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Tokenizer/Token.php',
-];
-$ignoreErrors[] = [
-	// identifier: return.type
 	'message' => '#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:extractTokenKind\\(\\) should return int\\|non\\-empty\\-string but returns int\\|string\\|null\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Tokenizer/Tokens.php',

--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -2258,12 +2258,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Tokenizer/Analyzer/SwitchAnalyzer.php',
 ];
 $ignoreErrors[] = [
-	// identifier: offsetAccess.notFound
-	'message' => '#^Offset int might not exist on array\\<10001\\|10002\\|10003\\|10004\\|10005\\|10006\\|10007\\|10008\\|10009\\|10010\\|10011\\|10012\\|10013\\|10014\\|10015\\|10016\\|10017\\|10018\\|10019\\|10020\\|10021\\|10022\\|10023\\|10024\\|10025\\|10026\\|10027\\|10028\\|10029\\|10030\\|10031\\|10032\\|10033\\|10034\\|10035\\|10036\\|10037\\|10038\\|10039, string\\>\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Tokenizer/CT.php',
-];
-$ignoreErrors[] = [
 	// identifier: return.type
 	'message' => '#^Method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:getContent\\(\\) should return non\\-empty\\-string but returns string\\.$#',
 	'count' => 1,

--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -927,7 +927,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: return.type
-	'message' => '#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixer\\:\\:getElements\\(\\) should return list\\<array\\{start\\: int, visibility\\: string, abstract\\: bool, static\\: bool, readonly\\: bool, type\\: string, name\\: string, end\\: int\\}\\> but returns list\\<array\\{start\\: int, visibility\\: \'public\', abstract\\: false, static\\: false, readonly\\: bool, type\\: string, name\\?\\: string, end\\: int\\}\\|array\\{start\\: int, visibility\\: string, abstract\\: bool, static\\: bool, readonly\\: bool\\}\\>\\.$#',
+	'message' => '#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixer\\:\\:getElements\\(\\) should return list\\<array\\{start\\: int, visibility\\: string, abstract\\: bool, static\\: bool, readonly\\: bool, type\\: string, name\\: string, end\\: int\\}\\> but returns list\\<array\\{start\\: int, visibility\\: \'public\', abstract\\: false, static\\: false, readonly\\: bool, type\\: string, name\\?\\: string, end\\: int\\}\\|array\\{start\\: int, visibility\\: non\\-empty\\-string, abstract\\: bool, static\\: bool, readonly\\: bool\\}\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/ClassNotation/OrderedClassElementsFixer.php',
 ];
@@ -939,7 +939,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
-	'message' => '#^Offset \'end\' might not exist on array\\{abstract\\: bool, end\\?\\: int, name\\?\\: string, readonly\\: bool, start\\: int, static\\: bool, type\\?\\: string, visibility\\: string\\}\\.$#',
+	'message' => '#^Offset \'end\' might not exist on array\\{abstract\\: bool, end\\?\\: int, name\\?\\: string, readonly\\: bool, start\\: int, static\\: bool, type\\?\\: string, visibility\\: non\\-empty\\-string\\}\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/ClassNotation/OrderedClassElementsFixer.php',
 ];
@@ -1521,7 +1521,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
-	'message' => '#^Offset string might not exist on array\\<string, string\\>\\.$#',
+	'message' => '#^Offset non\\-empty\\-string might not exist on array\\<string, string\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/PhpUnit/PhpUnitConstructFixer.php',
 ];
@@ -2259,12 +2259,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: return.type
-	'message' => '#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:extractTokenKind\\(\\) should return int\\|non\\-empty\\-string but returns int\\|string\\.$#',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Tokenizer/Tokens.php',
-];
-$ignoreErrors[] = [
-	// identifier: return.type
 	'message' => '#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findGivenKind\\(\\) should return array\\<int, array\\<int\\<0, max\\>, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\> but returns array\\<\'\'\\|int, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Tokenizer/Tokens.php',
@@ -2301,13 +2295,13 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
-	'message' => '#^Offset int\\|non\\-empty\\-string might not exist on array\\<int\\|non\\-empty\\-string, int\\>\\.$#',
+	'message' => '#^Offset int\\|string might not exist on array\\<int\\|string, int\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Tokenizer/Tokens.php',
 ];
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
-	'message' => '#^Offset int\\|non\\-empty\\-string might not exist on non\\-empty\\-array\\<int\\|non\\-empty\\-string, int\\>\\.$#',
+	'message' => '#^Offset int\\|string might not exist on non\\-empty\\-array\\<int\\|string, int\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Tokenizer/Tokens.php',
 ];

--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -927,7 +927,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: return.type
-	'message' => '#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixer\\:\\:getElements\\(\\) should return list\\<array\\{start\\: int, visibility\\: string, abstract\\: bool, static\\: bool, readonly\\: bool, type\\: string, name\\: string, end\\: int\\}\\> but returns list\\<array\\{start\\: int, visibility\\: \'public\', abstract\\: false, static\\: false, readonly\\: bool, type\\: string, name\\?\\: string, end\\: int\\}\\|array\\{start\\: int, visibility\\: non\\-empty\\-string, abstract\\: bool, static\\: bool, readonly\\: bool\\}\\>\\.$#',
+	'message' => '#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixer\\:\\:getElements\\(\\) should return list\\<array\\{start\\: int, visibility\\: string, abstract\\: bool, static\\: bool, readonly\\: bool, type\\: string, name\\: string, end\\: int\\}\\> but returns list\\<array\\{start\\: int, visibility\\: \'public\', abstract\\: false, static\\: false, readonly\\: bool, type\\: string, name\\?\\: string, end\\: int\\}\\|array\\{start\\: int, visibility\\: string, abstract\\: bool, static\\: bool, readonly\\: bool\\}\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/ClassNotation/OrderedClassElementsFixer.php',
 ];
@@ -939,7 +939,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
-	'message' => '#^Offset \'end\' might not exist on array\\{abstract\\: bool, end\\?\\: int, name\\?\\: string, readonly\\: bool, start\\: int, static\\: bool, type\\?\\: string, visibility\\: non\\-empty\\-string\\}\\.$#',
+	'message' => '#^Offset \'end\' might not exist on array\\{abstract\\: bool, end\\?\\: int, name\\?\\: string, readonly\\: bool, start\\: int, static\\: bool, type\\?\\: string, visibility\\: string\\}\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/ClassNotation/OrderedClassElementsFixer.php',
 ];
@@ -1107,7 +1107,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
-	'message' => '#^Offset non\\-empty\\-string might not exist on array\\<int\\|string, bool\\|null\\>\\.$#',
+	'message' => '#^Offset string might not exist on array\\<int\\|string, bool\\|null\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/ControlStructure/YodaStyleFixer.php',
 ];
@@ -1473,7 +1473,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
-	'message' => '#^Offset non\\-empty\\-string might not exist on array\\<string, array\\{int, string\\}\\>\\.$#',
+	'message' => '#^Offset string might not exist on array\\<string, array\\{int, string\\}\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/Operator/LongToShorthandOperatorFixer.php',
 ];
@@ -1521,7 +1521,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
-	'message' => '#^Offset non\\-empty\\-string might not exist on array\\<string, string\\>\\.$#',
+	'message' => '#^Offset string might not exist on array\\<string, string\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/PhpUnit/PhpUnitConstructFixer.php',
 ];
@@ -1563,7 +1563,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
-	'message' => '#^Offset non\\-empty\\-string might not exist on array\\<string, array\\{positive\\: string, negative\\: string\\|false, argument_count\\?\\: int, swap_arguments\\?\\: true\\}\\|true\\>\\.$#',
+	'message' => '#^Offset string might not exist on array\\<string, array\\{positive\\: string, negative\\: string\\|false, argument_count\\?\\: int, swap_arguments\\?\\: true\\}\\|true\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php',
 ];
@@ -1587,7 +1587,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
-	'message' => '#^Offset non\\-empty\\-string might not exist on array\\<string, string\\>\\.$#',
+	'message' => '#^Offset string might not exist on array\\<string, string\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/PhpUnit/PhpUnitExpectationFixer.php',
 ];
@@ -2019,7 +2019,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: offsetAccess.notFound
-	'message' => '#^Offset non\\-empty\\-string might not exist on array\\<string, callable\\(int\\)\\: void\\>\\.$#',
+	'message' => '#^Offset string might not exist on non\\-empty\\-array\\<string, callable\\(int\\)\\: void\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/Whitespace/NoExtraBlankLinesFixer.php',
 ];
@@ -2259,7 +2259,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: return.type
-	'message' => '#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:extractTokenKind\\(\\) should return int\\|non\\-empty\\-string but returns int\\|string\\|null\\.$#',
+	'message' => '#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:extractTokenKind\\(\\) should return int\\|non\\-empty\\-string but returns int\\|string\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Tokenizer/Tokens.php',
 ];
@@ -2505,7 +2505,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: return.type
-	'message' => '#^Method PhpCsFixer\\\\Tests\\\\AutoReview\\\\ProjectCodeTest\\:\\:extractFunctionNamesCalledInClass\\(\\) should return list\\<string\\> but returns array\\<int, non\\-empty\\-string\\>\\.$#',
+	'message' => '#^Method PhpCsFixer\\\\Tests\\\\AutoReview\\\\ProjectCodeTest\\:\\:extractFunctionNamesCalledInClass\\(\\) should return list\\<string\\> but returns array\\<int, string\\>\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../tests/AutoReview/ProjectCodeTest.php',
 ];
@@ -2541,7 +2541,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	// identifier: argument.type
-	'message' => '#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\)\\: mixed\\)\\|null, Closure\\(PhpCsFixer\\\\Tokenizer\\\\Token\\)\\: non\\-empty\\-string given\\.$#',
+	'message' => '#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\)\\: mixed\\)\\|null, Closure\\(PhpCsFixer\\\\Tokenizer\\\\Token\\)\\: string given\\.$#',
 	'count' => 1,
 	'path' => __DIR__ . '/../../tests/AutoReview/ProjectCodeTest.php',
 ];

--- a/src/Tokenizer/CT.php
+++ b/src/Tokenizer/CT.php
@@ -65,6 +65,8 @@ final class CT
      * Get name for custom token.
      *
      * @param int $value custom token value
+     *
+     * @return non-empty-string
      */
     public static function getName(int $value): string
     {
@@ -73,6 +75,8 @@ final class CT
         }
 
         $tokens = self::getMapById();
+
+        \assert(isset($tokens[$value]));
 
         return 'CT::'.$tokens[$value];
     }
@@ -90,7 +94,7 @@ final class CT
     }
 
     /**
-     * @return array<self::T_*, string>
+     * @return array<self::T_*, non-empty-string>
      */
     private static function getMapById(): array
     {

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -45,7 +45,7 @@ final class Token
     private bool $changed = false;
 
     /**
-     * @param array{int, string}|string $token token prototype
+     * @param array{int, non-empty-string}|string $token token prototype
      */
     public function __construct($token)
     {
@@ -133,8 +133,8 @@ final class Token
      *
      * If tokens are arrays, then only keys defined in parameter token are checked.
      *
-     * @param array{0: int, 1?: string}|string|Token $other         token or it's prototype
-     * @param bool                                   $caseSensitive perform a case sensitive comparison
+     * @param array{0: int, 1?: non-empty-string}|string|Token $other         token or it's prototype
+     * @param bool                                             $caseSensitive perform a case sensitive comparison
      */
     public function equals($other, bool $caseSensitive = true): bool
     {
@@ -194,8 +194,8 @@ final class Token
     /**
      * Check if token is equals to one of given.
      *
-     * @param list<array{0: int, 1?: string}|string|Token> $others        array of tokens or token prototypes
-     * @param bool                                         $caseSensitive perform a case sensitive comparison
+     * @param list<array{0: int, 1?: non-empty-string}|string|Token> $others        array of tokens or token prototypes
+     * @param bool                                                   $caseSensitive perform a case sensitive comparison
      */
     public function equalsAny(array $others, bool $caseSensitive = true): bool
     {

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -233,13 +233,15 @@ final class Token
     }
 
     /**
-     * @return array{int, string}|string
+     * @return array{int, non-empty-string}|string
      */
     public function getPrototype()
     {
         if (!$this->isArray) {
             return $this->content;
         }
+
+        \assert('' !== $this->content);
 
         return [
             $this->id,
@@ -251,8 +253,6 @@ final class Token
      * Get token's content.
      *
      * It shall be used only for getting the content of token, not for checking it against excepted value.
-     *
-     * @return non-empty-string
      */
     public function getContent(): string
     {
@@ -274,7 +274,7 @@ final class Token
      *
      * It shall be used only for getting the name of token, not for checking it against excepted value.
      *
-     * @return null|string token name
+     * @return null|non-empty-string token name
      */
     public function getName(): ?string
     {
@@ -290,7 +290,7 @@ final class Token
      *
      * It shall be used only for getting the name of token, not for checking it against excepted value.
      *
-     * @return null|string token name
+     * @return null|non-empty-string token name
      */
     public static function getNameForId(int $id): ?string
     {
@@ -299,6 +299,8 @@ final class Token
         }
 
         $name = token_name($id);
+
+        \assert('' !== $name);
 
         return 'UNKNOWN' === $name ? null : $name;
     }
@@ -362,6 +364,9 @@ final class Token
      * Check if token prototype is an array.
      *
      * @return bool is array
+     *
+     * @phpstan-assert-if-true !null $this->getId()
+     * @phpstan-assert-if-true !'' $this->getContent()
      */
     public function isArray(): bool
     {
@@ -465,7 +470,7 @@ final class Token
     /**
      * @return array{
      *     id: int|null,
-     *     name: string|null,
+     *     name: non-empty-string|null,
      *     content: string,
      *     isArray: bool,
      *     changed: bool,
@@ -482,6 +487,9 @@ final class Token
         ];
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function toJson(): string
     {
         $jsonResult = json_encode($this->toArray(), JSON_PRETTY_PRINT | JSON_NUMERIC_CHECK);
@@ -495,6 +503,8 @@ final class Token
                 JSON_PRETTY_PRINT | JSON_NUMERIC_CHECK
             );
         }
+
+        \assert(false !== $jsonResult);
 
         return $jsonResult;
     }

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -45,7 +45,7 @@ final class Token
     private bool $changed = false;
 
     /**
-     * @param array{int, non-empty-string}|string $token token prototype
+     * @param array{int, string}|string $token token prototype
      */
     public function __construct($token)
     {
@@ -133,8 +133,8 @@ final class Token
      *
      * If tokens are arrays, then only keys defined in parameter token are checked.
      *
-     * @param array{0: int, 1?: non-empty-string}|string|Token $other         token or it's prototype
-     * @param bool                                             $caseSensitive perform a case sensitive comparison
+     * @param array{0: int, 1?: string}|string|Token $other         token or it's prototype
+     * @param bool                                   $caseSensitive perform a case sensitive comparison
      */
     public function equals($other, bool $caseSensitive = true): bool
     {
@@ -194,8 +194,8 @@ final class Token
     /**
      * Check if token is equals to one of given.
      *
-     * @param list<array{0: int, 1?: non-empty-string}|string|Token> $others        array of tokens or token prototypes
-     * @param bool                                                   $caseSensitive perform a case sensitive comparison
+     * @param list<array{0: int, 1?: string}|string|Token> $others        array of tokens or token prototypes
+     * @param bool                                         $caseSensitive perform a case sensitive comparison
      */
     public function equalsAny(array $others, bool $caseSensitive = true): bool
     {

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -365,8 +365,8 @@ final class Token
      *
      * @return bool is array
      *
-     * @phpstan-assert-if-true !null $this->getId()
-     * @phpstan-assert-if-true !'' $this->getContent()
+     * @phpstan-assert-if-true !=null $this->getId()
+     * @phpstan-assert-if-true !='' $this->getContent()
      */
     public function isArray(): bool
     {
@@ -376,7 +376,7 @@ final class Token
     /**
      * Check if token is one of type cast tokens.
      *
-     * @phpstan-assert-if-true !'' $this->getContent()
+     * @phpstan-assert-if-true !='' $this->getContent()
      */
     public function isCast(): bool
     {
@@ -386,7 +386,7 @@ final class Token
     /**
      * Check if token is one of classy tokens: T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM.
      *
-     * @phpstan-assert-if-true !'' $this->getContent()
+     * @phpstan-assert-if-true !='' $this->getContent()
      */
     public function isClassy(): bool
     {
@@ -396,7 +396,7 @@ final class Token
     /**
      * Check if token is one of comment tokens: T_COMMENT or T_DOC_COMMENT.
      *
-     * @phpstan-assert-if-true !'' $this->getContent()
+     * @phpstan-assert-if-true !='' $this->getContent()
      */
     public function isComment(): bool
     {
@@ -408,7 +408,7 @@ final class Token
     /**
      * Check if token is one of object operator tokens: T_OBJECT_OPERATOR or T_NULLSAFE_OBJECT_OPERATOR.
      *
-     * @phpstan-assert-if-true !'' $this->getContent()
+     * @phpstan-assert-if-true !='' $this->getContent()
      */
     public function isObjectOperator(): bool
     {
@@ -420,7 +420,7 @@ final class Token
      *
      * @param int|list<int> $possibleKind kind or array of kinds
      *
-     * @phpstan-assert-if-true !'' $this->getContent()
+     * @phpstan-assert-if-true !='' $this->getContent()
      */
     public function isGivenKind($possibleKind): bool
     {
@@ -430,7 +430,7 @@ final class Token
     /**
      * Check if token is a keyword.
      *
-     * @phpstan-assert-if-true !'' $this->getContent()
+     * @phpstan-assert-if-true !='' $this->getContent()
      */
     public function isKeyword(): bool
     {
@@ -442,7 +442,7 @@ final class Token
     /**
      * Check if token is a native PHP constant: true, false or null.
      *
-     * @phpstan-assert-if-true !'' $this->getContent()
+     * @phpstan-assert-if-true !='' $this->getContent()
      */
     public function isNativeConstant(): bool
     {
@@ -454,7 +454,7 @@ final class Token
     /**
      * Returns if the token is of a Magic constants type.
      *
-     * @phpstan-assert-if-true !'' $this->getContent()
+     * @phpstan-assert-if-true !='' $this->getContent()
      *
      * @see https://php.net/manual/en/language.constants.predefined.php
      */

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -375,6 +375,8 @@ final class Token
 
     /**
      * Check if token is one of type cast tokens.
+     *
+     * @phpstan-assert-if-true !'' $this->getContent()
      */
     public function isCast(): bool
     {
@@ -383,6 +385,8 @@ final class Token
 
     /**
      * Check if token is one of classy tokens: T_CLASS, T_INTERFACE, T_TRAIT or T_ENUM.
+     *
+     * @phpstan-assert-if-true !'' $this->getContent()
      */
     public function isClassy(): bool
     {
@@ -391,6 +395,8 @@ final class Token
 
     /**
      * Check if token is one of comment tokens: T_COMMENT or T_DOC_COMMENT.
+     *
+     * @phpstan-assert-if-true !'' $this->getContent()
      */
     public function isComment(): bool
     {
@@ -401,6 +407,8 @@ final class Token
 
     /**
      * Check if token is one of object operator tokens: T_OBJECT_OPERATOR or T_NULLSAFE_OBJECT_OPERATOR.
+     *
+     * @phpstan-assert-if-true !'' $this->getContent()
      */
     public function isObjectOperator(): bool
     {
@@ -411,6 +419,8 @@ final class Token
      * Check if token is one of given kind.
      *
      * @param int|list<int> $possibleKind kind or array of kinds
+     *
+     * @phpstan-assert-if-true !'' $this->getContent()
      */
     public function isGivenKind($possibleKind): bool
     {
@@ -419,6 +429,8 @@ final class Token
 
     /**
      * Check if token is a keyword.
+     *
+     * @phpstan-assert-if-true !'' $this->getContent()
      */
     public function isKeyword(): bool
     {
@@ -429,6 +441,8 @@ final class Token
 
     /**
      * Check if token is a native PHP constant: true, false or null.
+     *
+     * @phpstan-assert-if-true !'' $this->getContent()
      */
     public function isNativeConstant(): bool
     {
@@ -439,6 +453,8 @@ final class Token
 
     /**
      * Returns if the token is of a Magic constants type.
+     *
+     * @phpstan-assert-if-true !'' $this->getContent()
      *
      * @see https://php.net/manual/en/language.constants.predefined.php
      */

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -94,7 +94,7 @@ class Tokens extends \SplFixedArray
      * was ever seen inside the collection (but may not be part of it any longer).
      * The key is token kind and the value is always true.
      *
-     * @var array<int|non-empty-string, int>
+     * @var array<int|string, int>
      */
     private array $foundTokenKinds = [];
 
@@ -151,7 +151,6 @@ class Tokens extends \SplFixedArray
         }
 
         // inlined extractTokenKind() call on the hot path
-        /** @var int|non-empty-string */
         $tokenKind = $token->isArray() ? $token->getId() : $token->getContent();
 
         return $blockEdgeKinds[$tokenKind] ?? null;
@@ -1422,7 +1421,6 @@ class Tokens extends \SplFixedArray
     private function registerFoundToken($token): void
     {
         // inlined extractTokenKind() call on the hot path
-        /** @var int|non-empty-string */
         $tokenKind = $token instanceof Token
             ? ($token->isArray() ? $token->getId() : $token->getContent())
             : (\is_array($token) ? $token[0] : $token);
@@ -1439,7 +1437,6 @@ class Tokens extends \SplFixedArray
     private function unregisterFoundToken($token): void
     {
         // inlined extractTokenKind() call on the hot path
-        /** @var int|non-empty-string */
         $tokenKind = $token instanceof Token
             ? ($token->isArray() ? $token->getId() : $token->getContent())
             : (\is_array($token) ? $token[0] : $token);
@@ -1454,7 +1451,7 @@ class Tokens extends \SplFixedArray
     /**
      * @param array{int}|string|Token $token token prototype
      *
-     * @return int|non-empty-string
+     * @return int|string
      */
     private function extractTokenKind($token)
     {


### PR DESCRIPTION
introduced wrongly in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7598

Empty content is allowed and actually heavily used.