### PR TITLE
chore: do not call `Tokens::setSize` in `GroupImportFixer`

### DIFF
--- a/src/Fixer/Import/GroupImportFixer.php
+++ b/src/Fixer/Import/GroupImportFixer.php
@@ -312,10 +312,6 @@ final class GroupImportFixer extends AbstractFixer implements ConfigurableFixerI
     {
         $insertedTokens = 0;
 
-        if (\count($tokens) === $insertIndex) {
-            $tokens->setSize($insertIndex + 1);
-        }
-
         $newTokens = [
             new Token([T_USE, 'use']),
             new Token([T_WHITESPACE, ' ']),


### PR DESCRIPTION
This is the only call to `Tokens::setSize` from outside to `Tokens` class.