### PR TITLE
fix: `BlankLineAfterOpeningTagFixer` - add blank line in file starting with multi-line comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,8 +214,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-#        run: vendor/bin/paraunit run --testsuite unit,integration
-        run: vendor/bin/phpunit tests/Fixer/PhpTag/BlankLineAfterOpeningTagFixerTest.php
+        run: vendor/bin/paraunit run --testsuite unit,integration
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,8 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+#        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/phpunit tests/Fixer/PhpTag/BlankLineAfterOpeningTagFixerTest.php
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php
+++ b/src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php
@@ -77,12 +77,16 @@ final class BlankLineAfterOpeningTagFixer extends AbstractFixer implements White
         }
 
         $newLineIndex = $openTagIndex + 1;
-        if (isset($tokens[$newLineIndex]) && !str_contains($tokens[$newLineIndex]->getContent(), "\n")) {
-            if ($tokens[$newLineIndex]->isWhitespace()) {
+        if (!$tokens->offsetExists($newLineIndex)) {
+            return;
+        }
+
+        if ($tokens[$newLineIndex]->isWhitespace()) {
+            if (!str_contains($tokens[$newLineIndex]->getContent(), "\n")) {
                 $tokens[$newLineIndex] = new Token([T_WHITESPACE, $lineEnding.$tokens[$newLineIndex]->getContent()]);
-            } else {
-                $tokens->insertAt($newLineIndex, new Token([T_WHITESPACE, $lineEnding]));
             }
+        } else {
+            $tokens->insertAt($newLineIndex, new Token([T_WHITESPACE, $lineEnding]));
         }
     }
 }

--- a/tests/Fixer/PhpTag/BlankLineAfterOpeningTagFixerTest.php
+++ b/tests/Fixer/PhpTag/BlankLineAfterOpeningTagFixerTest.php
@@ -163,6 +163,22 @@ $foo = $bar;
                 echo 1;
                 EOD,
         ];
+
+        yield 'file starting with multi-line comment' => [
+            <<<'PHP'
+                <?php
+
+                /**
+                 * @author yes
+                 */
+                PHP,
+            <<<'PHP'
+                <?php
+                /**
+                 * @author yes
+                 */
+                PHP,
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8249