### PR TITLE
chore: block changing tokens collection size using `PhpCsFixer\Tokenizer\Tokens::setSize`

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -300,14 +300,7 @@ class Tokens extends \SplFixedArray
     #[\ReturnTypeWillChange]
     public function setSize($size): bool
     {
-        if (\count($this) !== $size) {
-            $this->changed = true;
-            $this->namespaceDeclarations = null;
-
-            return parent::setSize($size);
-        }
-
-        return true;
+        throw new \RuntimeException(\sprintf('Do not change tokens collection size using %s.', __METHOD__));
     }
 
     /**
@@ -425,7 +418,7 @@ class Tokens extends \SplFixedArray
         $this->blockStartCache = [];
         $this->blockEndCache = [];
 
-        $this->setSize($count);
+        $this->updateSize($count);
     }
 
     /**
@@ -922,7 +915,7 @@ class Tokens extends \SplFixedArray
         $this->namespaceDeclarations = null;
         $this->blockStartCache = [];
         $this->blockEndCache = [];
-        $this->setSize($oldSize + $itemsCount);
+        $this->updateSize($oldSize + $itemsCount);
 
         krsort($slices);
         $farthestSliceIndex = array_key_first($slices);
@@ -1050,13 +1043,13 @@ class Tokens extends \SplFixedArray
         }
 
         // clear memory
-        $this->setSize(0);
+        $this->updateSize(0);
         $this->blockStartCache = [];
         $this->blockEndCache = [];
 
         $tokens = token_get_all($code, TOKEN_PARSE);
 
-        $this->setSize(\count($tokens));
+        $this->updateSize(\count($tokens));
 
         foreach ($tokens as $index => $token) {
             $this[$index] = new Token($token);
@@ -1244,6 +1237,16 @@ class Tokens extends \SplFixedArray
     {
         $transformers = Transformers::createSingleton();
         $transformers->transform($this);
+    }
+
+    private function updateSize(int $size): void
+    {
+        if (\count($this) !== $size) {
+            $this->changed = true;
+            $this->namespaceDeclarations = null;
+
+            parent::setSize($size);
+        }
     }
 
     /**

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -300,7 +300,7 @@ class Tokens extends \SplFixedArray
     #[\ReturnTypeWillChange]
     public function setSize($size): bool
     {
-        throw new \RuntimeException(\sprintf('Do not change tokens collection size using %s.', __METHOD__));
+        throw new \RuntimeException('Changing tokens collection size explicitly is not allowed.');
     }
 
     /**

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -1856,6 +1856,30 @@ $bar;',
         self::assertTrue($tokens->isTokenKindFound(T_VARIABLE));
     }
 
+    public function testSettingSizeThrowsException(): void
+    {
+        $tokens = new Tokens();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Changing tokens collection size explicitly is not allowed.');
+
+        $tokens->setSize(3);
+    }
+
+    public function testSettingSizeInTryCatchBlockDoesNotChangeSize(): void
+    {
+        $tokens = Tokens::fromCode('<?php $x = true;');
+        $size = $tokens->getSize();
+
+        try {
+            $tokens->setSize(5);
+        } catch (\RuntimeException $exception) {
+            self::assertSame('Changing tokens collection size explicitly is not allowed.', $exception->getMessage());
+        }
+
+        self::assertSame($size, $tokens->getSize());
+    }
+
     private function getBlockEdgeCachingTestTokens(): Tokens
     {
         Tokens::clearCache();


### PR DESCRIPTION
There is no reasonable situation that any fixer (or in fact anyscript using `PhpCsFixer\Tokenizer\Tokens`) would need to change the size of the token's collection via the `setSize` method.

Adding tokens is done via `offsetSet` method (usually used with syntax `$tokens[$index] = new Token($tokenData);`
Removing tokens is done via `offsetUnset` method.