### PR TITLE
Fixed ExplicitIndirectVariableFixer unit tests to reflect the fixer wrong behavior

### DIFF
--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -40,23 +40,28 @@ final class ExplicitIndirectVariableFixerTest extends AbstractFixerTestCase
      */
     public static function provideFixCases(): iterable
     {
+        yield 'variable variable property fetch' => [
+            '<?php echo ${$foo->bar};',
+            '<?php echo $$foo->bar;',
+        ];
+
         yield 'variable variable function call' => [
-            '<?php echo ${$foo}($bar);',
+            '<?php echo ${$foo($bar)};',
             '<?php echo $$foo($bar);',
         ];
 
         yield 'variable variable array fetch' => [
-            '<?php echo ${$foo}[\'bar\'][\'baz\'];',
+            '<?php echo ${$foo[\'bar\'][\'baz\']};',
             '<?php echo $$foo[\'bar\'][\'baz\'];',
         ];
 
         yield 'dynamic property access' => [
-            '<?php echo $foo->{$bar}[\'baz\'];',
+            '<?php echo $foo->{$bar[\'baz\']};',
             '<?php echo $foo->$bar[\'baz\'];',
         ];
 
         yield 'dynamic property access with method call' => [
-            '<?php echo $foo->{$bar}[\'baz\']();',
+            '<?php echo $foo->{$bar[\'baz\']}();',
             '<?php echo $foo->$bar[\'baz\']();',
         ];
 
@@ -81,7 +86,7 @@ $foo
         ];
 
         yield 'dynamic static property access using variable variable with method call' => [
-            '<?php echo Foo::${$bar}->baz();',
+            '<?php echo Foo::${$bar->baz}();',
             '<?php echo Foo::$$bar->baz();',
         ];
     }
@@ -102,12 +107,12 @@ $foo
     public static function provideFix80Cases(): iterable
     {
         yield 'dynamic property fetch with nullsafe operator' => [
-            '<?php echo $foo?->{$bar}["baz"];',
+            '<?php echo $foo?->{$bar["baz"]};',
             '<?php echo $foo?->$bar["baz"];',
         ];
 
         yield 'dynamic property fetch with nullsafe operator and method call' => [
-            '<?php echo $foo?->{$bar}["baz"]();',
+            '<?php echo $foo?->{$bar["baz"]}();',
             '<?php echo $foo?->$bar["baz"]();',
         ];
     }


### PR DESCRIPTION
@see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8261

### Problem description

First, I want to express my gratitude for this awesome work, second, I want to contribute.

Purpose of the `ExplicitIndirectVariableFixer` fixer is to modify `PHP 5.6` code in order to make it work with the `PHP
7.0+` interpreter, **NOT** changing the behavior of the code.

For instance, in `PHP 7.0+`, you can no longer write `$$foo->bar`, you **MUST** write `${$foo->bar}` instead.

Quoting PHP manual [Changes to the handling of indirect variables, properties, and methods ](https://www.php.net/manual/en/migration70.incompatible.php):

> Indirect access to variables, properties, and methods will now be evaluated strictly in left-to-right order, as
> opposed to the previous mix of special cases. The table below shows how the order of evaluation has changed.
>
> |      Expression       |  PHP 5 interpretation   |  PHP 7 interpretation   |
> |:---------------------:|:-----------------------:|:-----------------------:|
> | `$$foo['bar']['baz']` | `${$foo['bar']['baz']}` | `($$foo)['bar']['baz']` |
> |  `$foo->$bar['baz']`  |  `$foo->{$bar['baz']}`  |  `($foo->$bar)['baz']`  |
> | `$foo->$bar['baz']()` | `$foo->{$bar['baz']}()` | `($foo->$bar)['baz']()` |
> | `Foo::$bar['baz']()`  | `Foo::{$bar['baz']}()`  | `(Foo::$bar)['baz']()`  |
>
> Code that used the old right-to-left evaluation order must be rewritten to explicitly use that evaluation order with
> curly braces **(see the above middle column)**. This will make the code both forwards compatible with PHP 7.x and
> backwards
> compatible with PHP 5.x.

These are precisely the examples used in the code documentation and unit tests of the `ExplicitIndirectVariableFixer`
method.
Despite of the warning: **"(see the above middle column)"**, the developer took the "PHP7 interpretation" column instead of the "PHP 5 interpretation" column in order to build the fixer.

I know... at first, you will think I made a mistake or misunderstood, since this rule has been performing this way for
years... So, here is the **BUG** proof:

Run this on PHP 5.6 ([https://3v4l.org/XB19f#v5.6.40](https://3v4l.org/XB19f#v5.6.40))

```php
<?php
$baz = 'bat';
$foo = array('bar' => 'baz');

echo $$foo['bar'];
echo PHP_EOL;
echo ${$foo['bar']};
echo PHP_EOL;

// PHP 5.6 output:
bat
bat
```

Run this on PHP 7.0 ([https://3v4l.org/jBLbv#v7.0.0](https://3v4l.org/jBLbv#v7.0.0))

```php
<?php
$baz = 'bat';
$foo = array('bar' => 'baz');

echo ${$foo}['bar']; // This is the way `ExplicitIndirectVariableFixer` currently fixes the code.
echo PHP_EOL;
echo ${$foo['bar']}; // This is the way `ExplicitIndirectVariableFixer` SHOULD fix the code.
echo PHP_EOL;

// PHP7.0 output
Notice: Array to string conversion in /in/jBLbv on line 5

Notice: Undefined variable: Array in /in/jBLbv on line 5

bat
```

In this pull request, I changed the `ExplicitIndirectVariableFixerTest::provideFixCases()` and `ExplicitIndirectVariableFixerTest::provideFix80Cases()` data provider methods in order to reflect the right logic, I also added a missing case.

> |  Expression   | PHP 5 interpretation  | PHP 7 interpretation  |
> |:-------------:|:---------------------:|:---------------------:|
> | `$$foo->bar`  |    `${$foo->bar}`     |    `($$foo)->bar`     |

This pull request doesn't contain an actual fix for `ExplicitIndirectVariableFixer` since I am not used to the way fixers work yet. When I am used, if this bug is still open, I will fix it. In the meantime, people will be aware of the wrong behavior.

For information, I did exactly the same bug report on RectorPHP: https://github.com/rectorphp/rector/issues/8861