### PR TITLE
chore: remove not needed PHP version requirements in descriptions

### DIFF
--- a/doc/rules/function_notation/combine_nested_dirname.rst
+++ b/doc/rules/function_notation/combine_nested_dirname.rst
@@ -3,7 +3,7 @@ Rule ``combine_nested_dirname``
 ===============================
 
 Replace multiple nested calls of ``dirname`` by only one call with second
-``$level`` parameter. Requires PHP >= 7.0.
+``$level`` parameter.
 
 Warning
 -------

--- a/doc/rules/function_notation/phpdoc_to_param_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_param_type.rst
@@ -3,7 +3,7 @@ Rule ``phpdoc_to_param_type``
 =============================
 
 Takes ``@param`` annotations of non-mixed types and adjusts accordingly the
-function signature. Requires PHP >= 7.0.
+function signature.
 
 Warning
 -------

--- a/doc/rules/function_notation/phpdoc_to_property_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_property_type.rst
@@ -3,7 +3,7 @@ Rule ``phpdoc_to_property_type``
 ================================
 
 Takes ``@var`` annotation of non-mixed types and adjusts accordingly the
-property signature. Requires PHP >= 7.4.
+property signature..
 
 Warning
 -------

--- a/doc/rules/function_notation/void_return.rst
+++ b/doc/rules/function_notation/void_return.rst
@@ -3,7 +3,7 @@ Rule ``void_return``
 ====================
 
 Add ``void`` return type to functions with missing or empty return statements,
-but priority is given to ``@return`` annotations. Requires PHP >= 7.1.
+but priority is given to ``@return`` annotations.
 
 Warning
 -------

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -361,7 +361,7 @@ Function Notation
 
 - `combine_nested_dirname <./function_notation/combine_nested_dirname.rst>`_ *(risky)*
 
-  Replace multiple nested calls of ``dirname`` by only one call with second ``$level`` parameter. Requires PHP >= 7.0.
+  Replace multiple nested calls of ``dirname`` by only one call with second ``$level`` parameter.
 - `date_time_create_from_format_call <./function_notation/date_time_create_from_format_call.rst>`_ *(risky)*
 
   The first argument of ``DateTime::createFromFormat`` method must start with ``!``.
@@ -406,10 +406,10 @@ Function Notation
   Adds or removes ``?`` before single type declarations or ``|null`` at the end of union types when parameters have a default ``null`` value.
 - `phpdoc_to_param_type <./function_notation/phpdoc_to_param_type.rst>`_ *(experimental, risky)*
 
-  Takes ``@param`` annotations of non-mixed types and adjusts accordingly the function signature. Requires PHP >= 7.0.
+  Takes ``@param`` annotations of non-mixed types and adjusts accordingly the function signature.
 - `phpdoc_to_property_type <./function_notation/phpdoc_to_property_type.rst>`_ *(experimental, risky)*
 
-  Takes ``@var`` annotation of non-mixed types and adjusts accordingly the property signature. Requires PHP >= 7.4.
+  Takes ``@var`` annotation of non-mixed types and adjusts accordingly the property signature..
 - `phpdoc_to_return_type <./function_notation/phpdoc_to_return_type.rst>`_ *(experimental, risky)*
 
   Takes ``@return`` annotation of non-mixed types and adjusts accordingly the function signature.
@@ -430,7 +430,7 @@ Function Notation
   Anonymous functions with one-liner return statement must use arrow functions.
 - `void_return <./function_notation/void_return.rst>`_ *(risky)*
 
-  Add ``void`` return type to functions with missing or empty return statements, but priority is given to ``@return`` annotations. Requires PHP >= 7.1.
+  Add ``void`` return type to functions with missing or empty return statements, but priority is given to ``@return`` annotations.
 
 Import
 ------
@@ -492,7 +492,7 @@ Language Construct
   Error control operator should be added to deprecation notices and/or removed from other cases.
 - `explicit_indirect_variable <./language_construct/explicit_indirect_variable.rst>`_
 
-  Add curly braces to indirect variables to make them clear to understand. Requires PHP >= 7.0.
+  Add curly braces to indirect variables to make them clear to understand.
 - `function_to_constant <./language_construct/function_to_constant.rst>`_ *(risky)*
 
   Replace core functions calls returning constants with the constants.
@@ -520,7 +520,7 @@ List Notation
 
 - `list_syntax <./list_notation/list_syntax.rst>`_
 
-  List (``array`` destructuring) assignment should be declared using the configured syntax. Requires PHP >= 7.1.
+  List (``array`` destructuring) assignment should be declared using the configured syntax.
 
 Namespace Notation
 ------------------
@@ -613,7 +613,7 @@ Operator
   Use the Elvis operator ``?:`` where possible.
 - `ternary_to_null_coalescing <./operator/ternary_to_null_coalescing.rst>`_
 
-  Use ``null`` coalescing operator ``??`` where possible. Requires PHP >= 7.0.
+  Use ``null`` coalescing operator ``??`` where possible.
 - `unary_operator_spaces <./operator/unary_operator_spaces.rst>`_
 
   Unary operators should be placed adjacent to their operands.
@@ -856,7 +856,7 @@ Strict
 
 - `declare_strict_types <./strict/declare_strict_types.rst>`_ *(risky)*
 
-  Force strict types declaration in all files. Requires PHP >= 7.0.
+  Force strict types declaration in all files.
 - `strict_comparison <./strict/strict_comparison.rst>`_ *(risky)*
 
   Comparisons should be strict.

--- a/doc/rules/language_construct/explicit_indirect_variable.rst
+++ b/doc/rules/language_construct/explicit_indirect_variable.rst
@@ -3,7 +3,6 @@ Rule ``explicit_indirect_variable``
 ===================================
 
 Add curly braces to indirect variables to make them clear to understand.
-Requires PHP >= 7.0.
 
 Examples
 --------

--- a/doc/rules/list_notation/list_syntax.rst
+++ b/doc/rules/list_notation/list_syntax.rst
@@ -3,7 +3,7 @@ Rule ``list_syntax``
 ====================
 
 List (``array`` destructuring) assignment should be declared using the
-configured syntax. Requires PHP >= 7.1.
+configured syntax.
 
 Configuration
 -------------

--- a/doc/rules/operator/ternary_to_null_coalescing.rst
+++ b/doc/rules/operator/ternary_to_null_coalescing.rst
@@ -2,7 +2,7 @@
 Rule ``ternary_to_null_coalescing``
 ===================================
 
-Use ``null`` coalescing operator ``??`` where possible. Requires PHP >= 7.0.
+Use ``null`` coalescing operator ``??`` where possible.
 
 Examples
 --------

--- a/doc/rules/strict/declare_strict_types.rst
+++ b/doc/rules/strict/declare_strict_types.rst
@@ -2,7 +2,7 @@
 Rule ``declare_strict_types``
 =============================
 
-Force strict types declaration in all files. Requires PHP >= 7.0.
+Force strict types declaration in all files.
 
 Warning
 -------

--- a/src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+++ b/src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
@@ -30,7 +30,7 @@ final class CombineNestedDirnameFixer extends AbstractFixer
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Replace multiple nested calls of `dirname` by only one call with second `$level` parameter. Requires PHP >= 7.0.',
+            'Replace multiple nested calls of `dirname` by only one call with second `$level` parameter.',
             [
                 new CodeSample(
                     "<?php\ndirname(dirname(dirname(\$path)));\n"

--- a/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
@@ -62,7 +62,7 @@ final class PhpdocToParamTypeFixer extends AbstractPhpdocToTypeDeclarationFixer 
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Takes `@param` annotations of non-mixed types and adjusts accordingly the function signature. Requires PHP >= 7.0.',
+            'Takes `@param` annotations of non-mixed types and adjusts accordingly the function signature.',
             [
                 new CodeSample(
                     '<?php

--- a/src/Fixer/FunctionNotation/PhpdocToPropertyTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToPropertyTypeFixer.php
@@ -53,7 +53,7 @@ final class PhpdocToPropertyTypeFixer extends AbstractPhpdocToTypeDeclarationFix
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Takes `@var` annotation of non-mixed types and adjusts accordingly the property signature. Requires PHP >= 7.4.',
+            'Takes `@var` annotation of non-mixed types and adjusts accordingly the property signature..',
             [
                 new CodeSample(
                     '<?php

--- a/src/Fixer/FunctionNotation/VoidReturnFixer.php
+++ b/src/Fixer/FunctionNotation/VoidReturnFixer.php
@@ -33,7 +33,7 @@ final class VoidReturnFixer extends AbstractFixer
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Add `void` return type to functions with missing or empty return statements, but priority is given to `@return` annotations. Requires PHP >= 7.1.',
+            'Add `void` return type to functions with missing or empty return statements, but priority is given to `@return` annotations.',
             [
                 new CodeSample(
                     "<?php\nfunction foo(\$a) {};\n"

--- a/src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
+++ b/src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
@@ -30,7 +30,7 @@ final class ExplicitIndirectVariableFixer extends AbstractFixer
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Add curly braces to indirect variables to make them clear to understand. Requires PHP >= 7.0.',
+            'Add curly braces to indirect variables to make them clear to understand.',
             [
                 new CodeSample(
                     <<<'EOT'

--- a/src/Fixer/ListNotation/ListSyntaxFixer.php
+++ b/src/Fixer/ListNotation/ListSyntaxFixer.php
@@ -51,7 +51,7 @@ final class ListSyntaxFixer extends AbstractFixer implements ConfigurableFixerIn
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'List (`array` destructuring) assignment should be declared using the configured syntax. Requires PHP >= 7.1.',
+            'List (`array` destructuring) assignment should be declared using the configured syntax.',
             [
                 new CodeSample(
                     "<?php\nlist(\$sample) = \$array;\n"

--- a/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+++ b/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
@@ -29,7 +29,7 @@ final class TernaryToNullCoalescingFixer extends AbstractFixer
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Use `null` coalescing operator `??` where possible. Requires PHP >= 7.0.',
+            'Use `null` coalescing operator `??` where possible.',
             [
                 new CodeSample(
                     "<?php\n\$sample = isset(\$a) ? \$a : \$b;\n"

--- a/src/Fixer/Strict/DeclareStrictTypesFixer.php
+++ b/src/Fixer/Strict/DeclareStrictTypesFixer.php
@@ -30,7 +30,7 @@ final class DeclareStrictTypesFixer extends AbstractFixer implements Whitespaces
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Force strict types declaration in all files. Requires PHP >= 7.0.',
+            'Force strict types declaration in all files.',
             [
                 new CodeSample(
                     "<?php\n"


### PR DESCRIPTION
Follow up to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/5929