### PR TITLE
docs: fix unconsistency in config doc

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -114,7 +114,7 @@ The following example shows how to use all ``PhpCsFixer`` rules but without the 
     return (new PhpCsFixer\Config())
         ->setRules([
             '@PhpCsFixer' => true,
-            'comment_type' => false,
+            'align_multiline_comment' => false,
         ])
         ->setFinder($finder)
     ;


### PR DESCRIPTION
Small change to fix an inconsistency between the example and the text above it
And AFAIK `comment_type` is not a rule then the example seems invalid