### PR TITLE
feat: create `@PHP82Migration:risky` ruleset

### DIFF
--- a/.php-cs-fixer.php-highest.php
+++ b/.php-cs-fixer.php-highest.php
@@ -23,7 +23,7 @@ $config = require __DIR__.'/.php-cs-fixer.dist.php';
 
 $config->setRules(array_merge($config->getRules(), [
     '@PHP83Migration' => true,
-    '@PHP80Migration:risky' => true,
+    '@PHP82Migration:risky' => true,
     'fully_qualified_strict_types' => ['import_symbols' => true],
     'php_unit_attributes' => false, // as is not yet supported by PhpCsFixerInternal/configurable_fixer_template
 ]));

--- a/doc/ruleSets/PHP82MigrationRisky.rst
+++ b/doc/ruleSets/PHP82MigrationRisky.rst
@@ -1,0 +1,19 @@
+==================================
+Rule set ``@PHP82Migration:risky``
+==================================
+
+Rules to improve code for PHP 8.2 compatibility.
+
+Warning
+-------
+
+This set contains rules that are risky
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using this rule set may lead to changes in your code's logic and behaviour. Use it with caution and review changes before incorporating them into your code base.
+
+Rules
+-----
+
+- `@PHP80Migration:risky <./PHP80MigrationRisky.rst>`_
+- `phpdoc_readonly_class_comment_to_keyword <./../rules/class_notation/phpdoc_readonly_class_comment_to_keyword.rst>`_

--- a/doc/ruleSets/index.rst
+++ b/doc/ruleSets/index.rst
@@ -23,6 +23,7 @@ List of Available Rule sets
 - `@PHP80Migration:risky <./PHP80MigrationRisky.rst>`_
 - `@PHP81Migration <./PHP81Migration.rst>`_
 - `@PHP82Migration <./PHP82Migration.rst>`_
+- `@PHP82Migration:risky <./PHP82MigrationRisky.rst>`_
 - `@PHP83Migration <./PHP83Migration.rst>`_
 - `@PHP84Migration <./PHP84Migration.rst>`_
 - `@PHPUnit30Migration:risky <./PHPUnit30MigrationRisky.rst>`_

--- a/doc/rules/alias/modernize_strpos.rst
+++ b/doc/rules/alias/modernize_strpos.rst
@@ -40,6 +40,7 @@ Rule sets
 The rule is part of the following rule sets:
 
 - `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_
 - `@Symfony:risky <./../../ruleSets/SymfonyRisky.rst>`_
 
 References

--- a/doc/rules/alias/no_alias_functions.rst
+++ b/doc/rules/alias/no_alias_functions.rst
@@ -121,6 +121,10 @@ The rule is part of the following rule sets:
 
   ``['sets' => ['@all']]``
 
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_ with config:
+
+  ``['sets' => ['@all']]``
+
 - `@PhpCsFixer:risky <./../../ruleSets/PhpCsFixerRisky.rst>`_ with config:
 
   ``['sets' => ['@all']]``

--- a/doc/rules/alias/pow_to_exponentiation.rst
+++ b/doc/rules/alias/pow_to_exponentiation.rst
@@ -36,6 +36,7 @@ The rule is part of the following rule sets:
 - `@PHP71Migration:risky <./../../ruleSets/PHP71MigrationRisky.rst>`_
 - `@PHP74Migration:risky <./../../ruleSets/PHP74MigrationRisky.rst>`_
 - `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_
 - `@PhpCsFixer:risky <./../../ruleSets/PhpCsFixerRisky.rst>`_
 - `@Symfony:risky <./../../ruleSets/SymfonyRisky.rst>`_
 

--- a/doc/rules/alias/random_api_migration.rst
+++ b/doc/rules/alias/random_api_migration.rst
@@ -94,6 +94,10 @@ The rule is part of the following rule sets:
 
   ``['replacements' => ['mt_rand' => 'random_int', 'rand' => 'random_int']]``
 
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_ with config:
+
+  ``['replacements' => ['mt_rand' => 'random_int', 'rand' => 'random_int']]``
+
 
 References
 ----------

--- a/doc/rules/basic/non_printable_character.rst
+++ b/doc/rules/basic/non_printable_character.rst
@@ -61,6 +61,7 @@ The rule is part of the following rule sets:
 - `@PHP71Migration:risky <./../../ruleSets/PHP71MigrationRisky.rst>`_
 - `@PHP74Migration:risky <./../../ruleSets/PHP74MigrationRisky.rst>`_
 - `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_
 - `@PhpCsFixer:risky <./../../ruleSets/PhpCsFixerRisky.rst>`_
 - `@Symfony:risky <./../../ruleSets/SymfonyRisky.rst>`_
 

--- a/doc/rules/class_notation/no_php4_constructor.rst
+++ b/doc/rules/class_notation/no_php4_constructor.rst
@@ -38,6 +38,7 @@ Rule sets
 The rule is part of the following rule sets:
 
 - `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_
 - `@PhpCsFixer:risky <./../../ruleSets/PhpCsFixerRisky.rst>`_
 - `@Symfony:risky <./../../ruleSets/SymfonyRisky.rst>`_
 

--- a/doc/rules/class_notation/no_unneeded_final_method.rst
+++ b/doc/rules/class_notation/no_unneeded_final_method.rst
@@ -80,6 +80,7 @@ Rule sets
 The rule is part of the following rule sets:
 
 - `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_
 - `@PhpCsFixer:risky <./../../ruleSets/PhpCsFixerRisky.rst>`_
 - `@Symfony:risky <./../../ruleSets/SymfonyRisky.rst>`_
 

--- a/doc/rules/class_notation/phpdoc_readonly_class_comment_to_keyword.rst
+++ b/doc/rules/class_notation/phpdoc_readonly_class_comment_to_keyword.rst
@@ -29,6 +29,14 @@ Example #1
    +    
    +    readonly class C {
         }
+
+Rule sets
+---------
+
+The rule is part of the following rule set:
+
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_
+
 References
 ----------
 

--- a/doc/rules/function_notation/combine_nested_dirname.rst
+++ b/doc/rules/function_notation/combine_nested_dirname.rst
@@ -36,6 +36,7 @@ The rule is part of the following rule sets:
 - `@PHP71Migration:risky <./../../ruleSets/PHP71MigrationRisky.rst>`_
 - `@PHP74Migration:risky <./../../ruleSets/PHP74MigrationRisky.rst>`_
 - `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_
 - `@PhpCsFixer:risky <./../../ruleSets/PhpCsFixerRisky.rst>`_
 - `@Symfony:risky <./../../ruleSets/SymfonyRisky.rst>`_
 

--- a/doc/rules/function_notation/implode_call.rst
+++ b/doc/rules/function_notation/implode_call.rst
@@ -44,6 +44,7 @@ The rule is part of the following rule sets:
 
 - `@PHP74Migration:risky <./../../ruleSets/PHP74MigrationRisky.rst>`_
 - `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_
 - `@PhpCsFixer:risky <./../../ruleSets/PhpCsFixerRisky.rst>`_
 - `@Symfony:risky <./../../ruleSets/SymfonyRisky.rst>`_
 

--- a/doc/rules/function_notation/no_unreachable_default_argument_value.rst
+++ b/doc/rules/function_notation/no_unreachable_default_argument_value.rst
@@ -38,6 +38,7 @@ The rule is part of the following rule sets:
 - `@PER-CS:risky <./../../ruleSets/PER-CSRisky.rst>`_
 - `@PER:risky <./../../ruleSets/PERRisky.rst>`_
 - `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_
 - `@PSR12:risky <./../../ruleSets/PSR12Risky.rst>`_
 - `@PhpCsFixer:risky <./../../ruleSets/PhpCsFixerRisky.rst>`_
 - `@Symfony:risky <./../../ruleSets/SymfonyRisky.rst>`_

--- a/doc/rules/function_notation/use_arrow_functions.rst
+++ b/doc/rules/function_notation/use_arrow_functions.rst
@@ -36,6 +36,7 @@ The rule is part of the following rule sets:
 
 - `@PHP74Migration:risky <./../../ruleSets/PHP74MigrationRisky.rst>`_
 - `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_
 
 References
 ----------

--- a/doc/rules/function_notation/void_return.rst
+++ b/doc/rules/function_notation/void_return.rst
@@ -35,6 +35,7 @@ The rule is part of the following rule sets:
 - `@PHP71Migration:risky <./../../ruleSets/PHP71MigrationRisky.rst>`_
 - `@PHP74Migration:risky <./../../ruleSets/PHP74MigrationRisky.rst>`_
 - `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_
 
 References
 ----------

--- a/doc/rules/language_construct/get_class_to_class_keyword.rst
+++ b/doc/rules/language_construct/get_class_to_class_keyword.rst
@@ -45,6 +45,7 @@ Rule sets
 The rule is part of the following rule sets:
 
 - `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_
 - `@Symfony:risky <./../../ruleSets/SymfonyRisky.rst>`_
 
 References

--- a/doc/rules/strict/declare_strict_types.rst
+++ b/doc/rules/strict/declare_strict_types.rst
@@ -35,6 +35,7 @@ The rule is part of the following rule sets:
 - `@PHP71Migration:risky <./../../ruleSets/PHP71MigrationRisky.rst>`_
 - `@PHP74Migration:risky <./../../ruleSets/PHP74MigrationRisky.rst>`_
 - `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_
+- `@PHP82Migration:risky <./../../ruleSets/PHP82MigrationRisky.rst>`_
 
 References
 ----------

--- a/src/RuleSet/Sets/PHP82MigrationRiskySet.php
+++ b/src/RuleSet/Sets/PHP82MigrationRiskySet.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\RuleSet\Sets;
+
+use PhpCsFixer\RuleSet\AbstractMigrationSetDescription;
+
+/**
+ * @internal
+ */
+final class PHP82MigrationRiskySet extends AbstractMigrationSetDescription
+{
+    public function getRules(): array
+    {
+        return [
+            '@PHP80Migration:risky' => true,
+            'phpdoc_readonly_class_comment_to_keyword' => true,
+        ];
+    }
+}

--- a/tests/RuleSet/Sets/PHP82MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHP82MigrationRiskySetTest.php
@@ -17,6 +17,6 @@ namespace PhpCsFixer\Tests\RuleSet\Sets;
 /**
  * @internal
  *
- * @covers \PhpCsFixer\RuleSet\Sets\PHP80MigrationRiskySet
+ * @covers \PhpCsFixer\RuleSet\Sets\PHP82MigrationRiskySet
  */
 final class PHP82MigrationRiskySetTest extends AbstractSetTestCase {}

--- a/tests/RuleSet/Sets/PHP82MigrationRiskySetTest.php
+++ b/tests/RuleSet/Sets/PHP82MigrationRiskySetTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\RuleSet\Sets;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\RuleSet\Sets\PHP80MigrationRiskySet
+ */
+final class PHP82MigrationRiskySetTest extends AbstractSetTestCase {}


### PR DESCRIPTION
@keradus shouldn't this go before https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8275 ?

(or at least we should add phpdoc_readonly_class_comment_to_keyword` to `.php-cs-fixer.php-highest.php`)