### PR TITLE
chore: mark remaining Analysis as `@internal`

### DIFF
--- a/src/Tokenizer/Analyzer/Analysis/DataProviderAnalysis.php
+++ b/src/Tokenizer/Analyzer/Analysis/DataProviderAnalysis.php
@@ -17,6 +17,9 @@ namespace PhpCsFixer\Tokenizer\Analyzer\Analysis;
 use PhpCsFixer\Console\Application;
 use PhpCsFixer\Utils;
 
+/**
+ * @internal
+ */
 final class DataProviderAnalysis
 {
     private string $name;

--- a/src/Tokenizer/Analyzer/Analysis/StartEndTokenAwareAnalysis.php
+++ b/src/Tokenizer/Analyzer/Analysis/StartEndTokenAwareAnalysis.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tokenizer\Analyzer\Analysis;
 
+/**
+ * @internal
+ */
 interface StartEndTokenAwareAnalysis
 {
     /**


### PR DESCRIPTION
they are already used only in internal classes