### PR TITLE
feat: `PhpUnitTestCaseStaticMethodCallsFixer` - make sure all static protected methods are handled

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
@@ -360,6 +360,8 @@ final class PhpUnitTestCaseStaticMethodCallsFixer extends AbstractPhpUnitFixer i
         'atLeastOnce' => true,
         'atMost' => true,
         'createStub' => true,
+        'createConfiguredStub' => true,
+        'createStubForIntersectionOfInterfaces' => true,
         'exactly' => true,
         'never' => true,
         'once' => true,

--- a/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
@@ -36,7 +36,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
     public function testFixerContainsAllPhpunitStaticMethodsInItsList(): void
     {
         $assertionRefClass = new \ReflectionClass(TestCase::class);
-        $updatedStaticMethodsList = $assertionRefClass->getMethods(\ReflectionMethod::IS_PUBLIC);
+        $updatedStaticMethodsList = $assertionRefClass->getMethods(\ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_PROTECTED);
 
         $staticMethods = (new \ReflectionClass(PhpUnitTestCaseStaticMethodCallsFixer::class))->getConstant('STATIC_METHODS');
 


### PR DESCRIPTION
Follow up to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8319