### PR TITLE
fix: `NullableTypeDeclarationFixer` - do not break multi-line declaration

### DIFF
--- a/src/Fixer/LanguageConstruct/NullableTypeDeclarationFixer.php
+++ b/src/Fixer/LanguageConstruct/NullableTypeDeclarationFixer.php
@@ -274,8 +274,9 @@ class ValueObject
             $this->createTypeDeclarationTokens($normalizedType, $isQuestionMarkSyntax)
         );
 
-        if (!$tokens[$typeAnalysis->getStartIndex() - 1]->equals('(')) {
-            $tokens->ensureWhitespaceAtIndex($typeAnalysis->getStartIndex() - 1, 1, ' ');
+        $prevStartIndex = $typeAnalysis->getStartIndex() - 1;
+        if (!$tokens[$prevStartIndex]->isWhitespace() && !$tokens[$prevStartIndex]->equals('(')) {
+            $tokens->ensureWhitespaceAtIndex($prevStartIndex, 1, ' ');
         }
     }
 

--- a/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
@@ -217,6 +217,21 @@ class Foo
                 }
                 PHP,
         ];
+
+        yield 'multiline function declaration' => [
+            <<<'PHP'
+                <?php function foo(
+                    null|string $bar,
+                    string $baz
+                ) {}
+                PHP,
+            <<<'PHP'
+                <?php function foo(
+                    ?string $bar,
+                    string $baz
+                ) {}
+                PHP,
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8330