### PR TITLE
chore: add types in `Symfony\Component\Console\Command\Command` classes

### DIFF
--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -212,18 +212,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Console/Command/WorkerCommand.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\WorkerCommand\\:\\:\\$defaultDescription has no type specified\\.$#',
-	'identifier' => 'missingType.property',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/WorkerCommand.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\WorkerCommand\\:\\:\\$defaultName has no type specified\\.$#',
-	'identifier' => 'missingType.property',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/WorkerCommand.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Offset \'allow\\-risky\' might not exist on array\\<string, mixed\\>\\.$#',
 	'identifier' => 'offsetAccess.notFound',
 	'count' => 1,

--- a/src/Console/Command/WorkerCommand.php
+++ b/src/Console/Command/WorkerCommand.php
@@ -49,9 +49,9 @@ final class WorkerCommand extends Command
     /** @var string Prefix used before JSON-encoded error printed in the worker's process */
     public const ERROR_PREFIX = 'WORKER_ERROR::';
 
-    protected static $defaultName = 'worker';
+    protected static string $defaultName = 'worker';
 
-    protected static $defaultDescription = 'Internal command for running fixers in parallel';
+    protected static string $defaultDescription = 'Internal command for running fixers in parallel';
 
     private ToolInfoInterface $toolInfo;
     private ConfigurationResolver $configurationResolver;


### PR DESCRIPTION
Can we do it after https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8342?