### PR TITLE
fix: `CommentsAnalyzer` - allow other forms of assignment as valid structural elements for phpdocs

### DIFF
--- a/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
@@ -320,6 +320,32 @@ $bar;',
         yield ['<?php /* Before anonymous function */ fn($x) => $x + 1;'];
 
         yield ['<?php /* @var int $x */ [$x] = [2];'];
+
+        yield ['<?php /* @var string $x */ $x ??= $y;'];
+
+        yield ['<?php /* @var string $x */ $x .= $y;'];
+
+        yield ['<?php /* @var int $x */ $x &= 1;'];
+
+        yield ['<?php /* @var int $x */ $x |= 1;'];
+
+        yield ['<?php /* @var int $x */ $x ^= 1;'];
+
+        yield ['<?php /* @var int $x */ $x >>= 1;'];
+
+        yield ['<?php /* @var int $x */ $x <<= 1;'];
+
+        yield ['<?php /* @var float $x */ $x += 10;'];
+
+        yield ['<?php /* @var float $x */ $x -= 10;'];
+
+        yield ['<?php /* @var float $x */ $x *= 10;'];
+
+        yield ['<?php /* @var float $x */ $x /= 10;'];
+
+        yield ['<?php /* @var float $x */ $x %= 10;'];
+
+        yield ['<?php /* @var float $x */ $x **= 10;'];
     }
 
     /**


### PR DESCRIPTION
This came from an issue with `phpdoc_to_comment` where it changed `@var` over other assignments like null coalesce equal as plain comments:
```diff
-/** @var string $x */
+// @var string $x
$x ??= 'apple';

```

The underlying check is in `CommentsAnalyzer` so fixing the issue there.