### PR TITLE
refactor: Use native `Yaml::parseFile()` instead of custom method

### DIFF
--- a/tests/AutoReview/CiConfigurationTest.php
+++ b/tests/AutoReview/CiConfigurationTest.php
@@ -82,11 +82,11 @@ final class CiConfigurationTest extends TestCase
 
     public function testDockerCIBuildsComposeServices(): void
     {
-        $compose = self::parseYamlFromFile(__DIR__.'/../../compose.yaml');
+        $compose = Yaml::parseFile(__DIR__.'/../../compose.yaml');
         $composeServices = array_keys($compose['services']);
         sort($composeServices);
 
-        $ci = self::parseYamlFromFile(__DIR__.'/../../.github/workflows/docker.yml');
+        $ci = Yaml::parseFile(__DIR__.'/../../.github/workflows/docker.yml');
         $ciServices = array_map(
             static fn ($item) => $item['docker-service'],
             $ci['jobs']['docker-compose-build']['strategy']['matrix']['include']
@@ -184,7 +184,7 @@ final class CiConfigurationTest extends TestCase
 
     private function getPhpVersionUsedByCiForDeployments(): string
     {
-        $yaml = self::parseYamlFromFile(__DIR__.'/../../.github/workflows/ci.yml');
+        $yaml = Yaml::parseFile(__DIR__.'/../../.github/workflows/ci.yml');
 
         $version = $yaml['jobs']['deployment']['env']['php-version'];
 
@@ -252,7 +252,7 @@ final class CiConfigurationTest extends TestCase
      */
     private function getGitHubCiEnvs(): array
     {
-        $yaml = self::parseYamlFromFile(__DIR__.'/../../.github/workflows/ci.yml');
+        $yaml = Yaml::parseFile(__DIR__.'/../../.github/workflows/ci.yml');
 
         return $yaml['env'];
     }
@@ -262,7 +262,7 @@ final class CiConfigurationTest extends TestCase
      */
     private function getPhpVersionsUsedByGitHub(): array
     {
-        $yaml = self::parseYamlFromFile(__DIR__.'/../../.github/workflows/ci.yml');
+        $yaml = Yaml::parseFile(__DIR__.'/../../.github/workflows/ci.yml');
 
         $phpVersions = $yaml['jobs']['tests']['strategy']['matrix']['php-version'] ?? [];
 
@@ -278,7 +278,7 @@ final class CiConfigurationTest extends TestCase
      */
     private function getPhpVersionsUsedForBuildingOfficialImages(): array
     {
-        $yaml = self::parseYamlFromFile(__DIR__.'/../../.github/workflows/release.yml');
+        $yaml = Yaml::parseFile(__DIR__.'/../../.github/workflows/release.yml');
 
         return array_map(
             static fn ($item) => $item['php-version'],
@@ -291,7 +291,7 @@ final class CiConfigurationTest extends TestCase
      */
     private function getPhpVersionsUsedForBuildingLocalImages(): array
     {
-        $yaml = self::parseYamlFromFile(__DIR__.'/../../.github/workflows/docker.yml');
+        $yaml = Yaml::parseFile(__DIR__.'/../../.github/workflows/docker.yml');
 
         return array_map(
             static fn ($item) => substr($item, 4),
@@ -303,19 +303,5 @@ final class CiConfigurationTest extends TestCase
                 static fn ($item) => str_starts_with($item, 'php-')
             )
         );
-    }
-
-    /**
-     * @return mixed
-     */
-    private function parseYamlFromFile(string $file)
-    {
-        $yamlRaw = file_get_contents($file);
-
-        if (false === $yamlRaw) {
-            throw new \RuntimeException('Fail to read/parse file.');
-        }
-
-        return Yaml::parse($yamlRaw);
     }
 }


### PR DESCRIPTION
Follows [this thread](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8375#discussion_r1918135917).