### PR TITLE
fix: `NativeTypeDeclarationCasingFixer` - fix for promoted properties, enums, `false` and `mixed`

### DIFF
--- a/src/Fixer/Casing/NativeTypeDeclarationCasingFixer.php
+++ b/src/Fixer/Casing/NativeTypeDeclarationCasingFixer.php
@@ -20,76 +20,11 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\FixerDefinition\VersionSpecification;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
-use PhpCsFixer\Tokenizer\Analyzer\Analysis\TypeAnalysis;
-use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
-use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
-use PhpCsFixer\Tokenizer\TokensAnalyzer;
 
 final class NativeTypeDeclarationCasingFixer extends AbstractFixer
 {
-    /*
-     * https://wiki.php.net/rfc/typed_class_constants
-     * Supported types
-     * Class constant type declarations support all type declarations supported by PHP,
-     * except `void`, `callable`, `never`.
-     *
-     * array
-     * bool
-     * callable
-     * float
-     * int
-     * iterable
-     * object
-     * mixed
-     * parent
-     * self
-     * string
-     * any class or interface name -> not native, so not applicable for this Fixer
-     * ?type -> not native, `?` has no casing, so not applicable for this Fixer
-     *
-     * Not in the list referenced but supported:
-     * null
-     * static
-     */
-    private const CLASS_CONST_SUPPORTED_HINTS = [
-        'array' => true,
-        'bool' => true,
-        'float' => true,
-        'int' => true,
-        'iterable' => true,
-        'mixed' => true,
-        'null' => true,
-        'object' => true,
-        'parent' => true,
-        'self' => true,
-        'string' => true,
-        'static' => true,
-    ];
-
-    private const CLASS_PROPERTY_SUPPORTED_HINTS = [
-        'array' => true,
-        'bool' => true,
-        'float' => true,
-        'int' => true,
-        'iterable' => true,
-        'mixed' => true,
-        'null' => true,
-        'object' => true,
-        'parent' => true,
-        'self' => true,
-        'static' => true,
-        'string' => true,
-    ];
-
-    private const TYPE_SEPARATION_TYPES = [
-        CT::T_TYPE_ALTERNATION,
-        CT::T_TYPE_INTERSECTION,
-        CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_OPEN,
-        CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_CLOSE,
-    ];
-
     /**
      * https://secure.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.
      *
@@ -114,52 +49,40 @@ final class NativeTypeDeclarationCasingFixer extends AbstractFixer
      *
      * @var array<string, true>
      */
-    private array $functionTypeHints;
-
-    private FunctionsAnalyzer $functionsAnalyzer;
-
-    /**
-     * @var list<array{int}|string>
-     */
-    private array $beforePropertyTypeTokens;
+    private array $types;
 
     public function __construct()
     {
         parent::__construct();
 
-        $this->beforePropertyTypeTokens = ['{', ';', [T_PRIVATE], [T_PROTECTED], [T_PUBLIC], [T_VAR]];
-
-        $this->functionTypeHints = [
+        $this->types = [
             'array' => true,
             'bool' => true,
             'callable' => true,
             'float' => true,
             'int' => true,
             'iterable' => true,
+            'mixed' => true,
             'object' => true,
+            'parent' => true,
             'self' => true,
+            'static' => true,
             'string' => true,
             'void' => true,
         ];
 
         if (\PHP_VERSION_ID >= 8_00_00) {
-            $this->functionTypeHints['false'] = true;
-            $this->functionTypeHints['mixed'] = true;
-            $this->functionTypeHints['null'] = true;
-            $this->functionTypeHints['static'] = true;
+            $this->types['false'] = true;
+            $this->types['null'] = true;
         }
 
         if (\PHP_VERSION_ID >= 8_01_00) {
-            $this->functionTypeHints['never'] = true;
-
-            $this->beforePropertyTypeTokens[] = [T_READONLY];
+            $this->types['never'] = true;
         }
 
         if (\PHP_VERSION_ID >= 8_02_00) {
-            $this->functionTypeHints['true'] = true;
+            $this->types['true'] = true;
         }
-
-        $this->functionsAnalyzer = new FunctionsAnalyzer();
     }
 
     public function getDefinition(): FixerDefinitionInterface
@@ -194,167 +117,27 @@ final class NativeTypeDeclarationCasingFixer extends AbstractFixer
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
-        $this->fixFunctions($tokens);
-        $this->fixClassConstantsAndProperties($tokens);
-    }
-
-    private function fixFunctions(Tokens $tokens): void
-    {
-        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
-            if ($tokens[$index]->isGivenKind([T_FUNCTION, T_FN])) {
-                $this->fixFunctionReturnType($tokens, $index);
-                $this->fixFunctionArgumentTypes($tokens, $index);
+        foreach ($tokens as $index => $token) {
+            $content = $token->getContent();
+            $lowercaseContent = strtolower($content);
+            if ($content === $lowercaseContent) {
+                continue;
             }
-        }
-    }
-
-    private function fixFunctionArgumentTypes(Tokens $tokens, int $index): void
-    {
-        foreach ($this->functionsAnalyzer->getFunctionArguments($tokens, $index) as $argument) {
-            $this->fixArgumentType($tokens, $argument->getTypeAnalysis());
-        }
-    }
-
-    private function fixFunctionReturnType(Tokens $tokens, int $index): void
-    {
-        $this->fixArgumentType($tokens, $this->functionsAnalyzer->getFunctionReturnType($tokens, $index));
-    }
-
-    private function fixArgumentType(Tokens $tokens, ?TypeAnalysis $type = null): void
-    {
-        if (null === $type) {
-            return;
-        }
-
-        for ($index = $type->getStartIndex(); $index <= $type->getEndIndex(); ++$index) {
-            if ($tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(T_NS_SEPARATOR)) {
+            if (!isset($this->types[$lowercaseContent])) {
                 continue;
             }
 
-            $this->fixCasing($this->functionTypeHints, $tokens, $index);
-        }
-    }
-
-    private function fixClassConstantsAndProperties(Tokens $tokens): void
-    {
-        $analyzer = new TokensAnalyzer($tokens);
-        $elements = array_reverse($analyzer->getClassyElements(), true);
-
-        foreach ($elements as $index => $element) {
-            if ('const' === $element['type']) {
-                if (\PHP_VERSION_ID >= 8_03_00 && !$this->isConstWithoutType($tokens, $index)) {
-                    foreach ($this->getNativeTypeHintCandidatesForConstant($tokens, $index) as $nativeTypeHintIndex) {
-                        $this->fixCasing($this::CLASS_CONST_SUPPORTED_HINTS, $tokens, $nativeTypeHintIndex);
-                    }
-                }
-
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
+            if ($tokens[$prevIndex]->equals('=') || $tokens[$prevIndex]->isGivenKind(T_NS_SEPARATOR)) {
                 continue;
             }
 
-            if ('property' === $element['type']) {
-                foreach ($this->getNativeTypeHintCandidatesForProperty($tokens, $index) as $nativeTypeHintIndex) {
-                    $this->fixCasing($this::CLASS_PROPERTY_SUPPORTED_HINTS, $tokens, $nativeTypeHintIndex);
-                }
-            }
-        }
-    }
-
-    /** @return iterable<int> */
-    private function getNativeTypeHintCandidatesForConstant(Tokens $tokens, int $index): iterable
-    {
-        $constNameIndex = $this->getConstNameIndex($tokens, $index);
-        $index = $this->getFirstIndexOfType($tokens, $index);
-
-        do {
-            $typeEnd = $this->getTypeEnd($tokens, $index, $constNameIndex);
-
-            if ($typeEnd === $index) {
-                yield $index;
+            $nextIndex = $tokens->getNextMeaningfulToken($index);
+            if ($tokens[$nextIndex]->equals('=') || $tokens[$nextIndex]->isGivenKind(T_NS_SEPARATOR)) {
+                continue;
             }
 
-            do {
-                $index = $tokens->getNextMeaningfulToken($index);
-            } while ($tokens[$index]->isGivenKind(self::TYPE_SEPARATION_TYPES));
-        } while ($index < $constNameIndex);
-    }
-
-    private function isConstWithoutType(Tokens $tokens, int $index): bool
-    {
-        $index = $tokens->getNextMeaningfulToken($index);
-
-        return $tokens[$index]->isGivenKind(T_STRING) && $tokens[$tokens->getNextMeaningfulToken($index)]->equals('=');
-    }
-
-    private function getConstNameIndex(Tokens $tokens, int $index): int
-    {
-        return $tokens->getPrevMeaningfulToken(
-            $tokens->getNextTokenOfKind($index, ['=']),
-        );
-    }
-
-    /** @return iterable<int> */
-    private function getNativeTypeHintCandidatesForProperty(Tokens $tokens, int $index): iterable
-    {
-        $propertyNameIndex = $index;
-        $index = $tokens->getPrevTokenOfKind($index, $this->beforePropertyTypeTokens);
-
-        $index = $this->getFirstIndexOfType($tokens, $index);
-
-        do {
-            $typeEnd = $this->getTypeEnd($tokens, $index, $propertyNameIndex);
-
-            if ($typeEnd === $index) {
-                yield $index;
-            }
-
-            do {
-                $index = $tokens->getNextMeaningfulToken($index);
-            } while ($tokens[$index]->isGivenKind(self::TYPE_SEPARATION_TYPES));
-        } while ($index < $propertyNameIndex);
-
-        return [];
-    }
-
-    private function getFirstIndexOfType(Tokens $tokens, int $index): int
-    {
-        $index = $tokens->getNextMeaningfulToken($index);
-
-        if ($tokens[$index]->isGivenKind(CT::T_NULLABLE_TYPE)) {
-            $index = $tokens->getNextMeaningfulToken($index);
-        }
-
-        if ($tokens[$index]->isGivenKind(CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_OPEN)) {
-            $index = $tokens->getNextMeaningfulToken($index);
-        }
-
-        return $index;
-    }
-
-    private function getTypeEnd(Tokens $tokens, int $index, int $upperLimit): int
-    {
-        if (!$tokens[$index]->isGivenKind([T_STRING, T_NS_SEPARATOR])) {
-            return $index; // callable, array, self, static, etc.
-        }
-
-        $endIndex = $index;
-        while ($tokens[$index]->isGivenKind([T_STRING, T_NS_SEPARATOR]) && $index < $upperLimit) {
-            $endIndex = $index;
-            $index = $tokens->getNextMeaningfulToken($index);
-        }
-
-        return $endIndex;
-    }
-
-    /**
-     * @param array<string, true> $supportedTypeHints
-     */
-    private function fixCasing(array $supportedTypeHints, Tokens $tokens, int $index): void
-    {
-        $typeContent = $tokens[$index]->getContent();
-        $typeContentLower = strtolower($typeContent);
-
-        if (isset($supportedTypeHints[$typeContentLower]) && $typeContent !== $typeContentLower) {
-            $tokens[$index] = new Token([$tokens[$index]->getId(), $typeContentLower]);
+            $tokens[$index] = new Token([$token->getId(), $lowercaseContent]);
         }
     }
 }

--- a/src/Fixer/Casing/NativeTypeDeclarationCasingFixer.php
+++ b/src/Fixer/Casing/NativeTypeDeclarationCasingFixer.php
@@ -62,7 +62,6 @@ final class NativeTypeDeclarationCasingFixer extends AbstractFixer
             'float' => true,
             'int' => true,
             'iterable' => true,
-            'mixed' => true,
             'object' => true,
             'parent' => true,
             'self' => true,
@@ -73,6 +72,7 @@ final class NativeTypeDeclarationCasingFixer extends AbstractFixer
 
         if (\PHP_VERSION_ID >= 8_00_00) {
             $this->types['false'] = true;
+            $this->types['mixed'] = true;
             $this->types['null'] = true;
         }
 

--- a/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
@@ -328,6 +328,27 @@ function Foo(INTEGER $a) {}
                     private NULL|INT|BOOL $a4 = false;
                 };',
         ];
+
+        yield 'promoted properties' => [
+            <<<'PHP'
+                <?php class Foo extends Bar {
+                    public function __construct(
+                        public int $i,
+                        protected PARENT $p, // "PARENT" should be fixed to lowercase
+                        private string $s
+                    ) {}
+                }
+                PHP,
+            <<<'PHP'
+                <?php class Foo extends Bar {
+                    public function __construct(
+                        public INT $i,
+                        protected PARENT $p, // "PARENT" should be fixed to lowercase
+                        private STRING $s
+                    ) {}
+                }
+                PHP,
+        ];
     }
 
     /**
@@ -567,14 +588,14 @@ function Foo(INTEGER $a) {}
         ];
 
         yield 'enum, int' => [
-            '<?php enum E: string {
+            '<?php enum E: STRING { // "STRING" should be fixed to lowercase
                 case Hearts = "H";
 
                 const int TEST = 789;
                 const self A = self::Hearts;
                 const static B = self::Hearts;
             }',
-            '<?php enum E: string {
+            '<?php enum E: STRING { // "STRING" should be fixed to lowercase
                 case Hearts = "H";
 
                 const INT TEST = 789;
@@ -589,6 +610,11 @@ function Foo(INTEGER $a) {}
             }
 
             CONST A = 1;',
+        ];
+
+        yield 'fix "false" in type' => [ // "FALSE" should be fixed to lowercase
+            '<?php class Foo { private FALSE|int $bar; private FALSE $baz; }',
+            '<?php class Foo { private FALSE|INT $bar; private FALSE $baz; }',
         ];
     }
 }

--- a/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
@@ -26,6 +26,18 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class NativeTypeDeclarationCasingFixerTest extends AbstractFixerTestCase
 {
     /**
+     * @requires PHP <8.0
+     */
+    public function testFixPre80(): void
+    {
+        $this->doTest('<?php
+                class D {
+                    private MIXED $m;
+                };
+            ');
+    }
+
+    /**
      * @dataProvider provideFixCases
      */
     public function testFix(string $expected, ?string $input = null): void
@@ -208,12 +220,11 @@ function Foo(INTEGER $a) {}
                     private float $cx = 3.14;
                     private int $dx = 667;
                     private iterable $ex = [];
-                    private mixed $f;
-                    private object $g;
-                    private parent $h;
-                    private self $i;
-                    private static $j;
-                    private ?string $k;
+                    private object $f;
+                    private parent $g;
+                    private self $h;
+                    private static $i;
+                    private ?string $j;
 
                     private $INT = 1;
                     private FOO $bar;
@@ -229,12 +240,11 @@ function Foo(INTEGER $a) {}
                     private FLOAT $cx = 3.14;
                     private INT $dx = 667;
                     private ITERABLE $ex = [];
-                    private MIXED $f;
-                    private OBJECT $g;
-                    private PARENT $h;
-                    private Self $i;
-                    private STatic $j;
-                    private ?STRIng $k;
+                    private OBJECT $f;
+                    private PARENT $g;
+                    private Self $h;
+                    private STatic $i;
+                    private ?STRIng $j;
 
                     private $INT = 1;
                     private FOO $bar;
@@ -270,6 +280,19 @@ function Foo(INTEGER $a) {}
      */
     public static function provideFix80Cases(): iterable
     {
+        yield 'class properties single type' => [
+            '<?php
+                class D {
+                    private mixed $m;
+                };
+            ',
+            '<?php
+                class D {
+                    private MIXED $m;
+                };
+            ',
+        ];
+
         yield [
             '<?php class T { public function Foo(object $A): static {}}',
             '<?php class T { public function Foo(object $A): StatiC {}}',

--- a/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
@@ -334,7 +334,7 @@ function Foo(INTEGER $a) {}
                 <?php class Foo extends Bar {
                     public function __construct(
                         public int $i,
-                        protected PARENT $p, // "PARENT" should be fixed to lowercase
+                        protected parent $p,
                         private string $s
                     ) {}
                 }
@@ -343,7 +343,7 @@ function Foo(INTEGER $a) {}
                 <?php class Foo extends Bar {
                     public function __construct(
                         public INT $i,
-                        protected PARENT $p, // "PARENT" should be fixed to lowercase
+                        protected PARENT $p,
                         private STRING $s
                     ) {}
                 }
@@ -588,14 +588,14 @@ function Foo(INTEGER $a) {}
         ];
 
         yield 'enum, int' => [
-            '<?php enum E: STRING { // "STRING" should be fixed to lowercase
+            '<?php enum E: string {
                 case Hearts = "H";
 
                 const int TEST = 789;
                 const self A = self::Hearts;
                 const static B = self::Hearts;
             }',
-            '<?php enum E: STRING { // "STRING" should be fixed to lowercase
+            '<?php enum E: STRING {
                 case Hearts = "H";
 
                 const INT TEST = 789;
@@ -612,8 +612,8 @@ function Foo(INTEGER $a) {}
             CONST A = 1;',
         ];
 
-        yield 'fix "false" in type' => [ // "FALSE" should be fixed to lowercase
-            '<?php class Foo { private FALSE|int $bar; private FALSE $baz; }',
+        yield 'fix "false" in type' => [
+            '<?php class Foo { private false|int $bar; private false $baz; }',
             '<?php class Foo { private FALSE|INT $bar; private FALSE $baz; }',
         ];
     }


### PR DESCRIPTION
The fix may not be limited to what is mentioned in the title, those are the cases I have found.

The original code of the fixer was focused on finding all the places where the types can be.

The new - much shorter - simply checks if the token is a good candidate (name and casing), and then checks few cases where it is not a type.