### PR TITLE
chore: remove redundant check

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -893,10 +893,6 @@ final class ConfigurationResolver
     {
         $value = $this->options[$optionName];
 
-        if (!\is_string($value)) {
-            throw new InvalidConfigurationException(\sprintf('Expected boolean or string value for option "%s".', $optionName));
-        }
-
         if ('yes' === $value) {
             return true;
         }


### PR DESCRIPTION
- option is always string, cannot be boolean,
- there is validation in line 908 