### PR TITLE
fix: `NativeTypeDeclarationCasingFixer` - fix for enum with "Mixed" case

### DIFF
--- a/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
@@ -627,6 +627,20 @@ function Foo(INTEGER $a) {}
             }',
         ];
 
+        yield 'enum with "Mixed" case' => [
+            <<<'PHP'
+                <?php
+                enum Foo
+                {
+                    case Mixed;
+                    public function bar()
+                    {
+                        self::Mixed;
+                    }
+                }
+                PHP,
+        ];
+
         yield 'do not fix' => [
             '<?php class Foo {
                 PUBLIC CONST FOO&STRINGABLE G = A::B;


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8394