### PR TITLE
fix: NativeTypeDeclarationCasingFixer should not touch property names

### DIFF
--- a/src/Fixer/Casing/NativeTypeDeclarationCasingFixer.php
+++ b/src/Fixer/Casing/NativeTypeDeclarationCasingFixer.php
@@ -128,7 +128,7 @@ final class NativeTypeDeclarationCasingFixer extends AbstractFixer
             }
 
             $prevIndex = $tokens->getPrevMeaningfulToken($index);
-            if ($tokens[$prevIndex]->equals('=') || $tokens[$prevIndex]->isGivenKind([T_CASE, T_DOUBLE_COLON, T_NS_SEPARATOR])) {
+            if ($tokens[$prevIndex]->equals('=') || $tokens[$prevIndex]->isGivenKind([T_CASE, T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_NS_SEPARATOR])) {
                 continue;
             }
 

--- a/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
@@ -263,6 +263,14 @@ function Foo(INTEGER $a) {}
             '<?php class Foo { static $bar; }',
             '<?php class Foo { STATIC $bar; }',
         ];
+
+        yield 'dynamic property' => [
+            '<?php class Foo {
+                public function doFoo() {
+                    $this->Object->doBar();
+                }
+            }',
+        ];
     }
 
     /**


### PR DESCRIPTION
before this fix php-cs-fixer changed

```php
<?php class Foo {
                public function doFoo() {
                    $this->Object->doBar();
                }
            }
```

to

```php
<?php class Foo {
                public function doFoo() {
                    $this->object->doBar();
                }
            }
```

which I think is wrong