### PR TITLE
fix: `NativeTypeDeclarationCasingFixer` - do not touch constants named as native types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,8 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/phpunit tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
+#        run: vendor/bin/paraunit run --testsuite unit,integration
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,8 +214,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
-#        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/paraunit run --testsuite unit,integration
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/src/Fixer/Casing/NativeTypeDeclarationCasingFixer.php
+++ b/src/Fixer/Casing/NativeTypeDeclarationCasingFixer.php
@@ -20,6 +20,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\FixerDefinition\VersionSpecification;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -134,6 +135,13 @@ final class NativeTypeDeclarationCasingFixer extends AbstractFixer
 
             $nextIndex = $tokens->getNextMeaningfulToken($index);
             if ($tokens[$nextIndex]->equals('=') || $tokens[$nextIndex]->isGivenKind(T_NS_SEPARATOR)) {
+                continue;
+            }
+
+            if (
+                !$tokens[$prevIndex]->isGivenKind([T_CONST, CT::T_NULLABLE_TYPE, CT::T_TYPE_ALTERNATION, CT::T_TYPE_COLON])
+                && !$tokens[$nextIndex]->isGivenKind([T_VARIABLE, CT::T_TYPE_ALTERNATION])
+            ) {
                 continue;
             }
 

--- a/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeTypeDeclarationCasingFixerTest.php
@@ -271,6 +271,16 @@ function Foo(INTEGER $a) {}
                 }
             }',
         ];
+
+        yield 'constants' => [
+            <<<'PHP'
+                <?php
+                function f() {}
+                if (True === $x) {
+                } elseif (True == $y) {
+                } elseif ($z === False) {}
+                PHP,
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8402