### PR TITLE
chore: ensure that `dev-tools` dependencies are bumped only in pull requests

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -83,10 +83,13 @@ jobs:
       - name: Check - composer-require-checker
         run: ./dev-tools/vendor/bin/composer-require-checker check composer.json --config-file .composer-require-checker.json
 
+      - name: Check - composer bump
+        if: ${{ github.event_name == 'pull_request' }}
+        run: composer bump --dry-run --working-dir=./dev-tools
+
       - name: Check - composer normalize
         run: |
           composer normalize --dry-run --working-dir=./dev-tools ../composer.json
-          composer bump --dry-run --working-dir=./dev-tools
           composer normalize --dry-run --working-dir=./dev-tools composer.json
 
       - name: Check - shell scripts


### PR DESCRIPTION
Follow up to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8389

The new `if` condition is the opposite to the one from line 42 -> if we unlock dev-tools we will not check if they are bumped.