### PR TITLE
CI: no need to unlock deps on master

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -36,12 +36,6 @@ jobs:
           os: ${{ runner.os }}
           php: ${{ env.php-version }}
 
-      ## We want to have a lock-file used on PR level, so contributors are not bothered by SCA complains unrelated to their changes,
-      ## and same time we want to be aware that we are complying with bleeding edge of SCA tools as maintainers observing the push hook.
-      - name: Unlock dev-tools
-        if: ${{ github.event_name != 'pull_request' }}
-        run: rm ./dev-tools/composer.lock
-
       - name: Cache dev-tools
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
We wanted that when there was no automation to update the deps, so unlocked deps failing on  master were indicator for us to perform the update (manually). Now, the same notification is coming if automated update is failing.