### PR TITLE
chore: allow PHPUnit ^12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,20 @@ jobs:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
         run: php php-cs-fixer fix --rules=no_unreachable_default_argument_value,nullable_type_declaration_for_default_null_value --diff vendor
 
+      - name: Check if we have to convert PHPDocs to attributes in tests
+        if: matrix.run-tests == 'yes'
+        id: convert-phpdocs-to-attributes
+        run: |
+          set +e
+          vendor/bin/phpunit --atleast-version 12
+          echo "exitcode=$?" >> $GITHUB_OUTPUT
+
+      - name: Convert PHPDocs to attributes in tests
+        if: matrix.run-tests == 'yes' && steps.convert-phpdocs-to-attributes.outputs.exitcode == 0
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
+        run: php php-cs-fixer fix --quiet --config=dev-tools/.php-cs-fixer.php-unit-attributes.php
+
       - name: Run tests
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'
         env:

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "react/promise": "^2.0 || ^3.0",
         "react/socket": "^1.0",
         "react/stream": "^1.0",
-        "sebastian/diff": "^4.0 || ^5.1 || ^6.0",
+        "sebastian/diff": "^4.0 || ^5.1 || ^6.0 || ^7.0",
         "symfony/console": "^5.4 || ^6.4 || ^7.0",
         "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0",
         "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
@@ -55,7 +55,7 @@
         "php-cs-fixer/accessible-object": "^1.1",
         "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.6",
         "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.6",
-        "phpunit/phpunit": "^9.6.22 || ^10.5.45 || ^11.5.7",
+        "phpunit/phpunit": "^9.6.22 || ^10.5.45 || ^11.5.7 || ^12.0.2",
         "symfony/var-dumper": "^5.4.48 || ^6.4.18 || ^7.2.0",
         "symfony/yaml": "^5.4.45 || ^6.4.18 || ^7.2.0"
     },

--- a/dev-tools/.php-cs-fixer.php-unit-attributes.php
+++ b/dev-tools/.php-cs-fixer.php-unit-attributes.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+$config = require __DIR__.'/../.php-cs-fixer.dist.php';
+
+$config->setRules([
+    'fully_qualified_strict_types' => ['import_symbols' => true],
+    'ordered_imports' => true,
+    'php_unit_attributes' => true,
+    'phpdoc_trim' => true,
+]);
+
+return $config;


### PR DESCRIPTION
Why not simply `php php-cs-fixer fix --quiet --rules=php_unit_attributes`? Because of [this](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8429).