### PR TITLE
CI: run tests using PHPUnit 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,13 @@ jobs:
             run-tests: 'yes'
             PHP_CS_FIXER_IGNORE_ENV: 1
 
+          - operating-system: 'ubuntu-24.04'
+            php-version: '8.4'
+            job-description: 'tests using PHPUnit 12'
+            install-phpunit-12: 'yes'
+            run-tests: 'yes'
+            PHP_CS_FIXER_IGNORE_ENV: 1
+
     name: PHP ${{ matrix.php-version }} ${{ matrix.job-description }}
 
     runs-on: ${{ matrix.operating-system }}
@@ -208,6 +215,15 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
         run: php php-cs-fixer fix --rules=no_unreachable_default_argument_value,nullable_type_declaration_for_default_null_value --diff vendor
+
+      - name: Install PHPUnit 12
+        if: matrix.run-tests == 'yes' && matrix.install-phpunit-12 == 'yes'
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
+          FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
+        run: |
+          composer require --dev --with-all-dependencies phpunit/phpunit:^12.0.2
+          php php-cs-fixer fix --quiet --rules=php_unit_attributes
 
       - name: Run tests
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "react/promise": "^2.0 || ^3.0",
         "react/socket": "^1.0",
         "react/stream": "^1.0",
-        "sebastian/diff": "^4.0 || ^5.1 || ^6.0",
+        "sebastian/diff": "^4.0 || ^5.1 || ^6.0 || ^7.0",
         "symfony/console": "^5.4 || ^6.4 || ^7.0",
         "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0",
         "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",


### PR DESCRIPTION
As [discussed](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8428#discussion_r1949979240) we cannot allow PHPUnit 12 in `composer.json` as it would result with someone cloning the repo, running `composer update` and having many tests failed.

But we can have a step in CI where we ensure, that after transforming PHPDocs to attributes in tests, they all are passing for PHPUnit 12.