### PR TITLE
fix: `PhpUnitAttributesFixer` - convert correctly version constraint

### DIFF
--- a/doc/rules/php_unit/php_unit_attributes.rst
+++ b/doc/rules/php_unit/php_unit_attributes.rst
@@ -43,7 +43,7 @@ Example #1
    -     * @requires PHP 8.0
          */
    +    #[\PHPUnit\Framework\Attributes\DataProvider('giveMeSomeData')]
-   +    #[\PHPUnit\Framework\Attributes\RequiresPhp('8.0')]
+   +    #[\PHPUnit\Framework\Attributes\RequiresPhp('>= 8.0')]
         public function testSomething($expected, $actual) {}
     }
 
@@ -70,7 +70,7 @@ With configuration: ``['keep_annotations' => true]``.
          * @requires PHP 8.0
          */
    +    #[\PHPUnit\Framework\Attributes\DataProvider('giveMeSomeData')]
-   +    #[\PHPUnit\Framework\Attributes\RequiresPhp('8.0')]
+   +    #[\PHPUnit\Framework\Attributes\RequiresPhp('>= 8.0')]
         public function testSomething($expected, $actual) {}
     }
 References

--- a/src/Fixer/PhpUnit/PhpUnitAttributesFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitAttributesFixer.php
@@ -472,7 +472,7 @@ final class PhpUnitAttributesFixer extends AbstractPhpUnitFixer implements Confi
 
     private static function fixVersionConstraint(string $version): string
     {
-        if (Preg::match('/^[\d\.]+$/', $version)) {
+        if (Preg::match('/^[\d\.-]+(dev|(RC|alpha|beta)[\d\.])?$/', $version)) {
             $version = '>= '.$version;
         }
 

--- a/src/Fixer/PhpUnit/PhpUnitAttributesFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitAttributesFixer.php
@@ -458,16 +458,25 @@ final class PhpUnitAttributesFixer extends AbstractPhpUnitFixer implements Confi
         } elseif ('RequiresPhp' === $attributeName && isset($matches[3])) {
             $attributeTokens = [self::createEscapedStringToken($matches[2].' '.$matches[3])];
         } else {
-            $attributeTokens = [self::createEscapedStringToken($matches[2])];
+            $attributeTokens = [self::createEscapedStringToken(self::fixVersionConstraint($matches[2]))];
         }
 
         if (isset($matches[3]) && 'RequiresPhp' !== $attributeName) {
             $attributeTokens[] = new Token(',');
             $attributeTokens[] = new Token([T_WHITESPACE, ' ']);
-            $attributeTokens[] = self::createEscapedStringToken($matches[3]);
+            $attributeTokens[] = self::createEscapedStringToken(self::fixVersionConstraint($matches[3]));
         }
 
         return self::createAttributeTokens($tokens, $index, $attributeName, ...$attributeTokens);
+    }
+
+    private static function fixVersionConstraint(string $version): string
+    {
+        if (Preg::match('/^[\d\.]+$/', $version)) {
+            $version = '>= '.$version;
+        }
+
+        return $version;
     }
 
     /**

--- a/tests/Fixer/PhpUnit/PhpUnitAttributesFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitAttributesFixerTest.php
@@ -521,6 +521,12 @@ final class PhpUnitAttributesFixerTest extends AbstractFixerTestCase
             '@requires PHP 6|8',
         );
 
+        yield 'handle RequiresPhp with alpha versions' => self::createCase(
+            ['class', 'method'],
+            "#[RequiresPhp('>= 5.4.0-alpha1')]",
+            '@requires PHP 5.4.0-alpha1',
+        );
+
         yield 'handle RequiresPhpExtension' => self::createCase(
             ['class', 'method'],
             "#[RequiresPhpExtension('mysqli', '>= 8.3.0')]",

--- a/tests/Fixer/PhpUnit/PhpUnitAttributesFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitAttributesFixerTest.php
@@ -491,10 +491,34 @@ final class PhpUnitAttributesFixerTest extends AbstractFixerTestCase
             '@requires OSFAMILY Windows',
         );
 
-        yield 'handle RequiresPhp' => self::createCase(
+        yield 'handle RequiresPhp with only version' => self::createCase(
             ['class', 'method'],
-            "#[RequiresPhp('8.1.20')]",
+            "#[RequiresPhp('>= 8.1.20')]",
             '@requires PHP 8.1.20',
+        );
+
+        yield 'handle RequiresPhp with caret' => self::createCase(
+            ['class', 'method'],
+            "#[RequiresPhp('^8.1.21')]",
+            '@requires PHP ^8.1.21',
+        );
+
+        yield 'handle RequiresPhp with less than' => self::createCase(
+            ['class', 'method'],
+            "#[RequiresPhp('<8.1.22')]",
+            '@requires PHP <8.1.22',
+        );
+
+        yield 'handle RequiresPhp with less than and space' => self::createCase(
+            ['class', 'method'],
+            "#[RequiresPhp('< 8.1.23')]",
+            '@requires PHP < 8.1.23',
+        );
+
+        yield 'handle RequiresPhp with alternative versions' => self::createCase(
+            ['class', 'method'],
+            "#[RequiresPhp('6|8')]",
+            '@requires PHP 6|8',
         );
 
         yield 'handle RequiresPhpExtension' => self::createCase(
@@ -503,10 +527,22 @@ final class PhpUnitAttributesFixerTest extends AbstractFixerTestCase
             '@requires extension mysqli >= 8.3.0',
         );
 
+        yield 'handle RequiresPhpExtension with only version' => self::createCase(
+            ['class', 'method'],
+            "#[RequiresPhpExtension('mysqli', '>= 8.3.0')]",
+            '@requires extension mysqli 8.3.0',
+        );
+
         yield 'handle RequiresPhpunit' => self::createCase(
             ['class', 'method'],
             "#[RequiresPhpunit('^10.1.0')]",
             '@requires PHPUnit ^10.1.0',
+        );
+
+        yield 'handle RequiresPhpunit with only version' => self::createCase(
+            ['class', 'method'],
+            "#[RequiresPhpunit('>= 11.1.1')]",
+            '@requires PHPUnit 11.1.1',
         );
 
         yield 'handle RequiresSetting' => self::createCase(


### PR DESCRIPTION
To test different/more cases:
1. Make sure you use PHP 8.
2. Checkout out the branch with the fix.
3. Run `composer update` -> PHPUnit 11 will be installed which supports both - annotations and attributes.
4. Create file `generate.php`:
```php
<?php
const CASES = [
    '5',
    '5.3',
    '5.3.7',
    '8',
    '8.3',
    '8.4',
    PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.(PHP_RELEASE_VERSION - 1),
    PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION,
    PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.(PHP_RELEASE_VERSION + 1),
    '8.5',
    '5|6',
    '5|8',
    '5||8',
    '5|'.PHP_MAJOR_VERSION.'.'.(PHP_RELEASE_VERSION - 1),
    '5|'.PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
    '5|'.PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.(PHP_RELEASE_VERSION - 1),
    '5|'.PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION,
    '5|'.PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.(PHP_RELEASE_VERSION + 1),
];

$php = "<?php\nclass FooTest extends PHPUnit\\Framework\\TestCase\n{";
foreach (CASES as $index => $case) {
    $php .= sprintf(
        <<<'PHP'

                /**
                 * @requires PHP %s
                 */
                public function test%d(): void
                {
                    self::assertTrue(true);
                }

            PHP,
        $case,
        $index
    );
}
$php .= "}\n";

file_put_contents('Foo1Test.php', $php);
```
5. Update `CASES` to what you want verify.
6. Run these:
```console
php generate.php
cp Foo1Test.php Foo2Test.php
PHP_CS_FIXER_ENFORCE_CACHE=0 php php-cs-fixer fix Foo1Test.php --allow-risky=yes --rules=psr_autoloading
PHP_CS_FIXER_ENFORCE_CACHE=0 php php-cs-fixer fix Foo2Test.php --allow-risky=yes --rules=psr_autoloading
PHP_CS_FIXER_ENFORCE_CACHE=0 php php-cs-fixer fix Foo2Test.php --rules=php_unit_attributes
vendor/bin/phpunit Foo1Test.php --order-by=default --testdox-text=.result1.txt | tee log1.log
vendor/bin/phpunit Foo2Test.php --order-by=default --testdox-text=.result2.txt | tee log2.log
```
7. Compare `log1.log` (annotations) with `log2.log` (attributes) to see if the same tests were skipped.