### PR TITLE
fix: Rule `final_class`. Issue with adding `final` to a class that has child classes.

### DIFF
--- a/src/Fixer/ClassNotation/FinalInternalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalInternalClassFixer.php
@@ -379,7 +379,7 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurabl
     private function isParentClass(Tokens $tokens, int $classIndex): bool
     {
         $className = $this->getClassName($tokens, $classIndex);
-        if (null === $className) {
+        if ($tokens->countTokenKind(T_CLASS) === 1) {
             return false;
         }
 
@@ -404,7 +404,7 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurabl
     private function getClassName(Tokens $tokens, int $classIndex): ?string
     {
         $nextIndex = $tokens->getNextMeaningfulToken($classIndex);
-        if (null !== $nextIndex && $tokens[$nextIndex]->isGivenKind(T_STRING)) {
+        if ($tokens[$nextIndex]->isGivenKind(T_STRING)) {
             return $tokens[$nextIndex]->getContent();
         }
 

--- a/src/Fixer/ClassNotation/FinalInternalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalInternalClassFixer.php
@@ -389,7 +389,7 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurabl
             }
 
             $nextIndex = $tokens->getNextMeaningfulToken($index);
-            if (null === $nextIndex || !$tokens[$nextIndex]->isGivenKind(T_STRING)) {
+            if (!$tokens[$nextIndex]->isGivenKind(T_STRING)) {
                 continue;
             }
 

--- a/tests/Fixer/ClassNotation/FinalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalClassFixerTest.php
@@ -72,6 +72,11 @@ final class FinalClassFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
+            '<?php class MyClass {} final class MyChildClass extends MyClass {}',
+            '<?php class MyClass {} class MyChildClass extends MyClass {}',
+        ];
+
+        yield [
             '<?php final class MyClass extends MyAbstract {}',
             '<?php class MyClass extends MyAbstract {}',
         ];

--- a/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
@@ -191,6 +191,25 @@ class Bar {}
 ',
         ];
 
+        yield 'multiple classes, both with annotations, with one extending another class' => [
+            '<?php
+
+/** @internal */
+class Foo {}
+
+/** @internal */
+final class Bar extends Foo {}
+',
+            '<?php
+
+/** @internal */
+class Foo {}
+
+/** @internal */
+class Bar extends Foo {}
+',
+        ];
+
         yield [
             "<?php\n/** @CUSTOM */final class A{}",
             "<?php\n/** @CUSTOM */class A{}",


### PR DESCRIPTION
This PR aims to resolve the issue related to the `final_class` rule (doc: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/class_notation/final_class.rst).  

### **Main Issue:**  
When adding the `final_class` rule and running `php-cs-fixer`, the reserved keyword `final` (https://www.php.net/manual/en/language.oop5.final.php) is added to classes that have child classes, which causes an error.  

### **Example:**  
#### **Before fix:**  
```php
<?php
class MyClass {}
class MyChildClass extends MyClass {}
```
#### **Expected after fix:**  
```php
<?php
class MyClass {}
final class MyChildClass extends MyClass {}
```

### **Solution:**  
I have implemented a fix for cases where the `\PhpCsFixer\Tokenizer\Tokens` class contains information about both the parent and child classes.  

> [!WARNING]
However, if the issue occurs across different files, it becomes problematic since we do not have enough information to determine whether a class has child classes.  

A potential solution would be to perform a preliminary analysis of all files before applying the fix. However, this would be quite resource-intensive. Specifically, before fixing `src/Runner/Runner.php:387`, we would need to iterate through all files, store potential class hierarchy data, and then modify `\PhpCsFixer\Fixer\ClassNotation\FinalInternalClassFixer` to check for child classes.  

For now, I am leaving it as is. I would appreciate any recommendations and suggestions.