### PR TITLE
fix: `OrderedImportsFixer` - do not take the braces part in grouped imports into account

### DIFF
--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -307,9 +307,9 @@ use Bar;
      */
     private function sortAlphabetically(array $first, array $second): int
     {
-        // Replace backslashes by spaces before sorting for correct sort order
-        $firstNamespace = str_replace('\\', ' ', $this->prepareNamespace($first['namespace']));
-        $secondNamespace = str_replace('\\', ' ', $this->prepareNamespace($second['namespace']));
+        // Replace backslashes by spaces and remove opening braces before sorting for correct sort order
+        $firstNamespace = str_replace(['\\', '{'], [' ', ''], $this->prepareNamespace($first['namespace']));
+        $secondNamespace = str_replace(['\\', '{'], [' ', ''], $this->prepareNamespace($second['namespace']));
 
         return true === $this->configuration['case_sensitive']
             ? $firstNamespace <=> $secondNamespace

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -1988,8 +1988,8 @@ use function some\a\{fn_a, fn_b};
                 use Foo\Bravo;
                 use Foo\{Delta, Delta2};
                 use Foo\Foxtrot\Uniform\Charlie\Kilo;
-                use Foo\November\{Rain, Sunhine};
-                use Foo\November\Sunhine;
+                use Foo\November\{Golf, Juliett};
+                use Foo\November\Hotel;
                 use Foo\{Yankee007, Yankee42, Yankee99};
                 use Foo\{Zulu, Zulu2};
                 PHP,
@@ -2001,8 +2001,8 @@ use function some\a\{fn_a, fn_b};
                 use Foo\{Yankee99, Yankee42, Yankee007};
                 use Foo\Bravo;
                 use Foo\Foxtrot\Uniform\Charlie\Kilo;
-                use Foo\November\Sunhine;
-                use Foo\November\{Rain, Sunhine};
+                use Foo\November\Hotel;
+                use Foo\November\{Juliett, Golf};
                 PHP,
         ];
     }

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -1980,6 +1980,14 @@ use function some\a\{fn_a, fn_b};
                 'case_sensitive' => true,
             ],
         ];
+
+        yield 'do not take the braces part in grouped imports into account' => [
+            <<<'PHP'
+                <?php
+                use Foo\{Bar, Baz};
+                use Foo\NotBarNorBar\DeeperClass;
+                PHP,
+        ];
     }
 
     /**

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -1981,11 +1981,28 @@ use function some\a\{fn_a, fn_b};
             ],
         ];
 
-        yield 'do not take the braces part in grouped imports into account' => [
+        yield 'do not take the braces in grouped imports into account' => [
             <<<'PHP'
                 <?php
-                use Foo\{Bar, Baz};
-                use Foo\NotBarNorBar\DeeperClass;
+                use Foo\{Alfa, Alfa2};
+                use Foo\Bravo;
+                use Foo\{Delta, Delta2};
+                use Foo\Foxtrot\Uniform\Charlie\Kilo;
+                use Foo\November\{Rain, Sunhine};
+                use Foo\November\Sunhine;
+                use Foo\{Yankee007, Yankee42, Yankee99};
+                use Foo\{Zulu, Zulu2};
+                PHP,
+            <<<'PHP'
+                <?php
+                use Foo\{Zulu, Zulu2};
+                use Foo\{Delta2, Delta};
+                use Foo\{Alfa, Alfa2};
+                use Foo\{Yankee99, Yankee42, Yankee007};
+                use Foo\Bravo;
+                use Foo\Foxtrot\Uniform\Charlie\Kilo;
+                use Foo\November\Sunhine;
+                use Foo\November\{Rain, Sunhine};
                 PHP,
         ];
     }


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/5347