### PR TITLE
fix: `TrailingCommaInMultilineFixer` - handle empty match body

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/phpunit tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
+        run: vendor/bin/paraunit run --testsuite unit,integration
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php
+++ b/src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php
@@ -174,7 +174,7 @@ final class TrailingCommaInMultilineFixer extends AbstractFixer implements Confi
             }
 
             if ($fixMatch && $tokens[$prevIndex]->isGivenKind(T_MATCH)) {
-                $this->fixMatch($tokens, $index);
+                $this->fixBlock($tokens, $tokens->getNextTokenOfKind($index, ['{']));
 
                 continue;
             }
@@ -232,39 +232,6 @@ final class TrailingCommaInMultilineFixer extends AbstractFixer implements Confi
             if (!$endToken->isComment() && !$endToken->isWhitespace()) {
                 $tokens->ensureWhitespaceAtIndex($endIndex, 1, ' ');
             }
-        }
-    }
-
-    private function fixMatch(Tokens $tokens, int $index): void
-    {
-        $index = $tokens->getNextTokenOfKind($index, ['{']);
-        $closeIndex = $index;
-        $isMultiline = false;
-        $depth = 1;
-
-        do {
-            ++$closeIndex;
-
-            if ($tokens[$closeIndex]->equals('{')) {
-                ++$depth;
-            } elseif ($tokens[$closeIndex]->equals('}')) {
-                --$depth;
-            } elseif (!$isMultiline && str_contains($tokens[$closeIndex]->getContent(), "\n")) {
-                $isMultiline = true;
-            }
-        } while ($depth > 0);
-
-        if (!$isMultiline) {
-            return;
-        }
-
-        $previousIndex = $tokens->getPrevMeaningfulToken($closeIndex);
-        if (!$tokens->isPartialCodeMultiline($previousIndex, $closeIndex)) {
-            return;
-        }
-
-        if (!$tokens[$previousIndex]->equals(',')) {
-            $tokens->insertAt($previousIndex + 1, new Token(','));
         }
     }
 }

--- a/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
+++ b/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
@@ -787,7 +787,7 @@ $x = match ($a) { 1 => 0,
             <<<'PHP'
                 <?php
                 $a = match($x) {
-                    default => 1,
+                    default => function () {},
                 };
                 $b = match($y) {
                     // Hello!
@@ -798,7 +798,7 @@ $x = match ($a) { 1 => 0,
             <<<'PHP'
                 <?php
                 $a = match($x) {
-                    default => 1
+                    default => function () {}
                 };
                 $b = match($y) {
                     // Hello!

--- a/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
+++ b/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
@@ -782,5 +782,31 @@ $x = match ($a) { 1 => 0,
             }',
             ['elements' => [TrailingCommaInMultilineFixer::ELEMENTS_ARRAYS, TrailingCommaInMultilineFixer::ELEMENTS_PARAMETERS]],
         ];
+
+        yield 'empty match' => [
+            <<<'PHP'
+                <?php
+                $a = match($x) {
+                    default => 1,
+                };
+                $b = match($y) {
+                    // Hello!
+                };
+                $c = match($z) {
+                };
+                PHP,
+            <<<'PHP'
+                <?php
+                $a = match($x) {
+                    default => 1
+                };
+                $b = match($y) {
+                    // Hello!
+                };
+                $c = match($z) {
+                };
+                PHP,
+            ['elements' => ['match']],
+        ];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8478