### PR TITLE
fix: `OrderedImportsFixer` - fix syntax error with grouped use statement and multiple use with comma

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit tests/Fixer/Import/OrderedImportsFixerTest.php
+        run: vendor/bin/paraunit run --testsuite unit,integration
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/phpunit tests/Fixer/Import/OrderedImportsFixerTest.php
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -603,6 +603,9 @@ use Bar;
             if ($use['group']) {
                 // a group import must start with `use` and cannot be part of comma separated import list
                 self::fixCommaToUse($tokens, $tokens->getPrevMeaningfulToken($index));
+
+                $closeGroupIndex = $tokens->getNextTokenOfKind($index, [[CT::T_GROUP_IMPORT_BRACE_CLOSE]]);
+                self::fixCommaToUse($tokens, $tokens->getNextMeaningfulToken($closeGroupIndex));
             }
         }
     }

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -602,16 +602,22 @@ use Bar;
 
             if ($use['group']) {
                 // a group import must start with `use` and cannot be part of comma separated import list
-                $prev = $tokens->getPrevMeaningfulToken($index);
-                if ($tokens[$prev]->equals(',')) {
-                    $tokens[$prev] = new Token(';');
-                    $tokens->insertAt($prev + 1, new Token([T_USE, 'use']));
-
-                    if (!$tokens[$prev + 2]->isWhitespace()) {
-                        $tokens->insertAt($prev + 2, new Token([T_WHITESPACE, ' ']));
-                    }
-                }
+                self::fixCommaToUse($tokens, $tokens->getPrevMeaningfulToken($index));
             }
+        }
+    }
+
+    private static function fixCommaToUse(Tokens $tokens, int $index): void
+    {
+        if (!$tokens[$index]->equals(',')) {
+            return;
+        }
+
+        $tokens[$index] = new Token(';');
+        $tokens->insertAt($index + 1, new Token([T_USE, 'use']));
+
+        if (!$tokens[$index + 2]->isWhitespace()) {
+            $tokens->insertAt($index + 2, new Token([T_WHITESPACE, ' ']));
         }
     }
 }

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -821,6 +821,19 @@ use A\A,G\G;use Foo3\Bar\{ClassA};use H\H,J\J;use Ioo2\Bar\{ClassB};use K\K,M\M;
 ',
         ];
 
+        yield 'grouped import changing location to comma separated imports' => [
+            <<<'PHP'
+                <?php
+                use A;
+                use B;use C\{C1, C2, C3};use D;
+                PHP,
+            <<<'PHP'
+                <?php
+                use C\{C1, C2, C3};
+                use D, A, B;
+                PHP,
+        ];
+
         yield 'many grouped imports' => [
             '<?php
 use Foo\Bar\{ClassA, ClassB, ClassC};


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8165