### PR TITLE
fix: `PhpdocAlignFixer` - align correctly type with UTF8 characters

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -379,7 +379,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
                     .$item['hint'];
 
                 if ('' !== $item['var']) {
-                    $line .= $this->getIndent((0 !== $hintMax ? $hintMax : -1) - \strlen($item['hint']) + $spacingForTag, $spacingForTag)
+                    $line .= $this->getIndent((0 !== $hintMax ? $hintMax : -1) - mb_strlen($item['hint']) + $spacingForTag, $spacingForTag)
                         .$item['var']
                         .(
                             '' !== $item['desc']

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -1520,6 +1520,24 @@ function foo($typeless): void {}',
      */
 ',
         ];
+
+        yield 'type with UTF8 characters' => [
+            ['tags' => ['param'], 'align' => PhpdocAlignFixer::ALIGN_VERTICAL],
+            <<<'PHP'
+                <?php
+                /**
+                 * @param Foooooooooooooooo $x
+                 * @param Bar‹Baz›      $y
+                 */
+                PHP,
+            <<<'PHP'
+                <?php
+                /**
+                 * @param Foooooooooooooooo $x
+                 * @param Bar‹Baz› $y
+                 */
+                PHP,
+        ];
     }
 
     /**

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -1527,7 +1527,7 @@ function foo($typeless): void {}',
                 <?php
                 /**
                  * @param Foooooooooooooooo $x
-                 * @param Bar‹Baz›      $y
+                 * @param Bar‹Baz›          $y
                  */
                 PHP,
             <<<'PHP'


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8307