### PR TITLE
refactor: Runner - unify paths used when using parallel runner

### DIFF
--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -2098,7 +2098,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Offset \'file\' might not exist on non\\-empty\\-array\\.$#',
 	'identifier' => 'offsetAccess.notFound',
-	'count' => 1,
+	'count' => 2,
 	'path' => __DIR__ . '/../../src/Runner/Runner.php',
 ];
 $ignoreErrors[] = [

--- a/src/Console/Command/WorkerCommand.php
+++ b/src/Console/Command/WorkerCommand.php
@@ -152,10 +152,10 @@ final class WorkerCommand extends Command
                         /** @var iterable<int, string> $files */
                         $files = $json['files'];
 
-                        foreach ($files as $absolutePath) {
+                        foreach ($files as $path) {
                             // Reset events because we want to collect only those coming from analysed files chunk
                             $this->events = [];
-                            $runner->setFileIterator(new \ArrayIterator([new \SplFileInfo($absolutePath)]));
+                            $runner->setFileIterator(new \ArrayIterator([new \SplFileInfo($path)]));
                             $analysisResult = $runner->fix();
 
                             if (1 !== \count($this->events)) {
@@ -168,11 +168,11 @@ final class WorkerCommand extends Command
 
                             $out->write([
                                 'action' => ParallelAction::WORKER_RESULT,
-                                'file' => $absolutePath,
+                                'file' => $path,
                                 'fileHash' => $this->events[0]->getFileHash(),
                                 'status' => $this->events[0]->getStatus(),
                                 'fixInfo' => array_pop($analysisResult),
-                                'errors' => $this->errorsManager->forPath($absolutePath),
+                                'errors' => $this->errorsManager->forPath($path),
                             ]);
                         }
 

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -406,7 +406,7 @@ final class Runner
      */
     private function fixFile(\SplFileInfo $file, LintingResultInterface $lintingResult): ?array
     {
-        $name = $file->getPathname();
+        $filePathname = $file->getPathname();
 
         try {
             $lintingResult->check();
@@ -416,7 +416,7 @@ final class Runner
                 new FileProcessed(FileProcessed::STATUS_INVALID)
             );
 
-            $this->errorsManager->report(new Error(Error::TYPE_INVALID, $name, $e));
+            $this->errorsManager->report(new Error(Error::TYPE_INVALID, $filePathname, $e));
 
             return null;
         }
@@ -453,11 +453,11 @@ final class Runner
         } catch (\ParseError $e) {
             $this->dispatchEvent(FileProcessed::NAME, new FileProcessed(FileProcessed::STATUS_LINT));
 
-            $this->errorsManager->report(new Error(Error::TYPE_LINT, $name, $e));
+            $this->errorsManager->report(new Error(Error::TYPE_LINT, $filePathname, $e));
 
             return null;
         } catch (\Throwable $e) {
-            $this->processException($name, $e);
+            $this->processException($filePathname, $e);
 
             return null;
         }
@@ -484,7 +484,7 @@ final class Runner
             } catch (LintingException $e) {
                 $this->dispatchEvent(FileProcessed::NAME, new FileProcessed(FileProcessed::STATUS_LINT));
 
-                $this->errorsManager->report(new Error(Error::TYPE_LINT, $name, $e, $fixInfo['appliedFixers'], $fixInfo['diff']));
+                $this->errorsManager->report(new Error(Error::TYPE_LINT, $filePathname, $e, $fixInfo['appliedFixers'], $fixInfo['diff']));
 
                 return null;
             }
@@ -532,11 +532,11 @@ final class Runner
             }
         }
 
-        $this->cacheManager->setFileHash($name, $newHash);
+        $this->cacheManager->setFileHash($filePathname, $newHash);
 
         $this->dispatchEvent(
             FileProcessed::NAME,
-            new FileProcessed(null !== $fixInfo ? FileProcessed::STATUS_FIXED : FileProcessed::STATUS_NO_CHANGES, $name, $newHash)
+            new FileProcessed(null !== $fixInfo ? FileProcessed::STATUS_FIXED : FileProcessed::STATUS_NO_CHANGES, $filePathname, $newHash)
         );
 
         return $fixInfo;

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -306,7 +306,8 @@ final class Runner
 
                         // Pass-back information about applied changes (only if there are any)
                         if (isset($workerResponse['fixInfo'])) {
-                            $changed[$workerResponse['file']] = $workerResponse['fixInfo'];
+                            $relativePath = $this->directory->getRelativePathTo($workerResponse['file']);
+                            $changed[$relativePath] = $workerResponse['fixInfo'];
 
                             if ($this->stopOnViolation) {
                                 $processPool->endAll();

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -212,7 +212,7 @@ final class Runner
                     break;
                 }
 
-                $files[] = $current->getPathName();
+                $files[] = $current->getPathname();
 
                 $fileIterator->next();
             }

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -212,7 +212,7 @@ final class Runner
                     break;
                 }
 
-                $files[] = $current->getRealPath();
+                $files[] = $current->getPathName();
 
                 $fileIterator->next();
             }
@@ -289,7 +289,7 @@ final class Runner
                         $this->dispatchEvent(FileProcessed::NAME, new FileProcessed($workerResponse['status']));
 
                         if (isset($workerResponse['fileHash'])) {
-                            $this->cacheManager->setFileHash($fileRelativePath, $workerResponse['fileHash']);
+                            $this->cacheManager->setFileHash($workerResponse['file'], $workerResponse['fileHash']);
                         }
 
                         foreach ($workerResponse['errors'] ?? [] as $error) {
@@ -306,7 +306,7 @@ final class Runner
 
                         // Pass-back information about applied changes (only if there are any)
                         if (isset($workerResponse['fixInfo'])) {
-                            $changed[$fileRelativePath] = $workerResponse['fixInfo'];
+                            $changed[$workerResponse['file']] = $workerResponse['fixInfo'];
 
                             if ($this->stopOnViolation) {
                                 $processPool->endAll();

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -391,8 +391,8 @@ final class Runner
             Tokens::clearCache();
 
             if (null !== $fixInfo) {
-                $name = $this->directory->getRelativePathTo($file->__toString());
-                $changed[$name] = $fixInfo;
+                $relativePath = $this->directory->getRelativePathTo($file->__toString());
+                $changed[$relativePath] = $fixInfo;
 
                 if ($this->stopOnViolation) {
                     break;

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -492,9 +492,9 @@ final class Runner
             }
 
             if (!$this->isDryRun) {
-                $fileName = $file->getRealPath();
+                $fileRealPath = $file->getRealPath();
 
-                if (!file_exists($fileName)) {
+                if (!file_exists($fileRealPath)) {
                     throw new IOException(
                         \sprintf('Failed to write file "%s" (no longer) exists.', $file->getPathname()),
                         0,
@@ -503,32 +503,32 @@ final class Runner
                     );
                 }
 
-                if (is_dir($fileName)) {
+                if (is_dir($fileRealPath)) {
                     throw new IOException(
-                        \sprintf('Cannot write file "%s" as the location exists as directory.', $fileName),
+                        \sprintf('Cannot write file "%s" as the location exists as directory.', $fileRealPath),
                         0,
                         null,
-                        $fileName
+                        $fileRealPath
                     );
                 }
 
-                if (!is_writable($fileName)) {
+                if (!is_writable($fileRealPath)) {
                     throw new IOException(
-                        \sprintf('Cannot write to file "%s" as it is not writable.', $fileName),
+                        \sprintf('Cannot write to file "%s" as it is not writable.', $fileRealPath),
                         0,
                         null,
-                        $fileName
+                        $fileRealPath
                     );
                 }
 
-                if (false === @file_put_contents($fileName, $new)) {
+                if (false === @file_put_contents($fileRealPath, $new)) {
                     $error = error_get_last();
 
                     throw new IOException(
-                        \sprintf('Failed to write file "%s", "%s".', $fileName, null !== $error ? $error['message'] : 'no reason available'),
+                        \sprintf('Failed to write file "%s", "%s".', $fileRealPath, null !== $error ? $error['message'] : 'no reason available'),
                         0,
                         null,
-                        $fileName
+                        $fileRealPath
                     );
                 }
             }

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -282,9 +282,6 @@ final class Runner
                 function (array $workerResponse) use ($processPool, $process, $identifier, $getFileChunk, &$changed): void {
                     // File analysis result (we want close-to-realtime progress with frequent cache savings)
                     if (ParallelAction::WORKER_RESULT === $workerResponse['action']) {
-                        $fileAbsolutePath = $workerResponse['file'];
-                        $fileRelativePath = $this->directory->getRelativePathTo($fileAbsolutePath);
-
                         // Dispatch an event for each file processed and dispatch its status (required for progress output)
                         $this->dispatchEvent(FileProcessed::NAME, new FileProcessed($workerResponse['status']));
 


### PR DESCRIPTION
Sequential runner is not using absolute paths, thus parallel runner shouldn't as well

as side effect, closes #8059

