### PR TITLE
CI: set `FAST_LINT_TEST_CASES=1` for code coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
             job-description: 'code coverage'
             run-tests: 'yes'
             collect-code-coverage: 'yes'
+            FAST_LINT_TEST_CASES: 1
 
           - operating-system: 'ubuntu-24.04'
             php-version: '8.3'


### PR DESCRIPTION
Code coverage job is the slowest one.