### PR TITLE
fix: `MethodArgumentSpaceFixer` - handle when nested in HTML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit --filter=misc/method_argument_space
+        run: vendor/bin/paraunit run --testsuite unit,integration
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/phpunit --filter=misc/method_argument_space
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -321,7 +321,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurab
         do {
             $prevWhitespaceTokenIndex = $tokens->getPrevTokenOfKind(
                 $searchIndex,
-                [[T_ENCAPSED_AND_WHITESPACE], [T_WHITESPACE]],
+                [[T_ENCAPSED_AND_WHITESPACE], [T_INLINE_HTML], [T_WHITESPACE]],
             );
 
             $searchIndex = $prevWhitespaceTokenIndex;

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -1064,6 +1064,16 @@ foo(
                 TEXT;
             }
             PHP];
+
+        yield 'misc/method_argument_space' => [<<<'PHP'
+            <div>
+                <?php echo in_array(
+                    24,
+                    $elements
+                ) ? 'yes' : 'no';
+                ?>
+            </div>
+            PHP];
     }
 
     /**

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -1065,7 +1065,7 @@ foo(
             }
             PHP];
 
-        yield 'misc/method_argument_space' => [<<<'PHP'
+        yield [<<<'PHP'
             <div>
                 <?php echo in_array(
                     24,

--- a/tests/Fixtures/Integration/misc/method_argument_space,statement_indentation.test
+++ b/tests/Fixtures/Integration/misc/method_argument_space,statement_indentation.test
@@ -6,7 +6,7 @@ Integration of fixers: method_argument_space,statement_indentation.
 <div>
     <?php echo in_array(
         (int)
-            $needle,
+        $needle,
         $haystack
     ) ? 'yes' : 'no';
     ?>

--- a/tests/Fixtures/Integration/misc/method_argument_space,statement_indentation.test
+++ b/tests/Fixtures/Integration/misc/method_argument_space,statement_indentation.test
@@ -1,0 +1,23 @@
+--TEST--
+Integration of fixers: method_argument_space,statement_indentation.
+--RULESET--
+{"method_argument_space": true, "statement_indentation": true}
+--EXPECT--
+<div>
+    <?php echo in_array(
+        (int)
+            $needle,
+        $haystack
+    ) ? 'yes' : 'no';
+    ?>
+</div>
+
+--INPUT--
+<div>
+    <?php echo in_array(
+        (int)
+        $needle,
+            $haystack
+    ) ? 'yes' : 'no';
+    ?>
+</div>


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8502

Please, notice that the failures before the fix are:

> Code built on expected code must not change.

and

> Expected no changes made to test "Integration of fixers: method_argument_space,statement_indentation. "--EXPECT-- part run"" in "misc/method_argument_space,statement_indentation.test".