### PR TITLE
chore: make options that have default and allowed sets the same size the same array

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit --filter=testFixerConfigurationDefinitions
+        run: vendor/bin/paraunit run --testsuite unit,integration
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/phpunit --filter=testFixerConfigurationDefinitions
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/doc/rules/basic/no_trailing_comma_in_singleline.rst
+++ b/doc/rules/basic/no_trailing_comma_in_singleline.rst
@@ -15,7 +15,7 @@ Which elements to fix.
 
 Allowed values: a subset of ``['arguments', 'array', 'array_destructuring', 'group_import']``
 
-Default value: ``['arguments', 'array_destructuring', 'array', 'group_import']``
+Default value: ``['arguments', 'array', 'array_destructuring', 'group_import']``
 
 Examples
 --------

--- a/doc/rules/class_notation/visibility_required.rst
+++ b/doc/rules/class_notation/visibility_required.rst
@@ -16,7 +16,7 @@ The structural elements to fix (PHP >= 7.1 required for ``const``).
 
 Allowed values: a subset of ``['const', 'method', 'property']``
 
-Default value: ``['property', 'method', 'const']``
+Default value: ``['const', 'method', 'property']``
 
 Examples
 --------

--- a/doc/rules/php_unit/php_unit_construct.rst
+++ b/doc/rules/php_unit/php_unit_construct.rst
@@ -23,7 +23,7 @@ List of assertion methods to fix.
 
 Allowed values: a subset of ``['assertEquals', 'assertNotEquals', 'assertNotSame', 'assertSame']``
 
-Default value: ``['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']``
+Default value: ``['assertEquals', 'assertNotEquals', 'assertNotSame', 'assertSame']``
 
 Examples
 --------

--- a/doc/rules/phpdoc/phpdoc_types.rst
+++ b/doc/rules/phpdoc/phpdoc_types.rst
@@ -14,7 +14,7 @@ Type groups to fix.
 
 Allowed values: a subset of ``['alias', 'meta', 'simple']``
 
-Default value: ``['simple', 'alias', 'meta']``
+Default value: ``['alias', 'meta', 'simple']``
 
 Examples
 --------

--- a/src/Fixer/Basic/NoTrailingCommaInSinglelineFixer.php
+++ b/src/Fixer/Basic/NoTrailingCommaInSinglelineFixer.php
@@ -63,7 +63,7 @@ final class NoTrailingCommaInSinglelineFixer extends AbstractFixer implements Co
 
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
-        $elements = ['arguments', 'array_destructuring', 'array', 'group_import'];
+        $elements = ['arguments', 'array', 'array_destructuring', 'group_import'];
 
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('elements', 'Which elements to fix.'))

--- a/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+++ b/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
@@ -96,11 +96,13 @@ class Sample
 
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
+        $elements = ['const', 'method', 'property'];
+
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('elements', 'The structural elements to fix (PHP >= 7.1 required for `const`).'))
                 ->setAllowedTypes(['string[]'])
-                ->setAllowedValues([new AllowedValueSubset(['property', 'method', 'const'])])
-                ->setDefault(['property', 'method', 'const'])
+                ->setAllowedValues([new AllowedValueSubset($elements)])
+                ->setDefault($elements)
                 ->getOption(),
         ]);
     }

--- a/src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitConstructFixer.php
@@ -127,9 +127,9 @@ final class FooTest extends \PHPUnit_Framework_TestCase {
     {
         $assertMethods = [
             'assertEquals',
-            'assertSame',
             'assertNotEquals',
             'assertNotSame',
+            'assertSame',
         ];
 
         return new FixerConfigurationResolver([

--- a/src/Fixer/Phpdoc/PhpdocTypesFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesFixer.php
@@ -50,17 +50,6 @@ final class PhpdocTypesFixer extends AbstractPhpdocTypesFixer implements Configu
      * @var array<string, list<string>>
      */
     private const POSSIBLE_TYPES = [
-        'simple' => [
-            'array',
-            'bool',
-            'callable',
-            'float',
-            'int',
-            'iterable',
-            'null',
-            'object',
-            'string',
-        ],
         'alias' => [
             'boolean',
             'double',
@@ -77,6 +66,17 @@ final class PhpdocTypesFixer extends AbstractPhpdocTypesFixer implements Configu
             'static',
             'true',
             'void',
+        ],
+        'simple' => [
+            'array',
+            'bool',
+            'callable',
+            'float',
+            'int',
+            'iterable',
+            'null',
+            'object',
+            'string',
         ],
     ];
 

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -714,7 +714,7 @@ abstract class AbstractFixerTestCase extends TestCase
 
         $allowedValues = $option->getAllowedValues();
 
-        if (null !== $allowedValues) {
+        if (null === $allowedValues) {
             return;
         }
 

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -718,7 +718,7 @@ abstract class AbstractFixerTestCase extends TestCase
             return;
         }
 
-        $allowedValueSubset = reset($allowedValues);
+        $allowedValueSubset = $allowedValues[0];
 
         if (
             !$allowedValueSubset instanceof AllowedValueSubset

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -714,7 +714,7 @@ abstract class AbstractFixerTestCase extends TestCase
 
         $allowedValues = $option->getAllowedValues();
 
-        if (!is_countable($allowedValues) || 1 !== \count($allowedValues)) {
+        if (null !== $allowedValues) {
             return;
         }
 


### PR DESCRIPTION
Currently, some sets are the same size, but the order is different, e.g.:
![image](https://github.com/user-attachments/assets/c9ff3cac-3c83-47d9-8e1e-47706c64dd22)
(from https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.73.1/doc/rules/class_notation/visibility_required.rst)

Let's make them in the same order.