### PR TITLE
chore: `FunctionsAnalyzerTest` cleanup

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -55,7 +55,7 @@ parameters:
         -
             message: '#^Method PhpCsFixer\\Tests\\.+::provide.+Cases\(\) return type has no value type specified in iterable type iterable\.$#'
             path: tests
-            count: 254
+            count: 251
     tipsOfTheDay: false
     symfony:
         consoleApplicationLoader: dev-tools/phpstan/console-application.php


### PR DESCRIPTION
- `assertIsGlobalFunctionCall` code moved to `testIsGlobalFunctionCall` and other `testIsGlobalFunctionCall*` call `testIsGlobalFunctionCall`
- order of params in `testIsGlobalFunctionCallPhp81` swapped to match other `testIsGlobalFunctionCall*` methods
- added missing return types for iterables