### PR TITLE
fix: `NoMultipleStatementsPerLineFixer` - handle `set` and `get` in different casing in property hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,16 +232,14 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-#        run: vendor/bin/phpunit --testsuite unit,integration
-        run: vendor/bin/phpunit tests/Fixer/Basic/NoMultipleStatementsPerLineFixerTest.php tests/Tokenizer/Transformer/BraceTransformerTest.php
+        run: vendor/bin/phpunit --testsuite unit,integration
 
       - name: Run tests (via ParaUnit)
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes' && matrix.AVOID_PARAUNIT != 'yes'
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-#        run: vendor/bin/paraunit run --testsuite unit,integration
-        run: vendor/bin/phpunit tests/Fixer/Basic/NoMultipleStatementsPerLineFixerTest.php tests/Tokenizer/Transformer/BraceTransformerTest.php
+        run: vendor/bin/paraunit run --testsuite unit,integration
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,14 +232,16 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit --testsuite unit,integration
+#        run: vendor/bin/phpunit --testsuite unit,integration
+        run: vendor/bin/phpunit tests/Fixer/Basic/NoMultipleStatementsPerLineFixerTest.php tests/Tokenizer/Transformer/BraceTransformerTest.php
 
       - name: Run tests (via ParaUnit)
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes' && matrix.AVOID_PARAUNIT != 'yes'
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+#        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/phpunit tests/Fixer/Basic/NoMultipleStatementsPerLineFixerTest.php tests/Tokenizer/Transformer/BraceTransformerTest.php
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/src/Tokenizer/Transformer/BraceTransformer.php
+++ b/src/Tokenizer/Transformer/BraceTransformer.php
@@ -183,7 +183,7 @@ final class BraceTransformer extends AbstractTransformer
         if (!$tokens[$nextIndex]->equalsAny([
             [T_STRING, 'get'],
             [T_STRING, 'set'],
-        ])) {
+        ], false)) {
             return;
         }
 

--- a/tests/Fixer/Basic/NoMultipleStatementsPerLineFixerTest.php
+++ b/tests/Fixer/Basic/NoMultipleStatementsPerLineFixerTest.php
@@ -108,6 +108,7 @@ final class NoMultipleStatementsPerLineFixerTest extends AbstractFixerTestCase
     public string $readable { get; }
     public string $writeable { set; }
     public string $both { get; set; }
+    public string $differentCasing { GET; Set; }
 }',
         ];
     }

--- a/tests/Tokenizer/Transformer/BraceTransformerTest.php
+++ b/tests/Tokenizer/Transformer/BraceTransformerTest.php
@@ -482,6 +482,23 @@ final class BraceTransformerTest extends AbstractTransformerTestCase
                 143 => CT::T_PROPERTY_HOOK_BRACE_CLOSE,
             ],
         ];
+
+        yield 'property hooks: casing' => [
+            <<<'PHP'
+                <?php
+                class PropertyHooks
+                {
+                    public string $bar { // << this one
+                        Get => strtolower($this->bar);
+                        SET => strtoupper($value);
+                    } // << this one
+                }
+                PHP,
+            [
+                13 => CT::T_PROPERTY_HOOK_BRACE_OPEN,
+                39 => CT::T_PROPERTY_HOOK_BRACE_CLOSE,
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
```cli
$ echo '$o = new class {
    public string $p {
        GET => "Value is " . $this->p;
        SET(string $x) => strtoupper($x);
    }
};
$o->p = "hello";
var_dump($o->p);' | php -a

string(14) "Value is HELLO"
```