### PR TITLE
DX: cleanup `SemicolonAfterInstructionFixerTest`

### DIFF
--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -2690,12 +2690,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#',
-	'identifier' => 'booleanNot.exprNotBoolean',
-	'count' => 1,
-	'path' => __DIR__ . '/../../tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Call to new PhpCsFixer\\\\FixerConfiguration\\\\AliasedFixerOption\\(\\) on a separate line has no effect\\.$#',
 	'identifier' => 'new.resultUnused',
 	'count' => 1,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -37,7 +37,6 @@
         <testsuite name="short-open-tag">
             <file>./tests/Fixer/PhpTag/NoClosingTagFixerTest.php</file>
             <file>./tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php</file>
-            <file>./tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php</file>
             <file>./tests/Tokenizer/TokensTest.php</file>
         </testsuite>
     </testsuites>

--- a/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
+++ b/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
@@ -93,6 +93,11 @@ A is equal to 5
 A is equal to 5
 <?php } ?>',
         ];
+
+        yield 'open tag with echo' => [
+            "<?= '1_'; ?> <?php ?><?= 1; ?>",
+            "<?= '1_' ?> <?php ?><?= 1; ?>",
+        ];
     }
 
     /**
@@ -114,17 +119,5 @@ A is equal to 5
             '<?php $a = [1,2,3]; echo $a{1}; ?>',
             '<?php $a = [1,2,3]; echo $a{1} ?>',
         ];
-    }
-
-    public function testOpenWithEcho(): void
-    {
-        if (!\ini_get('short_open_tag')) {
-            self::markTestSkipped('The short_open_tag option is required to be enabled.');
-        }
-
-        $this->doTest(
-            "<?= '1_'; ?> <?php ?><?= 1; ?>",
-            "<?= '1_' ?> <?php ?><?= 1; ?>"
-        );
     }
 }

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -84,7 +84,6 @@ use PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitTestCaseStaticMethodCallsFixerTest;
 use PhpCsFixer\Tests\Fixer\ReturnNotation\ReturnAssignmentFixerTest;
 use PhpCsFixer\Tests\Fixer\Semicolon\MultilineWhitespaceBeforeSemicolonsFixerTest;
 use PhpCsFixer\Tests\Fixer\Semicolon\NoEmptyStatementFixerTest;
-use PhpCsFixer\Tests\Fixer\Semicolon\SemicolonAfterInstructionFixerTest;
 use PhpCsFixer\Tests\Fixer\Semicolon\SpaceAfterSemicolonFixerTest;
 use PhpCsFixer\Tests\Fixer\Whitespace\BlankLineBeforeStatementFixerTest;
 use PhpCsFixer\Tests\Fixer\Whitespace\IndentationTypeFixerTest;
@@ -496,7 +495,6 @@ abstract class AbstractFixerTestCase extends TestCase
             PhpUnitTestCaseStaticMethodCallsFixerTest::class,
             ReturnAssignmentFixerTest::class,
             ReturnTypeDeclarationFixerTest::class,
-            SemicolonAfterInstructionFixerTest::class,
             SingleImportPerStatementFixerTest::class,
             SingleLineCommentStyleFixerTest::class,
             SingleSpaceAroundConstructFixerTest::class,


### PR DESCRIPTION
Tag `<?=` has nothing to do with the directive `short_open_tag`.