### PR TITLE
feat: `OrderedClassElementsFixerAdd` - add support for property hooks for abstract properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,14 +232,16 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit --testsuite unit,integration
+#        run: vendor/bin/phpunit --testsuite unit,integration
+        run: vendor/bin/phpunit tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
 
       - name: Run tests (via ParaUnit)
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes' && matrix.AVOID_PARAUNIT != 'yes'
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+#        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/phpunit tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -1719,5 +1719,16 @@ class A
                 }
                 PHP,
         ];
+
+        yield 'property hook for abstract property' => [
+            <<<'PHP'
+                <?php abstract class Foo
+                {
+                    abstract string $a { get; }
+                    abstract public string $b { get; }
+                    abstract protected string $c { get; }
+                }
+                PHP,
+        ];
     }
 }


### PR DESCRIPTION
Closes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8556