### PR TITLE
fix: `StatementIndentationFixer` - handle functions `set` and `get` (like property hooks, but not)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,14 +232,16 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit --testsuite unit,integration
+#        run: vendor/bin/phpunit --testsuite unit,integration
+        run: vendor/bin/phpunit tests/Fixer/Whitespace/StatementIndentationFixerTest.php tests/Tokenizer/Transformer/BraceTransformerTest.php
 
       - name: Run tests (via ParaUnit)
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes' && matrix.AVOID_PARAUNIT != 'yes'
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+#        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/phpunit tests/Fixer/Whitespace/StatementIndentationFixerTest.php tests/Tokenizer/Transformer/BraceTransformerTest.php
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -1489,6 +1489,18 @@ $foo = [
                     return false;
                 PHP,
         ];
+
+        yield 'functions "set" and "get" (like property hooks, but not)' => [
+            <<<'PHP'
+                <?php if ($x) {
+                    set();
+                } elseif ($y) {
+                    SET();
+                } else {
+                    get();
+                }
+                PHP,
+        ];
     }
 
     /**

--- a/tests/Tokenizer/Transformer/BraceTransformerTest.php
+++ b/tests/Tokenizer/Transformer/BraceTransformerTest.php
@@ -163,6 +163,20 @@ final class BraceTransformerTest extends AbstractTransformerTestCase
                 14 => CT::T_CURLY_CLOSE,
             ],
         ];
+
+        yield 'functions "set" and "get" (like property hooks, but not)' => [
+            <<<'PHP'
+                <?php if ($x) {
+                    set();
+                } elseif ($y) {
+                    SET();
+                } else {
+                    get();
+                }
+
+                PHP,
+            [],
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8515