### PR TITLE
chore: add missing priority test for `BracesPositionFixer` and `MultilinePromotedPropertiesFixer`

### DIFF
--- a/src/Fixer/Basic/BracesPositionFixer.php
+++ b/src/Fixer/Basic/BracesPositionFixer.php
@@ -163,7 +163,7 @@ $bar = function () { $result = true;
      * {@inheritdoc}
      *
      * Must run before SingleLineEmptyBodyFixer, StatementIndentationFixer.
-     * Must run after ControlStructureBracesFixer, NoMultipleStatementsPerLineFixer.
+     * Must run after ControlStructureBracesFixer, MultilinePromotedPropertiesFixer, NoMultipleStatementsPerLineFixer.
      */
     public function getPriority(): int
     {

--- a/src/Fixer/FunctionNotation/MultilinePromotedPropertiesFixer.php
+++ b/src/Fixer/FunctionNotation/MultilinePromotedPropertiesFixer.php
@@ -92,7 +92,7 @@ final class MultilinePromotedPropertiesFixer extends AbstractFixer implements Co
     /**
      * {@inheritdoc}
      *
-     * Must run before TrailingCommaInMultilineFixer.
+     * Must run before BracesPositionFixer, TrailingCommaInMultilineFixer.
      */
     public function getPriority(): int
     {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -549,6 +549,7 @@ final class FixerFactoryTest extends TestCase
                 'no_unneeded_control_parentheses',
             ],
             'multiline_promoted_properties' => [
+                'braces_position',
                 'trailing_comma_in_multiline',
             ],
             'multiline_string_to_heredoc' => [

--- a/tests/Fixtures/Integration/priority/multiline_promoted_properties,braces_position.test
+++ b/tests/Fixtures/Integration/priority/multiline_promoted_properties,braces_position.test
@@ -1,0 +1,26 @@
+--TEST--
+Integration of fixers: multiline_promoted_properties,braces_position.
+--RULESET--
+{"braces_position": true, "multiline_promoted_properties": true}
+--REQUIREMENTS--
+{"php": 80000}
+--EXPECT--
+<?php
+class Foo
+{
+    public function __construct(
+        private array $x
+    ) {
+        $this->y = 42;
+    }
+}
+
+--INPUT--
+<?php
+class Foo
+{
+    public function __construct(private array $x)
+    {
+        $this->y = 42;
+    }
+}


### PR DESCRIPTION
I was a bit too eager with merging https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8595.