### PR TITLE
fix: `FullyQualifiedStrictTypesFixer` - fix fatal error of "Cannot redeclare class `Resource`"

### DIFF
--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -433,6 +433,10 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
             return false;
         }
 
+        if ('resource' === strtolower($symbol)) {
+            return false;
+        }
+
         if ((new TypeAnalysis($symbol))->isReservedType()) {
             return true;
         }

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -2706,6 +2706,33 @@ function foo($a) {}',
                 PHP,
             ['import_symbols' => true],
         ];
+
+        yield 'Usage of class Resource from other namespace' => [
+            <<<'PHP'
+                <?php
+                namespace Foo;
+                use App\Resource;
+                class Resource
+                {
+                    public function bar(): string
+                    {
+                        return \App\Resource::class;
+                    }
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                namespace Foo;
+                class Resource
+                {
+                    public function bar(): string
+                    {
+                        return \App\Resource::class;
+                    }
+                }
+                PHP,
+            ['import_symbols' => true],
+        ];
     }
 
     /**
@@ -2744,7 +2771,7 @@ function foo($a) {}',
             '<?php function foo(): \A|\B|\C {}',
         ];
 
-        yield 'aaa' => [
+        yield [
             '<?php function foo(): A | B | C {}',
             '<?php function foo(): \A | \B | \C {}',
         ];

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -2711,7 +2711,6 @@ function foo($a) {}',
             <<<'PHP'
                 <?php
                 namespace Foo;
-                use App\Resource;
                 class Resource
                 {
                     public function bar(): string
@@ -2720,17 +2719,7 @@ function foo($a) {}',
                     }
                 }
                 PHP,
-            <<<'PHP'
-                <?php
-                namespace Foo;
-                class Resource
-                {
-                    public function bar(): string
-                    {
-                        return \App\Resource::class;
-                    }
-                }
-                PHP,
+            null,
             ['import_symbols' => true],
         ];
     }

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -624,7 +624,11 @@ abstract class AbstractFixerTestCase extends TestCase
             self::assertTokens($expectedTokens, $tokens);
         }
 
-        self::assertNull($this->lintSource($expected));
+        if (str_contains($expected, 'return \App\Resource::class;') && '1' !== getenv('FAST_LINT_TEST_CASES')) {
+            self::assertNotNull($this->lintSource($expected));
+        } else {
+            self::assertNull($this->lintSource($expected));
+        }
 
         Tokens::clearCache();
         $tokens = Tokens::fromCode($expected);

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -624,11 +624,7 @@ abstract class AbstractFixerTestCase extends TestCase
             self::assertTokens($expectedTokens, $tokens);
         }
 
-        if (str_contains($expected, 'return \App\Resource::class;') && '1' !== getenv('FAST_LINT_TEST_CASES')) {
-            self::assertNotNull($this->lintSource($expected));
-        } else {
-            self::assertNull($this->lintSource($expected));
-        }
+        self::assertNull($this->lintSource($expected));
 
         Tokens::clearCache();
         $tokens = Tokens::fromCode($expected);


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8628