### PR TITLE
fix: `FullyQualifiedStrictTypesFixer` - fix fatal error of "Cannot redeclare class `Resource`" (fix by making `resource` not reserved keyword)

### DIFF
--- a/src/Tokenizer/Analyzer/Analysis/TypeAnalysis.php
+++ b/src/Tokenizer/Analyzer/Analysis/TypeAnalysis.php
@@ -45,7 +45,6 @@ final class TypeAnalysis implements StartEndTokenAwareAnalysis
         'null',
         'object',
         'parent',
-        'resource',
         'self',
         'static',
         'string',

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -2706,6 +2706,22 @@ function foo($a) {}',
                 PHP,
             ['import_symbols' => true],
         ];
+
+        yield 'Usage of class Resource from other namespace' => [
+            <<<'PHP'
+                <?php
+                namespace Foo;
+                class Resource
+                {
+                    public function bar(): string
+                    {
+                        return \App\Resource::class;
+                    }
+                }
+                PHP,
+            null,
+            ['import_symbols' => true],
+        ];
     }
 
     /**
@@ -2744,7 +2760,7 @@ function foo($a) {}',
             '<?php function foo(): \A|\B|\C {}',
         ];
 
-        yield 'aaa' => [
+        yield [
             '<?php function foo(): A | B | C {}',
             '<?php function foo(): \A | \B | \C {}',
         ];

--- a/tests/Tokenizer/Analyzer/Analysis/TypeAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/TypeAnalysisTest.php
@@ -85,7 +85,7 @@ final class TypeAnalysisTest extends TestCase
 
         yield ['object', true];
 
-        yield ['resource', true];
+        yield ['resource', false];
 
         yield ['self', true];
 


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8628

Alternative approach to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8630