### PR TITLE
fix(dependabot): convert time values to string types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: weekly
       day: friday
-      time: 12:30
+      time: '12:30'
       timezone: Europe/Warsaw
     versioning-strategy: increase
     groups:
@@ -22,7 +22,7 @@ updates:
     schedule:
       interval: weekly
       day: friday
-      time: 12:30
+      time: '12:30'
       timezone: Europe/Warsaw
   - package-ecosystem: github-actions
     directory: /
@@ -31,5 +31,5 @@ updates:
     schedule:
       interval: weekly
       day: friday
-      time: 12:30
+      time: '12:30'
       timezone: Europe/Warsaw


### PR DESCRIPTION
This is a follow-up fix to PR #8622, addressing an issue in `dependabot.yml` to ensure that all time-related values are explicitly defined as strings.