### PR TITLE
Fix links in doc

### DIFF
--- a/doc/cookbook_fixers.rst
+++ b/doc/cookbook_fixers.rst
@@ -21,7 +21,8 @@ discouraged - it is meant only to give more people more chance to
 contribute, and to detect bugs (`Linus's Law`_).
 
 If possible, try to get acquainted with the public interface for the
-`Tokens class`_ and `Token class`_ classes.
+`PhpCsFixer\\Tokenizer\\Tokens <./../src/Tokenizer/Tokens.php>`_ and
+`PhpCsFixer\\Tokenizer\\Token <./../src/Tokenizer/Token.php>`_ classes.
 
 Assumptions
 -----------
@@ -30,7 +31,7 @@ Assumptions
 * Forked PHP-CS-Fixer/PHP-CS-Fixer into your own GitHub Account.
 * Cloned your forked repository locally.
 * Installed the dependencies of PHP CS Fixer using Composer_.
-* You have read `CONTRIBUTING.md`_.
+* You have read `CONTRIBUTING.md <./../CONTRIBUTING.md>`_.
 
 Step by step
 ------------
@@ -326,8 +327,8 @@ Now you need to do some reading, because all these symbols obey a list
 defined by the PHP compiler. It is the `List of Parser Tokens`_.
 
 Internally, PHP CS Fixer transforms some of PHP native tokens into custom
-tokens through the use of Transformers_, they aim to help you reason about the
-changes you may want to do in the fixers.
+tokens through the use of `PhpCsFixer\\Tokenizer\\Transformer <./../src/Tokenizer/Transformer>`_ transformers,
+they aim to help you reason about the changes you may want to do in the fixers.
 
 So we can get to move forward, humor me in believing that comments have
 one symbol name: ``T_COMMENT``.
@@ -526,10 +527,6 @@ Why am I asked to use ``getPrevMeaningfulToken()`` instead of ``getPrevNonWhites
   or a whitespace, the returned token will always be ``->``.
 
 .. _Composer: https://getcomposer.org
-.. _CONTRIBUTING.md: ./../CONTRIBUTING.md
 .. _idempotent: https://en.wikipedia.org/wiki/Idempotence#Computer_science_meaning
 .. _Linus's Law: https://en.wikipedia.org/wiki/Linus%27s_Law
 .. _List of Parser Tokens: https://php.net/manual/en/tokens.php
-.. _Token class: ./../src/Tokenizer/Token.php
-.. _Tokens class: ./../src/Tokenizer/Tokens.php
-.. _Transformers: ./../src/Tokenizer/Transformer

--- a/doc/custom_rules.rst
+++ b/doc/custom_rules.rst
@@ -3,7 +3,7 @@ Creating custom rules
 =====================
 
 If you need to enforce some specific code style rules, you can implement your
-own fixers.
+own fixers. There is a `cookbook <./cookbook_fixers.rst>`_ with basic instructions on how to build a new fixer.
 
 For each rule you want to add, create a class that implements
 `PhpCsFixer\\Fixer\\FixerInterface <./../src/Fixer/FixerInterface.php>`_.

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -21,7 +21,9 @@ If you do not have config file, you can run following command to fix non-hidden,
 
     php php-cs-fixer.phar fix .
 
-You can also fix files in parallel, utilising more CPU cores. You can do this by using config class that implements ``PhpCsFixer\Runner\Parallel\ParallelConfig\ParallelAwareConfigInterface``, and use ``setParallelConfig()`` method. Recommended way is to utilise auto-detecting parallel configuration:
+You can also fix files in parallel, utilising more CPU cores. You can do this by using config class that implements
+`PhpCsFixer\\ParallelAwareConfigInterface <./../src/ParallelAwareConfigInterface.php>`_, and use ``setParallelConfig()`` method.
+Recommended way is to utilise auto-detecting parallel configuration:
 
 .. code-block:: php
 


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8030) and also fixes the `ParallelAwareConfigInterface` namespace.