### PR TITLE
fix: Allow non-doc comment on opening inline brace line

### DIFF
--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -302,7 +302,13 @@ class Sample
                 $nonWhiteAbove = $this->findCommentBlockStart($tokens, $nonWhiteAbove, $elementAboveEnd);
                 $nonWhiteAboveComment = $tokens->getPrevNonWhitespace($nonWhiteAbove);
 
-                $this->correctLineBreaks($tokens, $nonWhiteAboveComment, $nonWhiteAbove, $nonWhiteAboveComment === $class['open'] ? 1 : 2);
+                if ($nonWhiteAboveComment === $class['open']) {
+                    if ($tokens[$nonWhiteAboveComment - 1]->isWhitespace() && substr_count($tokens[$nonWhiteAboveComment - 1]->getContent(), "\n") > 0) {
+                        $this->correctLineBreaks($tokens, $nonWhiteAboveComment, $nonWhiteAbove, 1);
+                    }
+                } else {
+                    $this->correctLineBreaks($tokens, $nonWhiteAboveComment, $nonWhiteAbove, 2);
+                }
             } else {
                 // 2. The comment belongs to the code above the element,
                 //    make sure there is a blank line above the element (i.e. 2 line breaks)

--- a/src/Fixer/Comment/CommentToPhpdocFixer.php
+++ b/src/Fixer/Comment/CommentToPhpdocFixer.php
@@ -124,6 +124,10 @@ final class CommentToPhpdocFixer extends AbstractFixer implements ConfigurableFi
                 continue;
             }
 
+            if (Preg::match('~(?:#|//|/\*+|\R(?:\s*\*)?)\s*\@(?=\w+-(ignore|suppress))([a-zA-Z0-9_\\\-]+)(?=\s|\(|$)~', $tokens[$index]->getContent())) {
+                continue;
+            }
+
             $commentIndices = $commentsAnalyzer->getCommentBlockIndices($tokens, $index);
 
             if ($this->isCommentCandidate($tokens, $commentIndices)) {

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -78,8 +78,7 @@ public function Foo(){}
         ];
 
         yield 'comment' => [
-            '<?php class A {
-/* function comment */
+            '<?php class A {/* function comment */
 public function Bar(){}
 }',
             '<?php class A {/* function comment */public function Bar(){}
@@ -222,6 +221,36 @@ public function A(){}
                 public function H(){}
                 public function B7(){}
                 private function C(){}
+                };',
+        ];
+
+        yield [
+            '<?php class Foo extends X\Y { // @phpstan-ignore method.internal
+                // regular comment
+                };',
+        ];
+
+        yield [
+            '<?php class Foo extends X\Y { // @phpstan-ignore method.internal
+                public $p;
+                };',
+        ];
+
+        yield [
+            '<?php $a = new class extends X\Y { // @phpstan-ignore method.internal
+                public function m(){}
+                };',
+        ];
+
+        yield [
+            '<?php class Foo extends X\Y
+                {
+ // @phpstan-ignore method.internal
+                public $p;
+                };',
+            '<?php class Foo extends X\Y
+                { // @phpstan-ignore method.internal
+                public $p;
                 };',
         ];
 

--- a/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
+++ b/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
@@ -350,5 +350,54 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
             '<?php /* header comment */ $foo = true; class Foo { /** @phpstan-use Bar<Baz> $bar */ use Bar; }',
             '<?php /* header comment */ $foo = true; class Foo { /* @phpstan-use Bar<Baz> $bar */ use Bar; }',
         ];
+
+        yield [
+            '<?php
+            $foo = new class extends Foo { // @phpstan-ignore method.internal
+                /** @foo */
+                public function m(): void {}
+            };
+',
+            '<?php
+            $foo = new class extends Foo { // @phpstan-ignore method.internal
+                // @foo
+                public function m(): void {}
+            };
+',
+        ];
+
+        yield [
+            '<?php
+            $foo = new class extends Foo { // @psalm-suppress all
+                /** @foo */
+                public function m(): void {}
+            };
+',
+            '<?php
+            $foo = new class extends Foo { // @psalm-suppress all
+                // @foo
+                public function m(): void {}
+            };
+',
+        ];
+
+        yield [
+            <<<'EOT'
+                <?php
+                $foo = new class extends Foo { /**
+                 * @phpstan-return void
+                 * @foo
+                 */
+                    public function m(): void {}
+                };
+                EOT,
+            <<<'EOT'
+                <?php
+                $foo = new class extends Foo { // @phpstan-return void
+                    // @foo
+                    public function m(): void {}
+                };
+                EOT,
+        ];
     }
 }

--- a/tests/Fixtures/Integration/misc/issue_6492.test
+++ b/tests/Fixtures/Integration/misc/issue_6492.test
@@ -1,0 +1,26 @@
+--TEST--
+PHPStan comment after anonymous class opening brace must stay.
+--RULESET--
+{"@PhpCsFixer": true, "@PhpCsFixer:risky": true}
+--EXPECT--
+<?php
+
+use Ns\Foo;
+
+$a = new class extends Foo { // comment1
+};
+
+$b = new class extends Foo { // comment1
+    public function m(): void {}
+};
+
+--INPUT--
+<?php
+
+$a = new class() extends Ns\Foo { // comment1
+};
+
+$b = new class() extends Ns\Foo { // comment1
+public function m(): void {
+}
+};

--- a/tests/Fixtures/Integration/misc/issue_6492.test
+++ b/tests/Fixtures/Integration/misc/issue_6492.test
@@ -1,5 +1,5 @@
 --TEST--
-PHPStan comment after anonymous class opening brace must stay.
+PHPStan comment after anonymous class opening brace must stay on the same line.
 --RULESET--
 {"@PhpCsFixer": true, "@PhpCsFixer:risky": true}
 --EXPECT--
@@ -7,20 +7,20 @@ PHPStan comment after anonymous class opening brace must stay.
 
 use Ns\Foo;
 
-$a = new class extends Foo { // comment1
+$a = new class extends Foo { // @phpstan-ignore method.internal
 };
 
-$b = new class extends Foo { // comment1
+$b = new class extends Foo { // @phpstan-ignore method.internal
     public function m(): void {}
 };
 
 --INPUT--
 <?php
 
-$a = new class() extends Ns\Foo { // comment1
+$a = new class() extends Ns\Foo { // @phpstan-ignore method.internal
 };
 
-$b = new class() extends Ns\Foo { // comment1
+$b = new class() extends Ns\Foo { // @phpstan-ignore method.internal
 public function m(): void {
 }
 };


### PR DESCRIPTION
fix #6492

PHP CS Fixer must not move comments after opening brace when the brace is placed on the same line as the meaningful token before. This is important especially for line comments for static analysers.

When there is a new line before opening brace, new line before comment is correctly still added as before.