### PR TITLE
DX: add transformer for PHP 8.4+ tokens

### DIFF
--- a/src/AbstractDoctrineAnnotationFixer.php
+++ b/src/AbstractDoctrineAnnotationFixer.php
@@ -216,16 +216,10 @@ abstract class AbstractDoctrineAnnotationFixer extends AbstractFixer implements 
             return true;
         }
 
-        $modifierKinds = [T_PUBLIC, T_PROTECTED, T_PRIVATE, T_FINAL, T_ABSTRACT, T_NS_SEPARATOR, T_STRING, CT::T_NULLABLE_TYPE];
+        $modifierKinds = [T_PUBLIC, T_PROTECTED, T_PRIVATE, T_FINAL, T_ABSTRACT, T_NS_SEPARATOR, T_STRING, CT::T_NULLABLE_TYPE, CT::T_PRIVATE_SET, CT::T_PROTECTED_SET, CT::T_PUBLIC_SET];
 
         if (\defined('T_READONLY')) { // @TODO: drop condition when PHP 8.1+ is required
             $modifierKinds[] = T_READONLY;
-        }
-
-        if (\defined('T_PRIVATE_SET')) { // @TODO: drop condition when PHP 8.4+ is required
-            $modifierKinds[] = T_PRIVATE_SET;
-            $modifierKinds[] = T_PROTECTED_SET;
-            $modifierKinds[] = T_PUBLIC_SET;
         }
 
         while ($tokens[$index]->isGivenKind($modifierKinds)) {

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -522,16 +522,10 @@ class Sample
      */
     private function getFirstTokenIndexOfClassElement(Tokens $tokens, array $class, array $element): int
     {
-        $modifierTypes = [T_PRIVATE, T_PROTECTED, T_PUBLIC, T_ABSTRACT, T_FINAL, T_STATIC, T_STRING, T_NS_SEPARATOR, T_VAR, CT::T_NULLABLE_TYPE, CT::T_ARRAY_TYPEHINT, CT::T_TYPE_ALTERNATION, CT::T_TYPE_INTERSECTION, CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_OPEN, CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_CLOSE];
+        $modifierTypes = [T_PRIVATE, T_PROTECTED, T_PUBLIC, T_ABSTRACT, T_FINAL, T_STATIC, T_STRING, T_NS_SEPARATOR, T_VAR, CT::T_NULLABLE_TYPE, CT::T_ARRAY_TYPEHINT, CT::T_TYPE_ALTERNATION, CT::T_TYPE_INTERSECTION, CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_OPEN, CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_CLOSE, CT::T_PRIVATE_SET, CT::T_PROTECTED_SET, CT::T_PUBLIC_SET];
 
         if (\defined('T_READONLY')) { // @TODO: drop condition when PHP 8.1+ is required
             $modifierTypes[] = T_READONLY;
-        }
-
-        if (\defined('T_PRIVATE_SET')) { // @TODO: drop condition when PHP 8.4+ is required
-            $modifierTypes[] = T_PRIVATE_SET;
-            $modifierTypes[] = T_PROTECTED_SET;
-            $modifierTypes[] = T_PUBLIC_SET;
         }
 
         $firstElementAttributeIndex = $element['index'];

--- a/src/Fixer/ClassNotation/OrderedTypesFixer.php
+++ b/src/Fixer/ClassNotation/OrderedTypesFixer.php
@@ -237,16 +237,10 @@ interface Bar
     private function fixPropertyType(Tokens $tokens, int $index): void
     {
         $propertyIndex = $index;
-        $propertyModifiers = [T_PRIVATE, T_PROTECTED, T_PUBLIC, T_STATIC, T_VAR];
+        $propertyModifiers = [T_PRIVATE, T_PROTECTED, T_PUBLIC, T_STATIC, T_VAR, CT::T_PRIVATE_SET, CT::T_PROTECTED_SET, CT::T_PUBLIC_SET];
 
         if (\defined('T_READONLY')) {
             $propertyModifiers[] = T_READONLY; // @TODO drop condition when PHP 8.1 is supported
-        }
-
-        if (\defined('T_PRIVATE_SET')) { // @TODO: drop condition when PHP 8.4+ is required
-            $propertyModifiers[] = T_PRIVATE_SET;
-            $propertyModifiers[] = T_PROTECTED_SET;
-            $propertyModifiers[] = T_PUBLIC_SET;
         }
 
         do {

--- a/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+++ b/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
@@ -174,12 +174,7 @@ class Sample
     {
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 
-        $propertyTypeDeclarationKinds = [T_STRING, T_NS_SEPARATOR, CT::T_NULLABLE_TYPE, CT::T_ARRAY_TYPEHINT, CT::T_TYPE_ALTERNATION, CT::T_TYPE_INTERSECTION, CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_OPEN, CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_CLOSE];
-
-        if (\defined('T_PRIVATE_SET')) { // @TODO: drop condition when PHP 8.4+ is required
-            $propertyKindsAsymmetric = [T_PRIVATE_SET, T_PROTECTED_SET, T_PUBLIC_SET];
-            array_push($propertyTypeDeclarationKinds, ...$propertyKindsAsymmetric);
-        }
+        $propertyTypeDeclarationKinds = [T_STRING, T_NS_SEPARATOR, CT::T_NULLABLE_TYPE, CT::T_ARRAY_TYPEHINT, CT::T_TYPE_ALTERNATION, CT::T_TYPE_INTERSECTION, CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_OPEN, CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_CLOSE, CT::T_PRIVATE_SET, CT::T_PROTECTED_SET, CT::T_PUBLIC_SET];
 
         if (\defined('T_READONLY')) { // @TODO: drop condition when PHP 8.1+ is required
             $propertyReadOnlyType = T_READONLY;

--- a/src/Tokenizer/CT.php
+++ b/src/Tokenizer/CT.php
@@ -60,6 +60,9 @@ final class CT
     public const T_DYNAMIC_CLASS_CONSTANT_FETCH_CURLY_BRACE_CLOSE = 10_039;
     public const T_PROPERTY_HOOK_BRACE_OPEN = 10_040;
     public const T_PROPERTY_HOOK_BRACE_CLOSE = 10_041;
+    public const T_PUBLIC_SET = 10_042; // @TODO: drop constant when PHP 8.4+ is required
+    public const T_PROTECTED_SET = 10_043; // @TODO: drop constant when PHP 8.4+ is required
+    public const T_PRIVATE_SET = 10_044; // @TODO: drop constant when PHP 8.4+ is required
 
     private function __construct() {}
 

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -331,6 +331,9 @@ final class Token
                 CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC => CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC,
                 CT::T_FUNCTION_IMPORT => CT::T_FUNCTION_IMPORT,
                 CT::T_NAMESPACE_OPERATOR => CT::T_NAMESPACE_OPERATOR,
+                CT::T_PRIVATE_SET => CT::T_PRIVATE_SET,
+                CT::T_PROTECTED_SET => CT::T_PROTECTED_SET,
+                CT::T_PUBLIC_SET => CT::T_PUBLIC_SET,
                 CT::T_USE_LAMBDA => CT::T_USE_LAMBDA,
                 CT::T_USE_TRAIT => CT::T_USE_TRAIT,
             ];

--- a/src/Tokenizer/Transformer/ForwardCompatibilityTransformer.php
+++ b/src/Tokenizer/Transformer/ForwardCompatibilityTransformer.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer\Transformer;
+
+use PhpCsFixer\Tokenizer\AbstractTransformer;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * Transforms tokens added in non-lowest supported PHP version to custom tokens.
+ *
+ * @internal
+ */
+final class ForwardCompatibilityTransformer extends AbstractTransformer
+{
+    /** @var array<int, int> */
+    private array $map = [];
+
+    public function __construct()
+    {
+        if (\defined('T_PUBLIC_SET')) { // @TODO: drop condition when PHP 8.4+ is required
+            $this->map[T_PUBLIC_SET] = CT::T_PUBLIC_SET;
+            $this->map[T_PROTECTED_SET] = CT::T_PROTECTED_SET;
+            $this->map[T_PRIVATE_SET] = CT::T_PRIVATE_SET;
+        }
+    }
+
+    public function getRequiredPhpVersionId(): int
+    {
+        return 8_04_00;
+    }
+
+    public function process(Tokens $tokens, Token $token, int $index): void
+    {
+        if (!isset($this->map[$token->getId()])) {
+            return;
+        }
+
+        $tokens[$index] = new Token([
+            $this->map[$token->getId()],
+            $token->getContent(),
+        ]);
+    }
+
+    public function getCustomTokens(): array
+    {
+        return [
+            CT::T_PUBLIC_SET,
+            CT::T_PROTECTED_SET,
+            CT::T_PRIVATE_SET,
+        ];
+    }
+}

--- a/tests/Tokenizer/CTTest.php
+++ b/tests/Tokenizer/CTTest.php
@@ -16,6 +16,7 @@ namespace PhpCsFixer\Tests\Tokenizer;
 
 use PhpCsFixer\Tests\TestCase;
 use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Transformer\ForwardCompatibilityTransformer;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -67,7 +68,16 @@ final class CTTest extends TestCase
     public function testConstants(string $name, int $value): void
     {
         self::assertGreaterThan(10_000, $value);
-        self::assertFalse(\defined($name), 'The CT name must not use native T_* name.');
+
+        $forwardCompatibilityTransformerTokens = \Closure::bind(static fn (ForwardCompatibilityTransformer $forwardCompatibilityTransformer): array => array_keys($forwardCompatibilityTransformer->map), null, ForwardCompatibilityTransformer::class)(new ForwardCompatibilityTransformer());
+
+        if (\defined($name)) {
+            self::assertContains(
+                \constant($name),
+                $forwardCompatibilityTransformerTokens,
+                \sprintf('The CT can use native T_* name only in %s.', ForwardCompatibilityTransformer::class),
+            );
+        }
     }
 
     /**

--- a/tests/Tokenizer/Transformer/ForwardCompatibilityTransformerTest.php
+++ b/tests/Tokenizer/Transformer/ForwardCompatibilityTransformerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Tokenizer\Transformer;
+
+use PhpCsFixer\Tests\Test\AbstractTransformerTestCase;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Transformer\ForwardCompatibilityTransformer;
+
+/**
+ * @covers \PhpCsFixer\Tokenizer\Transformer\ForwardCompatibilityTransformer
+ *
+ * @internal
+ *
+ * @phpstan-import-type _TransformerTestExpectedTokens from AbstractTransformerTestCase
+ */
+final class ForwardCompatibilityTransformerTest extends AbstractTransformerTestCase
+{
+    /**
+     * @param _TransformerTestExpectedTokens $expectedTokens
+     *
+     * @dataProvider provideProcess84Cases
+     *
+     * @requires PHP 8.4
+     */
+    public function testProcess84(string $source, array $expectedTokens): void
+    {
+        $this->doTest($source, $expectedTokens, (new ForwardCompatibilityTransformer())->getCustomTokens());
+    }
+
+    /**
+     * @return iterable<string, array{string, _TransformerTestExpectedTokens}>
+     */
+    public static function provideProcess84Cases(): iterable
+    {
+        yield 'T_*_SET' => [
+            <<<'PHP'
+                <?php class Foo
+                {
+                    public public(set) bool $a;
+                    public protected(set) bool $b;
+                    public private(set) bool $c;
+                }
+                PHP,
+            [
+                9 => CT::T_PUBLIC_SET,
+                18 => CT::T_PROTECTED_SET,
+                27 => CT::T_PRIVATE_SET,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This is NOT BC break as PHP 8.4 is not officially supported yet.