### PR TITLE
fix: `LowercaseStaticReferenceFixer` - do not change global constants

### DIFF
--- a/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
@@ -256,17 +256,23 @@ final class LowercaseStaticReferenceFixerTest extends AbstractFixerTestCase
         yield [
             <<<'PHP'
                 <?php
-                define("SELF", "foo");
-                define("PARENT", "bar");
-                bar(self);
-                echo parent;
                 class Foo {
-                    public static function f()
-                    {
-                        return self;
-                    }
+                    public    self $a;
+                    protected self $b;
+                    private   self $c;
                 }
                 PHP,
+            <<<'PHP'
+                <?php
+                class Foo {
+                    public    SELF $a;
+                    protected SELF $b;
+                    private   SELF $c;
+                }
+                PHP,
+        ];
+
+        yield [
             <<<'PHP'
                 <?php
                 define("SELF", "foo");

--- a/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
@@ -252,6 +252,35 @@ final class LowercaseStaticReferenceFixerTest extends AbstractFixerTestCase
                     }
                 }',
         ];
+
+        yield [
+            <<<'PHP'
+                <?php
+                define("SELF", "foo");
+                define("PARENT", "bar");
+                bar(self);
+                echo parent;
+                class Foo {
+                    public static function f()
+                    {
+                        return self;
+                    }
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                define("SELF", "foo");
+                define("PARENT", "bar");
+                bar(SELF);
+                echo PARENT;
+                class Foo {
+                    public static function f()
+                    {
+                        return SELF;
+                    }
+                }
+                PHP,
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8725