### PR TITLE
chore: cleanup PsrAutoloadingFixerTest.php keywords handling, as always defined currently

### DIFF
--- a/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
+++ b/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
@@ -349,7 +349,7 @@ class PsrAutoloadingFixer {}
 
         $cases = ['.php', 'Foo.class.php', '4Foo.php', '$#.php'];
 
-        foreach (['__halt_compiler', 'abstract', 'and', 'array', 'as', 'break', 'case', 'catch', 'class', 'clone', 'const', 'continue', 'declare', 'default', 'die', 'do', 'echo', 'else', 'elseif', 'empty', 'enddeclare', 'endfor', 'endforeach', 'endif', 'endswitch', 'endwhile', 'eval', 'exit', 'extends', 'final', 'for', 'foreach', 'function', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof', 'interface', 'isset', 'list', 'namespace', 'new', 'or', 'print', 'private', 'protected', 'public', 'require', 'require_once', 'return', 'static', 'switch', 'throw', 'try', 'unset', 'use', 'var', 'while', 'xor'] as $keyword) {
+        foreach (['__halt_compiler', 'abstract', 'and', 'array', 'as', 'break', 'callable', 'case', 'catch', 'class', 'clone', 'const', 'continue', 'declare', 'default', 'die', 'do', 'echo', 'else', 'elseif', 'empty', 'enddeclare', 'endfor', 'endforeach', 'endif', 'endswitch', 'endwhile', 'eval', 'exit', 'extends', 'final', 'finally', 'for', 'foreach', 'function', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof', 'insteadof', 'interface', 'isset', 'list', 'namespace', 'new', 'or', 'print', 'private', 'protected', 'public', 'require', 'require_once', 'return', 'static', 'switch', 'throw', 'trait', 'try', 'unset', 'use', 'var', 'while', 'xor'] as $keyword) {
             $cases[] = $keyword.'.php';
             $cases[] = strtoupper($keyword).'.php';
         }
@@ -360,10 +360,6 @@ class PsrAutoloadingFixer {}
         }
 
         foreach ([
-            'T_CALLABLE' => 'callable',
-            'T_FINALLY' => 'finally',
-            'T_INSTEADOF' => 'insteadof',
-            'T_TRAIT' => 'trait',
         ] as $tokenType => $tokenValue) {
             if (\defined($tokenType)) {
                 $cases[] = $tokenValue.'.php';

--- a/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
+++ b/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
@@ -351,6 +351,7 @@ class PsrAutoloadingFixer {}
 
         foreach (['__halt_compiler', 'abstract', 'and', 'array', 'as', 'break', 'case', 'catch', 'class', 'clone', 'const', 'continue', 'declare', 'default', 'die', 'do', 'echo', 'else', 'elseif', 'empty', 'enddeclare', 'endfor', 'endforeach', 'endif', 'endswitch', 'endwhile', 'eval', 'exit', 'extends', 'final', 'for', 'foreach', 'function', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof', 'interface', 'isset', 'list', 'namespace', 'new', 'or', 'print', 'private', 'protected', 'public', 'require', 'require_once', 'return', 'static', 'switch', 'throw', 'try', 'unset', 'use', 'var', 'while', 'xor'] as $keyword) {
             $cases[] = $keyword.'.php';
+            $cases[] = strtoupper($keyword).'.php';
         }
 
         foreach (['__CLASS__', '__DIR__', '__FILE__', '__FUNCTION__', '__LINE__', '__METHOD__', '__NAMESPACE__', '__TRAIT__'] as $magicConstant) {

--- a/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
+++ b/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
@@ -353,7 +353,7 @@ class PsrAutoloadingFixer {}
             $cases[] = $keyword.'.php';
         }
 
-        foreach (['__CLASS__', '__DIR__', '__FILE__', '__FUNCTION__', '__LINE__', '__METHOD__', '__NAMESPACE__'] as $magicConstant) {
+        foreach (['__CLASS__', '__DIR__', '__FILE__', '__FUNCTION__', '__LINE__', '__METHOD__', '__NAMESPACE__', '__TRAIT__'] as $magicConstant) {
             $cases[] = $magicConstant.'.php';
             $cases[] = strtolower($magicConstant).'.php';
         }
@@ -363,7 +363,6 @@ class PsrAutoloadingFixer {}
             'T_FINALLY' => 'finally',
             'T_INSTEADOF' => 'insteadof',
             'T_TRAIT' => 'trait',
-            'T_TRAIT_C' => '__trait__',
         ] as $tokenType => $tokenValue) {
             if (\defined($tokenType)) {
                 $cases[] = $tokenValue.'.php';

--- a/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
+++ b/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
@@ -359,14 +359,6 @@ class PsrAutoloadingFixer {}
             $cases[] = strtolower($magicConstant).'.php';
         }
 
-        foreach ([
-        ] as $tokenType => $tokenValue) {
-            if (\defined($tokenType)) {
-                $cases[] = $tokenValue.'.php';
-                $cases[] = strtoupper($tokenValue).'.php';
-            }
-        }
-
         yield from array_map(static fn ($case): array => [
             '<?php
 namespace Aaa;


### PR DESCRIPTION
inspired by https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8708/files#diff-639c306b175846d9de67327cdde49dbb71aa5a262a7e7ed8b0a51d38008d23f0L368