### PR TITLE
feat: allowUnsupportedPhpVersion

### DIFF
--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -43,7 +43,7 @@ set_error_handler(static function (int $severity, string $message, string $file,
     }
 
     if (false !== getenv('PHP_CS_FIXER_IGNORE_ENV')) {
-        fwrite(STDERR, "Setting PHP_CS_FIXER_IGNORE_ENV environment variable is deprecated and will be removed in 4.0, use failOnUnsupportedVersion config instead.\n");
+        fwrite(STDERR, "Setting PHP_CS_FIXER_IGNORE_ENV environment variable is deprecated and will be removed in 4.0, use unsupportedPhpVersionAllowed config instead.\n");
     }
 
     foreach (['json', 'tokenizer'] as $extension) {

--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -42,6 +42,10 @@ set_error_handler(static function (int $severity, string $message, string $file,
         exit(1);
     }
 
+    if (false !== getenv('PHP_CS_FIXER_IGNORE_ENV')) {
+        fwrite(STDERR, "Setting PHP_CS_FIXER_IGNORE_ENV environment variable is deprecated and will be removed in 4.0, use failOnUnsupportedVersion config instead.\n");
+    }
+
     foreach (['json', 'tokenizer'] as $extension) {
         if (!extension_loaded($extension)) {
             fwrite(STDERR, sprintf("PHP extension ext-%s is missing from your system. Install or enable it.\n", $extension));

--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -42,6 +42,7 @@ set_error_handler(static function (int $severity, string $message, string $file,
         exit(1);
     }
 
+    // @TODO 4.0 cleanup
     if (false !== getenv('PHP_CS_FIXER_IGNORE_ENV')) {
         fwrite(STDERR, "Setting PHP_CS_FIXER_IGNORE_ENV environment variable is deprecated and will be removed in 4.0, use unsupportedPhpVersionAllowed config instead.\n");
     }

--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -35,19 +35,11 @@ set_error_handler(static function (int $severity, string $message, string $file,
         exit(1);
     }
 
-    if (\PHP_VERSION_ID < (int) '70400' || \PHP_VERSION_ID >= (int) '80400') {
-        fwrite(STDERR, "PHP needs to be a minimum version of PHP 7.4.0 and maximum version of PHP 8.3.*.\n");
+    if (\PHP_VERSION_ID < (int) '70400') {
+        fwrite(STDERR, "PHP needs to be a minimum version of PHP 7.4.0.\n");
         fwrite(STDERR, 'Current PHP version: '.PHP_VERSION.".\n");
 
-        if (filter_var(getenv('PHP_CS_FIXER_IGNORE_ENV'), FILTER_VALIDATE_BOOLEAN)) {
-            fwrite(STDERR, "Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Execution may be unstable.\n");
-        } else {
-            fwrite(STDERR, "To ignore this requirement please set `PHP_CS_FIXER_IGNORE_ENV`.\n");
-            fwrite(STDERR, "If you use PHP version higher than supported, you may experience code modified in a wrong way.\n");
-            fwrite(STDERR, "Please report such cases at https://github.com/PHP-CS-Fixer/PHP-CS-Fixer .\n");
-
-            exit(1);
-        }
+        exit(1);
     }
 
     foreach (['json', 'tokenizer'] as $extension) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -23,7 +23,7 @@ use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
  * @author Katsuhiro Ogawa <ko.fivestar@gmail.com>
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-class Config implements ConfigInterface, ParallelAwareConfigInterface, FailOnUnsupportedVersionConfigInterface
+class Config implements ConfigInterface, ParallelAwareConfigInterface, UnsupportedPhpVersionAllowedConfigInterface
 {
     /**
      * @var non-empty-string
@@ -71,7 +71,7 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, FailOnUns
 
     private bool $usingCache = true;
 
-    private bool $failOnUnsupportedVersion = true;
+    private bool $isUnsupportedPhpVersionAllowed = false;
 
     public function __construct(string $name = 'default')
     {
@@ -95,7 +95,7 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, FailOnUns
 
         // @TODO 4.0 cleanup
         if (false !== getenv('PHP_CS_FIXER_IGNORE_ENV')) {
-            $this->failOnUnsupportedVersion = false === filter_var(getenv('PHP_CS_FIXER_IGNORE_ENV'), FILTER_VALIDATE_BOOL);
+            $this->isUnsupportedPhpVersionAllowed = filter_var(getenv('PHP_CS_FIXER_IGNORE_ENV'), FILTER_VALIDATE_BOOL);
         }
     }
 
@@ -172,9 +172,9 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, FailOnUns
         return $this->usingCache;
     }
 
-    public function getFailOnUnsupportedVersion(): bool
+    public function getUnsupportedPhpVersionAllowed(): bool
     {
-        return $this->failOnUnsupportedVersion;
+        return $this->isUnsupportedPhpVersionAllowed;
     }
 
     public function registerCustomFixers(iterable $fixers): ConfigInterface
@@ -272,9 +272,9 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, FailOnUns
         return $this;
     }
 
-    public function setFailOnUnsupportedVersion(bool $failOnUnsupportedVersion): ConfigInterface
+    public function setUnsupportedPhpVersionAllowed(bool $isUnsupportedPhpVersionAllowed): ConfigInterface
     {
-        $this->failOnUnsupportedVersion = $failOnUnsupportedVersion;
+        $this->isUnsupportedPhpVersionAllowed = $isUnsupportedPhpVersionAllowed;
 
         return $this;
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -71,6 +71,8 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface
 
     private bool $usingCache = true;
 
+    private bool $failOnUnsupportedVersion = false;
+
     public function __construct(string $name = 'default')
     {
         // @TODO 4.0 cleanup
@@ -89,6 +91,11 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface
             $this->parallelConfig = ParallelConfigFactory::detect();
         } else {
             $this->parallelConfig = ParallelConfigFactory::sequential();
+        }
+
+        // @TODO 4.0 cleanup
+        if (false !== getenv('PHP_CS_FIXER_IGNORE_ENV')) {
+            $this->failOnUnsupportedVersion = false === filter_var(getenv('PHP_CS_FIXER_IGNORE_ENV'), FILTER_VALIDATE_BOOL);
         }
     }
 
@@ -163,6 +170,11 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface
     public function getUsingCache(): bool
     {
         return $this->usingCache;
+    }
+
+    public function getFailOnUnsupportedVersion(): bool
+    {
+        return $this->failOnUnsupportedVersion;
     }
 
     public function registerCustomFixers(iterable $fixers): ConfigInterface
@@ -256,6 +268,13 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface
     public function setUsingCache(bool $usingCache): ConfigInterface
     {
         $this->usingCache = $usingCache;
+
+        return $this;
+    }
+
+    public function setFailOnUnsupportedVersion(bool $failOnUnsupportedVersion): ConfigInterface
+    {
+        $this->failOnUnsupportedVersion = $failOnUnsupportedVersion;
 
         return $this;
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -23,7 +23,7 @@ use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
  * @author Katsuhiro Ogawa <ko.fivestar@gmail.com>
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-class Config implements ConfigInterface, ParallelAwareConfigInterface
+class Config implements ConfigInterface, ParallelAwareConfigInterface, FailOnUnsupportedVersionConfigInterface
 {
     /**
      * @var non-empty-string
@@ -71,7 +71,7 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface
 
     private bool $usingCache = true;
 
-    private bool $failOnUnsupportedVersion = false;
+    private bool $failOnUnsupportedVersion = true;
 
     public function __construct(string $name = 'default')
     {

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -22,6 +22,7 @@ use PhpCsFixer\Fixer\FixerInterface;
  */
 interface ConfigInterface
 {
+    /** @internal */
     public const PHP_VERSION_SYNTAX_SUPPORTED = '8.3';
 
     /**

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -100,11 +100,6 @@ interface ConfigInterface
     public function getUsingCache(): bool;
 
     /**
-     * Returns true if execution should fail on unsupported PHP version.
-     */
-    public function getFailOnUnsupportedVersion(): bool;
-
-    /**
      * Adds a suite of custom fixers.
      *
      * Name of custom fixer should follow `VendorName/rule_name` convention.
@@ -166,6 +161,4 @@ interface ConfigInterface
     public function setRules(array $rules): self;
 
     public function setUsingCache(bool $usingCache): self;
-
-    public function setFailOnUnsupportedVersion(bool $failOnUnsupportedVersion): self;
 }

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -22,6 +22,8 @@ use PhpCsFixer\Fixer\FixerInterface;
  */
 interface ConfigInterface
 {
+    public const PHP_VERSION_SYNTAX_SUPPORTED = '8.3';
+
     /**
      * Returns the path to the cache file.
      *
@@ -98,6 +100,11 @@ interface ConfigInterface
     public function getUsingCache(): bool;
 
     /**
+     * Returns true if execution should fail on unsupported PHP version.
+     */
+    public function getFailOnUnsupportedVersion(): bool;
+
+    /**
      * Adds a suite of custom fixers.
      *
      * Name of custom fixer should follow `VendorName/rule_name` convention.
@@ -159,4 +166,6 @@ interface ConfigInterface
     public function setRules(array $rules): self;
 
     public function setUsingCache(bool $usingCache): self;
+
+    public function setFailOnUnsupportedVersion(bool $failOnUnsupportedVersion): self;
 }

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -25,7 +25,6 @@ use PhpCsFixer\Console\Output\Progress\ProgressOutputFactory;
 use PhpCsFixer\Console\Output\Progress\ProgressOutputType;
 use PhpCsFixer\Console\Report\FixReport\ReportSummary;
 use PhpCsFixer\Error\ErrorsManager;
-use PhpCsFixer\FailOnUnsupportedVersionConfigInterface;
 use PhpCsFixer\Runner\Event\FileProcessed;
 use PhpCsFixer\Runner\Runner;
 use PhpCsFixer\ToolInfoInterface;
@@ -213,6 +212,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
                 new InputOption('dry-run', '', InputOption::VALUE_NONE, 'Only shows which files would have been modified.'),
                 new InputOption('rules', '', InputOption::VALUE_REQUIRED, 'List of rules that should be run against configured paths.'),
                 new InputOption('using-cache', '', InputOption::VALUE_REQUIRED, 'Should cache be used (can be `yes` or `no`).'),
+                new InputOption('fail-on-unsupported-version', '', InputOption::VALUE_REQUIRED, 'Should the command refuse to run on unsupported PHP version (can be `yes` or `no`).'),
                 new InputOption('cache-file', '', InputOption::VALUE_REQUIRED, 'The path to the cache file.'),
                 new InputOption('diff', '', InputOption::VALUE_NONE, 'Prints diff for each file.'),
                 new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats.'),
@@ -244,6 +244,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
                 'path' => $input->getArgument('path'),
                 'path-mode' => $input->getOption('path-mode'),
                 'using-cache' => $input->getOption('using-cache'),
+                'fail-on-unsupported-version' => $input->getOption('fail-on-unsupported-version'),
                 'cache-file' => $input->getOption('cache-file'),
                 'format' => $input->getOption('format'),
                 'diff' => $input->getOption('diff'),
@@ -272,8 +273,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
                     PHP_VERSION
                 );
 
-                $config = $resolver->getConfig();
-                if ($config instanceof FailOnUnsupportedVersionConfigInterface && $config->getFailOnUnsupportedVersion()) {
+                if ($resolver->getFailOnUnsupportedVersion()) {
                     $message .= ' Add Config::setFailOnUnsupportedVersion(false) to turn this into a warning.';
                     $stdErr->writeln(\sprintf(
                         $stdErr->isDecorated() ? '<bg=red;fg=white;>%s</>' : '%s',

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -274,7 +274,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
                 );
 
                 if (!$resolver->getUnsupportedPhpVersionAllowed()) {
-                    $message .= ' Add Config::setUnsupportedPhpVersionAllowed(true) to to allow executions on unsupported PHP versions. Such execution may be unstable and you may experience code modified in a wrong way.';
+                    $message .= ' Add Config::setUnsupportedPhpVersionAllowed(true) to allow executions on unsupported PHP versions. Such execution may be unstable and you may experience code modified in a wrong way.';
                     $stdErr->writeln(\sprintf(
                         $stdErr->isDecorated() ? '<bg=red;fg=white;>%s</>' : '%s',
                         $message

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -264,7 +264,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
         if (null !== $stdErr) {
             $stdErr->writeln(Application::getAboutWithRuntime(true));
 
-            if (version_compare(PHP_VERSION, ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED, '>')) {
+            if (version_compare(PHP_VERSION, ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED.'.99', '>')) {
                 $message = \sprintf(
                     'PHP CS Fixer currently supports PHP syntax only up to PHP %s, current PHP version: %s. Use at your own risk.',
                     ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED,

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -268,7 +268,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
             if (version_compare(PHP_VERSION, ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED.'.99', '>')) {
                 $message = \sprintf(
-                    'PHP CS Fixer currently supports PHP syntax only up to PHP %s, current PHP version: %s. Use at your own risk.',
+                    'PHP CS Fixer currently supports PHP syntax only up to PHP %s, current PHP version: %s. Execution may be unstable. You may experience code modified in a wrong way. Please report such cases at https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.',
                     ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED,
                     PHP_VERSION
                 );

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -268,13 +268,13 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
             if (version_compare(PHP_VERSION, ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED.'.99', '>')) {
                 $message = \sprintf(
-                    'PHP CS Fixer currently supports PHP syntax only up to PHP %s, current PHP version: %s. Execution may be unstable. You may experience code modified in a wrong way. Please report such cases at https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.',
+                    'PHP CS Fixer currently supports PHP syntax only up to PHP %s, current PHP version: %s.',
                     ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED,
                     PHP_VERSION
                 );
 
                 if (!$resolver->getUnsupportedPhpVersionAllowed()) {
-                    $message .= ' Add Config::setUnsupportedPhpVersionAllowed(true) to turn this into a warning.';
+                    $message .= ' Add Config::setUnsupportedPhpVersionAllowed(true) to to allow executions on unsupported PHP versions. Such execution may be unstable and you may experience code modified in a wrong way.';
                     $stdErr->writeln(\sprintf(
                         $stdErr->isDecorated() ? '<bg=red;fg=white;>%s</>' : '%s',
                         $message
@@ -282,7 +282,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
                     return 1;
                 }
-                $message .= ' Remove Config::setUnsupportedPhpVersionAllowed(true) to turn this into an error.';
+                $message .= ' Execution may be unstable. You may experience code modified in a wrong way. Please report such cases at https://github.com/PHP-CS-Fixer/PHP-CS-Fixer. Remove Config::setUnsupportedPhpVersionAllowed(true) to allow executions only on supported PHP versions.';
                 $stdErr->writeln(\sprintf(
                     $stdErr->isDecorated() ? '<bg=yellow;fg=black;>%s</>' : '%s',
                     $message

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -25,6 +25,7 @@ use PhpCsFixer\Console\Output\Progress\ProgressOutputFactory;
 use PhpCsFixer\Console\Output\Progress\ProgressOutputType;
 use PhpCsFixer\Console\Report\FixReport\ReportSummary;
 use PhpCsFixer\Error\ErrorsManager;
+use PhpCsFixer\FailOnUnsupportedVersionConfigInterface;
 use PhpCsFixer\Runner\Event\FileProcessed;
 use PhpCsFixer\Runner\Runner;
 use PhpCsFixer\ToolInfoInterface;
@@ -271,8 +272,9 @@ use Symfony\Component\Stopwatch\Stopwatch;
                     PHP_VERSION
                 );
 
-                if ($resolver->getConfig()->getFailOnUnsupportedVersion()) {
-                    $message .= ' Remove Config::setFailOnUnsupportedVersion(true) to turn this into a warning.';
+                $config = $resolver->getConfig();
+                if ($config instanceof FailOnUnsupportedVersionConfigInterface && $config->getFailOnUnsupportedVersion()) {
+                    $message .= ' Add Config::setFailOnUnsupportedVersion(false) to turn this into a warning.';
                     $stdErr->writeln(\sprintf(
                         $stdErr->isDecorated() ? '<bg=red;fg=white;>%s</>' : '%s',
                         $message
@@ -280,7 +282,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
                     return 1;
                 }
-                $message .= ' Add Config::setFailOnUnsupportedVersion(true) to turn this into an error.';
+                $message .= ' Remove Config::setFailOnUnsupportedVersion(false) to turn this into an error.';
                 $stdErr->writeln(\sprintf(
                     $stdErr->isDecorated() ? '<bg=yellow;fg=black;>%s</>' : '%s',
                     $message

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -263,6 +263,30 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
         if (null !== $stdErr) {
             $stdErr->writeln(Application::getAboutWithRuntime(true));
+
+            if (version_compare(PHP_VERSION, ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED, '>')) {
+                $message = \sprintf(
+                    'PHP CS Fixer currently supports PHP syntax only up to PHP %s, current PHP version: %s. Use at your own risk.',
+                    ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED,
+                    PHP_VERSION
+                );
+
+                if ($resolver->getConfig()->getFailOnUnsupportedVersion()) {
+                    $message .= ' Remove Config::setFailOnUnsupportedVersion(true) to turn this into a warning.';
+                    $stdErr->writeln(\sprintf(
+                        $stdErr->isDecorated() ? '<bg=red;fg=white;>%s</>' : '%s',
+                        $message
+                    ));
+
+                    return 1;
+                }
+                $message .= ' Add Config::setFailOnUnsupportedVersion(true) to turn this into an error.';
+                $stdErr->writeln(\sprintf(
+                    $stdErr->isDecorated() ? '<bg=yellow;fg=black;>%s</>' : '%s',
+                    $message
+                ));
+            }
+
             $isParallel = $resolver->getParallelConfig()->getMaxProcesses() > 1;
 
             $stdErr->writeln(\sprintf(

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -212,7 +212,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
                 new InputOption('dry-run', '', InputOption::VALUE_NONE, 'Only shows which files would have been modified.'),
                 new InputOption('rules', '', InputOption::VALUE_REQUIRED, 'List of rules that should be run against configured paths.'),
                 new InputOption('using-cache', '', InputOption::VALUE_REQUIRED, 'Should cache be used (can be `yes` or `no`).'),
-                new InputOption('fail-on-unsupported-version', '', InputOption::VALUE_REQUIRED, 'Should the command refuse to run on unsupported PHP version (can be `yes` or `no`).'),
+                new InputOption('allow-unsupported-php-version', '', InputOption::VALUE_REQUIRED, 'Should the command refuse to run on unsupported PHP version (can be `yes` or `no`).'),
                 new InputOption('cache-file', '', InputOption::VALUE_REQUIRED, 'The path to the cache file.'),
                 new InputOption('diff', '', InputOption::VALUE_NONE, 'Prints diff for each file.'),
                 new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats.'),
@@ -244,7 +244,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
                 'path' => $input->getArgument('path'),
                 'path-mode' => $input->getOption('path-mode'),
                 'using-cache' => $input->getOption('using-cache'),
-                'fail-on-unsupported-version' => $input->getOption('fail-on-unsupported-version'),
+                'allow-unsupported-php-version' => $input->getOption('allow-unsupported-php-version'),
                 'cache-file' => $input->getOption('cache-file'),
                 'format' => $input->getOption('format'),
                 'diff' => $input->getOption('diff'),
@@ -273,8 +273,8 @@ use Symfony\Component\Stopwatch\Stopwatch;
                     PHP_VERSION
                 );
 
-                if ($resolver->getFailOnUnsupportedVersion()) {
-                    $message .= ' Add Config::setFailOnUnsupportedVersion(false) to turn this into a warning.';
+                if (!$resolver->getUnsupportedPhpVersionAllowed()) {
+                    $message .= ' Add Config::setUnsupportedPhpVersionAllowed(true) to turn this into a warning.';
                     $stdErr->writeln(\sprintf(
                         $stdErr->isDecorated() ? '<bg=red;fg=white;>%s</>' : '%s',
                         $message
@@ -282,7 +282,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
                     return 1;
                 }
-                $message .= ' Remove Config::setFailOnUnsupportedVersion(false) to turn this into an error.';
+                $message .= ' Remove Config::setUnsupportedPhpVersionAllowed(true) to turn this into an error.';
                 $stdErr->writeln(\sprintf(
                     $stdErr->isDecorated() ? '<bg=yellow;fg=black;>%s</>' : '%s',
                     $message

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -72,6 +72,7 @@ use Symfony\Component\Finder\Finder as SymfonyFinder;
  *      show-progress: null|string,
  *      stop-on-violation: null|bool,
  *      using-cache: null|string,
+ *      fail-on-unsupported-version: null|bool,
  *      verbosity: null|string,
  *  }
  */

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -480,8 +480,10 @@ final class ConfigurationResolver
     {
         if (null === $this->isUnsupportedPhpVersionAllowed) {
             $config = $this->getConfig();
-            if (null === $this->options['allow-unsupported-php-version'] && $config instanceof UnsupportedPhpVersionAllowedConfigInterface) {
-                $this->isUnsupportedPhpVersionAllowed = $config->getUnsupportedPhpVersionAllowed();
+            if (null === $this->options['allow-unsupported-php-version']) {
+                $this->isUnsupportedPhpVersionAllowed = $config instanceof UnsupportedPhpVersionAllowedConfigInterface
+                    ? $config->getUnsupportedPhpVersionAllowed()
+                    : false;
             } else {
                 $this->isUnsupportedPhpVersionAllowed = $this->resolveOptionBooleanValue('allow-unsupported-php-version');
             }

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -479,8 +479,8 @@ final class ConfigurationResolver
     public function getUnsupportedPhpVersionAllowed(): bool
     {
         if (null === $this->isUnsupportedPhpVersionAllowed) {
-            $config = $this->getConfig();
             if (null === $this->options['allow-unsupported-php-version']) {
+                $config = $this->getConfig();
                 $this->isUnsupportedPhpVersionAllowed = $config instanceof UnsupportedPhpVersionAllowedConfigInterface
                     ? $config->getUnsupportedPhpVersionAllowed()
                     : false;

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -29,7 +29,6 @@ use PhpCsFixer\Console\Report\FixReport\ReporterInterface;
 use PhpCsFixer\Differ\DifferInterface;
 use PhpCsFixer\Differ\NullDiffer;
 use PhpCsFixer\Differ\UnifiedDiffer;
-use PhpCsFixer\FailOnUnsupportedVersionConfigInterface;
 use PhpCsFixer\Finder;
 use PhpCsFixer\Fixer\DeprecatedFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
@@ -43,6 +42,7 @@ use PhpCsFixer\Runner\Parallel\ParallelConfig;
 use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 use PhpCsFixer\StdinFileInfo;
 use PhpCsFixer\ToolInfoInterface;
+use PhpCsFixer\UnsupportedPhpVersionAllowedConfigInterface;
 use PhpCsFixer\Utils;
 use PhpCsFixer\WhitespacesFixerConfig;
 use PhpCsFixer\WordMatcher;
@@ -72,7 +72,7 @@ use Symfony\Component\Finder\Finder as SymfonyFinder;
  *      show-progress: null|string,
  *      stop-on-violation: null|bool,
  *      using-cache: null|string,
- *      fail-on-unsupported-version: null|bool,
+ *      allow-unsupported-php-version: null|bool,
  *      verbosity: null|string,
  *  }
  */
@@ -123,7 +123,7 @@ final class ConfigurationResolver
         'show-progress' => null,
         'stop-on-violation' => null,
         'using-cache' => null,
-        'fail-on-unsupported-version' => null,
+        'allow-unsupported-php-version' => null,
         'verbosity' => null,
     ];
 
@@ -158,7 +158,7 @@ final class ConfigurationResolver
 
     private ?bool $usingCache = null;
 
-    private ?bool $failOnUnsupportedVersion = null;
+    private ?bool $isUnsupportedPhpVersionAllowed = null;
 
     private ?FixerFactory $fixerFactory = null;
 
@@ -476,18 +476,18 @@ final class ConfigurationResolver
         return $this->usingCache;
     }
 
-    public function getFailOnUnsupportedVersion(): bool
+    public function getUnsupportedPhpVersionAllowed(): bool
     {
-        if (null === $this->failOnUnsupportedVersion) {
+        if (null === $this->isUnsupportedPhpVersionAllowed) {
             $config = $this->getConfig();
-            if (null === $this->options['fail-on-unsupported-version'] && $config instanceof FailOnUnsupportedVersionConfigInterface) {
-                $this->failOnUnsupportedVersion = $config->getFailOnUnsupportedVersion();
+            if (null === $this->options['allow-unsupported-php-version'] && $config instanceof UnsupportedPhpVersionAllowedConfigInterface) {
+                $this->isUnsupportedPhpVersionAllowed = $config->getUnsupportedPhpVersionAllowed();
             } else {
-                $this->failOnUnsupportedVersion = $this->resolveOptionBooleanValue('fail-on-unsupported-version');
+                $this->isUnsupportedPhpVersionAllowed = $this->resolveOptionBooleanValue('allow-unsupported-php-version');
             }
         }
 
-        return $this->failOnUnsupportedVersion;
+        return $this->isUnsupportedPhpVersionAllowed;
     }
 
     /**

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -29,6 +29,7 @@ use PhpCsFixer\Console\Report\FixReport\ReporterInterface;
 use PhpCsFixer\Differ\DifferInterface;
 use PhpCsFixer\Differ\NullDiffer;
 use PhpCsFixer\Differ\UnifiedDiffer;
+use PhpCsFixer\FailOnUnsupportedVersionConfigInterface;
 use PhpCsFixer\Finder;
 use PhpCsFixer\Fixer\DeprecatedFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
@@ -121,6 +122,7 @@ final class ConfigurationResolver
         'show-progress' => null,
         'stop-on-violation' => null,
         'using-cache' => null,
+        'fail-on-unsupported-version' => null,
         'verbosity' => null,
     ];
 
@@ -154,6 +156,8 @@ final class ConfigurationResolver
     private ?RuleSet $ruleSet = null;
 
     private ?bool $usingCache = null;
+
+    private ?bool $failOnUnsupportedVersion = null;
 
     private ?FixerFactory $fixerFactory = null;
 
@@ -469,6 +473,20 @@ final class ConfigurationResolver
         $this->usingCache = $this->usingCache && $this->isCachingAllowedForRuntime();
 
         return $this->usingCache;
+    }
+
+    public function getFailOnUnsupportedVersion(): bool
+    {
+        if (null === $this->failOnUnsupportedVersion) {
+            $config = $this->getConfig();
+            if (null === $this->options['fail-on-unsupported-version'] && $config instanceof FailOnUnsupportedVersionConfigInterface) {
+                $this->failOnUnsupportedVersion = $config->getFailOnUnsupportedVersion();
+            } else {
+                $this->failOnUnsupportedVersion = $this->resolveOptionBooleanValue('fail-on-unsupported-version');
+            }
+        }
+
+        return $this->failOnUnsupportedVersion;
     }
 
     /**

--- a/src/FailOnUnsupportedVersionConfigInterface.php
+++ b/src/FailOnUnsupportedVersionConfigInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer;
+
+/**
+ * @TODO 4.0 Include parallel runner config in main ConfigInterface
+ */
+interface FailOnUnsupportedVersionConfigInterface extends ConfigInterface
+{
+    /**
+     * Returns true if execution should fail on unsupported PHP version.
+     */
+    public function getFailOnUnsupportedVersion(): bool;
+
+    public function setFailOnUnsupportedVersion(bool $failOnUnsupportedVersion): ConfigInterface;
+}

--- a/src/FailOnUnsupportedVersionConfigInterface.php
+++ b/src/FailOnUnsupportedVersionConfigInterface.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 namespace PhpCsFixer;
 
 /**
- * @TODO 4.0 Include parallel runner config in main ConfigInterface
+ * @TODO 4.0 Include in main ConfigInterface
  */
 interface FailOnUnsupportedVersionConfigInterface extends ConfigInterface
 {

--- a/src/UnsupportedPhpVersionAllowedConfigInterface.php
+++ b/src/UnsupportedPhpVersionAllowedConfigInterface.php
@@ -17,12 +17,12 @@ namespace PhpCsFixer;
 /**
  * @TODO 4.0 Include in main ConfigInterface
  */
-interface FailOnUnsupportedVersionConfigInterface extends ConfigInterface
+interface UnsupportedPhpVersionAllowedConfigInterface extends ConfigInterface
 {
     /**
      * Returns true if execution should fail on unsupported PHP version.
      */
-    public function getFailOnUnsupportedVersion(): bool;
+    public function getUnsupportedPhpVersionAllowed(): bool;
 
-    public function setFailOnUnsupportedVersion(bool $failOnUnsupportedVersion): ConfigInterface;
+    public function setUnsupportedPhpVersionAllowed(bool $isUnsupportedPhpVersionAllowed): ConfigInterface;
 }

--- a/src/UnsupportedPhpVersionAllowedConfigInterface.php
+++ b/src/UnsupportedPhpVersionAllowedConfigInterface.php
@@ -20,7 +20,7 @@ namespace PhpCsFixer;
 interface UnsupportedPhpVersionAllowedConfigInterface extends ConfigInterface
 {
     /**
-     * Returns true if execution should fail on unsupported PHP version.
+     * Returns true if execution should be allowed on unsupported PHP version whose syntax is not yet supported by the fixer.
      */
     public function getUnsupportedPhpVersionAllowed(): bool;
 

--- a/tests/AutoReview/BinEntryFileTest.php
+++ b/tests/AutoReview/BinEntryFileTest.php
@@ -44,7 +44,7 @@ final class BinEntryFileTest extends TestCase
 
         self::assertEqualsCanonicalizing([
             '    if (\PHP_VERSION_ID === (int) \'80000\') { // TODO use 8_00_00 once only PHP 7.4+ is supported by this entry file'."\n",
-            '    if (\PHP_VERSION_ID < (int) \'70400\' || \PHP_VERSION_ID >= (int) \'80400\') {'."\n",
+            '    if (\PHP_VERSION_ID < (int) \'70400\') {'."\n",
         ], $phpVersionIdLines, 'Seems supported PHP versions changed in "./php-cs-fixer" - edit the README.md (and this test file) to match them!');
     }
 }

--- a/tests/AutoReview/CiConfigurationTest.php
+++ b/tests/AutoReview/CiConfigurationTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\AutoReview;
 
+use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\Preg;
 use PhpCsFixer\Tests\TestCase;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -210,21 +211,7 @@ final class CiConfigurationTest extends TestCase
 
     private function getMaxPhpVersionFromEntryFile(): string
     {
-        $tokens = Tokens::fromCode((string) file_get_contents(__DIR__.'/../../php-cs-fixer'));
-        $sequence = $tokens->findSequence([
-            [T_STRING, 'PHP_VERSION_ID'],
-            [T_IS_GREATER_OR_EQUAL],
-            [T_INT_CAST],
-            [T_CONSTANT_ENCAPSED_STRING],
-        ]);
-
-        if (null === $sequence) {
-            throw new \LogicException("Can't find version - perhaps entry file was modified?");
-        }
-
-        $phpVerId = trim(end($sequence)->getContent(), '\'');
-
-        return $this->convertPhpVerIdToNiceVer((string) ((int) $phpVerId - 100));
+        return ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED;
     }
 
     private function getMinPhpVersionFromEntryFile(): string

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -141,11 +141,6 @@ final class FixCommandTest extends TestCase
         self::assertSame(8, $cmdTester->getStatusCode());
     }
 
-    /**
-     * @requires PHP 8.4
-     *
-     * @covers \PhpCsFixer\Console\Command\FixCommand
-     */
     public function testUnsupportedVersionWarningRun(): void
     {
         if (\PHP_VERSION_ID < 80_400) {
@@ -174,11 +169,6 @@ final class FixCommandTest extends TestCase
         self::assertStringContainsString('Add Config::setFailOnUnsupportedVersion(true) to turn this into an error.', $cmdTester->getDisplay());
     }
 
-    /**
-     * @requires PHP 8.4
-     *
-     * @covers \PhpCsFixer\Console\Command\FixCommand
-     */
     public function testUnsupportedVersionErrorRun(): void
     {
         if (\PHP_VERSION_ID < 80_400) {

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -167,7 +167,6 @@ final class FixCommandTest extends TestCase
 
         self::assertStringContainsString('PHP CS Fixer currently supports PHP syntax only up to PHP '.ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED, $cmdTester->getDisplay());
         self::assertStringContainsString('Add Config::setFailOnUnsupportedVersion(true) to turn this into an error.', $cmdTester->getDisplay());
-        self::assertSame(0, $cmdTester->getStatusCode());
     }
 
     public function testUnsupportedVersionErrorRun(): void

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -143,7 +143,7 @@ final class FixCommandTest extends TestCase
 
     public function testUnsupportedVersionWarningRun(): void
     {
-        if (version_compare(PHP_VERSION, ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED .'.99', '<=')) {
+        if (version_compare(PHP_VERSION, ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED.'.99', '<=')) {
             self::markTestSkipped('This test requires version of PHP higher than '.ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED);
         }
 
@@ -171,7 +171,7 @@ final class FixCommandTest extends TestCase
 
     public function testUnsupportedVersionErrorRun(): void
     {
-        if (version_compare(PHP_VERSION, ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED .'.99', '<=')) {
+        if (version_compare(PHP_VERSION, ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED.'.99', '<=')) {
             self::markTestSkipped('This test requires version of PHP higher than '.ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED);
         }
 

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Console\Command;
 
+use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
 use PhpCsFixer\Console\Application;
 use PhpCsFixer\Console\Command\FixCommand;
@@ -138,6 +139,65 @@ final class FixCommandTest extends TestCase
         self::assertStringContainsString('Parallel runner is an experimental feature and may be unstable, use it at your own risk. Feedback highly appreciated!', $cmdTester->getDisplay());
         self::assertStringContainsString('(header_comment)', $cmdTester->getDisplay());
         self::assertSame(8, $cmdTester->getStatusCode());
+    }
+
+    public function testUnsupportedVersionWarningRun(): void
+    {
+        if (\PHP_VERSION_ID < 80_400) {
+            self::markTestSkipped('This test requires PHP 8.4 or higher.');
+        }
+
+        $pathToDistConfig = __DIR__.'/../../../.php-cs-fixer.dist.php';
+        $configWithFixedParallelConfig = <<<PHP
+            <?php
+
+            \$config = require '{$pathToDistConfig}';
+
+            return \$config;
+            PHP;
+        $tmpFile = tempnam(sys_get_temp_dir(), 'php-cs-fixer-parallel-config-').'.php';
+        file_put_contents($tmpFile, $configWithFixedParallelConfig);
+
+        $cmdTester = $this->doTestExecute(
+            [
+                '--config' => $tmpFile,
+                'path' => [__DIR__],
+            ]
+        );
+
+        self::assertStringContainsString('PHP CS Fixer currently supports PHP syntax only up to PHP '.ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED, $cmdTester->getDisplay());
+        self::assertStringContainsString('Add Config::setFailOnUnsupportedVersion(true) to turn this into an error.', $cmdTester->getDisplay());
+        self::assertSame(0, $cmdTester->getStatusCode());
+    }
+
+    public function testUnsupportedVersionErrorRun(): void
+    {
+        if (\PHP_VERSION_ID < 80_400) {
+            self::markTestSkipped('This test requires PHP 8.4 or higher.');
+        }
+
+        $pathToDistConfig = __DIR__.'/../../../.php-cs-fixer.dist.php';
+        $configWithFixedParallelConfig = <<<PHP
+            <?php
+
+            \$config = require '{$pathToDistConfig}';
+            \$config->setFailOnUnsupportedVersion(true);
+
+            return \$config;
+            PHP;
+        $tmpFile = tempnam(sys_get_temp_dir(), 'php-cs-fixer-parallel-config-').'.php';
+        file_put_contents($tmpFile, $configWithFixedParallelConfig);
+
+        $cmdTester = $this->doTestExecute(
+            [
+                '--config' => $tmpFile,
+                'path' => [__DIR__],
+            ]
+        );
+
+        self::assertStringContainsString('PHP CS Fixer currently supports PHP syntax only up to PHP '.ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED, $cmdTester->getDisplay());
+        self::assertStringContainsString('Remove Config::setFailOnUnsupportedVersion(true) to turn this into a warning.', $cmdTester->getDisplay());
+        self::assertSame(1, $cmdTester->getStatusCode());
     }
 
     /**

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -152,6 +152,7 @@ final class FixCommandTest extends TestCase
             <?php
 
             \$config = require '{$pathToDistConfig}';
+            \$config->setFailOnUnsupportedVersion(false);
 
             return \$config;
             PHP;
@@ -166,7 +167,7 @@ final class FixCommandTest extends TestCase
         );
 
         self::assertStringContainsString('PHP CS Fixer currently supports PHP syntax only up to PHP '.ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED, $cmdTester->getDisplay());
-        self::assertStringContainsString('Add Config::setFailOnUnsupportedVersion(true) to turn this into an error.', $cmdTester->getDisplay());
+        self::assertStringContainsString('Remove Config::setFailOnUnsupportedVersion(false) to turn this into an error.', $cmdTester->getDisplay());
     }
 
     public function testUnsupportedVersionErrorRun(): void
@@ -180,7 +181,6 @@ final class FixCommandTest extends TestCase
             <?php
 
             \$config = require '{$pathToDistConfig}';
-            \$config->setFailOnUnsupportedVersion(true);
 
             return \$config;
             PHP;
@@ -195,7 +195,7 @@ final class FixCommandTest extends TestCase
         );
 
         self::assertStringContainsString('PHP CS Fixer currently supports PHP syntax only up to PHP '.ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED, $cmdTester->getDisplay());
-        self::assertStringContainsString('Remove Config::setFailOnUnsupportedVersion(true) to turn this into a warning.', $cmdTester->getDisplay());
+        self::assertStringContainsString('Add Config::setFailOnUnsupportedVersion(false) to turn this into a warning.', $cmdTester->getDisplay());
         self::assertSame(1, $cmdTester->getStatusCode());
     }
 

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -170,7 +170,7 @@ final class FixCommandTest extends TestCase
         );
 
         self::assertStringContainsString('PHP CS Fixer currently supports PHP syntax only up to PHP '.ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED, $cmdTester->getDisplay());
-        self::assertStringContainsString('Remove Config::setUnsupportedPhpVersionAllowed(true) to turn this into an error.', $cmdTester->getDisplay());
+        self::assertStringContainsString('Execution may be unstable. You may experience code modified in a wrong way.', $cmdTester->getDisplay());
     }
 
     public function testUnsupportedVersionErrorRun(): void
@@ -199,7 +199,7 @@ final class FixCommandTest extends TestCase
         );
 
         self::assertStringContainsString('PHP CS Fixer currently supports PHP syntax only up to PHP '.ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED, $cmdTester->getDisplay());
-        self::assertStringContainsString('Add Config::setUnsupportedPhpVersionAllowed(true) to turn this into a warning.', $cmdTester->getDisplay());
+        self::assertStringContainsString('Add Config::setUnsupportedPhpVersionAllowed(true) to allow executions on unsupported PHP versions.', $cmdTester->getDisplay());
         self::assertSame(1, $cmdTester->getStatusCode());
     }
 

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -143,8 +143,8 @@ final class FixCommandTest extends TestCase
 
     public function testUnsupportedVersionWarningRun(): void
     {
-        if (\PHP_VERSION_ID < 80_400) {
-            self::markTestSkipped('This test requires PHP 8.4 or higher.');
+        if (version_compare(PHP_VERSION, ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED .'.99', '<=')) {
+            self::markTestSkipped('This test requires version of PHP higher than '.ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED);
         }
 
         $pathToDistConfig = __DIR__.'/../../../.php-cs-fixer.dist.php';
@@ -171,8 +171,8 @@ final class FixCommandTest extends TestCase
 
     public function testUnsupportedVersionErrorRun(): void
     {
-        if (\PHP_VERSION_ID < 80_400) {
-            self::markTestSkipped('This test requires PHP 8.4 or higher.');
+        if (version_compare(PHP_VERSION, ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED .'.99', '<=')) {
+            self::markTestSkipped('This test requires version of PHP higher than '.ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED);
         }
 
         $pathToDistConfig = __DIR__.'/../../../.php-cs-fixer.dist.php';

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -141,6 +141,9 @@ final class FixCommandTest extends TestCase
         self::assertSame(8, $cmdTester->getStatusCode());
     }
 
+    /**
+     * @large
+     */
     public function testUnsupportedVersionWarningRun(): void
     {
         if (version_compare(PHP_VERSION, ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED.'.99', '<=')) {

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -152,7 +152,7 @@ final class FixCommandTest extends TestCase
             <?php
 
             \$config = require '{$pathToDistConfig}';
-            \$config->setFailOnUnsupportedVersion(false);
+            \$config->setUnsupportedPhpVersionAllowed(true);
 
             return \$config;
             PHP;
@@ -167,7 +167,7 @@ final class FixCommandTest extends TestCase
         );
 
         self::assertStringContainsString('PHP CS Fixer currently supports PHP syntax only up to PHP '.ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED, $cmdTester->getDisplay());
-        self::assertStringContainsString('Remove Config::setFailOnUnsupportedVersion(false) to turn this into an error.', $cmdTester->getDisplay());
+        self::assertStringContainsString('Remove Config::setUnsupportedPhpVersionAllowed(true) to turn this into an error.', $cmdTester->getDisplay());
     }
 
     public function testUnsupportedVersionErrorRun(): void
@@ -181,7 +181,7 @@ final class FixCommandTest extends TestCase
             <?php
 
             \$config = require '{$pathToDistConfig}';
-            \$config->setFailOnUnsupportedVersion(true);
+            \$config->setUnsupportedPhpVersionAllowed(false);
 
             return \$config;
             PHP;
@@ -196,7 +196,7 @@ final class FixCommandTest extends TestCase
         );
 
         self::assertStringContainsString('PHP CS Fixer currently supports PHP syntax only up to PHP '.ConfigInterface::PHP_VERSION_SYNTAX_SUPPORTED, $cmdTester->getDisplay());
-        self::assertStringContainsString('Add Config::setFailOnUnsupportedVersion(false) to turn this into a warning.', $cmdTester->getDisplay());
+        self::assertStringContainsString('Add Config::setUnsupportedPhpVersionAllowed(true) to turn this into a warning.', $cmdTester->getDisplay());
         self::assertSame(1, $cmdTester->getStatusCode());
     }
 

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -181,6 +181,7 @@ final class FixCommandTest extends TestCase
             <?php
 
             \$config = require '{$pathToDistConfig}';
+            \$config->setFailOnUnsupportedVersion(true);
 
             return \$config;
             PHP;

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -141,6 +141,11 @@ final class FixCommandTest extends TestCase
         self::assertSame(8, $cmdTester->getStatusCode());
     }
 
+    /**
+     * @requires PHP 8.4
+     *
+     * @covers \PhpCsFixer\Console\Command\FixCommand
+     */
     public function testUnsupportedVersionWarningRun(): void
     {
         if (\PHP_VERSION_ID < 80_400) {
@@ -169,6 +174,11 @@ final class FixCommandTest extends TestCase
         self::assertStringContainsString('Add Config::setFailOnUnsupportedVersion(true) to turn this into an error.', $cmdTester->getDisplay());
     }
 
+    /**
+     * @requires PHP 8.4
+     *
+     * @covers \PhpCsFixer\Console\Command\FixCommand
+     */
     public function testUnsupportedVersionErrorRun(): void
     {
         if (\PHP_VERSION_ID < 80_400) {

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1217,7 +1217,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
 
         $options = $definition->getOptions();
         self::assertSame(
-            ['path-mode', 'allow-risky', 'config', 'dry-run', 'rules', 'using-cache', 'cache-file', 'diff', 'format', 'stop-on-violation', 'show-progress', 'sequential'],
+            ['path-mode', 'allow-risky', 'config', 'dry-run', 'rules', 'using-cache', 'fail-on-unsupported-version', 'cache-file', 'diff', 'format', 'stop-on-violation', 'show-progress', 'sequential'],
             array_keys($options),
             'Expected options mismatch, possibly test needs updating.'
         );

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1217,7 +1217,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
 
         $options = $definition->getOptions();
         self::assertSame(
-            ['path-mode', 'allow-risky', 'config', 'dry-run', 'rules', 'using-cache', 'fail-on-unsupported-version', 'cache-file', 'diff', 'format', 'stop-on-violation', 'show-progress', 'sequential'],
+            ['path-mode', 'allow-risky', 'config', 'dry-run', 'rules', 'using-cache', 'allow-unsupported-php-version', 'cache-file', 'diff', 'format', 'stop-on-violation', 'show-progress', 'sequential'],
             array_keys($options),
             'Expected options mismatch, possibly test needs updating.'
         );

--- a/tests/Fixtures/.php-cs-fixer.custom.php
+++ b/tests/Fixtures/.php-cs-fixer.custom.php
@@ -12,6 +12,7 @@
 
 use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\FailOnUnsupportedVersionConfigInterface;
+use PhpCsFixer\UnsupportedPhpVersionAllowedConfigInterface;
 
 /**
  * Custom config class/file for PHPUnit test.
@@ -20,7 +21,7 @@ use PhpCsFixer\FailOnUnsupportedVersionConfigInterface;
  *
  * @internal
  */
-final class CustomConfig implements ConfigInterface, FailOnUnsupportedVersionConfigInterface
+final class CustomConfig implements ConfigInterface, UnsupportedPhpVersionAllowedConfigInterface
 {
     /**
      * {@inheritdoc}
@@ -209,15 +210,15 @@ final class CustomConfig implements ConfigInterface, FailOnUnsupportedVersionCon
     /**
      * {@inheritdoc}
      */
-    public function getFailOnUnsupportedVersion(): bool
+    public function getUnsupportedPhpVersionAllowed(): bool
     {
-        return false;
+        return true;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setFailOnUnsupportedVersion(bool $failOnUnsupportedVersion): ConfigInterface
+    public function setUnsupportedPhpVersionAllowed(bool $isUnsupportedPhpVersionAllowed): ConfigInterface
     {
         return $this;
     }

--- a/tests/Fixtures/.php-cs-fixer.custom.php
+++ b/tests/Fixtures/.php-cs-fixer.custom.php
@@ -120,14 +120,6 @@ final class CustomConfig implements ConfigInterface
     /**
      * {@inheritdoc}
      */
-    public function getFailOnUnsupportedVersion(): bool
-    {
-        return false;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function registerCustomFixers(iterable $fixers): ConfigInterface
     {
         return $this;
@@ -209,14 +201,6 @@ final class CustomConfig implements ConfigInterface
      * {@inheritdoc}
      */
     public function setUsingCache(bool $usingCache): ConfigInterface
-    {
-        return $this;
-    }
-    
-    /**
-     * {@inheritdoc}
-     */
-    public function setFailOnUnsupportedVersion(bool $failOnUnsupportedVersion): ConfigInterface
     {
         return $this;
     }

--- a/tests/Fixtures/.php-cs-fixer.custom.php
+++ b/tests/Fixtures/.php-cs-fixer.custom.php
@@ -120,6 +120,14 @@ final class CustomConfig implements ConfigInterface
     /**
      * {@inheritdoc}
      */
+    public function getFailOnUnsupportedVersion(): bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function registerCustomFixers(iterable $fixers): ConfigInterface
     {
         return $this;
@@ -201,6 +209,14 @@ final class CustomConfig implements ConfigInterface
      * {@inheritdoc}
      */
     public function setUsingCache(bool $usingCache): ConfigInterface
+    {
+        return $this;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function setFailOnUnsupportedVersion(bool $failOnUnsupportedVersion): ConfigInterface
     {
         return $this;
     }

--- a/tests/Fixtures/.php-cs-fixer.custom.php
+++ b/tests/Fixtures/.php-cs-fixer.custom.php
@@ -11,6 +11,7 @@
  */
 
 use PhpCsFixer\ConfigInterface;
+use PhpCsFixer\FailOnUnsupportedVersionConfigInterface;
 
 /**
  * Custom config class/file for PHPUnit test.
@@ -19,7 +20,7 @@ use PhpCsFixer\ConfigInterface;
  *
  * @internal
  */
-final class CustomConfig implements ConfigInterface
+final class CustomConfig implements ConfigInterface, FailOnUnsupportedVersionConfigInterface
 {
     /**
      * {@inheritdoc}
@@ -201,6 +202,22 @@ final class CustomConfig implements ConfigInterface
      * {@inheritdoc}
      */
     public function setUsingCache(bool $usingCache): ConfigInterface
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFailOnUnsupportedVersion(): bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setFailOnUnsupportedVersion(bool $failOnUnsupportedVersion): ConfigInterface
     {
         return $this;
     }


### PR DESCRIPTION
Deprecates PHP_CS_FIXER_IGNORE_ENV

See #8719 and discussion in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8300#issuecomment-2865855890 and onwards.