### PR TITLE
fix: `ProtectedToPrivateFixer` - fix asymmetric visibility with only set visibility

### DIFF
--- a/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
+++ b/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
@@ -66,7 +66,7 @@ final class Sample
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isAnyTokenKindsFound([T_PROTECTED, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED])
+        return $tokens->isAnyTokenKindsFound([T_PROTECTED, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED, FCT::T_PROTECTED_SET])
             && (
                 $tokens->isAllTokenKindsFound([T_CLASS, T_FINAL])
                 || $tokens->isTokenKindFound(FCT::T_ENUM)

--- a/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
+++ b/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
@@ -369,17 +369,24 @@ echo DocumentStats::DRAFT->getStatusName();
      *
      * @requires PHP >= 8.4
      */
-    public function testFix84(string $expected, string $input): void
+    public function testFix84(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
 
     /**
-     * @return iterable<string, array{string, string}>
+     * @return iterable<string, array{string, 1?: string}>
      */
     public static function provideFix84Cases(): iterable
     {
-        yield 'asymmetric visibility' => [
+        yield 'asymmetric visibility with only set visibility' => [
+            '<?php
+            final class Foo {
+                protected(set) int $a;
+            }',
+        ];
+
+        yield 'asymmetric visibility with both visibilities' => [
             '<?php
             final class Foo {
                 public private(set) int $a;

--- a/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
+++ b/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
@@ -369,17 +369,21 @@ echo DocumentStats::DRAFT->getStatusName();
      *
      * @requires PHP >= 8.4
      */
-    public function testFix84(string $expected, ?string $input = null): void
+    public function testFix84(string $expected, string $input): void
     {
         $this->doTest($expected, $input);
     }
 
     /**
-     * @return iterable<string, array{string, 1?: string}>
+     * @return iterable<string, array{string, string}>
      */
     public static function provideFix84Cases(): iterable
     {
         yield 'asymmetric visibility with only set visibility' => [
+            '<?php
+            final class Foo {
+                private(set) int $a;
+            }',
             '<?php
             final class Foo {
                 protected(set) int $a;


### PR DESCRIPTION
Shame on me for not noticing it in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8569.