### PR TITLE
feat: `NoEmptyStatementFixer` - support abstract property hooks

### DIFF
--- a/src/Fixer/Semicolon/NoEmptyStatementFixer.php
+++ b/src/Fixer/Semicolon/NoEmptyStatementFixer.php
@@ -18,6 +18,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
 
@@ -91,6 +92,11 @@ final class NoEmptyStatementFixer extends AbstractFixer
             if ($tokens[$previousMeaningfulIndex]->equals('}')) {
                 $this->fixSemicolonAfterCurlyBraceClose($tokens, $index, $previousMeaningfulIndex);
 
+                continue;
+            }
+
+            $nextIndex = $tokens->getNextMeaningfulToken($index);
+            if (null !== $nextIndex && $tokens[$nextIndex]->isGivenKind(CT::T_PROPERTY_HOOK_BRACE_CLOSE)) {
                 continue;
             }
 

--- a/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
+++ b/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
@@ -665,16 +665,6 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
                 <?php interface I
                 {
                     public bool $a { get; }
-                    public bool $b { get;  }
-                    public bool $c { set; }
-                    public bool $d { set;  }
-                    public bool $e {/* hello1 */set/* hello2 */;/* hello3 *//* hello4 *//* hello5 */}
-                }
-                PHP,
-            <<<'PHP'
-                <?php interface I
-                {
-                    public bool $a { get; }
                     public bool $b { get; set; }
                     public bool $c { set; }
                     public bool $d { set; get; }
@@ -684,14 +674,6 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
         ];
 
         yield 'abstract class with property hooks' => [
-            <<<'PHP'
-                <?php abstract class A
-                {
-                    abstract public bool $a { get;  }
-                    abstract public bool $b { get{}  }
-                    abstract public bool $c { get; set{} }
-                }
-                PHP,
             <<<'PHP'
                 <?php abstract class A
                 {

--- a/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
+++ b/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
@@ -644,4 +644,62 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
             '<?php enum Foo{};',
         ];
     }
+
+    /**
+     * @dataProvider provideFix84Cases
+     *
+     * @requires PHP 8.4
+     */
+    public function testFix84(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string, array{string, 1?: string}>
+     */
+    public static function provideFix84Cases(): iterable
+    {
+        yield 'interface with property hooks' => [
+            <<<'PHP'
+                <?php interface I
+                {
+                    public bool $a { get; }
+                    public bool $b { get;  }
+                    public bool $c { set; }
+                    public bool $d { set;  }
+                    public bool $e {/* hello1 */set/* hello2 */;/* hello3 *//* hello4 *//* hello5 */}
+                }
+                PHP,
+            <<<'PHP'
+                <?php interface I
+                {
+                    public bool $a { get; }
+                    public bool $b { get; set; }
+                    public bool $c { set; }
+                    public bool $d { set; get; }
+                    public bool $e {/* hello1 */set/* hello2 */;/* hello3 */get/* hello4 */;/* hello5 */}
+                }
+                PHP,
+        ];
+
+        yield 'abstract class with property hooks' => [
+            <<<'PHP'
+                <?php abstract class A
+                {
+                    abstract public bool $a { get;  }
+                    abstract public bool $b { get{}  }
+                    abstract public bool $c { get; set{} }
+                }
+                PHP,
+            <<<'PHP'
+                <?php abstract class A
+                {
+                    abstract public bool $a { get; set; }
+                    abstract public bool $b { get{} set; }
+                    abstract public bool $c { get; set{} }
+                }
+                PHP,
+        ];
+    }
 }

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -532,7 +532,7 @@ abstract class AbstractFixerTestCase extends TestCase
             self::assertTokens($expectedTokens, $tokens);
         }
 
-        self::assertNull($this->lintSource($expected));
+        // self::assertNull($this->lintSource($expected));
 
         Tokens::clearCache();
         $tokens = Tokens::fromCode($expected);

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -532,7 +532,7 @@ abstract class AbstractFixerTestCase extends TestCase
             self::assertTokens($expectedTokens, $tokens);
         }
 
-        // self::assertNull($this->lintSource($expected));
+        self::assertNull($this->lintSource($expected));
 
         Tokens::clearCache();
         $tokens = Tokens::fromCode($expected);


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8761