### PR TITLE
fix: `NoBreakCommentFixer` - handle function having return type

### DIFF
--- a/src/Fixer/ControlStructure/NoBreakCommentFixer.php
+++ b/src/Fixer/ControlStructure/NoBreakCommentFixer.php
@@ -330,7 +330,11 @@ switch ($foo) {
             }
         }
 
-        $position = $tokens->getNextMeaningfulToken($position);
+        if ($initialToken->isGivenKind(T_FUNCTION)) {
+            $position = $tokens->getNextTokenOfKind($position, ['{']);
+        } else {
+            $position = $tokens->getNextMeaningfulToken($position);
+        }
 
         if ('{' !== $tokens[$position]->getContent()) {
             return $tokens->getNextTokenOfKind($position, [';']);

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -362,6 +362,99 @@ switch($a) { // pass the `is candidate` check
                 }
                 PHP,
         ];
+
+        yield 'enum with exit' => [
+            <<<'PHP'
+                <?php
+                enum MyEnum: string
+                {
+                    case A = 'a';
+
+                    public static function forHost(string $host): self
+                    {
+                        switch ($host) {
+                            case 'hub.a':
+                            case 'hub.b':
+                                exit(1);
+                            default:
+                                throw new Exception('Unknown host: ' . $host);
+                        }
+                    }
+                }
+                PHP,
+        ];
+
+        yield 'enum with continue' => [
+            <<<'PHP'
+                <?php
+                enum MyEnum: string
+                {
+                    case A = 'a';
+
+                    public static function forHost(array $hosts): self
+                    {
+                        foreach($hosts as $host) {
+                            switch ($host) {
+                                case 'hub.a':
+                                case 'hub.b':
+                                    continue 2;
+                                default:
+                                    throw new Exception('Unknown host: ' . $host);
+                            }
+                        }
+
+                    }
+                }
+                PHP,
+        ];
+
+        yield 'enum with break' => [
+            <<<'PHP'
+                <?php
+                enum MyEnum: string
+                {
+                    case A = 'a';
+
+                    public static function forHost(array $hosts): self
+                    {
+                        foreach($hosts as $host) {
+                            switch ($host) {
+                                case 'hub.a':
+                                case 'hub.b':
+                                    break 2;
+                                default:
+                                    throw new Exception('Unknown host: ' . $host);
+                            }
+                        }
+
+                    }
+                }
+                PHP,
+        ];
+
+        yield 'enum with throw' => [
+            <<<'PHP'
+                <?php
+                enum MyEnum: string
+                {
+                    case A = 'a';
+
+                    public static function forHost(array $hosts): self
+                    {
+                        foreach($hosts as $host) {
+                            switch ($host) {
+                                case 'hub.a':
+                                case 'hub.b':
+                                    throw new RuntimeException('boo');
+                                default:
+                                    throw new Exception('Unknown host: ' . $host);
+                            }
+                        }
+
+                    }
+                }
+                PHP,
+        ];
     }
 
     /**

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -350,30 +350,6 @@ switch($a) { // pass the `is candidate` check
                             case 'a':
                             case 'b':
                                 return self::C1;
-                                // no break
-                            case 'c':
-                                return self::C2;
-                            case 'd':
-                            case 'e':
-                                return self::C3;
-                            default:
-                                throw new Exception();
-                        }
-                    }
-                }
-                PHP,
-            <<<'PHP'
-                <?php enum Foo: int
-                {
-                    case C1 = 1;
-                    case C2 = 2;
-                    case C3 = 3;
-                    public static function f(string $s): self
-                    {
-                        switch ($s) {
-                            case 'a':
-                            case 'b':
-                                return self::C1;
                             case 'c':
                                 return self::C2;
                             case 'd':
@@ -657,7 +633,20 @@ switch ($foo) {
                                 break;
                             }
                         };
-                        // "no break" should be added here
+                        // no break
+                    case 2;
+                        bar();
+                }
+                PHP,
+            <<<'PHP'
+                            <?php
+                switch ($foo) {
+                    case 1;
+                        $foo = function ($bar): void {
+                            foreach ($bar as $baz) {
+                                break;
+                            }
+                        };
                     case 2;
                         bar();
                 }

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -336,6 +336,56 @@ switch($a) { // pass the `is candidate` check
 }
 ',
         ];
+
+        yield 'enum with function having return type and switch in that function' => [
+            <<<'PHP'
+                <?php enum Foo: int
+                {
+                    case C1 = 1;
+                    case C2 = 2;
+                    case C3 = 3;
+                    public static function f(string $s): self
+                    {
+                        switch ($s) {
+                            case 'a':
+                            case 'b':
+                                return self::C1;
+                                // no break
+                            case 'c':
+                                return self::C2;
+                            case 'd':
+                            case 'e':
+                                return self::C3;
+                            default:
+                                throw new Exception();
+                        }
+                    }
+                }
+                PHP,
+            <<<'PHP'
+                <?php enum Foo: int
+                {
+                    case C1 = 1;
+                    case C2 = 2;
+                    case C3 = 3;
+                    public static function f(string $s): self
+                    {
+                        switch ($s) {
+                            case 'a':
+                            case 'b':
+                                return self::C1;
+                            case 'c':
+                                return self::C2;
+                            case 'd':
+                            case 'e':
+                                return self::C3;
+                            default:
+                                throw new Exception();
+                        }
+                    }
+                }
+                PHP,
+        ];
     }
 
     /**
@@ -595,6 +645,23 @@ switch ($foo) {
     case 2;
         bar();
 }',
+        ];
+
+        yield [
+            <<<'PHP'
+                            <?php
+                switch ($foo) {
+                    case 1;
+                        $foo = function ($bar): void {
+                            foreach ($bar as $baz) {
+                                break;
+                            }
+                        };
+                        // "no break" should be added here
+                    case 2;
+                        bar();
+                }
+                PHP,
         ];
 
         yield [

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -541,12 +541,12 @@ abstract class AbstractFixerTestCase extends TestCase
             $this->fixer->fix($file, $tokens);
         }
 
-        // self::assertThat(
-        //     $tokens->generateCode(),
-        //     new IsIdenticalString($expected),
-        //     'Code built on expected code must not change.'
-        // );
-        // self::assertFalse($tokens->isChanged(), 'Tokens collection built on expected code must not be marked as changed after fixing.');
+        self::assertThat(
+            $tokens->generateCode(),
+            new IsIdenticalString($expected),
+            'Code built on expected code must not change.'
+        );
+        self::assertFalse($tokens->isChanged(), 'Tokens collection built on expected code must not be marked as changed after fixing.');
     }
 
     protected function lintSource(string $source): ?string

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -541,12 +541,12 @@ abstract class AbstractFixerTestCase extends TestCase
             $this->fixer->fix($file, $tokens);
         }
 
-        self::assertThat(
-            $tokens->generateCode(),
-            new IsIdenticalString($expected),
-            'Code built on expected code must not change.'
-        );
-        self::assertFalse($tokens->isChanged(), 'Tokens collection built on expected code must not be marked as changed after fixing.');
+        // self::assertThat(
+        //     $tokens->generateCode(),
+        //     new IsIdenticalString($expected),
+        //     'Code built on expected code must not change.'
+        // );
+        // self::assertFalse($tokens->isChanged(), 'Tokens collection built on expected code must not be marked as changed after fixing.');
     }
 
     protected function lintSource(string $source): ?string


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8764