### PR TITLE
chore: fix adding automatically to milestone "PHP 8.4 initial compatibility" if label is "topic/PHP8.4"

### DIFF
--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -10,6 +10,9 @@ jobs:
   add-to-milestone:
     runs-on: ubuntu-latest
     if: ${{ github.event.label.name == 'topic/PHP8.4' }}
+    env:
+      PR_URL: ${{github.event.pull_request.html_url}}
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
Fix for https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8770