### PR TITLE
fix: `VisibilityRequiredFixer` - do not add `public` incorrectly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,16 +241,14 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-#        run: vendor/bin/phpunit --testsuite unit,integration
-        run: vendor/bin/phpunit tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+        run: vendor/bin/phpunit --testsuite unit,integration
 
       - name: Run tests (via ParaUnit)
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes' && matrix.AVOID_PARAUNIT != 'yes'
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-#        run: vendor/bin/paraunit run --testsuite unit,integration
-        run: vendor/bin/phpunit tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+        run: vendor/bin/paraunit run --testsuite unit,integration
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,14 +241,16 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit --testsuite unit,integration
+#        run: vendor/bin/phpunit --testsuite unit,integration
+        run: vendor/bin/phpunit tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
 
       - name: Run tests (via ParaUnit)
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes' && matrix.AVOID_PARAUNIT != 'yes'
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/paraunit run --testsuite unit,integration
+#        run: vendor/bin/paraunit run --testsuite unit,integration
+        run: vendor/bin/phpunit tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
 
       - name: Run tests with "short_open_tag" enabled
         if: matrix.run-tests == 'yes' && matrix.collect-code-coverage != 'yes'

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -868,7 +868,9 @@ final class TokensAnalyzer
                 ];
                 $functionNameIndex = $this->tokens->getNextMeaningfulToken($index);
                 if ('__construct' === $this->tokens[$functionNameIndex]->getContent()) {
-                    foreach ($this->tokens->findGivenKind([CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE, FCT::T_READONLY]) as $kindElements) {
+                    $openParenthesis = $this->tokens->getNextMeaningfulToken($functionNameIndex);
+                    $closeParenthesis = $this->tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParenthesis);
+                    foreach ($this->tokens->findGivenKind([CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE, FCT::T_READONLY], $openParenthesis, $closeParenthesis) as $kindElements) {
                         foreach (array_keys($kindElements) as $promotedPropertyModifierIndex) {
                             /** @var int $promotedPropertyVariableIndex */
                             $promotedPropertyVariableIndex = $this->tokens->getNextTokenOfKind($promotedPropertyModifierIndex, [[T_VARIABLE]]);

--- a/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+++ b/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
@@ -682,6 +682,16 @@ AB# <- this is the name
                 }
                 PHP,
         ];
+
+        yield 'readonly class' => [
+            <<<'PHP'
+                <?php readonly class Foo
+                {
+                    public function __construct() {}
+                    public function bar(int $x): void {}
+                }
+                PHP,
+        ];
     }
 
     /**

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -814,10 +814,6 @@ enum Foo: string
                     'classIndex' => 3,
                     'type' => 'method',
                 ],
-                28 => [
-                    'classIndex' => 3,
-                    'type' => 'promoted_property', // This should not be here
-                ],
             ],
             <<<'PHP'
                 <?php readonly class Foo {

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -803,6 +803,29 @@ enum Foo: string
                 }
                 PHP,
         ];
+
+        yield 'readonly class' => [
+            [
+                11 => [
+                    'classIndex' => 3,
+                    'type' => 'method',
+                ],
+                22 => [
+                    'classIndex' => 3,
+                    'type' => 'method',
+                ],
+                28 => [
+                    'classIndex' => 3,
+                    'type' => 'promoted_property', // This should not be here
+                ],
+            ],
+            <<<'PHP'
+                <?php readonly class Foo {
+                    public function __construct() {}
+                    public function process(object $event): void {}
+                }
+                PHP,
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8786

Until only promoted properties visibilities where [here](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.77.0/src/Tokenizer/TokensAnalyzer.php#L871) it was ok, but since `readonly` [joined](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8773/files) the bug happened.