### PR TITLE
fix: `BracesPositionFixer` - do not throw error when variable is terminated by PHP close tag

### DIFF
--- a/src/Fixer/Basic/BracesPositionFixer.php
+++ b/src/Fixer/Basic/BracesPositionFixer.php
@@ -251,7 +251,7 @@ $bar = function () { $result = true;
 
                 $positionOption = 'control_structures_opening_brace';
             } elseif ($token->isGivenKind(T_VARIABLE)) {
-                $openBraceIndex = $tokens->getNextTokenOfKind($index, ['{', ';', [CT::T_PROPERTY_HOOK_BRACE_OPEN]]);
+                $openBraceIndex = $tokens->getNextTokenOfKind($index, ['{', ';', [CT::T_PROPERTY_HOOK_BRACE_OPEN], [T_CLOSE_TAG]]);
 
                 if (!$tokens[$openBraceIndex]->isGivenKind(CT::T_PROPERTY_HOOK_BRACE_OPEN)) {
                     continue;

--- a/tests/Fixer/Basic/BracesPositionFixerTest.php
+++ b/tests/Fixer/Basic/BracesPositionFixerTest.php
@@ -762,6 +762,30 @@ final class BracesPositionFixerTest extends AbstractFixerTestCase
                 }
                 PHP,
         ];
+
+        yield 'variable terminated by close tag' => [
+            <<<'PHP'
+                <?php
+
+                $pager = new class {
+                public function bar()
+                {
+                return 'baz';
+                }
+                };
+
+                echo $pager->bar()
+                ?>
+                PHP,
+            <<<'PHP'
+                <?php
+
+                $pager = new class { public function bar() { return 'baz'; } };
+
+                echo $pager->bar()
+                ?>
+                PHP,
+        ];
     }
 
     /**


### PR DESCRIPTION
The test case is just the slimmed down modified PHP code. The real code (slimmed too) causing errors is:
```php
<?php class A {} ?>
<!-- reproducer.php --!>
<?= $hello ?>

```

The erroring code snippet is meant for documentation. Though PHP-CS-Fixer proclaims it does not fully support mixed PHP code, I believe it should not error.
<img width="610" alt="image" src="https://github.com/user-attachments/assets/9de59cda-80aa-4860-be5c-b8025f476bf8" />

Most likely caused by #8782 

Fixes #8803 