### PR TITLE
feat: `MagicConstantCasingFixer` - support `__PROPERTY__`

### DIFF
--- a/src/Fixer/Casing/MagicConstantCasingFixer.php
+++ b/src/Fixer/Casing/MagicConstantCasingFixer.php
@@ -19,6 +19,7 @@ use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\FCT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -70,6 +71,7 @@ final class MagicConstantCasingFixer extends AbstractFixer
                 T_NS_C => '__NAMESPACE__',
                 CT::T_CLASS_CONSTANT => 'class',
                 T_TRAIT_C => '__TRAIT__',
+                FCT::T_PROPERTY_C => '__PROPERTY__',
             ];
         }
 

--- a/src/Tokenizer/FCT.php
+++ b/src/Tokenizer/FCT.php
@@ -43,4 +43,5 @@ final class FCT
     public const T_PRIVATE_SET = \PHP_VERSION_ID >= 8_04_00 ? T_PRIVATE_SET : -841;
     public const T_PROTECTED_SET = \PHP_VERSION_ID >= 8_04_00 ? T_PROTECTED_SET : -842;
     public const T_PUBLIC_SET = \PHP_VERSION_ID >= 8_04_00 ? T_PUBLIC_SET : -843;
+    public const T_PROPERTY_C = \PHP_VERSION_ID >= 8_04_00 ? T_PROPERTY_C : -844;
 }

--- a/tests/Fixer/Casing/MagicConstantCasingFixerTest.php
+++ b/tests/Fixer/Casing/MagicConstantCasingFixerTest.php
@@ -123,4 +123,30 @@ final class MagicConstantCasingFixerTest extends AbstractFixerTestCase
                 }',
         ];
     }
+
+    /**
+     * @requires PHP 8.4
+     *
+     * @dataProvider provideFix84Cases
+     */
+    public function testFix84(string $expected, ?string $input = null): void
+    {
+        $this->testFix($expected, $input);
+    }
+
+    /**
+     * @return iterable<int, array{string}>
+     */
+    public static function provideFix84Cases(): iterable
+    {
+        yield [
+            '<?php echo __PROPERTY__;',
+            '<?php echo __property__;',
+        ];
+
+        yield [
+            '<?php echo __PROPERTY__;',
+            '<?php echo __PrOpErTy__;',
+        ];
+    }
 }


### PR DESCRIPTION
If you've ever wondered what might be the least useful feature in PHP CS Fixer, this PR is a good candidate.