### PR TITLE
docs: fix whitespace around code examples and reference sections in rules' docs

### DIFF
--- a/doc/rules/alias/mb_str_functions.rst
+++ b/doc/rules/alias/mb_str_functions.rst
@@ -48,6 +48,7 @@ Example #1
    +$a = mb_stristr($a, $b);
    +$a = mb_strrchr($a, $b);
    +$a = mb_substr_count($a, $b);
+
 References
 ----------
 

--- a/doc/rules/alias/random_api_migration.rst
+++ b/doc/rules/alias/random_api_migration.rst
@@ -98,7 +98,6 @@ The rule is part of the following rule sets:
 
   ``['replacements' => ['mt_rand' => 'random_int', 'rand' => 'random_int']]``
 
-
 References
 ----------
 

--- a/doc/rules/array_notation/no_trailing_comma_in_singleline_array.rst
+++ b/doc/rules/array_notation/no_trailing_comma_in_singleline_array.rst
@@ -25,6 +25,7 @@ Example #1
     <?php
    -$a = array('sample',  );
    +$a = array('sample');
+
 References
 ----------
 

--- a/doc/rules/array_notation/return_to_yield_from.rst
+++ b/doc/rules/array_notation/return_to_yield_from.rst
@@ -19,6 +19,7 @@ Example #1
    -    return [1, 2, 3];
    +    yield from [1, 2, 3];
     }
+
 References
 ----------
 

--- a/doc/rules/attribute_notation/attribute_empty_parentheses.rst
+++ b/doc/rules/attribute_notation/attribute_empty_parentheses.rst
@@ -57,6 +57,7 @@ With configuration: ``['use_parentheses' => true]``.
    -#[Bar, Baz]
    +#[Bar(), Baz()]
     class Sample2 {}
+
 References
 ----------
 

--- a/doc/rules/attribute_notation/general_attribute_remove.rst
+++ b/doc/rules/attribute_notation/general_attribute_remove.rst
@@ -47,6 +47,7 @@ With configuration: ``['attributes' => ['\\A\\B\\Foo', 'A\\B\\Bar']]``.
    -#[\A\B\Foo]
    -#[BarAlias]
     function foo() {}
+
 References
 ----------
 

--- a/doc/rules/attribute_notation/ordered_attributes.rst
+++ b/doc/rules/attribute_notation/ordered_attributes.rst
@@ -80,6 +80,7 @@ With configuration: ``['sort_algorithm' => 'custom', 'order' => ['A\\B\\Qux', 'A
     #[\A\B\Corge(a: 'test')]
    +#[Foo]
     class Sample1 {}
+
 References
 ----------
 

--- a/doc/rules/basic/braces.rst
+++ b/doc/rules/basic/braces.rst
@@ -184,6 +184,7 @@ With configuration: ``['position_after_functions_and_oop_constructs' => 'same']`
    +        }
         }
     }
+
 References
 ----------
 

--- a/doc/rules/basic/braces_position.rst
+++ b/doc/rules/basic/braces_position.rst
@@ -253,7 +253,6 @@ The rule is part of the following rule sets:
 
   ``['allow_single_line_anonymous_functions' => true, 'allow_single_line_empty_anonymous_classes' => true]``
 
-
 References
 ----------
 

--- a/doc/rules/basic/curly_braces_position.rst
+++ b/doc/rules/basic/curly_braces_position.rst
@@ -226,6 +226,7 @@ With configuration: ``['allow_single_line_anonymous_functions' => true]``.
    +$result = true;
    +    return $result;
    +};
+
 References
 ----------
 

--- a/doc/rules/basic/numeric_literal_separator.rst
+++ b/doc/rules/basic/numeric_literal_separator.rst
@@ -90,6 +90,7 @@ With configuration: ``['override_existing' => true]``.
    +++ New
    -<?php $var = 24_40_21;
    +<?php $var = 244_021;
+
 References
 ----------
 

--- a/doc/rules/casing/native_function_type_declaration_casing.rst
+++ b/doc/rules/casing/native_function_type_declaration_casing.rst
@@ -72,6 +72,7 @@ Example #4
     {
         return 'hi!';
     }
+
 References
 ----------
 

--- a/doc/rules/class_notation/class_attributes_separation.rst
+++ b/doc/rules/class_notation/class_attributes_separation.rst
@@ -144,7 +144,6 @@ The rule is part of the following rule sets:
 
   ``['elements' => ['method' => 'one']]``
 
-
 References
 ----------
 

--- a/doc/rules/class_notation/class_definition.rst
+++ b/doc/rules/class_notation/class_definition.rst
@@ -201,7 +201,6 @@ The rule is part of the following rule sets:
 
   ``['single_line' => true]``
 
-
 References
 ----------
 

--- a/doc/rules/class_notation/final_class.rst
+++ b/doc/rules/class_notation/final_class.rst
@@ -38,6 +38,7 @@ Example #1
     <?php
    -class MyApp {}
    +final class MyApp {}
+
 References
 ----------
 

--- a/doc/rules/class_notation/final_public_method_for_abstract_class.rst
+++ b/doc/rules/class_notation/final_public_method_for_abstract_class.rst
@@ -36,6 +36,7 @@ Example #1
    +    final public function start()
         {}
     }
+
 References
 ----------
 

--- a/doc/rules/class_notation/ordered_class_elements.rst
+++ b/doc/rules/class_notation/ordered_class_elements.rst
@@ -199,7 +199,6 @@ The rule is part of the following rule sets:
 
   ``['order' => ['use_trait']]``
 
-
 References
 ----------
 

--- a/doc/rules/class_notation/ordered_interfaces.rst
+++ b/doc/rules/class_notation/ordered_interfaces.rst
@@ -138,6 +138,7 @@ With configuration: ``['order' => 'alpha', 'case_sensitive' => true]``.
 
    -interface ExampleB extends Casesensitivea, CaseSensitiveA, CasesensitiveA {}
    +interface ExampleB extends CaseSensitiveA, CasesensitiveA, Casesensitivea {}
+
 References
 ----------
 

--- a/doc/rules/class_notation/ordered_types.rst
+++ b/doc/rules/class_notation/ordered_types.rst
@@ -117,7 +117,6 @@ The rule is part of the following rule sets:
 
   ``['null_adjustment' => 'always_last', 'sort_algorithm' => 'none']``
 
-
 References
 ----------
 

--- a/doc/rules/class_notation/static_private_method.rst
+++ b/doc/rules/class_notation/static_private_method.rst
@@ -38,6 +38,7 @@ Example #1
             return 1;
         }
     }
+
 References
 ----------
 

--- a/doc/rules/class_usage/date_time_immutable.rst
+++ b/doc/rules/class_usage/date_time_immutable.rst
@@ -26,6 +26,7 @@ Example #1
     <?php
    -new DateTime();
    +new DateTimeImmutable();
+
 References
 ----------
 

--- a/doc/rules/comment/header_comment.rst
+++ b/doc/rules/comment/header_comment.rst
@@ -156,6 +156,7 @@ With configuration: ``['header' => '']``.
     namespace A\B;
 
     echo 1;
+
 References
 ----------
 

--- a/doc/rules/comment/single_line_comment_style.rst
+++ b/doc/rules/comment/single_line_comment_style.rst
@@ -92,7 +92,6 @@ The rule is part of the following rule sets:
 
   ``['comment_types' => ['hash']]``
 
-
 References
 ----------
 

--- a/doc/rules/constant_notation/native_constant_invocation.rst
+++ b/doc/rules/constant_notation/native_constant_invocation.rst
@@ -146,7 +146,6 @@ The rule is part of the following rule sets:
 
   ``['strict' => false]``
 
-
 References
 ----------
 

--- a/doc/rules/control_structure/empty_loop_body.rst
+++ b/doc/rules/control_structure/empty_loop_body.rst
@@ -53,7 +53,6 @@ The rule is part of the following rule sets:
 
   ``['style' => 'braces']``
 
-
 References
 ----------
 

--- a/doc/rules/control_structure/no_trailing_comma_in_list_call.rst
+++ b/doc/rules/control_structure/no_trailing_comma_in_list_call.rst
@@ -25,6 +25,7 @@ Example #1
     <?php
    -list($a, $b,) = foo();
    +list($a, $b) = foo();
+
 References
 ----------
 

--- a/doc/rules/control_structure/no_unneeded_braces.rst
+++ b/doc/rules/control_structure/no_unneeded_braces.rst
@@ -72,7 +72,6 @@ The rule is part of the following rule sets:
 
   ``['namespaces' => true]``
 
-
 References
 ----------
 

--- a/doc/rules/control_structure/no_unneeded_control_parentheses.rst
+++ b/doc/rules/control_structure/no_unneeded_control_parentheses.rst
@@ -77,7 +77,6 @@ The rule is part of the following rule sets:
 
   ``['statements' => ['break', 'clone', 'continue', 'echo_print', 'others', 'return', 'switch_case', 'yield', 'yield_from']]``
 
-
 References
 ----------
 

--- a/doc/rules/control_structure/no_unneeded_curly_braces.rst
+++ b/doc/rules/control_structure/no_unneeded_curly_braces.rst
@@ -66,6 +66,7 @@ With configuration: ``['namespaces' => true]``.
         function Bar(){}
    -}
    +
+
 References
 ----------
 

--- a/doc/rules/control_structure/simplified_if_return.rst
+++ b/doc/rules/control_structure/simplified_if_return.rst
@@ -18,6 +18,7 @@ Example #1
     <?php
    -if ($foo) { return true; } return false;
    +return (bool) ($foo)      ;
+
 References
 ----------
 

--- a/doc/rules/control_structure/trailing_comma_in_multiline.rst
+++ b/doc/rules/control_structure/trailing_comma_in_multiline.rst
@@ -151,7 +151,6 @@ The rule is part of the following rule sets:
 
   ``['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays', 'match', 'parameters']]``
 
-
 References
 ----------
 

--- a/doc/rules/doctrine_annotation/doctrine_annotation_array_assignment.rst
+++ b/doc/rules/doctrine_annotation/doctrine_annotation_array_assignment.rst
@@ -69,7 +69,6 @@ The rule is part of the following rule set:
 
   ``['operator' => ':']``
 
-
 References
 ----------
 

--- a/doc/rules/doctrine_annotation/doctrine_annotation_spaces.rst
+++ b/doc/rules/doctrine_annotation/doctrine_annotation_spaces.rst
@@ -151,7 +151,6 @@ The rule is part of the following rule set:
 
   ``['before_array_assignments_colon' => false]``
 
-
 References
 ----------
 

--- a/doc/rules/function_notation/date_time_create_from_format_call.rst
+++ b/doc/rules/function_notation/date_time_create_from_format_call.rst
@@ -36,6 +36,7 @@ Example #1
    +++ New
    -<?php \DateTime::createFromFormat('Y-m-d', '2022-02-11');
    +<?php \DateTime::createFromFormat('!Y-m-d', '2022-02-11');
+
 References
 ----------
 

--- a/doc/rules/function_notation/fopen_flags.rst
+++ b/doc/rules/function_notation/fopen_flags.rst
@@ -67,7 +67,6 @@ The rule is part of the following rule sets:
 
   ``['b_mode' => false]``
 
-
 References
 ----------
 

--- a/doc/rules/function_notation/function_typehint_space.rst
+++ b/doc/rules/function_notation/function_typehint_space.rst
@@ -38,6 +38,7 @@ Example #2
    -function sample(array  $a)
    +function sample(array $a)
     {}
+
 References
 ----------
 

--- a/doc/rules/function_notation/method_argument_space.rst
+++ b/doc/rules/function_notation/method_argument_space.rst
@@ -338,7 +338,6 @@ The rule is part of the following rule sets:
 
   ``['on_multiline' => 'ignore']``
 
-
 References
 ----------
 

--- a/doc/rules/function_notation/multiline_promoted_properties.rst
+++ b/doc/rules/function_notation/multiline_promoted_properties.rst
@@ -68,6 +68,7 @@ With configuration: ``['minimum_number_of_parameters' => 3]``.
     class Bar {
         public function __construct(private array $x) {}
     }
+
 References
 ----------
 

--- a/doc/rules/function_notation/native_function_invocation.rst
+++ b/doc/rules/function_notation/native_function_invocation.rst
@@ -205,7 +205,6 @@ The rule is part of the following rule sets:
 
   ``['include' => ['@compiler_optimized'], 'scope' => 'namespaced', 'strict' => true]``
 
-
 References
 ----------
 

--- a/doc/rules/function_notation/no_trailing_comma_in_singleline_function_call.rst
+++ b/doc/rules/function_notation/no_trailing_comma_in_singleline_function_call.rst
@@ -26,6 +26,7 @@ Example #1
     <?php
    -foo($a,);
    +foo($a);
+
 References
 ----------
 

--- a/doc/rules/function_notation/phpdoc_to_param_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_param_type.rst
@@ -110,6 +110,7 @@ With configuration: ``['union_types' => false]``.
    +function foo(Foo $foo) {}
     /** @param int|string $foo */
     function bar($foo) {}
+
 References
 ----------
 

--- a/doc/rules/function_notation/phpdoc_to_property_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_property_type.rst
@@ -112,6 +112,7 @@ With configuration: ``['union_types' => false]``.
    -    private $bar;
    +    private \Traversable $bar;
     }
+
 References
 ----------
 

--- a/doc/rules/function_notation/phpdoc_to_return_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_return_type.rst
@@ -137,6 +137,7 @@ Example #4
             return new static($prototype);
         }
     }
+
 References
 ----------
 

--- a/doc/rules/function_notation/regular_callable_call.rst
+++ b/doc/rules/function_notation/regular_callable_call.rst
@@ -48,6 +48,7 @@ Example #2
 
    -call_user_func(static function ($a, $b) { var_dump($a, $b); }, 1, 2);
    +(static function ($a, $b) { var_dump($a, $b); })(1, 2);
+
 References
 ----------
 

--- a/doc/rules/import/global_namespace_import.rst
+++ b/doc/rules/import/global_namespace_import.rst
@@ -120,7 +120,6 @@ The rule is part of the following rule sets:
 
   ``['import_classes' => false, 'import_constants' => false, 'import_functions' => false]``
 
-
 References
 ----------
 

--- a/doc/rules/import/group_import.rst
+++ b/doc/rules/import/group_import.rst
@@ -49,6 +49,7 @@ With configuration: ``['group_types' => ['classy']]``.
    -use A\Bar;
    +use A\{Bar, Foo};
     use function B\bar;
+
 References
 ----------
 

--- a/doc/rules/import/ordered_imports.rst
+++ b/doc/rules/import/ordered_imports.rst
@@ -188,7 +188,6 @@ The rule is part of the following rule sets:
 
   ``['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha']``
 
-
 References
 ----------
 

--- a/doc/rules/language_construct/class_keyword.rst
+++ b/doc/rules/language_construct/class_keyword.rst
@@ -45,6 +45,7 @@ Example #1
    -$bar = "\PhpCsFixer\Tokenizer\Tokens";
    +$foo = \PhpCsFixer\Tokenizer\Tokens::class;
    +$bar = \PhpCsFixer\Tokenizer\Tokens::class;
+
 References
 ----------
 

--- a/doc/rules/language_construct/class_keyword_remove.rst
+++ b/doc/rules/language_construct/class_keyword_remove.rst
@@ -26,6 +26,7 @@ Example #1
 
    -$className = Baz::class;
    +$className = 'Foo\Bar\Baz';
+
 References
 ----------
 

--- a/doc/rules/language_construct/single_space_after_construct.rst
+++ b/doc/rules/language_construct/single_space_after_construct.rst
@@ -68,6 +68,7 @@ With configuration: ``['constructs' => ['yield_from']]``.
 
    -yield  from  baz();
    +yield from baz();
+
 References
 ----------
 

--- a/doc/rules/namespace_notation/no_blank_lines_before_namespace.rst
+++ b/doc/rules/namespace_notation/no_blank_lines_before_namespace.rst
@@ -27,6 +27,7 @@ Example #1
    -
    -
     namespace Example;
+
 References
 ----------
 

--- a/doc/rules/namespace_notation/single_blank_line_before_namespace.rst
+++ b/doc/rules/namespace_notation/single_blank_line_before_namespace.rst
@@ -38,6 +38,7 @@ Example #2
 
    -
     namespace A{}
+
 References
 ----------
 

--- a/doc/rules/operator/new_expression_parentheses.rst
+++ b/doc/rules/operator/new_expression_parentheses.rst
@@ -76,6 +76,7 @@ With configuration: ``['use_parentheses' => true]``.
 
    -new class {}->bar();
    +(new class {})->bar();
+
 References
 ----------
 

--- a/doc/rules/operator/new_with_braces.rst
+++ b/doc/rules/operator/new_with_braces.rst
@@ -79,6 +79,7 @@ With configuration: ``['named_class' => false]``.
 
    -$x = new X();
    +$x = new X;
+
 References
 ----------
 

--- a/doc/rules/operator/new_with_parentheses.rst
+++ b/doc/rules/operator/new_with_parentheses.rst
@@ -100,7 +100,6 @@ The rule is part of the following rule sets:
 
   ``['anonymous_class' => false]``
 
-
 References
 ----------
 

--- a/doc/rules/operator/not_operator_with_space.rst
+++ b/doc/rules/operator/not_operator_with_space.rst
@@ -20,6 +20,7 @@ Example #1
    +if ( ! $bar) {
         echo "Help!";
     }
+
 References
 ----------
 

--- a/doc/rules/operator/not_operator_with_successor_space.rst
+++ b/doc/rules/operator/not_operator_with_successor_space.rst
@@ -20,6 +20,7 @@ Example #1
    +if (! $bar) {
         echo "Help!";
     }
+
 References
 ----------
 

--- a/doc/rules/operator/operator_linebreak.rst
+++ b/doc/rules/operator/operator_linebreak.rst
@@ -73,7 +73,6 @@ The rule is part of the following rule sets:
 
   ``['only_booleans' => true]``
 
-
 References
 ----------
 

--- a/doc/rules/php_unit/php_unit_attributes.rst
+++ b/doc/rules/php_unit/php_unit_attributes.rst
@@ -73,6 +73,7 @@ With configuration: ``['keep_annotations' => true]``.
    +    #[\PHPUnit\Framework\Attributes\RequiresPhp('>= 8.0')]
         public function testSomething($expected, $actual) {}
     }
+
 References
 ----------
 

--- a/doc/rules/php_unit/php_unit_data_provider_static.rst
+++ b/doc/rules/php_unit/php_unit_data_provider_static.rst
@@ -104,7 +104,6 @@ The rule is part of the following rule sets:
 
   ``['force' => true]``
 
-
 References
 ----------
 

--- a/doc/rules/php_unit/php_unit_dedicate_assert.rst
+++ b/doc/rules/php_unit/php_unit_dedicate_assert.rst
@@ -141,7 +141,6 @@ The rule is part of the following rule sets:
 
   ``['target' => '5.6']``
 
-
 References
 ----------
 

--- a/doc/rules/php_unit/php_unit_dedicate_assert_internal_type.rst
+++ b/doc/rules/php_unit/php_unit_dedicate_assert_internal_type.rst
@@ -92,7 +92,6 @@ The rule is part of the following rule sets:
 
   ``['target' => '7.5']``
 
-
 References
 ----------
 

--- a/doc/rules/php_unit/php_unit_expectation.rst
+++ b/doc/rules/php_unit/php_unit_expectation.rst
@@ -193,7 +193,6 @@ The rule is part of the following rule sets:
 
   ``['target' => '8.4']``
 
-
 References
 ----------
 

--- a/doc/rules/php_unit/php_unit_mock.rst
+++ b/doc/rules/php_unit/php_unit_mock.rst
@@ -114,7 +114,6 @@ The rule is part of the following rule sets:
 
   ``['target' => '5.5']``
 
-
 References
 ----------
 

--- a/doc/rules/php_unit/php_unit_namespaced.rst
+++ b/doc/rules/php_unit/php_unit_namespaced.rst
@@ -134,7 +134,6 @@ The rule is part of the following rule sets:
 
   ``['target' => '6.0']``
 
-
 References
 ----------
 

--- a/doc/rules/php_unit/php_unit_no_expectation_annotation.rst
+++ b/doc/rules/php_unit/php_unit_no_expectation_annotation.rst
@@ -161,7 +161,6 @@ The rule is part of the following rule sets:
 
   ``['target' => '4.3']``
 
-
 References
 ----------
 

--- a/doc/rules/php_unit/php_unit_size_class.rst
+++ b/doc/rules/php_unit/php_unit_size_class.rst
@@ -57,6 +57,7 @@ With configuration: ``['group' => 'medium']``.
    + * @medium
    + */
     class MyTest extends TestCase {}
+
 References
 ----------
 

--- a/doc/rules/php_unit/php_unit_test_case_static_method_calls.rst
+++ b/doc/rules/php_unit/php_unit_test_case_static_method_calls.rst
@@ -119,7 +119,6 @@ The rule is part of the following rule set:
 
   ``['call_type' => 'self']``
 
-
 References
 ----------
 

--- a/doc/rules/phpdoc/general_phpdoc_annotation_remove.rst
+++ b/doc/rules/phpdoc/general_phpdoc_annotation_remove.rst
@@ -79,6 +79,7 @@ With configuration: ``['annotations' => ['package', 'subpackage']]``.
      * @version 1.0
      */
     function foo() {}
+
 References
 ----------
 

--- a/doc/rules/phpdoc/general_phpdoc_tag_rename.rst
+++ b/doc/rules/phpdoc/general_phpdoc_tag_rename.rst
@@ -124,7 +124,6 @@ The rule is part of the following rule sets:
 
   ``['replacements' => ['inheritDocs' => 'inheritDoc']]``
 
-
 References
 ----------
 

--- a/doc/rules/phpdoc/no_superfluous_phpdoc_tags.rst
+++ b/doc/rules/phpdoc/no_superfluous_phpdoc_tags.rst
@@ -158,7 +158,6 @@ The rule is part of the following rule sets:
 
   ``['allow_hidden_params' => true, 'remove_inheritdoc' => true]``
 
-
 References
 ----------
 

--- a/doc/rules/phpdoc/phpdoc_array_type.rst
+++ b/doc/rules/phpdoc/phpdoc_array_type.rst
@@ -29,6 +29,7 @@ Example #1
    + * @param array<int> $x
    + * @param array<array<string>> $y
      */
+
 References
 ----------
 

--- a/doc/rules/phpdoc/phpdoc_line_span.rst
+++ b/doc/rules/phpdoc/phpdoc_line_span.rst
@@ -75,6 +75,7 @@ With configuration: ``['property' => 'single']``.
    +    /** @var bool */
         public $var;
     }
+
 References
 ----------
 

--- a/doc/rules/phpdoc/phpdoc_list_type.rst
+++ b/doc/rules/phpdoc/phpdoc_list_type.rst
@@ -29,6 +29,7 @@ Example #1
    + * @param list<int> $x
    + * @param list<list<string>> $y
      */
+
 References
 ----------
 

--- a/doc/rules/phpdoc/phpdoc_order.rst
+++ b/doc/rules/phpdoc/phpdoc_order.rst
@@ -121,7 +121,6 @@ The rule is part of the following rule sets:
 
   ``['order' => ['param', 'return', 'throws']]``
 
-
 References
 ----------
 

--- a/doc/rules/phpdoc/phpdoc_param_order.rst
+++ b/doc/rules/phpdoc/phpdoc_param_order.rst
@@ -24,6 +24,7 @@ Example #1
    - * @param array $b
      */
     function m($a, array $b, Foo $c) {}
+
 References
 ----------
 

--- a/doc/rules/phpdoc/phpdoc_separation.rst
+++ b/doc/rules/phpdoc/phpdoc_separation.rst
@@ -163,7 +163,6 @@ The rule is part of the following rule sets:
 
   ``['groups' => [['Annotation', 'NamedArgumentConstructor', 'Target'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['deprecated', 'link', 'see', 'since']]]``
 
-
 References
 ----------
 

--- a/doc/rules/phpdoc/phpdoc_tag_casing.rst
+++ b/doc/rules/phpdoc/phpdoc_tag_casing.rst
@@ -49,6 +49,7 @@ With configuration: ``['tags' => ['foo']]``.
    - * @Foo
    + * @foo
      */
+
 References
 ----------
 

--- a/doc/rules/phpdoc/phpdoc_tag_type.rst
+++ b/doc/rules/phpdoc/phpdoc_tag_type.rst
@@ -62,7 +62,6 @@ The rule is part of the following rule sets:
 
   ``['tags' => ['inheritDoc' => 'inline']]``
 
-
 References
 ----------
 

--- a/doc/rules/phpdoc/phpdoc_types_order.rst
+++ b/doc/rules/phpdoc/phpdoc_types_order.rst
@@ -137,7 +137,6 @@ The rule is part of the following rule sets:
 
   ``['null_adjustment' => 'always_last', 'sort_algorithm' => 'none']``
 
-
 References
 ----------
 

--- a/doc/rules/return_notation/simplified_null_return.rst
+++ b/doc/rules/return_notation/simplified_null_return.rst
@@ -31,6 +31,7 @@ Example #2
     function baz(): ?int { return null; }
    -function xyz(): void { return null; }
    +function xyz(): void { return; }
+
 References
 ----------
 

--- a/doc/rules/semicolon/multiline_whitespace_before_semicolons.rst
+++ b/doc/rules/semicolon/multiline_whitespace_before_semicolons.rst
@@ -62,7 +62,6 @@ The rule is part of the following rule set:
 
   ``['strategy' => 'new_line_for_chained_calls']``
 
-
 References
 ----------
 

--- a/doc/rules/semicolon/space_after_semicolon.rst
+++ b/doc/rules/semicolon/space_after_semicolon.rst
@@ -64,7 +64,6 @@ The rule is part of the following rule sets:
 
   ``['remove_in_empty_for_expressions' => true]``
 
-
 References
 ----------
 

--- a/doc/rules/string_notation/escape_implicit_backslashes.rst
+++ b/doc/rules/string_notation/escape_implicit_backslashes.rst
@@ -143,6 +143,7 @@ With configuration: ``['heredoc_syntax' => false]``.
     $hereDoc = <<<HEREDOC
     Interpret my \100 but not my \999
     HEREDOC;
+
 References
 ----------
 

--- a/doc/rules/string_notation/heredoc_closing_marker.rst
+++ b/doc/rules/string_notation/heredoc_closing_marker.rst
@@ -80,6 +80,7 @@ With configuration: ``['explicit_heredoc_style' => true]``.
    +<?php $a = <<<"EOD"
     Foo
     EOD;
+
 References
 ----------
 

--- a/doc/rules/string_notation/multiline_string_to_heredoc.rst
+++ b/doc/rules/string_notation/multiline_string_to_heredoc.rst
@@ -36,6 +36,7 @@ Example #2
    +line1
    +{$obj->getName()}
    +EOD;
+
 References
 ----------
 

--- a/doc/rules/whitespace/blank_line_before_statement.rst
+++ b/doc/rules/whitespace/blank_line_before_statement.rst
@@ -242,7 +242,6 @@ The rule is part of the following rule sets:
 
   ``['statements' => ['return']]``
 
-
 References
 ----------
 

--- a/doc/rules/whitespace/compact_nullable_typehint.rst
+++ b/doc/rules/whitespace/compact_nullable_typehint.rst
@@ -31,6 +31,7 @@ Example #1
    -function sample(? string $str): ? string
    +function sample(?string $str): ?string
     {}
+
 References
 ----------
 

--- a/doc/rules/whitespace/no_extra_blank_lines.rst
+++ b/doc/rules/whitespace/no_extra_blank_lines.rst
@@ -247,7 +247,6 @@ The rule is part of the following rule sets:
 
   ``['tokens' => ['attribute', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'square_brace_block', 'switch', 'throw', 'use']]``
 
-
 References
 ----------
 

--- a/doc/rules/whitespace/no_spaces_inside_parenthesis.rst
+++ b/doc/rules/whitespace/no_spaces_inside_parenthesis.rst
@@ -42,6 +42,7 @@ Example #2
    +function foo($bar, $baz)
     {
     }
+
 References
 ----------
 

--- a/doc/rules/whitespace/statement_indentation.rst
+++ b/doc/rules/whitespace/statement_indentation.rst
@@ -104,7 +104,6 @@ The rule is part of the following rule sets:
 
   ``['stick_comment_to_next_continuous_control_statement' => true]``
 
-
 References
 ----------
 

--- a/src/Documentation/FixerDocumentGenerator.php
+++ b/src/Documentation/FixerDocumentGenerator.php
@@ -248,6 +248,8 @@ final class FixerDocumentGenerator
                     - `{$set} <./../../ruleSets{$ruleSetPath}>`_{$configInfo}\n
                     RST;
             }
+
+            $doc = trim($doc);
         }
 
         $reflectionObject = new \ReflectionObject($fixer);
@@ -262,6 +264,7 @@ final class FixerDocumentGenerator
         $testFileName = Preg::replace('~(?= <|\.php>)~', 'Test', $testFileName);
 
         $doc .= <<<RST
+
 
             References
             ----------


### PR DESCRIPTION
The blank line between the code examples and reference being either none or two lines is quite infuriating. 🤷🏻‍♂️