### PR TITLE
fix: `OrderedClassElementsFixer` - handle property hooks

### DIFF
--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -1730,5 +1730,22 @@ class A
                 }
                 PHP,
         ];
+
+        yield 'property hook and const' => [
+            <<<'PHP'
+                <?php class Foo
+                {
+                    public const C = 0;
+                    public int $i { get {} }
+                }
+                PHP,
+            <<<'PHP'
+                <?php class Foo
+                {
+                    public int $i { get {} }
+                    public const C = 0;
+                }
+                PHP,
+        ];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8814