### PR TITLE
chore: demonstrate infinite loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           PHP_CS_FIXER_FUTURE_MODE: 1
-        run: php php-cs-fixer check --diff -v
+        run: php php-cs-fixer check --diff -v code.php --rules=ordered_class_elements,visibility_required
 
       # Should be checked on the lowest supported PHP version.
       # If any type can be converted from PHPDoc to native type on lowest supported PHP, we should commit such change.

--- a/code.php
+++ b/code.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+class code
+{
+    public int $i { get {} }
+    public const C = 0;
+}

--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -485,7 +485,7 @@ Custom values:
 
     private function findElementEnd(Tokens $tokens, int $index): int
     {
-        $index = $tokens->getNextTokenOfKind($index, ['(', '{', ';', [CT::T_PROPERTY_HOOK_BRACE_OPEN]]);
+        $index = $tokens->getNextTokenOfKind($index, ['(', '{', ';']);
 
         if ($tokens[$index]->equals('(')) {
             $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
@@ -494,10 +494,6 @@ Custom values:
 
         if ($tokens[$index]->equals('{')) {
             $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
-        }
-
-        if ($tokens[$index]->isGivenKind(CT::T_PROPERTY_HOOK_BRACE_OPEN)) {
-            $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PROPERTY_HOOK, $index);
         }
 
         for (++$index; $tokens[$index]->isWhitespace(" \t") || $tokens[$index]->isComment(); ++$index);

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -760,6 +760,7 @@ final class TokensAnalyzer
         ++$index; // skip the classy index itself
 
         for ($count = \count($this->tokens); $index < $count; ++$index) {
+            dump($index); // this loop will not end
             $token = $this->tokens[$index];
 
             if ($token->isGivenKind(T_ENCAPSED_AND_WHITESPACE)) {


### PR DESCRIPTION
Reverting https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8817 results with `ordered_class_elements` changing
```php
class code
{
    public int $i { get {} }
    public const C = 0;
}
```
to
```php
class code
{ }
    public const C = 0;
    public int $i { get {}
}
```
where the `}` from `{ }` is a property hook close brace, so we are in the situation where the closing property hook brace is BEFORE the opening property hook brace.

That makes `visibility_required` - to be precise `for` loop in `TokensAnalyzer::findClassyElements` - never ending.