### PR TITLE
fix: `VisibilityRequiredFixer` - handle promoted property with visibility and reference, but without type

### DIFF
--- a/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+++ b/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
@@ -286,7 +286,11 @@ class Sample
 
     private function isKeywordPlacedProperly(Tokens $tokens, int $keywordIndex, int $comparedIndex): bool
     {
-        return $keywordIndex + 2 === $comparedIndex && ' ' === $tokens[$keywordIndex + 1]->getContent();
+        return ' ' === $tokens[$keywordIndex + 1]->getContent()
+                && (
+                    $keywordIndex + 2 === $comparedIndex
+                    || $keywordIndex + 3 === $comparedIndex && $tokens[$keywordIndex + 2]->equals('&')
+                );
     }
 
     private function moveTokenAndEnsureSingleSpaceFollows(Tokens $tokens, int $fromIndex, int $toIndex): void

--- a/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+++ b/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
@@ -683,6 +683,17 @@ AB# <- this is the name
                 }
                 PHP,
         ];
+
+        yield 'promoted property with visibility and reference, but without type' => [
+            <<<'PHP'
+                <?php class Foo
+                {
+                    public function __construct(
+                        private &$bar,
+                    ) {}
+                }
+                PHP,
+        ];
     }
 
     /**
@@ -979,6 +990,25 @@ var_dump(Foo::CAT->test());',
                     readonly private(set) protected Bar $a;
                     protected(set) readonly public Bar $b;
                     private(set) public readonly Baz $c;
+                }
+                PHP,
+        ];
+
+        yield 'promoted property with visibility, set-visibility and reference' => [
+            <<<'PHP'
+                <?php class Foo
+                {
+                    public function __construct(
+                        protected private(set) int &$bar,
+                    ) {}
+                }
+                PHP,
+            <<<'PHP'
+                <?php class Foo
+                {
+                    public function __construct(
+                        private(set) protected int &$bar,
+                    ) {}
                 }
                 PHP,
         ];


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8819