### PR TITLE
fix: `LowercaseStaticReferenceFixer` - do not touch enum's cases

### DIFF
--- a/src/Fixer/Casing/LowercaseStaticReferenceFixer.php
+++ b/src/Fixer/Casing/LowercaseStaticReferenceFixer.php
@@ -104,7 +104,10 @@ class Foo extends Bar
         if ($tokens[$prevIndex]->isGivenKind(T_INSTANCEOF)) {
             return true;
         }
-        if (!$tokens[$prevIndex]->isGivenKind([T_CASE, T_NEW, T_PRIVATE, T_PROTECTED, T_PUBLIC, CT::T_NULLABLE_TYPE, CT::T_TYPE_COLON, CT::T_TYPE_ALTERNATION]) && !$tokens[$prevIndex]->equalsAny(['(', '{'])) {
+        if ($tokens[$prevIndex]->isGivenKind(T_CASE)) {
+            return !$tokens[$nextIndex]->equals(';');
+        }
+        if (!$tokens[$prevIndex]->isGivenKind([T_NEW, T_PRIVATE, T_PROTECTED, T_PUBLIC, CT::T_NULLABLE_TYPE, CT::T_TYPE_COLON, CT::T_TYPE_ALTERNATION]) && !$tokens[$prevIndex]->equalsAny(['(', '{'])) {
             return false;
         }
 

--- a/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
@@ -369,9 +369,23 @@ class Foo
             '<?php class A { final const PARENT = 42; }',
         ];
 
-        yield [
-            '<?php enum Foo: string { case PARENT = \'parent\'; }',
-        ];
+        yield [<<<'PHP'
+            <?php enum Foo: string
+            {
+                case SELF = 'self';
+                case STATIC = 'static';
+                case PARENT = 'parent';
+            }
+            PHP];
+
+        yield [<<<'PHP'
+            <?php enum Foo
+            {
+                case SELF;
+                case STATIC;
+                case PARENT;
+            }
+            PHP];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/laravel/pint/issues/380