### PR TITLE
CI: mark jobs allow-to-fail declarative, instead of imperative check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: php -l $(cat composer.json | jq -r '.bin[]')
 
   tests:
-    continue-on-error: ${{ matrix.operating-system == 'macos-latest' }}
+    continue-on-error: ${{ matrix.allow-to-fail == 'yes' }}
     strategy:
       fail-fast: false
       matrix:
@@ -133,12 +133,14 @@ jobs:
             php-version: '8.4'
             job-description: Fixer on macOS
             run-fixer: 'yes'
+            allow-to-fail: 'yes'
             FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional systems
 
           - operating-system: macos-latest
             php-version: '8.4'
             job-description: tests on macOS
             run-tests: 'yes'
+            allow-to-fail: 'yes'
             AVOID_PARAUNIT: 'yes' # macOS job is having weird issue on CI under ParaUnit
             FAST_LINT_TEST_CASES: 1 # we need full syntax check on one job at least, no need to do it on additional
 


### PR DESCRIPTION
extracted from #8827 