### PR TITLE
chore: do not use static variables for static content

### DIFF
--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -932,6 +932,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Fixer/ClassNotation/OrderedClassElementsFixer.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Offset mixed might not exist on array\\{setupbeforeclass\\: 1, dosetupbeforeclass\\: 2, teardownafterclass\\: 3, doteardownafterclass\\: 4, setup\\: 5, dosetup\\: 6, assertpreconditions\\: 7, assertpostconditions\\: 8, \\.\\.\\.\\}\\.$#',
+	'identifier' => 'offsetAccess.notFound',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Fixer/ClassNotation/OrderedClassElementsFixer.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$a of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixer\\:\\:sortGroupElements\\(\\) expects array\\{start\\: int, visibility\\: string, abstract\\: bool, static\\: bool, readonly\\: bool, type\\: string, name\\: string, end\\: int\\}, array&T given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -1008,6 +1014,12 @@ $ignoreErrors[] = [
 	'identifier' => 'offsetAccess.notFound',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Fixer/ClassNotation/ProtectedToPrivateFixer.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Offset int might not exist on array\\{1\\: \'\\|\\^\\#\\\\\\\\s\\*\\$\\|\', 3\\: \'\\|\\^/\\\\\\\\\\*\\[\\\\\\\\s\\\\\\\\\\*\\]\\*\\\\\\\\\\*\\+/\\$\\|\', 2\\: \'\\|\\^//\\\\\\\\s\\*\\$\\|\'\\}\\.$#',
+	'identifier' => 'offsetAccess.notFound',
+	'count' => 1,
+	'path' => __DIR__ . '/../../src/Fixer/Comment/NoEmptyCommentFixer.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Argument of an invalid type array\\<int\\<0, max\\>, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token supplied for foreach, only iterables are supported\\.$#',

--- a/src/Fixer/AbstractShortOperatorFixer.php
+++ b/src/Fixer/AbstractShortOperatorFixer.php
@@ -226,18 +226,15 @@ abstract class AbstractShortOperatorFixer extends AbstractFixer
 
     private function isOperatorCommutative(Token $operatorToken): bool
     {
-        static $commutativeKinds = ['*', '|', '&', '^']; // note that for arrays in PHP `+` is not commutative
-        static $nonCommutativeKinds = ['-', '/', '.', '%', '+'];
-
         if ($operatorToken->isGivenKind(T_COALESCE)) {
             return false;
         }
 
-        if ($operatorToken->equalsAny($commutativeKinds)) {
+        if ($operatorToken->equalsAny(['*', '|', '&', '^'])) { // note that for arrays in PHP `+` is not commutative
             return true;
         }
 
-        if ($operatorToken->equalsAny($nonCommutativeKinds)) {
+        if ($operatorToken->equalsAny(['-', '/', '.', '%', '+'])) {
             return false;
         }
 

--- a/src/Fixer/Alias/ModernizeStrposFixer.php
+++ b/src/Fixer/Alias/ModernizeStrposFixer.php
@@ -320,7 +320,7 @@ if (stripos($haystack, $needle) === false) {}
             T_SR,                  // >>
         ];
 
-        static $operatorsPerContent = [
+        return $token->isGivenKind($operatorsKinds) || $token->equalsAny([
             '!',
             '%',
             '*',
@@ -331,8 +331,6 @@ if (stripos($haystack, $needle) === false) {}
             '<',
             '>',
             '~',
-        ];
-
-        return $token->isGivenKind($operatorsKinds) || $token->equalsAny($operatorsPerContent);
+        ]);
     }
 }

--- a/src/Fixer/CastNotation/ShortScalarCastFixer.php
+++ b/src/Fixer/CastNotation/ShortScalarCastFixer.php
@@ -42,7 +42,7 @@ final class ShortScalarCastFixer extends AbstractFixer
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
-        static $castMap = [
+        $castMap = [
             'boolean' => 'bool',
             'integer' => 'int',
             'double' => 'float',

--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -514,7 +514,7 @@ Custom values:
      */
     private function sortElements(array $elements): array
     {
-        static $phpunitPositions = [
+        $phpunitPositions = [
             'setupbeforeclass' => 1,
             'dosetupbeforeclass' => 2,
             'teardownafterclass' => 3,

--- a/src/Fixer/Comment/NoEmptyCommentFixer.php
+++ b/src/Fixer/Comment/NoEmptyCommentFixer.php
@@ -149,7 +149,7 @@ final class NoEmptyCommentFixer extends AbstractFixer
 
     private function isEmptyComment(string $content): bool
     {
-        static $mapper = [
+        $mapper = [
             self::TYPE_HASH => '|^#\s*$|', // single line comment starting with '#'
             self::TYPE_SLASH_ASTERISK => '|^/\*[\s\*]*\*+/$|', // comment starting with '/*' and ending with '*/' (but not a PHPDoc)
             self::TYPE_DOUBLE_SLASH => '|^//\s*$|', // single line comment starting with '//'

--- a/src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
+++ b/src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
@@ -156,12 +156,11 @@ namespace {
         );
 
         // Case-insensitive constants handling
-        static $caseInsensitiveConstants = ['null', 'false', 'true'];
         $caseInsensitiveConstantsToEscape = [];
 
         foreach ($constantsToEscape as $constantIndex => $constant) {
             $loweredConstant = strtolower($constant);
-            if (\in_array($loweredConstant, $caseInsensitiveConstants, true)) {
+            if (\in_array($loweredConstant, ['null', 'false', 'true'], true)) {
                 $caseInsensitiveConstantsToEscape[] = $loweredConstant;
                 unset($constantsToEscape[$constantIndex]);
             }

--- a/src/Fixer/ControlStructure/YodaStyleFixer.php
+++ b/src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -469,7 +469,7 @@ return $foo === count($bar);
             ];
         }
 
-        static $otherTokens = [
+        $otherTokens = [
             // bitwise and, or, xor
             '&', '|', '^',
             // ternary operators

--- a/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+++ b/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
@@ -181,7 +181,7 @@ final class TernaryToNullCoalescingFixer extends AbstractFixer
             T_UNSET_CAST => true,
         ];
 
-        static $operatorsPerContent = [
+        $operatorsPerContent = [
             '!',
             '%',
             '&',

--- a/src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitConstructFixer.php
@@ -143,7 +143,7 @@ final class FooTest extends \PHPUnit_Framework_TestCase {
 
     private function fixAssertNegative(Tokens $tokens, int $index, string $method): ?int
     {
-        static $map = [
+        $map = [
             'false' => 'assertNotFalse',
             'null' => 'assertNotNull',
             'true' => 'assertNotTrue',
@@ -154,7 +154,7 @@ final class FooTest extends \PHPUnit_Framework_TestCase {
 
     private function fixAssertPositive(Tokens $tokens, int $index, string $method): ?int
     {
-        static $map = [
+        $map = [
             'false' => 'assertFalse',
             'null' => 'assertNull',
             'true' => 'assertTrue',

--- a/src/Fixer/StringNotation/StringLengthToEmptyFixer.php
+++ b/src/Fixer/StringNotation/StringLengthToEmptyFixer.php
@@ -255,7 +255,7 @@ final class StringLengthToEmptyFixer extends AbstractFunctionReferenceFixer
 
     private function isOfHigherPrecedence(Token $token): bool
     {
-        static $operatorsPerContent = [
+        $operatorsPerContent = [
             '!',
             '%',
             '*',

--- a/src/FixerFactory.php
+++ b/src/FixerFactory.php
@@ -209,18 +209,14 @@ final class FixerFactory
      */
     private function getFixersConflicts(FixerInterface $fixer): array
     {
-        static $conflictMap = [
+        return [
             'blank_lines_before_namespace' => [
                 'no_blank_lines_before_namespace',
                 'single_blank_line_before_namespace',
             ],
             'no_blank_lines_before_namespace' => ['single_blank_line_before_namespace'],
             'single_import_per_statement' => ['group_import'],
-        ];
-
-        $fixerName = $fixer->getName();
-
-        return \array_key_exists($fixerName, $conflictMap) ? $conflictMap[$fixerName] : [];
+        ][$fixer->getName()] ?? [];
     }
 
     /**

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -431,9 +431,7 @@ final class Token
      */
     public function isNativeConstant(): bool
     {
-        static $nativeConstantStrings = ['true', 'false', 'null'];
-
-        return $this->isArray && \in_array(strtolower($this->content), $nativeConstantStrings, true);
+        return $this->isArray && \in_array(strtolower($this->content), ['true', 'false', 'null'], true);
     }
 
     /**

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -593,7 +593,7 @@ final class TokensAnalyzer
      */
     public function isBinaryOperator(int $index): bool
     {
-        static $nonArrayOperators = [
+        $nonArrayOperators = [
             '=' => true,
             '*' => true,
             '/' => true,
@@ -605,7 +605,7 @@ final class TokensAnalyzer
             '.' => true,
         ];
 
-        static $potentialUnaryNonArrayOperators = [
+        $potentialUnaryNonArrayOperators = [
             '+' => true,
             '-' => true,
             '&' => true,
@@ -721,25 +721,23 @@ final class TokensAnalyzer
 
     public function isSuperGlobal(int $index): bool
     {
-        static $superNames = [
-            '$_COOKIE' => true,
-            '$_ENV' => true,
-            '$_FILES' => true,
-            '$_GET' => true,
-            '$_POST' => true,
-            '$_REQUEST' => true,
-            '$_SERVER' => true,
-            '$_SESSION' => true,
-            '$GLOBALS' => true,
-        ];
-
         $token = $this->tokens[$index];
 
         if (!$token->isGivenKind(T_VARIABLE)) {
             return false;
         }
 
-        return isset($superNames[strtoupper($token->getContent())]);
+        return \in_array(strtoupper($token->getContent()), [
+            '$_COOKIE',
+            '$_ENV',
+            '$_FILES',
+            '$_GET',
+            '$_POST',
+            '$_REQUEST',
+            '$_SERVER',
+            '$_SESSION',
+            '$GLOBALS',
+        ], true);
     }
 
     /**

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -81,7 +81,7 @@ final class FixerFactoryTest extends TestCase
      */
     public function testFixersPriorityCasesHaveIntegrationTest(string $fixerName, array $edges): void
     {
-        static $forPerformanceEdgesOnly = [
+        $forPerformanceEdgesOnly = [
             'function_to_constant' => [
                 'native_function_casing' => true,
             ],

--- a/tests/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDataProviderReturnTypeFixerTest.php
@@ -320,7 +320,7 @@ class FooTest extends TestCase {
      */
     private static function mapToTemplate(string ...$types): array
     {
-        static $template = '<?php
+        $template = '<?php
 class FooTest extends TestCase {
     /**
      * @dataProvider provideFooCases


### PR DESCRIPTION
Static variables with static content (e.g., static string or static array) appear to be slower than non-static variables or without any variables.

Also note that code without static variables is better for static analysis. That's why we get two new entries for phpstan baseline where phpstan knows for sure now how the array is structured.