### PR TITLE
fix: `NoUnreachableDefaultArgumentValueFixer` - do not crash on property hook

### DIFF
--- a/src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+++ b/src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
@@ -97,6 +97,12 @@ function example($foo = "two words", $bar) {}
                 continue;
             }
 
+            if ($token->isGivenKind(CT::T_PROPERTY_HOOK_BRACE_CLOSE)) {
+                $i = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PROPERTY_HOOK, $i);
+
+                continue;
+            }
+
             if (!$token->equals('=') || $this->isNonNullableTypehintedNullableVariable($tokens, $i)) {
                 continue;
             }

--- a/tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
@@ -303,5 +303,18 @@ $bar) {}',
             }
             PHP
         ];
+
+        yield 'do not crash 2' => [<<<'PHP'
+            <?php class Foo
+            {
+                public function __construct(
+                    public string $key {
+                        set(string $key) => $this->key = mb_strtolower($key);
+                    },
+                    public int $value,
+                ) {}
+            }
+            PHP
+        ];
     }
 }


### PR DESCRIPTION
fixes #8831