### PR TITLE
fix: PhpdocOrderFixer when phpstan- / psalm- order is specified

### DIFF
--- a/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
@@ -790,5 +790,56 @@ final class PhpdocOrderFixerTest extends AbstractFixerTestCase
                 EOF,
             ['order' => ['template', 'param', 'throws', 'return']],
         ];
+
+        yield 'multiline phpstan-return when phpstan order specified' => [
+            <<<'EOF'
+                    <?php
+                        /**
+                         * Returns next token if it's type equals to expected.
+                         *
+                         * @return array
+                         * @phpstan-param TTokenType $type
+                         * @phpstan-return (
+                         *     $type is 'TableRow'
+                         *         ? TTableRowToken
+                         *         : TOtherToken
+                         * )
+                         * @throws ParserException
+                         **/
+                EOF,
+            null,
+            ['order' => ['param', 'return', 'phpstan-param', 'phpstan-return', 'throws']],
+        ];
+
+        yield 'multiple phpstan-param when phpstan order specified' => [
+            <<<'EOF'
+                    <?php
+                        /**
+                         * @phpstan-param non-empty-list<TGitHubReleaseArray> $releases
+                         * @phpstan-param TCurrentVersionArray $currentVersion
+                         * @phpstan-return TGitHubReleaseArray|false
+                         */
+                EOF,
+            null,
+            ['order' => ['param', 'return', 'phpstan-param', 'phpstan-return', 'throws']],
+        ];
+
+        yield 'mixed param, phpstan-param and psalm-param with order specified' => [
+            <<<'EOF'
+                    <?php
+                        /**
+                         * @param array $releases
+                         * @param array $currentVersion
+                         * @psalm-param list<array> $releases
+                         * @psalm-param array<string> $releases
+                         * @phpstan-param non-empty-list<TGitHubReleaseArray> $releases
+                         * @phpstan-param TCurrentVersionArray $currentVersion
+                         * @return array|false
+                         * @phpstan-return TGitHubReleaseArray|false
+                         */
+                EOF,
+            null,
+            ['order' => ['param', 'psalm-param', 'phpstan-param', 'return']],
+        ];
     }
 }


### PR DESCRIPTION
In v3.77.0 PhpdocOrderFixer added default support for ordering phpstan- and psalm- annotations after any of the equivalent non-prefixed tags that are specified. This was implemented in #8777, then optimised (with no behaviour change) in #8812.

However, this produces incorrect diffs (including unexpectedly reordering tags of the same type, and entirely removing multiline returns) if the user has specified an explicit order for these annotations.

This can be seen IRL in https://github.com/Behat/Gherkin/actions/runs/16302601436/job/46040722894 - unchanged code in master that was passing CS at the last merge is now failing and the proposed diff is invalid.

This is happening because the implementation from #8777 adds duplicates for any tags that the user had explicitly configured. E.g. a configuration like `['param', 'phpstan-param', 'return']` was internally processed as `['param', 'phpstan-param', 'phpstan-param', 'return']`.

These duplicates then cause annotations to be moved multiple times, in some cases resulting in them being deleted from the output.

This PR fixes the issue by ensuring that annotations are only added to the user-provided order if they are not already specified.