### PR TITLE
chore: Command descriptions - use attribute and static properties

### DIFF
--- a/dev-tools/phpstan/baseline.php
+++ b/dev-tools/phpstan/baseline.php
@@ -68,30 +68,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Console/Command/CheckCommand.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\CheckCommand\\:\\:\\$defaultDescription has no type specified\\.$#',
-	'identifier' => 'missingType.property',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/CheckCommand.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\CheckCommand\\:\\:\\$defaultDescription overrides @final property PhpCsFixer\\\\Console\\\\Command\\\\FixCommand\\:\\:\\$defaultDescription\\.$#',
-	'identifier' => 'property.parentPropertyFinalByPhpDoc',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/CheckCommand.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\CheckCommand\\:\\:\\$defaultName has no type specified\\.$#',
-	'identifier' => 'missingType.property',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/CheckCommand.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\CheckCommand\\:\\:\\$defaultName overrides @final property PhpCsFixer\\\\Console\\\\Command\\\\FixCommand\\:\\:\\$defaultName\\.$#',
-	'identifier' => 'property.parentPropertyFinalByPhpDoc',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/CheckCommand.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Offset 1 might not exist on array\\.$#',
 	'identifier' => 'offsetAccess.notFound',
 	'count' => 2,
@@ -134,18 +110,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Console/Command/DescribeCommand.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\DescribeCommand\\:\\:\\$defaultName has no type specified\\.$#',
-	'identifier' => 'missingType.property',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/DescribeCommand.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\DocumentationCommand\\:\\:\\$defaultName has no type specified\\.$#',
-	'identifier' => 'missingType.property',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/DocumentationCommand.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#3 \\$cwd of class PhpCsFixer\\\\Console\\\\ConfigurationResolver constructor expects string, string\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -156,24 +120,6 @@ $ignoreErrors[] = [
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Console/Command/FixCommand.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\FixCommand\\:\\:\\$defaultDescription has no type specified\\.$#',
-	'identifier' => 'missingType.property',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/FixCommand.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\FixCommand\\:\\:\\$defaultName has no type specified\\.$#',
-	'identifier' => 'missingType.property',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/FixCommand.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\HelpCommand\\:\\:\\$defaultName has no type specified\\.$#',
-	'identifier' => 'missingType.property',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/HelpCommand.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$basePath of static method Symfony\\\\Component\\\\Filesystem\\\\Path\\:\\:makeRelative\\(\\) expects string, string\\|false given\\.$#',
@@ -188,18 +134,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Console/Command/ListFilesCommand.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\ListFilesCommand\\:\\:\\$defaultName has no type specified\\.$#',
-	'identifier' => 'missingType.property',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/ListFilesCommand.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\ListSetsCommand\\:\\:\\$defaultName has no type specified\\.$#',
-	'identifier' => 'missingType.property',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/ListSetsCommand.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Offset \'argv\' might not exist on array\\<mixed\\>\\.$#',
 	'identifier' => 'offsetAccess.notFound',
 	'count' => 1,
@@ -212,26 +146,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/../../src/Console/Command/SelfUpdateCommand.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\SelfUpdateCommand\\:\\:\\$defaultName has no type specified\\.$#',
-	'identifier' => 'missingType.property',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/SelfUpdateCommand.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Offset \'files\' might not exist on array\\.$#',
 	'identifier' => 'offsetAccess.notFound',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/WorkerCommand.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\WorkerCommand\\:\\:\\$defaultDescription has no type specified\\.$#',
-	'identifier' => 'missingType.property',
-	'count' => 1,
-	'path' => __DIR__ . '/../../src/Console/Command/WorkerCommand.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Property PhpCsFixer\\\\Console\\\\Command\\\\WorkerCommand\\:\\:\\$defaultName has no type specified\\.$#',
-	'identifier' => 'missingType.property',
 	'count' => 1,
 	'path' => __DIR__ . '/../../src/Console/Command/WorkerCommand.php',
 ];

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -53,6 +53,11 @@ parameters:
 
         # We retrieve these FQNs in various ways, we process them along the way, let's assume it's always class-string
         - '/^Parameter #2 \$fullName of class PhpCsFixer\\Tokenizer\\Analyzer\\Analysis\\NamespaceUseAnalysis constructor expects class-string, string given\.$/'
+
+        # Type for Command::$defaultName and ::$defaultDescription can not be specified because parent property also does not have a type
+        -
+            message: '/^Property PhpCsFixer\\Console\\Command\\\w+Command::\$default(?:Name|Description) has no type specified\.$/'
+            identifier: missingType.property
     tipsOfTheDay: false
     symfony:
         consoleApplicationLoader: dev-tools/phpstan/console-application.php

--- a/src/Console/Command/CheckCommand.php
+++ b/src/Console/Command/CheckCommand.php
@@ -27,9 +27,9 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'check', description: 'Checks if configured files/directories comply with configured rules.')]
 final class CheckCommand extends FixCommand
 {
-    protected static $defaultName = 'check';
+    protected static $defaultName = 'check'; // @phpstan-ignore property.parentPropertyFinalByPhpDoc
 
-    protected static $defaultDescription = 'Checks if configured files/directories comply with configured rules.';
+    protected static $defaultDescription = 'Checks if configured files/directories comply with configured rules.'; // @phpstan-ignore property.parentPropertyFinalByPhpDoc
 
     public function __construct(ToolInfoInterface $toolInfo)
     {

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -53,10 +53,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal
  */
-#[AsCommand(name: 'describe')]
+#[AsCommand(name: 'describe', description: 'Describe rule / ruleset.')]
 final class DescribeCommand extends Command
 {
     protected static $defaultName = 'describe';
+
+    protected static $defaultDescription = 'Describe rule / ruleset.';
 
     /**
      * @var ?list<string>
@@ -84,15 +86,12 @@ final class DescribeCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setDefinition(
-                [
-                    new InputArgument('name', InputArgument::REQUIRED, 'Name of rule / set.'),
-                    new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The path to a .php-cs-fixer.php file.'),
-                ]
-            )
-            ->setDescription('Describe rule / ruleset.')
-        ;
+        $this->setDefinition(
+            [
+                new InputArgument('name', InputArgument::REQUIRED, 'Name of rule / set.'),
+                new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The path to a .php-cs-fixer.php file.'),
+            ]
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Console/Command/DocumentationCommand.php
+++ b/src/Console/Command/DocumentationCommand.php
@@ -30,10 +30,12 @@ use Symfony\Component\Finder\SplFileInfo;
 /**
  * @internal
  */
-#[AsCommand(name: 'documentation')]
+#[AsCommand(name: 'documentation', description: 'Dumps the documentation of the project into its "/doc" directory.')]
 final class DocumentationCommand extends Command
 {
     protected static $defaultName = 'documentation';
+
+    protected static $defaultDescription = 'Dumps the documentation of the project into its "/doc" directory.';
 
     private Filesystem $filesystem;
 
@@ -45,10 +47,7 @@ final class DocumentationCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setAliases(['doc'])
-            ->setDescription('Dumps the documentation of the project into its "/doc" directory.')
-        ;
+        $this->setAliases(['doc']);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Console/Command/ListFilesCommand.php
+++ b/src/Console/Command/ListFilesCommand.php
@@ -30,10 +30,12 @@ use Symfony\Component\Filesystem\Path;
  *
  * @internal
  */
-#[AsCommand(name: 'list-files')]
+#[AsCommand(name: 'list-files', description: 'List all files being fixed by the given config.')]
 final class ListFilesCommand extends Command
 {
     protected static $defaultName = 'list-files';
+
+    protected static $defaultDescription = 'List all files being fixed by the given config.';
 
     private ConfigInterface $defaultConfig;
 
@@ -49,14 +51,11 @@ final class ListFilesCommand extends Command
 
     protected function configure(): void
     {
-        $this
-            ->setDefinition(
-                [
-                    new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The path to a .php-cs-fixer.php file.'),
-                ]
-            )
-            ->setDescription('List all files being fixed by the given config.')
-        ;
+        $this->setDefinition(
+            [
+                new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The path to a .php-cs-fixer.php file.'),
+            ]
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Console/Command/ListSetsCommand.php
+++ b/src/Console/Command/ListSetsCommand.php
@@ -33,21 +33,20 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal
  */
-#[AsCommand(name: 'list-sets')]
+#[AsCommand(name: 'list-sets', description: 'List all available RuleSets.')]
 final class ListSetsCommand extends Command
 {
     protected static $defaultName = 'list-sets';
 
+    protected static $defaultDescription = 'List all available RuleSets.';
+
     protected function configure(): void
     {
-        $this
-            ->setDefinition(
-                [
-                    new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats.', (new TextReporter())->getFormat()),
-                ]
-            )
-            ->setDescription('List all available RuleSets.')
-        ;
+        $this->setDefinition(
+            [
+                new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats.', (new TextReporter())->getFormat()),
+            ]
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -34,10 +34,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal
  */
-#[AsCommand(name: 'self-update')]
+#[AsCommand(name: 'self-update', description: 'Update php-cs-fixer.phar to the latest stable version.')]
 final class SelfUpdateCommand extends Command
 {
     protected static $defaultName = 'self-update';
+
+    protected static $defaultDescription = 'Update php-cs-fixer.phar to the latest stable version.';
 
     private NewVersionCheckerInterface $versionChecker;
 
@@ -66,7 +68,6 @@ final class SelfUpdateCommand extends Command
                     new InputOption('--force', '-f', InputOption::VALUE_NONE, 'Force update to next major version if available.'),
                 ]
             )
-            ->setDescription('Update php-cs-fixer.phar to the latest stable version.')
             ->setHelp(
                 <<<'EOT'
                     The <info>%command.name%</info> command replace your php-cs-fixer.phar by the


### PR DESCRIPTION
We can remove the static properties when dropping PHP 7.4 support.