### PR TITLE
chore: remove unused constants

### DIFF
--- a/src/Doctrine/Annotation/DocLexer.php
+++ b/src/Doctrine/Annotation/DocLexer.php
@@ -45,12 +45,9 @@ final class DocLexer
     public const T_CLOSE_PARENTHESIS = 103;
     public const T_COMMA = 104;
     public const T_EQUALS = 105;
-    public const T_FALSE = 106;
     public const T_NAMESPACE_SEPARATOR = 107;
     public const T_OPEN_CURLY_BRACES = 108;
     public const T_OPEN_PARENTHESIS = 109;
-    public const T_TRUE = 110;
-    public const T_NULL = 111;
     public const T_COLON = 112;
     public const T_MINUS = 113;
 

--- a/src/Fixer/Basic/CurlyBracesPositionFixer.php
+++ b/src/Fixer/Basic/CurlyBracesPositionFixer.php
@@ -55,16 +55,6 @@ final class CurlyBracesPositionFixer extends AbstractProxyFixer implements Confi
 
     use Indentation;
 
-    /**
-     * @internal
-     */
-    public const NEXT_LINE_UNLESS_NEWLINE_AT_SIGNATURE_END = 'next_line_unless_newline_at_signature_end';
-
-    /**
-     * @internal
-     */
-    public const SAME_LINE = 'same_line';
-
     private BracesPositionFixer $bracesPositionFixer;
 
     public function __construct()


### PR DESCRIPTION
They are all internal or in an internal class, so BC is kept.