### PR TITLE
feat: console application - add completion support

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -30,6 +30,8 @@ use PhpCsFixer\ToolInfo;
 use PhpCsFixer\Utils;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\CompleteCommand;
+use Symfony\Component\Console\Command\DumpCompletionCommand;
 use Symfony\Component\Console\Command\ListCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
@@ -176,7 +178,7 @@ final class Application extends BaseApplication
 
     protected function getDefaultCommands(): array
     {
-        return [new HelpCommand(), new ListCommand()];
+        return [new HelpCommand(), new ListCommand(), new CompleteCommand(), new DumpCompletionCommand()];
     }
 
     /**

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -91,7 +91,7 @@ final class DescribeCommand extends Command
     {
         $this->setDefinition(
             [
-                new InputArgument('name', InputArgument::REQUIRED, 'Name of rule / set.'),
+                new InputArgument('name', InputArgument::REQUIRED, 'Name of rule / set.', null, fn () => array_merge($this->getSetNames(), array_keys($this->getFixers()))),
                 new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The path to a .php-cs-fixer.php file.'),
             ]
         );

--- a/src/Console/Command/ListSetsCommand.php
+++ b/src/Console/Command/ListSetsCommand.php
@@ -50,7 +50,7 @@ final class ListSetsCommand extends Command
 
         $this->setDefinition(
             [
-                new InputOption('format', '', InputOption::VALUE_REQUIRED, \sprintf('To output results in other formats (can be %s).', implode(', ', array_map(static fn ($format) => \sprintf('`%s`', $format), $formats))), (new TextReporter())->getFormat()),
+                new InputOption('format', '', InputOption::VALUE_REQUIRED, \sprintf('To output results in other formats (can be %s).', implode(', ', array_map(static fn ($format) => \sprintf('`%s`', $format), $formats))), (new TextReporter())->getFormat(), $formats),
             ]
         );
     }


### PR DESCRIPTION
See https://symfony.com/doc/current/console/input.html#adding-argument-option-value-completion 
and `php-cs-fixer completion -h`

![2025-07-24 20 31 54](https://github.com/user-attachments/assets/43e28e21-1308-4687-8b72-bac0a0b78ff0)
