### PR TITLE
chore: apply changes from `PhpdocTypesFixer` for multiline array shapes

### DIFF
--- a/src/Console/Output/ErrorOutput.php
+++ b/src/Console/Output/ErrorOutput.php
@@ -123,7 +123,7 @@ final class ErrorOutput
      *     line?: int,
      *     file?: string,
      *     class?: class-string,
-     *     type?: '::'|'->',
+     *     type?: '->'|'::',
      *     args?: mixed[],
      *     object?: object,
      * } $trace

--- a/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+++ b/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
@@ -134,7 +134,7 @@ class Bar
      *     token: Token,
      *     type: string,
      *     class_is_final?: bool,
-     *     method_final_index: int|null,
+     *     method_final_index: null|int,
      *     method_is_constructor?: bool,
      *     method_is_private: bool,
      *     method_of_enum: bool

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -73,11 +73,11 @@ final class FullyQualifiedStrictTypesFixer extends AbstractFixer implements Conf
     private const CLASSY_KINDS = [\T_CLASS, \T_INTERFACE, \T_TRAIT, FCT::T_ENUM];
 
     /**
-     * @var array{
+     * @var null|array{
      *     constant?: list<class-string>,
      *     class?: list<class-string>,
      *     function?: list<class-string>
-     * }|null
+     * }
      */
     private ?array $discoveredSymbols;
 

--- a/src/Runner/Parallel/WorkerException.php
+++ b/src/Runner/Parallel/WorkerException.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Runner\Parallel;
 
-use Throwable;
-
 /**
  * @author Greg Korba <gre@codito.dev>
  *
@@ -32,7 +30,7 @@ final class WorkerException extends \RuntimeException
 
     /**
      * @param array{
-     *     class: class-string<Throwable>,
+     *     class: class-string<\Throwable>,
      *     message: string,
      *     file: string,
      *     line: int,

--- a/src/Tokenizer/Analyzer/ControlCaseStructuresAnalyzer.php
+++ b/src/Tokenizer/Analyzer/ControlCaseStructuresAnalyzer.php
@@ -56,11 +56,11 @@ final class ControlCaseStructuresAnalyzer
 
         /**
          * @var list<array{
-         *     kind: int|null,
+         *     kind: null|int,
          *     index: int,
          *     brace_count: int,
          *     cases: list<array{index: int, open: int}>,
-         *     default: array{index: int, open: int}|null,
+         *     default: null|array{index: int, open: int},
          *     alternative_syntax: bool,
          * }> $stack
          */

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -461,8 +461,8 @@ final class Token
 
     /**
      * @return array{
-     *     id: int|null,
-     *     name: non-empty-string|null,
+     *     id: null|int,
+     *     name: null|non-empty-string,
      *     content: string,
      *     isArray: bool,
      *     changed: bool,

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -72,9 +72,9 @@ final class TokensAnalyzer
      * Get indices of modifiers of a classy code (classes, interfaces and traits).
      *
      * @return array{
-     *     final: int|null,
-     *     abstract: int|null,
-     *     readonly: int|null
+     *     final: null|int,
+     *     abstract: null|int,
+     *     readonly: null|int
      * }
      */
     public function getClassyModifiers(int $index): array


### PR DESCRIPTION
Changes introduced by https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8893