### PR TITLE
fix: `PhpdocLineSpanFixer` - handle promoted properties

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php
@@ -63,6 +63,9 @@ final class PhpdocLineSpanFixer extends AbstractFixer implements WhitespacesAwar
         \T_STATIC,
         \T_STRING,
         \T_NS_SEPARATOR,
+        CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC,
+        CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED,
+        CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE,
         CT::T_ARRAY_TYPEHINT,
         CT::T_NULLABLE_TYPE,
         FCT::T_ATTRIBUTE,
@@ -125,13 +128,14 @@ final class PhpdocLineSpanFixer extends AbstractFixer implements WhitespacesAwar
         $analyzer = new TokensAnalyzer($tokens);
 
         foreach ($analyzer->getClassyElements() as $index => $element) {
-            if (!$this->hasDocBlock($tokens, $index)) {
+            $type = $element['type'];
+            $type = 'promoted_property' === $type ? 'property' : $type;
+
+            if (!isset($this->configuration[$type])) {
                 continue;
             }
 
-            $type = $element['type'];
-
-            if (!isset($this->configuration[$type])) {
+            if (!$this->hasDocBlock($tokens, $index)) {
                 continue;
             }
 

--- a/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
@@ -599,6 +599,42 @@ class Foo
      */
     public static function provideFix80Cases(): iterable
     {
+        yield 'It handles constructor property promotion' => [
+            '<?php
+
+class Foo
+{
+    public function __construct(
+        /** @var string[] */
+        #[Attribute1]
+        private array $foo1,
+
+        /** @var string[] */
+        private array $foo2,
+    ) {}
+}',
+            '<?php
+
+class Foo
+{
+    public function __construct(
+        /**
+         * @var string[]
+         */
+        #[Attribute1]
+        private array $foo1,
+
+        /**
+         * @var string[]
+         */
+        private array $foo2,
+    ) {}
+}',
+            [
+                'property' => 'single',
+            ],
+        ];
+
         yield 'It detects attributes between docblock and token' => [
             '<?php
 


### PR DESCRIPTION
When using the config `['property' => 'single']`, I would expect that promoted properties are also handled:

```php
class Foo
{
    public function __construct(
        /**
         * @var string[]
         */
        private array $foo1,

        /**
         * @var string[]
         */
        private array $foo2,
    ) {}
}
```