### PR TITLE
chore: do not call `Reflection*::setAccessible()` in PHP >= 8.1

### DIFF
--- a/src/Error/SourceExceptionFactory.php
+++ b/src/Error/SourceExceptionFactory.php
@@ -49,13 +49,13 @@ final class SourceExceptionFactory
             foreach (['file', 'line'] as $property) {
                 $propertyReflection = $exceptionReflection->getProperty($property);
 
-                if (\PHP_VERSION_ID < 80_100) {
+                if (\PHP_VERSION_ID < 8_01_00) {
                     $propertyReflection->setAccessible(true);
                 }
 
                 $propertyReflection->setValue($exception, $error[$property]);
 
-                if (\PHP_VERSION_ID < 80_100) {
+                if (\PHP_VERSION_ID < 8_01_00) {
                     $propertyReflection->setAccessible(false);
                 }
             }

--- a/src/Error/SourceExceptionFactory.php
+++ b/src/Error/SourceExceptionFactory.php
@@ -48,9 +48,16 @@ final class SourceExceptionFactory
             $exceptionReflection = new \ReflectionClass($exception);
             foreach (['file', 'line'] as $property) {
                 $propertyReflection = $exceptionReflection->getProperty($property);
-                $propertyReflection->setAccessible(true);
+
+                if (\PHP_VERSION_ID < 80_100) {
+                    $propertyReflection->setAccessible(true);
+                }
+
                 $propertyReflection->setValue($exception, $error[$property]);
-                $propertyReflection->setAccessible(false);
+
+                if (\PHP_VERSION_ID < 80_100) {
+                    $propertyReflection->setAccessible(false);
+                }
             }
         } catch (\Throwable $reflectionException) {
             // Ignore if we were not able to set file/line properties. In most cases it should be fine,


### PR DESCRIPTION
> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations