### PR TITLE
ci: allow PHP 8.5 for failure, till it's officially releaed and we get the stable support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
             php-version: '8.5'
             job-description: tests
             run-tests: 'yes'
+            allow-to-fail: 'yes' # with newest 8.5 development, we are not longer (and not yet) compatible with 8.5
             PHP_CS_FIXER_IGNORE_ENV: 1
 
     name: PHP ${{ matrix.php-version }} ${{ matrix.job-description }}


### PR DESCRIPTION
it started to fail on our CI, we need to re-fix it. probably same story will re-appear till `8.0@stable` will be stable