### PR TITLE
deps: remove `php-cs-fixer/accessible-object`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
         "keradus/cli-executor": "^2.2",
         "mikey179/vfsstream": "^1.6.12",
         "php-coveralls/php-coveralls": "^2.8",
-        "php-cs-fixer/accessible-object": "^1.1",
         "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.6",
         "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.6",
         "phpunit/phpunit": "^9.6.23 || ^10.5.47 || ^11.5.25",

--- a/tests/AbstractFixerTest.php
+++ b/tests/AbstractFixerTest.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace PhpCsFixer\Tests;
 
 use PhpCsFixer\AbstractFixer;
-use PhpCsFixer\AccessibleObject\AccessibleObject;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -50,7 +49,7 @@ final class AbstractFixerTest extends TestCase
     {
         $fixer = $this->createWhitespacesAwareFixerDouble();
 
-        $config = AccessibleObject::create($fixer)->whitespacesConfig;
+        $config = \Closure::bind(static fn ($fixer): WhitespacesFixerConfig => $fixer->whitespacesConfig, null, AbstractFixer::class)($fixer);
 
         self::assertSame('    ', $config->getIndent());
         self::assertSame("\n", $config->getLineEnding());
@@ -59,7 +58,7 @@ final class AbstractFixerTest extends TestCase
 
         $fixer->setWhitespacesConfig($newConfig);
 
-        $config = AccessibleObject::create($fixer)->whitespacesConfig;
+        $config = \Closure::bind(static fn ($fixer): WhitespacesFixerConfig => $fixer->whitespacesConfig, null, AbstractFixer::class)($fixer);
 
         self::assertSame("\t", $config->getIndent());
         self::assertSame("\r\n", $config->getLineEnding());

--- a/tests/AbstractFunctionReferenceFixerTest.php
+++ b/tests/AbstractFunctionReferenceFixerTest.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace PhpCsFixer\Tests;
 
 use PhpCsFixer\AbstractFunctionReferenceFixer;
-use PhpCsFixer\AccessibleObject\AccessibleObject;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -46,12 +45,12 @@ final class AbstractFunctionReferenceFixerTest extends TestCase
 
         self::assertSame(
             $expected,
-            AccessibleObject::create($fixer)->find(
+            \Closure::bind(static fn (AbstractFunctionReferenceFixer $fixer): ?array => $fixer->find(
                 $functionNameToSearch,
                 $tokens,
                 $start,
                 $end
-            )
+            ), null, AbstractFunctionReferenceFixer::class)($fixer)
         );
 
         self::assertFalse($tokens->isChanged());

--- a/tests/AbstractProxyFixerTest.php
+++ b/tests/AbstractProxyFixerTest.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace PhpCsFixer\Tests;
 
 use PhpCsFixer\AbstractProxyFixer;
-use PhpCsFixer\AccessibleObject\AccessibleObject;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
@@ -116,7 +115,10 @@ final class AbstractProxyFixerTest extends TestCase
 
         $proxyFixer->setWhitespacesConfig($config);
 
-        self::assertSame($config, AccessibleObject::create($whitespacesAwareFixer)->whitespacesConfig);
+        self::assertSame(
+            $config,
+            \Closure::bind(static fn ($fixer): WhitespacesFixerConfig => $fixer->whitespacesConfig, null, \get_class($whitespacesAwareFixer))($whitespacesAwareFixer),
+        );
     }
 
     public function testApplyFixInPriorityOrder(): void
@@ -127,8 +129,8 @@ final class AbstractProxyFixerTest extends TestCase
         $proxyFixer = $this->createProxyFixerDouble([$fixer1, $fixer2]);
         $proxyFixer->fix(new \SplFileInfo(__FILE__), Tokens::fromCode('<?php echo 1;'));
 
-        self::assertSame(2, AccessibleObject::create($fixer1)->fixCalled);
-        self::assertSame(1, AccessibleObject::create($fixer2)->fixCalled);
+        self::assertSame(2, \Closure::bind(static fn ($fixer): int => $fixer->fixCalled, null, \get_class($fixer1))($fixer1));
+        self::assertSame(1, \Closure::bind(static fn ($fixer): int => $fixer->fixCalled, null, \get_class($fixer2))($fixer2));
     }
 
     private function createFixerDouble(

--- a/tests/Cache/FileCacheManagerTest.php
+++ b/tests/Cache/FileCacheManagerTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Cache;
 
-use PhpCsFixer\AccessibleObject\AccessibleObject;
 use PhpCsFixer\Cache\CacheInterface;
 use PhpCsFixer\Cache\CacheManagerInterface;
 use PhpCsFixer\Cache\DirectoryInterface;
@@ -55,7 +54,7 @@ final class FileCacheManagerTest extends TestCase
         $manager = new FileCacheManager($handler, $signature);
         unset($manager);
 
-        self::assertSame(1, AccessibleObject::create($handler)->writeCallCount);
+        self::assertWriteCallCount(1, $handler);
     }
 
     public function testCreatesCacheIfCachedSignatureIsDifferent(): void
@@ -68,7 +67,7 @@ final class FileCacheManagerTest extends TestCase
         $manager = new FileCacheManager($handler, $signature);
         unset($manager);
 
-        self::assertSame(1, AccessibleObject::create($handler)->writeCallCount);
+        self::assertWriteCallCount(1, $handler);
     }
 
     public function testUsesCacheIfCachedSignatureIsEqualAndNoFileWasUpdated(): void
@@ -81,7 +80,7 @@ final class FileCacheManagerTest extends TestCase
         $manager = new FileCacheManager($handler, $signature);
         unset($manager);
 
-        self::assertSame(0, AccessibleObject::create($handler)->writeCallCount);
+        self::assertWriteCallCount(0, $handler);
     }
 
     public function testNeedFixingReturnsTrueIfCacheHasNoHash(): void
@@ -163,7 +162,7 @@ final class FileCacheManagerTest extends TestCase
 
         self::assertTrue($cache->has($file));
         self::assertSame(Hasher::calculate($fileContent), $cache->get($file));
-        self::assertSame(1, AccessibleObject::create($handler)->writeCallCount);
+        self::assertWriteCallCount(1, $handler);
     }
 
     public function testSetFileSetsHashOfFileContentDuringDryRunIfCacheHasNoHash(): void
@@ -230,6 +229,18 @@ final class FileCacheManagerTest extends TestCase
 
         self::assertTrue($cache->has($relativePathToFile));
         self::assertSame(Hasher::calculate($fileContent), $cache->get($relativePathToFile));
+    }
+
+    private static function assertWriteCallCount(int $writeCallCount, FileHandlerInterface $handler): void
+    {
+        self::assertSame(
+            $writeCallCount,
+            \Closure::bind(
+                static fn ($handler): int => $handler->writeCallCount,
+                null,
+                \get_class($handler)
+            )($handler),
+        );
     }
 
     private function getFile(): string

--- a/tests/Runner/RunnerTest.php
+++ b/tests/Runner/RunnerTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Runner;
 
-use PhpCsFixer\AccessibleObject\AccessibleObject;
 use PhpCsFixer\Cache\Directory;
 use PhpCsFixer\Cache\NullCacheManager;
 use PhpCsFixer\Console\Command\FixCommand;
@@ -322,7 +321,14 @@ final class RunnerTest extends TestCase
 
         $runner->fix();
 
-        self::assertSame($path, AccessibleObject::create($differ)->passedFile->getPath());
+        self::assertSame(
+            $path,
+            \Closure::bind(
+                static fn ($differ): string => $differ->passedFile->getPath(),
+                null,
+                \get_class($differ)
+            )($differ),
+        );
     }
 
     private function createDifferDouble(): DifferInterface

--- a/tests/Test/TokensWithObservedTransformers.php
+++ b/tests/Test/TokensWithObservedTransformers.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Test;
 
-use PhpCsFixer\AccessibleObject\AccessibleObject;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\Transformers;
@@ -49,7 +48,14 @@ class TokensWithObservedTransformers extends Tokens
         $this->observedModificationsPerTransformer = [];
 
         $transformers = Transformers::createSingleton();
-        foreach (AccessibleObject::create($transformers)->items as $transformer) {
+
+        $items = \Closure::bind(
+            static fn (Transformers $transformers): array => $transformers->items,
+            null,
+            Transformers::class
+        )($transformers);
+
+        foreach ($items as $transformer) {
             $this->currentTransformer = $transformer->getName();
             $this->observedModificationsPerTransformer[$this->currentTransformer] = [];
 


### PR DESCRIPTION
- one - not updated for 5 years - less dependency
- `php-cs-fixer/accessible-object` is [using `ReflectionClass::setAccessible‎`](https://github.com/PHP-CS-Fixer/AccessibleObject/blob/v1.1.0/src/AccessibleObject.php#L39)
- `ReflectionClass::setAccessible‎` [will be deprecated in PHP 8.5](https://github.com/php/php-src/pull/19273)
- will decrease deprecations found in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8934