### PR TITLE
chore: unify "token kind" meaning (extend `int` to `int|string`)

### DIFF
--- a/dev-tools/phpstan/baseline/argument.type.php
+++ b/dev-tools/phpstan/baseline/argument.type.php
@@ -117,11 +117,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../../src/Fixer/ClassNotation/OrderedTraitsFixer.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$possibleKind of method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:isGivenKind\\(\\) expects int\\|list\\<int\\>, list\\<int\\|string\\> given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Fixer/ControlStructure/YodaStyleFixer.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#3 \\$length of function substr expects int\\|null, int\\|false given\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../../src/Fixer/Import/FullyQualifiedStrictTypesFixer.php',
@@ -232,7 +227,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../../src/Tokenizer/Analyzer/ControlCaseStructuresAnalyzer.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$possibleKind of method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:isGivenKind\\(\\) expects int\\|list\\<int\\>, non\\-empty\\-array\\<int\\<0, max\\>, int\\> given\\.$#',
+    'message' => '#^Parameter \\#1 \\$possibleKind of method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:isGivenKind\\(\\) expects int\\|list\\<int\\|string\\>\\|string, non\\-empty\\-array\\<int\\<0, max\\>, int\\|string\\> given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../../src/Tokenizer/Tokens.php',
 ];

--- a/dev-tools/phpstan/baseline/offsetAccess.notFound.php
+++ b/dev-tools/phpstan/baseline/offsetAccess.notFound.php
@@ -1022,7 +1022,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../../src/Tokenizer/Tokens.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Offset int might not exist on non\\-empty\\-array\\<int, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\>\\.$#',
+    'message' => '#^Offset int\\|string might not exist on non\\-empty\\-array\\<int\\|string, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\>\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../../src/Tokenizer/Tokens.php',
 ];

--- a/dev-tools/phpstan/baseline/return.type.php
+++ b/dev-tools/phpstan/baseline/return.type.php
@@ -37,7 +37,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../../src/Fixer/Phpdoc/PhpdocAlignFixer.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findGivenKind\\(\\) should return array\\<int, array\\<int\\<0, max\\>, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\> but returns array\\<int, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\>\\.$#',
+    'message' => '#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findGivenKind\\(\\) should return array\\<int\\|string, array\\<int\\<0, max\\>, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\> but returns array\\<int\\|string, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\>\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../../src/Tokenizer/Tokens.php',
 ];

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -44,6 +44,13 @@ final class Token
     private ?int $id;
 
     /**
+     * Token ID (if available) or token content otherwise.
+     *
+     * @var _PhpTokenKind
+     */
+    private $kind;
+
+    /**
      * If token prototype is an array.
      */
     private bool $isArray;
@@ -74,10 +81,12 @@ final class Token
 
             $this->isArray = true;
             $this->id = $token[0];
+            $this->kind = $token[0];
             $this->content = $token[1];
         } elseif (\is_string($token)) {
             $this->isArray = false;
             $this->id = null;
+            $this->kind = $token;
             $this->content = $token;
         } else {
             throw new \InvalidArgumentException(\sprintf('Cannot recognize input value as valid Token prototype, got "%s".', get_debug_type($token)));
@@ -125,52 +134,40 @@ final class Token
         if ('&' === $other) {
             return '&' === $this->content && (null === $this->id || $this->isGivenKind([FCT::T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG, FCT::T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG]));
         }
-        if (null === $this->id && '&' === $this->content) {
+        if ('&' === $this->kind) {
             return $other instanceof self && '&' === $other->content && (null === $other->id || $other->isGivenKind([FCT::T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG, FCT::T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG]));
         }
 
         if ($other instanceof self) {
-            // Inlined getPrototype() on this very hot path.
             // We access the private properties of $other directly to save function call overhead.
             // This is only possible because $other is of the same class as `self`.
-            if (!$other->isArray) {
-                $otherPrototype = $other->content;
-            } else {
-                $otherPrototype = [
-                    $other->id,
-                    $other->content,
-                ];
-            }
-        } else {
-            $otherPrototype = $other;
+            $other = [$other->kind, $other->content];
+        } elseif (\is_string($other)) {
+            $other = [$other];
         }
 
-        if ($this->isArray !== \is_array($otherPrototype)) {
+        if ($this->kind !== $other[0]) {
             return false;
         }
 
         if (!$this->isArray) {
-            return $this->content === $otherPrototype;
+            return true;
         }
 
-        if ($this->id !== $otherPrototype[0]) {
-            return false;
-        }
-
-        if (isset($otherPrototype[1])) {
+        if (isset($other[1])) {
             if ($caseSensitive) {
-                if ($this->content !== $otherPrototype[1]) {
+                if ($this->content !== $other[1]) {
                     return false;
                 }
-            } elseif (0 !== strcasecmp($this->content, $otherPrototype[1])) {
+            } elseif (0 !== strcasecmp($this->content, $other[1])) {
                 return false;
             }
         }
 
         // detect unknown keys
-        unset($otherPrototype[0], $otherPrototype[1]);
+        unset($other[0], $other[1]);
 
-        return [] === $otherPrototype;
+        return [] === $other;
     }
 
     /**
@@ -249,6 +246,16 @@ final class Token
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    /**
+     * Get token's kind.
+     *
+     * @return _PhpTokenKind token ID (if available) or token content otherwise
+     */
+    public function getKind()
+    {
+        return $this->kind;
     }
 
     /**
@@ -402,14 +409,14 @@ final class Token
     /**
      * Check if token is one of given kind.
      *
-     * @param int|list<int> $possibleKind kind or array of kinds
+     * @param _PhpTokenKind|list<_PhpTokenKind> $possibleKind kind or array of kinds
      *
      * @phpstan-assert-if-true !=null $this->getId()
      * @phpstan-assert-if-true !='' $this->getContent()
      */
     public function isGivenKind($possibleKind): bool
     {
-        return $this->isArray && (\is_array($possibleKind) ? \in_array($this->id, $possibleKind, true) : $this->id === $possibleKind);
+        return \is_array($possibleKind) ? \in_array($this->kind, $possibleKind, true) : $this->kind === $possibleKind;
     }
 
     /**

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -165,10 +165,7 @@ class Tokens extends \SplFixedArray
             }
         }
 
-        // inlined extractTokenKind() call on the hot path
-        $tokenKind = $token->isArray() ? $token->getId() : $token->getContent();
-
-        return $blockEdgeKinds[$tokenKind] ?? null;
+        return $blockEdgeKinds[$token->getKind()] ?? null;
     }
 
     /**
@@ -534,11 +531,11 @@ class Tokens extends \SplFixedArray
     }
 
     /**
-     * @param int|non-empty-list<int> $possibleKind kind or array of kinds
-     * @param int                     $start        optional offset
-     * @param null|int                $end          optional limit
+     * @param _PhpTokenKind|non-empty-list<_PhpTokenKind> $possibleKind kind or array of kinds
+     * @param int                                         $start        optional offset
+     * @param null|int                                    $end          optional limit
      *
-     * @return ($possibleKind is int ? array<int<0, max>, Token> : array<int, array<int<0, max>, Token>>)
+     * @return ($possibleKind is array ? array<_PhpTokenKind, array<int<0, max>, Token>> : array<int<0, max>, Token>)
      */
     public function findGivenKind($possibleKind, int $start = 0, ?int $end = null): array
     {
@@ -559,7 +556,7 @@ class Tokens extends \SplFixedArray
             for ($i = $start; $i < $end; ++$i) {
                 $token = $this[$i];
                 if ($token->isGivenKind($possibleKinds)) {
-                    $elements[$token->getId()][$i] = $token;
+                    $elements[$token->getKind()][$i] = $token;
                 }
             }
         }
@@ -756,9 +753,9 @@ class Tokens extends \SplFixedArray
     /**
      * Get index for closest sibling token not of given kind.
      *
-     * @param int       $index     token index
-     * @param -1|1      $direction
-     * @param list<int> $kinds     possible tokens kinds
+     * @param int                 $index     token index
+     * @param -1|1                $direction
+     * @param list<_PhpTokenKind> $kinds     possible tokens kinds
      */
     public function getTokenNotOfKindsSibling(int $index, int $direction, array $kinds = []): ?int
     {
@@ -1035,7 +1032,7 @@ class Tokens extends \SplFixedArray
     {
         $token = $this[$index];
 
-        return null === $token->getId() && '' === $token->getContent();
+        return '' === $token->getKind();
     }
 
     public function clearAt(int $index): void
@@ -1515,8 +1512,7 @@ class Tokens extends \SplFixedArray
      */
     private function registerFoundToken(Token $token): void
     {
-        // inlined extractTokenKind() call on the hot path
-        $tokenKind = $token->isArray() ? $token->getId() : $token->getContent();
+        $tokenKind = $token->getKind();
 
         $this->foundTokenKinds[$tokenKind] ??= 0;
         ++$this->foundTokenKinds[$tokenKind];
@@ -1527,8 +1523,7 @@ class Tokens extends \SplFixedArray
      */
     private function unregisterFoundToken(Token $token): void
     {
-        // inlined extractTokenKind() call on the hot path
-        $tokenKind = $token->isArray() ? $token->getId() : $token->getContent();
+        $tokenKind = $token->getKind();
 
         \assert(($this->foundTokenKinds[$tokenKind] ?? 0) > 0);
         --$this->foundTokenKinds[$tokenKind];
@@ -1542,7 +1537,7 @@ class Tokens extends \SplFixedArray
     private function extractTokenKind($token)
     {
         return $token instanceof Token
-            ? ($token->isArray() ? $token->getId() : $token->getContent())
+            ? $token->getKind()
             : (\is_array($token) ? $token[0] : $token);
     }
 

--- a/tests/Test/Assert/AssertTokensTrait.php
+++ b/tests/Test/Assert/AssertTokensTrait.php
@@ -38,7 +38,7 @@ trait AssertTokensTrait
                 \sprintf("The token at index %d must be:\n%s,\ngot:\n%s.", $index, $expectedToken->toJson(), $inputToken->toJson())
             );
 
-            $expectedTokenKind = $expectedToken->isArray() ? $expectedToken->getId() : $expectedToken->getContent();
+            $expectedTokenKind = $expectedToken->getKind();
             self::assertTrue(
                 $inputTokens->isTokenKindFound($expectedTokenKind),
                 \sprintf(

--- a/tests/Test/TokensWithObservedTransformers.php
+++ b/tests/Test/TokensWithObservedTransformers.php
@@ -69,7 +69,7 @@ class TokensWithObservedTransformers extends Tokens
     private function extractTokenKind($token)
     {
         return $token instanceof Token
-            ? ($token->isArray() ? $token->getId() : $token->getContent())
+            ? $token->getKind()
             : (\is_array($token) ? $token[0] : $token);
     }
 }

--- a/tests/Tokenizer/TokenTest.php
+++ b/tests/Tokenizer/TokenTest.php
@@ -20,6 +20,7 @@ use PhpCsFixer\Tokenizer\FCT;
 use PhpCsFixer\Tokenizer\Token;
 
 /**
+ * @phpstan-import-type _PhpTokenKind from Token
  * @phpstan-import-type _PhpTokenPrototypePartial from Token
  *
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -72,6 +73,12 @@ final class TokenTest extends TestCase
     {
         self::assertSame('(', self::getBraceToken()->getPrototype());
         self::assertSame([\T_FOREACH, 'foreach'], self::getForeachToken()->getPrototype());
+    }
+
+    public function testGetKind(): void
+    {
+        self::assertSame('(', self::getBraceToken()->getKind());
+        self::assertSame(\T_FOREACH, self::getForeachToken()->getKind());
     }
 
     public function testIsArray(): void
@@ -228,22 +235,64 @@ final class TokenTest extends TestCase
         yield [new Token([FCT::T_NULLSAFE_OBJECT_OPERATOR, '?->']), true];
     }
 
-    public function testIsGivenKind(): void
+    /**
+     * @dataProvider provideIsGivenKindCases
+     *
+     * @param _PhpTokenKind|list<_PhpTokenKind> $kind
+     */
+    public function testIsGivenKind(bool $expected, Token $token, $kind): void
+    {
+        self::assertSame($expected, $token->isGivenKind($kind));
+    }
+
+    /**
+     * @return iterable<int, array{bool, Token, _PhpTokenKind|list<_PhpTokenKind>}>
+     */
+    public static function provideIsGivenKindCases(): iterable
     {
         $braceToken = self::getBraceToken();
+
+        yield [false, $braceToken, \T_FOR];
+
+        yield [false, $braceToken, \T_FOREACH];
+
+        yield [true, $braceToken, '('];
+
+        yield [false, $braceToken, ';'];
+
+        yield [false, $braceToken, [\T_FOR]];
+
+        yield [false, $braceToken, [\T_FOREACH]];
+
+        yield [false, $braceToken, [\T_FOR, \T_FOREACH, ';']];
+
+        yield [true, $braceToken, ['(']];
+
+        yield [false, $braceToken, [';']];
+
+        yield [true, $braceToken, ['(', ';']];
+
+        yield [true, $braceToken, [\T_FOREACH, '(']];
+
         $foreachToken = self::getForeachToken();
 
-        self::assertFalse($braceToken->isGivenKind(\T_FOR));
-        self::assertFalse($braceToken->isGivenKind(\T_FOREACH));
-        self::assertFalse($braceToken->isGivenKind([\T_FOR]));
-        self::assertFalse($braceToken->isGivenKind([\T_FOREACH]));
-        self::assertFalse($braceToken->isGivenKind([\T_FOR, \T_FOREACH]));
+        yield [false, $foreachToken, \T_FOR];
 
-        self::assertFalse($foreachToken->isGivenKind(\T_FOR));
-        self::assertTrue($foreachToken->isGivenKind(\T_FOREACH));
-        self::assertFalse($foreachToken->isGivenKind([\T_FOR]));
-        self::assertTrue($foreachToken->isGivenKind([\T_FOREACH]));
-        self::assertTrue($foreachToken->isGivenKind([\T_FOR, \T_FOREACH]));
+        yield [true, $foreachToken, \T_FOREACH];
+
+        yield [false, $foreachToken, '('];
+
+        yield [false, $foreachToken, [\T_FOR]];
+
+        yield [true, $foreachToken, [\T_FOREACH]];
+
+        yield [true, $foreachToken, [\T_FOR, \T_FOREACH]];
+
+        yield [false, $foreachToken, ['(']];
+
+        yield [false, $foreachToken, ['(', ';']];
+
+        yield [true, $foreachToken, [\T_FOREACH, '(']];
     }
 
     public function testIsKeywords(): void

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -521,8 +521,15 @@ final class TokensTest extends TestCase
         self::assertArrayHasKey(1, $found);
         self::assertSame(\T_CLASS, $found[1]->getId());
 
-        $found = $tokens->findGivenKind([\T_CLASS, \T_FUNCTION]);
+        $found = $tokens->findGivenKind(';');
         self::assertCount(2, $found);
+        self::assertArrayHasKey(20, $found);
+        self::assertSame(';', $found[20]->getKind());
+        self::assertArrayHasKey(37, $found);
+        self::assertSame(';', $found[37]->getKind());
+
+        $found = $tokens->findGivenKind([\T_CLASS, \T_FUNCTION, ';']);
+        self::assertCount(3, $found);
         self::assertArrayHasKey(\T_CLASS, $found);
         self::assertIsArray($found[\T_CLASS]);
         self::assertCount(1, $found[\T_CLASS]);
@@ -537,20 +544,34 @@ final class TokensTest extends TestCase
         self::assertArrayHasKey(26, $found[\T_FUNCTION]);
         self::assertSame(\T_FUNCTION, $found[\T_FUNCTION][26]->getId());
 
+        self::assertArrayHasKey(';', $found);
+        self::assertIsArray($found[';']);
+        self::assertCount(2, $found[';']);
+        self::assertArrayHasKey(20, $found[';']);
+        self::assertSame(';', $found[';'][20]->getKind());
+        self::assertArrayHasKey(37, $found[';']);
+        self::assertSame(';', $found[';'][37]->getKind());
+
         // test offset and limits of the search
-        $found = $tokens->findGivenKind([\T_CLASS, \T_FUNCTION], 10);
+        $found = $tokens->findGivenKind([\T_CLASS, \T_FUNCTION, ';'], 21);
         self::assertArrayHasKey(\T_CLASS, $found);
         self::assertCount(0, $found[\T_CLASS]);
         self::assertArrayHasKey(\T_FUNCTION, $found);
         self::assertCount(1, $found[\T_FUNCTION]);
         self::assertArrayHasKey(26, $found[\T_FUNCTION]);
+        self::assertArrayHasKey(';', $found);
+        self::assertCount(1, $found[';']);
+        self::assertArrayHasKey(37, $found[';']);
 
-        $found = $tokens->findGivenKind([\T_CLASS, \T_FUNCTION], 2, 10);
+        $found = $tokens->findGivenKind([\T_CLASS, \T_FUNCTION, ';'], 2, 21);
         self::assertArrayHasKey(\T_CLASS, $found);
         self::assertCount(0, $found[\T_CLASS]);
         self::assertArrayHasKey(\T_FUNCTION, $found);
         self::assertCount(1, $found[\T_FUNCTION]);
         self::assertArrayHasKey(9, $found[\T_FUNCTION]);
+        self::assertArrayHasKey(';', $found);
+        self::assertCount(1, $found[';']);
+        self::assertArrayHasKey(20, $found[';']);
     }
 
     /**


### PR DESCRIPTION
Part of #8852

* introduce `Token::getKind()`
* extend accepted input types (`int` to `_PhpTokenKind`) for
  - `Token::isGivenKind`
  - `Tokens::findGivenKind`
  - `Tokens::getTokenNotOfKindsSibling`