### PR TITLE
chore: `AbstractPhpdocTypesFixer` - remove `$tags` property

### DIFF
--- a/src/AbstractPhpdocTypesFixer.php
+++ b/src/AbstractPhpdocTypesFixer.php
@@ -29,13 +29,6 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 abstract class AbstractPhpdocTypesFixer extends AbstractFixer
 {
-    /**
-     * The annotation tags search inside.
-     *
-     * @var list<string>
-     */
-    protected array $tags = Annotation::TAGS_WITH_TYPES;
-
     public function isCandidate(Tokens $tokens): bool
     {
         return $tokens->isTokenKindFound(\T_DOC_COMMENT);
@@ -49,7 +42,7 @@ abstract class AbstractPhpdocTypesFixer extends AbstractFixer
             }
 
             $doc = new DocBlock($token->getContent());
-            $annotations = $doc->getAnnotationsOfType($this->tags);
+            $annotations = $doc->getAnnotationsOfType(Annotation::TAGS_WITH_TYPES);
 
             if (0 === \count($annotations)) {
                 continue;


### PR DESCRIPTION
as discussed in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/8972#discussion_r2296723264