### PR TITLE
test: update pipe operator tests after pipe & arrow function combination was prohibited

### DIFF
--- a/tests/Fixer/Operator/OperatorLinebreakFixerTest.php
+++ b/tests/Fixer/Operator/OperatorLinebreakFixerTest.php
@@ -271,13 +271,13 @@ endwhile;
             <<<'PHP'
                 <?php
                 $numberOfAdmins = getUsers()
-                    |> fn ($list) => array_filter($list, isAdmin(...))
+                    |> (fn ($list) => array_filter($list, isAdmin(...)))
                     |> count(...);
                 PHP,
             <<<'PHP'
                 <?php
                 $numberOfAdmins = getUsers() |>
-                    fn ($list) => array_filter($list, isAdmin(...)) |>
+                    (fn ($list) => array_filter($list, isAdmin(...))) |>
                     count(...);
                 PHP,
         ];

--- a/tests/Fixtures/Integration/php_compat/PHP8_5.test
+++ b/tests/Fixtures/Integration/php_compat/PHP8_5.test
@@ -24,7 +24,7 @@ class Foo
 
 // https://wiki.php.net/rfc/pipe-operator-v3
 $numberOfAdmins = getUsers()
-    |> fn ($list) => array_filter($list, isAdmin(...))
+    |> (fn ($list) => array_filter($list, isAdmin(...)))
     |> count(...);
 
 // https://wiki.php.net/rfc/marking_return_value_as_important
@@ -55,7 +55,7 @@ class Foo
 
 // https://wiki.php.net/rfc/pipe-operator-v3
 $numberOfAdmins = getUsers() |>
-    fn ($list) => array_filter($list, isAdmin(...)) |>
+    (fn ($list) => array_filter($list, isAdmin(...))) |>
     count(...);
 
 // https://wiki.php.net/rfc/marking_return_value_as_important


### PR DESCRIPTION
Ref. https://github.com/php/php-src/pull/19533