### PR TITLE
fix: cache FileHandler to read large cache file in chunks

### DIFF
--- a/src/Cache/FileHandler.php
+++ b/src/Cache/FileHandler.php
@@ -121,7 +121,7 @@ final class FileHandler implements FileHandlerInterface
                 return null;
             }
 
-            if ($fileObject->flock(LOCK_SH) === false) {
+            if (false === $fileObject->flock(\LOCK_SH)) {
                 return null;
             }
 
@@ -130,21 +130,21 @@ final class FileHandler implements FileHandlerInterface
                 $fileObject->rewind();
 
                 $content = '';
-                while ($fileObject->eof() === false) {
-                    $chunk = $fileObject->fread(8192);
+                while (false === $fileObject->eof()) {
+                    $chunk = $fileObject->fread(8_192);
 
-                    if ($chunk === false) {
+                    if (false === $chunk) {
                         return null;
                     }
 
-                    if ($chunk === '') {
+                    if ('' === $chunk) {
                         break;
                     }
 
                     $content .= $chunk;
                 }
             } finally {
-                $fileObject->flock(LOCK_UN);
+                $fileObject->flock(\LOCK_UN);
             }
 
             if (false === $content) {

--- a/src/Cache/FileHandler.php
+++ b/src/Cache/FileHandler.php
@@ -147,7 +147,7 @@ final class FileHandler implements FileHandlerInterface
                 $fileObject->flock(\LOCK_UN);
             }
 
-            if (false === $content) {
+            if ('' === $content) {
                 return null;
             }
 

--- a/src/Cache/FileHandler.php
+++ b/src/Cache/FileHandler.php
@@ -122,7 +122,8 @@ final class FileHandler implements FileHandlerInterface
             }
 
             if (false === $fileObject->flock(\LOCK_SH)) {
-                return null;
+                // Lock failed, OK - we continue without the lock.
+                // noop
             }
 
             // Read cache file in chunks

--- a/src/Cache/FileHandler.php
+++ b/src/Cache/FileHandler.php
@@ -137,8 +137,8 @@ final class FileHandler implements FileHandlerInterface
                         return null;
                     }
 
-                    if ('' === $chunk) {
-                        break;
+                        // If not at EOF, empty string means read error.
+                        return null;
                     }
 
                     $content .= $chunk;

--- a/src/Cache/FileHandler.php
+++ b/src/Cache/FileHandler.php
@@ -26,6 +26,8 @@ use Symfony\Component\Filesystem\Exception\IOException;
  */
 final class FileHandler implements FileHandlerInterface
 {
+    private const READ_CHUNK_SIZE = 4_096;
+
     private \SplFileInfo $fileInfo;
 
     private int $fileMTime = 0;
@@ -132,12 +134,13 @@ final class FileHandler implements FileHandlerInterface
 
                 $content = '';
                 while (false === $fileObject->eof()) {
-                    $chunk = $fileObject->fread(8_192);
+                    $chunk = $fileObject->fread(self::READ_CHUNK_SIZE);
 
                     if (false === $chunk) {
                         return null;
                     }
 
+                    if ('' === $chunk) {
                         // If not at EOF, empty string means read error.
                         return null;
                     }


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8994, where large cache file is not fully read into memory, and silently fails to parse it as json (as it is invalid) - by reading larger cache files in chunks instead

