### PR TITLE
test: `PhpdocNoAliasTagFixerTest` - add test for `@const` to `@var`

### DIFF
--- a/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
@@ -320,5 +320,35 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
                 class Foo {}
                 PHP,
         ];
+
+        yield [
+            <<<'PHP'
+                <?php
+                class Foo
+                {
+                    /**
+                     * @var int
+                     */
+                    const BAR = 1;
+
+                    /** @var int */
+                    const BAZ = 2;
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                class Foo
+                {
+                    /**
+                     * @const int
+                     */
+                    const BAR = 1;
+
+                    /** @const int */
+                    const BAZ = 2;
+                }
+                PHP,
+            ['replacements' => ['const' => 'var']],
+        ];
     }
 }


### PR DESCRIPTION
Closes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/8997