### PR TITLE
CI: fix smoke tests after #9005

### DIFF
--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -65,9 +65,7 @@ final class PharTest extends AbstractSmokeTestCase
 
     public function testDescribe(): void
     {
-        // @TODO 4.0 Remove this expectations
-        $this->expectDeprecation('Rule set "@PER" is deprecated. Use "@PER-CS" instead.');
-        $this->expectDeprecation('Rule set "@PER:risky" is deprecated. Use "@PER-CS:risky" instead.');
+        $this->expectDeprecationOfDeprecatedRuleSets();
 
         $command = new DescribeCommand();
 


### PR DESCRIPTION
follow up for https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9005