### PR TITLE
chore: phpstan - do not ignore all `internal` usage errors.

### DIFF
--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -13,6 +13,8 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
+namespace PhpCsFixer;
+
 use Composer\XdebugHandler\XdebugHandler;
 use PhpCsFixer\Console\Application;
 
@@ -20,7 +22,7 @@ error_reporting(\E_ALL & ~\E_DEPRECATED & ~\E_USER_DEPRECATED);
 
 set_error_handler(static function (int $severity, string $message, string $file, int $line): bool {
     if (0 !== ($severity & error_reporting())) {
-        throw new ErrorException($message, 0, $severity, $file, $line);
+        throw new \ErrorException($message, 0, $severity, $file, $line);
     }
 
     return true;
@@ -69,13 +71,13 @@ set_error_handler(static function (int $severity, string $message, string $file,
     if (class_exists('Phar')) {
         // Maybe this file is used as phar-stub? Let's try!
         try {
-            Phar::mapPhar('php-cs-fixer.phar');
+            \Phar::mapPhar('php-cs-fixer.phar');
 
             /** @phpstan-ignore requireOnce.fileNotFound */
             require_once 'phar://php-cs-fixer.phar/vendor/autoload.php';
 
             $require = false;
-        } catch (PharException $e) {
+        } catch (\PharException $e) {
         }
     }
 
@@ -92,7 +94,7 @@ set_error_handler(static function (int $severity, string $message, string $file,
         }
 
         if (null === $file) {
-            throw new RuntimeException('Unable to locate autoload.php file.');
+            throw new \RuntimeException('Unable to locate autoload.php file.');
         }
 
         require_once $file;

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -19,10 +19,11 @@ parameters:
     reportPossiblyNonexistentConstantArrayOffset: true
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
-        - identifier: method.internal
-        - identifier: method.internalClass
-        - identifier: new.internalClass
         - '/^Class [a-zA-Z\\]+ extends @final class PhpCsFixer\\(ConfigurationException\\InvalidConfigurationException|ConfigurationException\\InvalidFixerConfigurationException|Tokenizer\\Tokens|Console\\Command\\FixCommand)\.$/'
+
+        -
+            rawMessage: 'Call to internal method PHPUnit\Framework\TestCase::addToAssertionCount() from outside its root namespace PHPUnit.'
+            identifier: method.internal
 
         # We often need to iterate multiple times within single method and we re-use variable name
         -

--- a/tests/Runner/Parallel/ProcessFactoryTest.php
+++ b/tests/Runner/Parallel/ProcessFactoryTest.php
@@ -50,7 +50,7 @@ final class ProcessFactoryTest extends TestCase
         $application->addCommands([$fixCommand]);
 
         // In order to have full list of options supported by the command (e.g. `--verbose`)
-        $fixCommand->mergeApplicationDefinition(false);
+        $fixCommand->mergeApplicationDefinition(false); // @phpstan-ignore method.internal
 
         $this->inputDefinition = $fixCommand->getDefinition();
     }

--- a/tests/Runner/Parallel/ProcessPoolTest.php
+++ b/tests/Runner/Parallel/ProcessPoolTest.php
@@ -50,7 +50,7 @@ final class ProcessPoolTest extends TestCase
         $application->addCommands([$fixCommand]);
 
         // In order to have full list of options supported by the command (e.g. `--verbose`)
-        $fixCommand->mergeApplicationDefinition(false);
+        $fixCommand->mergeApplicationDefinition(false); // @phpstan-ignore method.internal
 
         $this->arrayInput = new ArrayInput([], $fixCommand->getDefinition());
 


### PR DESCRIPTION
I think we should not ignore all `internal` usage errors in phpstan. We should see if we accidentally use internal methods from other packages.

Phpstan does not report internal usages from same root namespace. 