### PR TITLE
CI: Test docs generation only once per CI pipeline

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,7 @@
     <testsuites>
         <testsuite name="unit">
             <directory>./tests/</directory>
+            <exclude>./tests/Console/Command/DocumentationCommandTest.php</exclude>
             <exclude>./tests/IntegrationTest.php</exclude>
             <exclude>./tests/AutoReview/</exclude>
             <exclude>./tests/Smoke/</exclude>
@@ -33,6 +34,7 @@
         </testsuite>
         <testsuite name="auto-review">
             <directory>./tests/AutoReview/</directory>
+            <file>./tests/Console/Command/DocumentationCommandTest.php</file>
         </testsuite>
         <testsuite name="short-open-tag">
             <file>./tests/Fixer/PhpTag/NoClosingTagFixerTest.php</file>

--- a/tests/Console/Command/DocumentationCommandTest.php
+++ b/tests/Console/Command/DocumentationCommandTest.php
@@ -37,10 +37,8 @@ final class DocumentationCommandTest extends TestCase
      */
     public function testGeneratingDocumentation(): void
     {
-        $filesystem = $this->createFilesystemDouble();
-
         $application = new Application();
-        $application->add(new DocumentationCommand($filesystem));
+        $application->add(new DocumentationCommand($this->createFilesystemDouble()));
 
         $command = $application->find('documentation');
         $commandTester = new CommandTester($command);


### PR DESCRIPTION
It does not make sense to run this test for whole PHP test matrix. Since it's a development command, not included in main CLI entrypoint, but exposed via dedicated `dev-tools/doc.php`, it's much better to treat this test as an auto-review test and run it only once per CI.