### PR TITLE
CI: don't prevent the build when remote coverage reporting service is down

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
             job-description: code coverage
             run-tests: 'yes'
             collect-code-coverage: 'yes'
+            allow-to-fail: 'yes' # don't prevent the build when remote coverage reporting service is down
 
           - operating-system: ubuntu-24.04
             php-version: '8.4'


### PR DESCRIPTION
just to unblock.
let's see if Coveralls recover on it's own, or if we need to fix it somehow

https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/actions/runs/17988916284/job/51174037500?pr=6083#step:15:660
```
Dump submitting json file: /home/runner/work/PHP-CS-Fixer/PHP-CS-Fixer/build/logs/coveralls-upload.json
File size: 3,523.27 kB
Submitting to https://coveralls.io/api/v1/jobs
Server error occurred. status: 500 Internal Server Error
Build processing error.
```