### PR TITLE
fix: `PhpdocToCommentFixer` on property hooks

### DIFF
--- a/src/Tokenizer/Analyzer/CommentsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/CommentsAnalyzer.php
@@ -200,7 +200,7 @@ final class CommentsAnalyzer
         }
 
         if ($token->isGivenKind(\T_STRING)) {
-            return $token->getContent() === 'get' || $token->getContent() === 'set';
+            return 'get' === $token->getContent() || 'set' === $token->getContent();
         }
 
         if ($token->isGivenKind(\T_CASE)) {

--- a/src/Tokenizer/Analyzer/CommentsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/CommentsAnalyzer.php
@@ -200,7 +200,8 @@ final class CommentsAnalyzer
         }
 
         if ($token->isGivenKind(\T_STRING)) {
-            return 'get' === $token->getContent() || 'set' === $token->getContent();
+            $content = strtolower($token->getContent());
+            return 'get' === $content || 'set' === $content;
         }
 
         if ($token->isGivenKind(\T_CASE)) {

--- a/src/Tokenizer/Analyzer/CommentsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/CommentsAnalyzer.php
@@ -199,6 +199,10 @@ final class CommentsAnalyzer
             return true;
         }
 
+        if ($token->isGivenKind(\T_STRING)) {
+            return $token->getContent() === 'get' || $token->getContent() === 'set';
+        }
+
         if ($token->isGivenKind(\T_CASE)) {
             $enumParent = $tokens->getPrevTokenOfKind($index, [[FCT::T_ENUM], [\T_SWITCH]]);
 

--- a/src/Tokenizer/Analyzer/CommentsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/CommentsAnalyzer.php
@@ -201,6 +201,7 @@ final class CommentsAnalyzer
 
         if ($token->isGivenKind(\T_STRING)) {
             $content = strtolower($token->getContent());
+
             return 'get' === $content || 'set' === $content;
         }
 

--- a/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
@@ -985,12 +985,20 @@ enum Foo: int
                 <?php
                 class Foo
                 {
-                    public int $bar {
+                    public int $a {
                         /** @var int */
-                        get => $this->bar;
+                        get => $this->a;
 
                         /** @var int */
-                        set => $this->bar = $value;
+                        set => $this->a = $value;
+                    }
+
+                    public int $b {
+                        /** @var int */
+                        GET => $this->b;
+
+                        /** @var int */
+                        SET => $this->b = $value;
                     }
                 }
                 PHP,

--- a/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
@@ -979,5 +979,21 @@ enum Foo: int
                 }
                 PHP,
         ];
+
+        yield 'property hooks' => [
+            <<<'PHP'
+                <?php
+                class Foo
+                {
+                    public int $bar {
+                        /** @var int */
+                        get => $this->bar;
+
+                        /** @var int */
+                        set => $this->bar = $value;
+                    }
+                }
+                PHP,
+        ];
     }
 }


### PR DESCRIPTION
Fixes that phpdocs gets converted to comments on property hooks. 
Fixes #9120 