### PR TITLE
chore: explicitly use php interpreter for paraunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "analyse-deps": "@php dev-tools/vendor/bin/composer-dependency-analyser",
         "auto-review": [
             "Composer\\Config::disableProcessTimeout",
-            "paraunit run --testsuite auto-review"
+            "@php ./vendor/bin/paraunit run --testsuite auto-review"
         ],
         "cs:check": "@php php-cs-fixer check --verbose --diff",
         "cs:fix": "@php php-cs-fixer fix",
@@ -158,7 +158,7 @@
         ],
         "test:integration": [
             "Composer\\Config::disableProcessTimeout",
-            "paraunit run --testsuite integration"
+            "@php ./vendor/bin/paraunit run --testsuite integration"
         ],
         "test:mutation": [
             "Composer\\Config::disableProcessTimeout",
@@ -170,11 +170,11 @@
         ],
         "test:smoke": [
             "Composer\\Config::disableProcessTimeout",
-            "paraunit run --testsuite smoke"
+            "@php ./vendor/bin/paraunit run --testsuite smoke"
         ],
         "test:unit": [
             "Composer\\Config::disableProcessTimeout",
-            "paraunit run --testsuite unit"
+            "@php ./vendor/bin/paraunit run --testsuite unit"
         ]
     },
     "scripts-descriptions": {


### PR DESCRIPTION
otherwise, I was experiencing memory running out issue on local machine.

looks weird for me, but no better solution on my end