### PR TITLE
feat: add `GitHubReporter`

### DIFF
--- a/dev-tools/phpstan/baseline/argument.type.php
+++ b/dev-tools/phpstan/baseline/argument.type.php
@@ -12,7 +12,12 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../../src/Console/ConfigurationResolver.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Parameter #1 $diffs of static method PhpCsFixer\\Console\\Report\\FixReport\\GitlabReporter::getLines() expects list<SebastianBergmann\\Diff\\Diff>, array<SebastianBergmann\\Diff\\Diff> given.',
+    'rawMessage' => 'Parameter #1 $diffs of static method PhpCsFixer\\Console\\Report\\FixReport\\LineExtractor::getLines() expects list<SebastianBergmann\\Diff\\Diff>, array<SebastianBergmann\\Diff\\Diff> given.',
+    'count' => 1,
+    'path' => __DIR__ . '/../../../src/Console/Report/FixReport/GitHubReporter.php',
+];
+$ignoreErrors[] = [
+    'rawMessage' => 'Parameter #1 $diffs of static method PhpCsFixer\\Console\\Report\\FixReport\\LineExtractor::getLines() expects list<SebastianBergmann\\Diff\\Diff>, array<SebastianBergmann\\Diff\\Diff> given.',
     'count' => 1,
     'path' => __DIR__ . '/../../../src/Console/Report/FixReport/GitlabReporter.php',
 ];
@@ -200,6 +205,11 @@ $ignoreErrors[] = [
     'rawMessage' => 'Parameter #3 $expectedOutputClass of method PhpCsFixer\\Tests\\Console\\Output\\Progress\\ProgressOutputFactoryTest::testValidProcessOutputIsCreated() expects class-string<Throwable>, string given.',
     'count' => 4,
     'path' => __DIR__ . '/../../../tests/Console/Output/Progress/ProgressOutputFactoryTest.php',
+];
+$ignoreErrors[] = [
+    'rawMessage' => 'Parameter #1 $diffs of static method PhpCsFixer\\Console\\Report\\FixReport\\LineExtractor::getLines() expects list<SebastianBergmann\\Diff\\Diff>, array<SebastianBergmann\\Diff\\Diff> given.',
+    'count' => 1,
+    'path' => __DIR__ . '/../../../tests/Console/Report/FixReport/LineExtractorTest.php',
 ];
 $ignoreErrors[] = [
     'rawMessage' => 'Parameter #3 $configuration of method PhpCsFixer\\Tests\\Fixer\\AttributeNotation\\GeneralAttributeRemoveFixerTest::testFix() expects array{attributes?: list<class-string>}, array{attributes: array{\'A\\\\B\\\\Bar\', \'Test\\\\AB\\\\Baz\', \'A\\\\B\\\\Quux\', \'A\\\\B\\\\Baz\', \'A\\\\B\\\\Foo\', \'\\\\AB\\\\Baz\'}} given.',

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -58,10 +58,11 @@ which will use the intersection of the paths from the config file and from the a
 
     php php-cs-fixer.phar fix --path-mode=intersection /path/to/dir
 
-The ``--format`` option for the output format. Supported formats are ``@auto`` (default one on v4+), ``txt`` (default one on v3), ``checkstyle``, ``gitlab``, ``json``, ``junit`` and ``xml``.
+The ``--format`` option for the output format. Supported formats are ``@auto`` (default one on v4+), ``txt`` (default one on v3), ``checkstyle``, ``github``, ``gitlab``, ``json``, ``junit`` and ``xml``.
 
 * ``@auto`` aims to auto-select best reporter for given CI or local execution (resolution into best format is outside of BC promise and is future-ready)
 
+  * ``github`` for GitHub Actions
   * ``gitlab`` for GitLab
 
 * ``@auto,{format}`` takes ``@auto`` under CI, and {format} otherwise
@@ -69,6 +70,7 @@ The ``--format`` option for the output format. Supported formats are ``@auto`` (
 NOTE: the output for the following formats are generated in accordance with schemas
 
 * ``checkstyle`` follows the common `"checkstyle" XML schema </doc/schemas/fix/checkstyle.xsd>`_
+* ``github`` follows the `GitHub Actions workflow commands <https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message>`_
 * ``gitlab`` follows the `codeclimate JSON schema </doc/schemas/fix/codeclimate.json>`_
 * ``json`` follows the `own JSON schema </doc/schemas/fix/schema.json>`_
 * ``junit`` follows the `JUnit XML schema from Jenkins </doc/schemas/fix/junit-10.xsd>`_
@@ -274,10 +276,16 @@ Then, add the following command to your CI:
 
 Where ``$COMMIT_RANGE`` is your range of commits, e.g. ``${{github.event.before}}...${{github.event.after}}`` or ``HEAD~..HEAD``.
 
+GitHub Actions Workflow Commands
+################################
+
+If you want to integrate with GitHub's workflow commands feature, in order for the report to contain correct line numbers, you
+will need to use both ``--format=github`` and ``--diff`` arguments.
+
 GitLab Code Quality Integration
 ###############################
 
-If you want to integrate with GitLab's Code Quality feature, in order for report to contain correct line numbers, you
+If you want to integrate with GitLab's Code Quality feature, in order for the report to contain correct line numbers, you
 will need to use both ``--format=gitlab`` and ``--diff`` arguments.
 
 Environment

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -111,15 +111,17 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
                 <info>$ php %command.full_name% --path-mode=intersection /path/to/dir</info>
 
-            The <comment>--format</comment> option for the output format. Supported formats are `@auto` (default one on v4+), `txt` (default one on v3), `json`, `xml`, `checkstyle`, `junit` and `gitlab`.
+            The <comment>--format</comment> option for the output format. Supported formats are `@auto` (default one on v4+), `txt` (default one on v3), `json`, `xml`, `checkstyle`, `junit`, `github` and `gitlab`.
 
             * `@auto` aims to auto-select best reporter for given CI or local execution (resolution into best format is outside of BC promise and is future-ready)
+              * `github` for GitHub Actions
               * `gitlab` for GitLab
             * `@auto,{format}` takes `@auto` under CI, and {format} otherwise
 
             NOTE: the output for the following formats are generated in accordance with schemas
 
             * `checkstyle` follows the common `"checkstyle" XML schema </doc/schemas/fix/checkstyle.xsd>`_
+            * `github` follows the `GitHub Actions workflow commands <https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message>`_
             * `gitlab` follows the `codeclimate JSON schema </doc/schemas/fix/codeclimate.json>`_
             * `json` follows the `own JSON schema </doc/schemas/fix/schema.json>`_
             * `junit` follows the `JUnit XML schema from Jenkins </doc/schemas/fix/junit-10.xsd>`_

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -681,7 +681,9 @@ final class ConfigurationResolver
             if ('@auto' === $this->format) {
                 $this->format = $parts[1] ?? 'txt';
 
-                if (filter_var(getenv('GITLAB_CI'), \FILTER_VALIDATE_BOOL)) {
+                if (filter_var(getenv('GITHUB_ACTIONS'), \FILTER_VALIDATE_BOOL)) {
+                    $this->format = 'github';
+                } elseif (filter_var(getenv('GITLAB_CI'), \FILTER_VALIDATE_BOOL)) {
                     $this->format = 'gitlab';
                 }
             }

--- a/src/Console/Report/FixReport/GitHubReporter.php
+++ b/src/Console/Report/FixReport/GitHubReporter.php
@@ -21,6 +21,8 @@ use SebastianBergmann\Diff\Parser;
 /**
  * Generates a report in GitHub Actions workflow command format to create file annotations.
  *
+ * @experimental
+ *
  * @author HypeMC <hypemc@gmail.com>
  *
  * @see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message

--- a/src/Console/Report/FixReport/GitHubReporter.php
+++ b/src/Console/Report/FixReport/GitHubReporter.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Console\Report\FixReport;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerFactory;
+use SebastianBergmann\Diff\Parser;
+
+/**
+ * Generates a report in GitHub Actions workflow command format to create file annotations.
+ *
+ * @author HypeMC <hypemc@gmail.com>
+ *
+ * @see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+ *
+ * @readonly
+ *
+ * @internal
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+final class GitHubReporter implements ReporterInterface
+{
+    private Parser $diffParser;
+
+    /**
+     * @var array<string, FixerInterface>
+     */
+    private array $fixers;
+
+    public function __construct()
+    {
+        $this->diffParser = new Parser();
+
+        $fixerFactory = new FixerFactory();
+        $fixerFactory->registerBuiltInFixers();
+
+        $this->fixers = $this->createFixers($fixerFactory);
+    }
+
+    public function getFormat(): string
+    {
+        return 'github';
+    }
+
+    /**
+     * Process changed files array. Returns generated report.
+     */
+    public function generate(ReportSummary $reportSummary): string
+    {
+        $report = '';
+
+        foreach ($reportSummary->getChanged() as $fileName => $change) {
+            $lines = LineExtractor::getLines($this->diffParser->parse($change['diff']));
+
+            foreach ($change['appliedFixers'] as $fixerName) {
+                $fixer = $this->fixers[$fixerName] ?? null;
+
+                $title = 'PHP-CS-Fixer.'.$fixerName;
+                $message = null !== $fixer
+                    ? $fixer->getDefinition()->getSummary()
+                    : $title.' (custom rule)';
+
+                $report .= \sprintf(
+                    '::error file=%s,line=%d,title=%s::%s',
+                    $this->escapeProperty($fileName),
+                    $lines['begin'],
+                    $this->escapeProperty($title),
+                    $this->escapeMessage($message),
+                ).\PHP_EOL;
+            }
+        }
+
+        return $report;
+    }
+
+    private function escapeProperty(string $value): string
+    {
+        return str_replace(
+            ['%', "\r", "\n", ':', ','],
+            ['%25', '%0D', '%0A', '%3A', '%2C'],
+            $value,
+        );
+    }
+
+    private function escapeMessage(string $value): string
+    {
+        return str_replace(
+            ['%', "\r", "\n"],
+            ['%25', '%0D', '%0A'],
+            $value,
+        );
+    }
+
+    /**
+     * @return array<string, FixerInterface>
+     */
+    private function createFixers(FixerFactory $fixerFactory): array
+    {
+        $fixers = [];
+
+        foreach ($fixerFactory->getFixers() as $fixer) {
+            $fixers[$fixer->getName()] = $fixer;
+        }
+
+        ksort($fixers);
+
+        return $fixers;
+    }
+}

--- a/src/Console/Report/FixReport/LineExtractor.php
+++ b/src/Console/Report/FixReport/LineExtractor.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Console\Report\FixReport;
+
+use SebastianBergmann\Diff\Chunk;
+use SebastianBergmann\Diff\Diff;
+use SebastianBergmann\Diff\Line;
+
+/**
+ * Extracts line ranges from diffs.
+ *
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+final class LineExtractor
+{
+    /**
+     * @param list<Diff> $diffs
+     *
+     * @return array{begin: int, end: int}
+     */
+    public static function getLines(array $diffs): array
+    {
+        if (isset($diffs[0])) {
+            $firstDiff = $diffs[0];
+
+            $firstChunk = \Closure::bind(static fn (Diff $diff) => array_shift($diff->chunks), null, $firstDiff)($firstDiff);
+
+            if ($firstChunk instanceof Chunk) {
+                return self::getBeginEndForDiffChunk($firstChunk);
+            }
+        }
+
+        return ['begin' => 0, 'end' => 0];
+    }
+
+    /**
+     * @return array{begin: int, end: int}
+     */
+    private static function getBeginEndForDiffChunk(Chunk $chunk): array
+    {
+        $start = \Closure::bind(static fn (Chunk $chunk): int => $chunk->start, null, $chunk)($chunk);
+        $startRange = \Closure::bind(static fn (Chunk $chunk): int => $chunk->startRange, null, $chunk)($chunk);
+        $lines = \Closure::bind(static fn (Chunk $chunk): array => $chunk->lines, null, $chunk)($chunk);
+
+        \assert(\count($lines) > 0);
+
+        $firstModifiedLineOffset = array_find_key($lines, static function (Line $line): bool {
+            $type = \Closure::bind(static fn (Line $line): int => $line->type, null, $line)($line);
+
+            return Line::UNCHANGED !== $type;
+        });
+        \assert(\is_int($firstModifiedLineOffset));
+
+        return [
+            // offset the start by where the first line is actually modified
+            'begin' => $start + $firstModifiedLineOffset,
+            // it's not where last modification takes place, only where diff (with --context) ends
+            'end' => $start + $startRange,
+        ];
+    }
+}

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -23,6 +23,7 @@ use PhpCsFixer\Console\Command\FixCommand;
 use PhpCsFixer\Console\ConfigurationResolver;
 use PhpCsFixer\Console\Output\Progress\ProgressOutputType;
 use PhpCsFixer\Console\Report\FixReport\CheckstyleReporter;
+use PhpCsFixer\Console\Report\FixReport\GitHubReporter;
 use PhpCsFixer\Console\Report\FixReport\GitlabReporter;
 use PhpCsFixer\Console\Report\FixReport\JsonReporter;
 use PhpCsFixer\Console\Report\FixReport\TextReporter;
@@ -304,7 +305,7 @@ final class ConfigurationResolverTest extends TestCase
     public function testResolveConfigFileChooseFileWithInvalidFormat(): void
     {
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessageMatches('/^The format "xls" is not defined, supported are "checkstyle", "gitlab", "json", "junit", "txt" and "xml"\.$/');
+        $this->expectExceptionMessageMatches('/^The format "xls" is not defined, supported are "checkstyle", "github", "gitlab", "json", "junit", "txt" and "xml"\.$/');
 
         $dirBase = self::getFixtureDir();
 
@@ -1508,18 +1509,25 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         yield [
             TextReporter::class,
             '@auto',
-            ['GITLAB_CI' => ''],
+            ['GITHUB_ACTIONS' => '', 'GITLAB_CI' => ''],
+        ];
+
+        yield [
+            GitHubReporter::class,
+            '@auto',
+            ['GITHUB_ACTIONS' => 'true'],
         ];
 
         yield [
             GitlabReporter::class,
             '@auto',
-            ['GITLAB_CI' => 'true'],
+            ['GITHUB_ACTIONS' => '', 'GITLAB_CI' => 'true'],
         ];
 
         yield [
             JsonReporter::class,
             '@auto,json',
+            ['GITHUB_ACTIONS' => ''],
         ];
     }
 

--- a/tests/Console/Report/FixReport/GitHubReporterTest.php
+++ b/tests/Console/Report/FixReport/GitHubReporterTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Console\Report\FixReport;
+
+use PhpCsFixer\Console\Report\FixReport\GitHubReporter;
+use PhpCsFixer\Console\Report\FixReport\ReporterInterface;
+
+/**
+ * @author HypeMC <hypemc@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Console\Report\FixReport\GitHubReporter
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+final class GitHubReporterTest extends AbstractReporterTestCase
+{
+    protected function createReporter(): ReporterInterface
+    {
+        return new GitHubReporter();
+    }
+
+    protected function getFormat(): string
+    {
+        return 'github';
+    }
+
+    protected static function createNoErrorReport(): string
+    {
+        return '';
+    }
+
+    protected static function createSimpleReport(): string
+    {
+        return '::error file=someFile.php,line=5,title=PHP-CS-Fixer.some_fixer_name_here::PHP-CS-Fixer.some_fixer_name_here (custom rule)'.\PHP_EOL;
+    }
+
+    protected static function createWithDiffReport(): string
+    {
+        return self::createSimpleReport();
+    }
+
+    protected static function createWithAppliedFixersReport(): string
+    {
+        return '::error file=someFile.php,line=0,title=PHP-CS-Fixer.some_fixer_name_here_1::PHP-CS-Fixer.some_fixer_name_here_1 (custom rule)'.\PHP_EOL
+            .'::error file=someFile.php,line=0,title=PHP-CS-Fixer.some_fixer_name_here_2::PHP-CS-Fixer.some_fixer_name_here_2 (custom rule)'.\PHP_EOL;
+    }
+
+    protected static function createWithTimeAndMemoryReport(): string
+    {
+        return self::createSimpleReport();
+    }
+
+    protected static function createComplexReport(): string
+    {
+        return '::error file=someFile.php,line=0,title=PHP-CS-Fixer.some_fixer_name_here_1::PHP-CS-Fixer.some_fixer_name_here_1 (custom rule)'.\PHP_EOL
+            .'::error file=someFile.php,line=0,title=PHP-CS-Fixer.some_fixer_name_here_2::PHP-CS-Fixer.some_fixer_name_here_2 (custom rule)'.\PHP_EOL
+            .'::error file=anotherFile.php,line=0,title=PHP-CS-Fixer.another_fixer_name_here::PHP-CS-Fixer.another_fixer_name_here (custom rule)'.\PHP_EOL;
+    }
+
+    protected function assertFormat(string $expected, string $input): void
+    {
+        self::assertSame($expected, $input);
+    }
+}

--- a/tests/Console/Report/FixReport/LineExtractorTest.php
+++ b/tests/Console/Report/FixReport/LineExtractorTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Console\Report\FixReport;
+
+use PhpCsFixer\Console\Report\FixReport\LineExtractor;
+use PhpCsFixer\Tests\TestCase;
+use SebastianBergmann\Diff\Parser;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Console\Report\FixReport\LineExtractor
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+final class LineExtractorTest extends TestCase
+{
+    /**
+     * @dataProvider provideGetLinesCases
+     *
+     * @param array{begin: int, end: int} $expected
+     */
+    public function testGetLines(array $expected, string $diff): void
+    {
+        $parser = new Parser();
+        self::assertSame($expected, LineExtractor::getLines($parser->parse($diff)));
+    }
+
+    /**
+     * @return iterable<string, array{0: array{begin: int, end: int}, 1: string}>
+     */
+    public static function provideGetLinesCases(): iterable
+    {
+        yield 'empty diff' => [
+            ['begin' => 0, 'end' => 0],
+            '',
+        ];
+
+        yield 'simple diff' => [
+            ['begin' => 5, 'end' => 9],
+            '--- Original
++++ New
+@@ -2,7 +2,7 @@
+
+ class Foo
+ {
+-    public function bar($foo = 1, $bar)
++    public function bar($foo, $bar)
+     {
+     }
+ }',
+        ];
+
+        yield 'diff with multiple chunks (only first one is used)' => [
+            ['begin' => 5, 'end' => 9],
+            '--- Original
++++ New
+@@ -2,7 +2,7 @@
+
+ class Foo
+ {
+-    public function bar($foo = 1, $bar)
++    public function bar($foo, $bar)
+     {
+     }
+ }
+@@ -12,4 +12,4 @@
+ {
+-    public function baz()
++    public function qux()
+     {
+     }',
+        ];
+
+        yield 'diff with modification on the first line of the chunk' => [
+            ['begin' => 2, 'end' => 6],
+            '--- Original
++++ New
+@@ -2,4 +2,4 @@
+-class Foo
++class Bar
+ {
+ }',
+        ];
+
+        yield 'diff with modification after some unchanged lines' => [
+            ['begin' => 8, 'end' => 13],
+            '--- Original
++++ New
+@@ -8,5 +8,5 @@
+-        $a = 1;
++        $a = 2;
+         $b = 2;
+     }',
+        ];
+    }
+}

--- a/tests/Console/Report/FixReport/ReporterFactoryTest.php
+++ b/tests/Console/Report/FixReport/ReporterFactoryTest.php
@@ -50,7 +50,7 @@ final class ReporterFactoryTest extends TestCase
 
         $builder->registerBuiltInReporters();
         self::assertSame(
-            ['checkstyle', 'gitlab', 'json', 'junit', 'txt', 'xml'],
+            ['checkstyle', 'github', 'gitlab', 'json', 'junit', 'txt', 'xml'],
             $builder->getFormats(),
         );
     }

--- a/tests/TextDiffTest.php
+++ b/tests/TextDiffTest.php
@@ -103,7 +103,7 @@ final class TextDiffTest extends TestCase
         sort($formats);
 
         self::assertSame(
-            ['checkstyle', 'gitlab', 'json', 'junit', 'txt', 'xml'],
+            ['checkstyle', 'github', 'gitlab', 'json', 'junit', 'txt', 'xml'],
             $formats,
         );
     }


### PR DESCRIPTION
Closes #5482

The logic for extracting line numbers from diffs was extracted from the existing GitLab reporter. However, it doesn't work well when there are multiple diffs in the same file, all errors end up being reported on the first diff line.

There are also cases where multiple fixers modify the same file and later changes revert earlier ones (for example `no_extra_blank_lines` and `blank_line_between_import_groups`). In those cases, no actual diff is produced.

<img width="607" height="624" alt="image" src="https://github.com/user-attachments/assets/ba4f67fa-6aa3-4bd2-9732-818699620c2e" />
