### PR TITLE
feature(TernaryToNullCoalescingFixer): support `isset` wrapped in parentheses

### DIFF
--- a/doc/rules/operator/ternary_to_null_coalescing.rst
+++ b/doc/rules/operator/ternary_to_null_coalescing.rst
@@ -16,6 +16,8 @@ Example #1
    +++ New
     <?php
    -$sample = isset($a) ? $a : $b;
+   -$sample = (isset($a)) ? $a : $b;
+   +$sample = $a ?? $b;
    +$sample = $a ?? $b;
 
 Rule sets

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -233,6 +233,26 @@ null
             '<?php $x = $THIS ?? null;',
             '<?php $x = isset($THIS) ? $THIS : null;',
         ];
+
+        yield 'Parenthesized isset.' => [
+            '<?php $x = $a ?? null;',
+            '<?php $x = (isset($a)) ? $a : null;',
+        ];
+
+        yield 'Parenthesized isset with spaces.' => [
+            '<?php $x = $a ?? null;',
+            '<?php $x = ( isset($a) ) ? $a : null;',
+        ];
+
+        yield 'Parenthesized isset with property access.' => [
+            '<?php $x = $obj->a ?? null;',
+            '<?php $x = (isset($obj->a)) ? $obj->a : null;',
+        ];
+
+        yield 'Parenthesized isset with array access.' => [
+            '<?php $x = $a[0] ?? 1;',
+            '<?php $x = (isset($a[0])) ? $a[0] : 1;',
+        ];
     }
 
     /**


### PR DESCRIPTION
Fix #9142

When `isset()` is wrapped in parentheses like `(isset($a)) ? $a : null`, the fixer now correctly transforms it to `$a ?? null`.

Previously, the fixer would skip such cases because after finding the closing parenthesis of `isset(...)`, the next meaningful token was `)` (the outer closing paren) instead of `?`.

### Changes

- Detect outer parentheses wrapping the `isset(...)` expression
- Skip past them when looking for the ternary `?` operator
- Include outer parens in the cleared range during the fix
- Added test cases for parenthesized isset with various operand types

### Test cases added

- `(isset($a)) ? $a : null` → `$a ?? null`
- `( isset($a) ) ? $a : null` → `$a ?? null` (with spaces)
- `(isset($obj->a)) ? $obj->a : null` → `$obj->a ?? null`
- `(isset($a[0])) ? $a[0] : 1` → `$a[0] ?? 1`