### PR TITLE
fix: make the progress bar not overwrite on GitHub Actions

### DIFF
--- a/src/Console/Output/Progress/PercentageBarOutput.php
+++ b/src/Console/Output/Progress/PercentageBarOutput.php
@@ -44,6 +44,7 @@ final class PercentageBarOutput implements ProgressOutputInterface
         $this->progressBar->setProgressCharacter('');
         $this->progressBar->setFormat('normal');
 
+        // when CI does not offer to overwrite the line, write to new line instead
         if (filter_var(getenv('GITHUB_ACTIONS'), \FILTER_VALIDATE_BOOLEAN)) {
             $this->progressBar->setOverwrite(false);
             $this->progressBar->minSecondsBetweenRedraws(10);

--- a/src/Console/Output/Progress/PercentageBarOutput.php
+++ b/src/Console/Output/Progress/PercentageBarOutput.php
@@ -44,6 +44,12 @@ final class PercentageBarOutput implements ProgressOutputInterface
         $this->progressBar->setProgressCharacter('');
         $this->progressBar->setFormat('normal');
 
+        if (filter_var(getenv('GITHUB_ACTIONS'), \FILTER_VALIDATE_BOOLEAN)) {
+            $this->progressBar->setOverwrite(false);
+            $this->progressBar->minSecondsBetweenRedraws(10);
+            $this->progressBar->maxSecondsBetweenRedraws(30);
+        }
+
         $this->progressBar->start();
     }
 

--- a/tests/Console/Output/Progress/PercentageBarOutputTest.php
+++ b/tests/Console/Output/Progress/PercentageBarOutputTest.php
@@ -67,7 +67,9 @@ final class PercentageBarOutputTest extends TestCase
         ];
     }
 
-    public function testPercentageBarProgressOutputOnGitHubActionsWithForcedAnsi(): void
+    // test preventing CLI looking like following (mind the missing line breaks), when CI does not offer line overwrite possibility:
+    //    0/500 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%  10/500 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   2%  50/100 [▓▓░░░░░░░░░░░░░░░░░░░░░░░░░░]  10%
+    public function testPercentageBarProgressOutputOnGitHubActionsDoesNotOverwriteTheLine(): void
     {
         if (!filter_var(getenv('GITHUB_ACTIONS'), \FILTER_VALIDATE_BOOLEAN)) {
             self::markTestSkipped('This test is only relevant when running in GitHub Actions environment.');
@@ -75,8 +77,10 @@ final class PercentageBarOutputTest extends TestCase
 
         $nbFiles = 100;
 
-        // mimic called with --ansi option
-        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
+        $output = new BufferedOutput(
+            BufferedOutput::VERBOSITY_NORMAL,
+            true, // mimic called with --ansi option
+        );
 
         $processOutput = new PercentageBarOutput(new OutputContext($output, 80, $nbFiles));
 

--- a/tests/Console/Output/Progress/PercentageBarOutputTest.php
+++ b/tests/Console/Output/Progress/PercentageBarOutputTest.php
@@ -67,6 +67,30 @@ final class PercentageBarOutputTest extends TestCase
         ];
     }
 
+    public function testPercentageBarProgressOutputOnGitHubActionsWithForcedAnsi(): void
+    {
+        if (!filter_var(getenv('GITHUB_ACTIONS'), \FILTER_VALIDATE_BOOLEAN)) {
+            self::markTestSkipped('This test is only relevant when running in GitHub Actions environment.');
+        }
+
+        $nbFiles = 100;
+
+        // mimic called with --ansi option
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
+
+        $processOutput = new PercentageBarOutput(new OutputContext($output, 80, $nbFiles));
+
+        for ($i = 0; $i < $nbFiles; ++$i) {
+            $processOutput->onFixerFileProcessed(new FileProcessed(FileProcessed::STATUS_FIXED));
+        }
+
+        self::assertSame(
+            '   0/100 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%'.\PHP_EOL
+            .' 100/100 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%',
+            rtrim($output->fetch()),
+        );
+    }
+
     /**
      * @param list<array{0: FileProcessed::STATUS_*, 1?: int}> $statuses
      * @param \Closure(FileProcessed::STATUS_*): void          $action


### PR DESCRIPTION
Fixes #9548 

I'm not sure if you want to support detecting other CI by adding a dependency to do that.