### PR TITLE
feat: introduce `ExitParenthesesFixer`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -10,3 +10,5 @@ cd245c59a94e44c47c027da59ee555ec94afe161
 b7294c5125cdf97c08822630473b83663d994279
 # Apply php_unit_attributes (#9578)
 e123e6411cdc1d0ec68b3fb38f3faf1abbc54895
+Apply `PhpUnitRequiresConstraintFixer` from https://github.com/kubawerlos/php-cs-fixer-custom-fixers (#9581)
+0a637f43509440d130830a4eb85ccb1686a2a2fd

--- a/doc/ruleSets/PER-CS3.0.rst
+++ b/doc/ruleSets/PER-CS3.0.rst
@@ -16,6 +16,7 @@ Rules
 -----
 
 - `@PER-CS2x0 <./PER-CS2x0.rst>`_
+- `exit_parentheses <./../rules/language_construct/exit_parentheses.rst>`_
 - `nullable_type_declaration <./../rules/language_construct/nullable_type_declaration.rst>`_
 - `operator_linebreak <./../rules/operator/operator_linebreak.rst>`_
 - `ordered_types <./../rules/class_notation/ordered_types.rst>`_ with config:

--- a/doc/ruleSets/PER-CS3x0.rst
+++ b/doc/ruleSets/PER-CS3x0.rst
@@ -8,6 +8,7 @@ Rules
 -----
 
 - `@PER-CS2x0 <./PER-CS2x0.rst>`_
+- `exit_parentheses <./../rules/language_construct/exit_parentheses.rst>`_
 - `nullable_type_declaration <./../rules/language_construct/nullable_type_declaration.rst>`_
 - `operator_linebreak <./../rules/operator/operator_linebreak.rst>`_
 - `ordered_types <./../rules/class_notation/ordered_types.rst>`_ with config:

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -520,6 +520,9 @@ Language Construct
 - `error_suppression <./language_construct/error_suppression.rst>`_ *(risky, configurable)*
 
   Error control operator should be added to deprecation notices and/or removed from other cases.
+- `exit_parentheses <./language_construct/exit_parentheses.rst>`_
+
+  Language constructs ``exit`` and ``die`` must be called with parentheses.
 - `explicit_indirect_variable <./language_construct/explicit_indirect_variable.rst>`_
 
   Add curly braces to indirect variables to make them clear to understand.

--- a/doc/rules/language_construct/exit_parentheses.rst
+++ b/doc/rules/language_construct/exit_parentheses.rst
@@ -1,0 +1,41 @@
+=========================
+Rule ``exit_parentheses``
+=========================
+
+Language constructs ``exit`` and ``die`` must be called with parentheses.
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -exit;
+   -die;
+   +exit();
+   +die();
+
+Rule sets
+---------
+
+The rule is part of the following rule sets:
+
+- `@PER <./../../ruleSets/PER.rst>`_ *(deprecated)*
+- `@PER-CS <./../../ruleSets/PER-CS.rst>`_
+- `@PER-CS3.0 <./../../ruleSets/PER-CS3.0.rst>`_ *(deprecated)*
+- `@PER-CS3x0 <./../../ruleSets/PER-CS3x0.rst>`_
+- `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_
+- `@Symfony <./../../ruleSets/Symfony.rst>`_
+
+References
+----------
+
+- Fixer class: `PhpCsFixer\\Fixer\\LanguageConstruct\\ExitParenthesesFixer <./../../../src/Fixer/LanguageConstruct/ExitParenthesesFixer.php>`_
+- Test class: `PhpCsFixer\\Tests\\Fixer\\LanguageConstruct\\ExitParenthesesFixerTest <./../../../tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php>`_
+
+The test class defines officially supported behaviour. Each test case is a part of our backward compatibility promise.

--- a/src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
+++ b/src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
@@ -228,7 +228,7 @@ final class NoUnneededControlParenthesesFixer extends AbstractFixer implements C
     /**
      * {@inheritdoc}
      *
-     * Must run before ConcatSpaceFixer, NewExpressionParenthesesFixer, NoTrailingWhitespaceFixer.
+     * Must run before ConcatSpaceFixer, ExitParenthesesFixer, NewExpressionParenthesesFixer, NoTrailingWhitespaceFixer.
      * Must run after ModernizeTypesCastingFixer, NoAlternativeSyntaxFixer.
      */
     public function getPriority(): int

--- a/src/Fixer/LanguageConstruct/ExitParenthesesFixer.php
+++ b/src/Fixer/LanguageConstruct/ExitParenthesesFixer.php
@@ -57,6 +57,12 @@ final class ExitParenthesesFixer extends AbstractFixer
                 continue;
             }
 
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
+
+            if (null !== $prevIndex && $tokens[$prevIndex]->isGivenKind([\T_DOUBLE_COLON, \T_CASE, \T_CONST])) {
+                continue;
+            }
+
             $nextIndex = $tokens->getNextMeaningfulToken($index);
 
             if (null !== $nextIndex && $tokens[$nextIndex]->equals('(')) {

--- a/src/Fixer/LanguageConstruct/ExitParenthesesFixer.php
+++ b/src/Fixer/LanguageConstruct/ExitParenthesesFixer.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\LanguageConstruct;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+final class ExitParenthesesFixer extends AbstractFixer
+{
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Language constructs `exit` and `die` must be called with parentheses.',
+            [
+                new CodeSample(
+                    <<<'PHP'
+                        <?php
+                        exit;
+                        die;
+
+                        PHP,
+                ),
+            ],
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(\T_EXIT);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        $slices = [];
+
+        for ($index = 0, $count = $tokens->count(); $index < $count; ++$index) {
+            if (!$tokens[$index]->isGivenKind(\T_EXIT)) {
+                continue;
+            }
+
+            $nextIndex = $tokens->getNextMeaningfulToken($index);
+
+            if (null !== $nextIndex && $tokens[$nextIndex]->equals('(')) {
+                continue;
+            }
+
+            $slices[$index + 1] = [new Token('('), new Token(')')];
+        }
+
+        if ([] !== $slices) {
+            $tokens->insertSlices($slices);
+        }
+    }
+}

--- a/src/Fixer/LanguageConstruct/ExitParenthesesFixer.php
+++ b/src/Fixer/LanguageConstruct/ExitParenthesesFixer.php
@@ -48,6 +48,16 @@ final class ExitParenthesesFixer extends AbstractFixer
         return $tokens->isTokenKindFound(\T_EXIT);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * Must run after NoUnneededControlParenthesesFixer.
+     */
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
         $slices = [];

--- a/src/Fixer/LanguageConstruct/ExitParenthesesFixer.php
+++ b/src/Fixer/LanguageConstruct/ExitParenthesesFixer.php
@@ -73,6 +73,15 @@ final class ExitParenthesesFixer extends AbstractFixer
                 continue;
             }
 
+            // In `switch ($x) { case exit: ... }` the `exit` keeps `T_EXIT` (unlike enum
+            // `case exit;`, where it is normalized to `T_STRING`). Skip to avoid rewriting
+            // switch case labels that happen to use the `exit` keyword as an expression.
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
+
+            if (null !== $prevIndex && $tokens[$prevIndex]->isGivenKind(\T_CASE)) {
+                continue;
+            }
+
             $slices[$index + 1] = [new Token('('), new Token(')')];
         }
 

--- a/src/Fixer/LanguageConstruct/ExitParenthesesFixer.php
+++ b/src/Fixer/LanguageConstruct/ExitParenthesesFixer.php
@@ -57,12 +57,6 @@ final class ExitParenthesesFixer extends AbstractFixer
                 continue;
             }
 
-            $prevIndex = $tokens->getPrevMeaningfulToken($index);
-
-            if (null !== $prevIndex && $tokens[$prevIndex]->isGivenKind([\T_DOUBLE_COLON, \T_CASE, \T_CONST])) {
-                continue;
-            }
-
             $nextIndex = $tokens->getNextMeaningfulToken($index);
 
             if (null !== $nextIndex && $tokens[$nextIndex]->equals('(')) {

--- a/src/RuleSet/Sets/PERCS3x0Set.php
+++ b/src/RuleSet/Sets/PERCS3x0Set.php
@@ -36,6 +36,7 @@ final class PERCS3x0Set extends AbstractRuleSetDefinition
     {
         return [
             '@PER-CS2x0' => true,
+            'exit_parentheses' => true,
             'nullable_type_declaration' => true,
             'operator_linebreak' => true,
             'ordered_types' => [

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -689,6 +689,7 @@ final class FixerFactoryTest extends TestCase
             ],
             'no_unneeded_control_parentheses' => [
                 'concat_space',
+                'exit_parentheses',
                 'new_expression_parentheses',
                 'no_trailing_whitespace',
             ],

--- a/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
@@ -143,6 +143,22 @@ final class ExitParenthesesFixerTest extends AbstractFixerTestCase
         yield 'exit with parenthesis on next line already' => [
             "<?php exit\n(0);",
         ];
+
+        yield 'class constant named exit is not touched' => [
+            '<?php class Foo { const EXIT = 1; } Foo::EXIT;',
+        ];
+
+        yield 'class constant access to exit is not touched' => [
+            '<?php echo Foo::exit;',
+        ];
+
+        yield 'method named exit on object is not touched' => [
+            '<?php $foo->exit;',
+        ];
+
+        yield 'method call named exit is not touched' => [
+            '<?php $foo->exit();',
+        ];
     }
 
     /**
@@ -165,6 +181,28 @@ final class ExitParenthesesFixerTest extends AbstractFixerTestCase
         yield 'exit inside match arm' => [
             "<?php match (\$x) {\n    1 => exit(),\n    default => null,\n};",
             "<?php match (\$x) {\n    1 => exit,\n    default => null,\n};",
+        ];
+    }
+
+    /**
+     * @dataProvider provideFix81Cases
+     *
+     * @requires PHP >= 8.1.0
+     */
+    #[DataProvider('provideFix81Cases')]
+    #[RequiresPhp('>= 8.1.0')]
+    public function testFix81(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1?: null|string}>
+     */
+    public static function provideFix81Cases(): iterable
+    {
+        yield 'enum case named exit is not touched' => [
+            '<?php enum E { case EXIT; }',
         ];
     }
 }

--- a/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\LanguageConstruct;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\LanguageConstruct\ExitParenthesesFixer
+ *
+ * @extends AbstractFixerTestCase<\PhpCsFixer\Fixer\LanguageConstruct\ExitParenthesesFixer>
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+final class ExitParenthesesFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1?: null|string}>
+     */
+    public static function provideFixCases(): iterable
+    {
+        yield 'bare exit statement' => [
+            '<?php exit();',
+            '<?php exit;',
+        ];
+
+        yield 'bare die statement' => [
+            '<?php die();',
+            '<?php die;',
+        ];
+
+        yield 'uppercase exit preserves casing' => [
+            '<?php EXIT();',
+            '<?php EXIT;',
+        ];
+
+        yield 'mixed case die preserves casing' => [
+            '<?php Die();',
+            '<?php Die;',
+        ];
+
+        yield 'exit already with empty parentheses' => [
+            '<?php exit();',
+        ];
+
+        yield 'exit with argument' => [
+            '<?php exit(0);',
+        ];
+
+        yield 'die with string argument' => [
+            '<?php die("bye");',
+        ];
+
+        yield 'exit inside if with no braces' => [
+            '<?php if ($x) exit();',
+            '<?php if ($x) exit;',
+        ];
+
+        yield 'die inside if with no braces' => [
+            '<?php if ($x) die();',
+            '<?php if ($x) die;',
+        ];
+
+        yield 'exit inside arrow function' => [
+            '<?php $f = fn () => exit();',
+            '<?php $f = fn () => exit;',
+        ];
+
+        yield 'exit followed by closing tag' => [
+            "<?php exit()?>\n",
+            "<?php exit?>\n",
+        ];
+
+        yield 'die followed by closing tag' => [
+            "<?php die()?>\n",
+            "<?php die?>\n",
+        ];
+
+        yield 'exit with space before semicolon' => [
+            '<?php exit() ;',
+            '<?php exit ;',
+        ];
+
+        yield 'exit with newline before semicolon' => [
+            "<?php exit()\n;",
+            "<?php exit\n;",
+        ];
+
+        yield 'string containing exit is not touched' => [
+            '<?php $x = "exit";',
+        ];
+
+        yield 'comment containing exit is not touched' => [
+            "<?php // exit;\n\$x = 1;",
+        ];
+
+        yield 'heredoc containing exit is not touched' => [
+            "<?php \$x = <<<EOT\nexit\nEOT;\n",
+        ];
+
+        yield 'multiple exits on separate lines' => [
+            "<?php\nif (\$a) exit();\nif (\$b) die();\n",
+            "<?php\nif (\$a) exit;\nif (\$b) die;\n",
+        ];
+
+        yield 'nested ternary with exit' => [
+            '<?php $x ? exit() : null;',
+            '<?php $x ? exit : null;',
+        ];
+
+        yield 'exit inside match arm' => [
+            "<?php match (\$x) {\n    1 => exit(),\n    default => null,\n};",
+            "<?php match (\$x) {\n    1 => exit,\n    default => null,\n};",
+        ];
+
+        yield 'exit with comment between keyword and semicolon' => [
+            '<?php exit() /* done */ ;',
+            '<?php exit /* done */ ;',
+        ];
+
+        yield 'exit with parenthesis on next line already' => [
+            "<?php exit\n(0);",
+        ];
+    }
+}

--- a/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
@@ -129,11 +129,6 @@ final class ExitParenthesesFixerTest extends AbstractFixerTestCase
             '<?php $x ? exit : null;',
         ];
 
-        yield 'exit inside match arm' => [
-            "<?php match (\$x) {\n    1 => exit(),\n    default => null,\n};",
-            "<?php match (\$x) {\n    1 => exit,\n    default => null,\n};",
-        ];
-
         yield 'exit with comment between keyword and semicolon' => [
             '<?php exit() /* done */ ;',
             '<?php exit /* done */ ;',
@@ -141,6 +136,27 @@ final class ExitParenthesesFixerTest extends AbstractFixerTestCase
 
         yield 'exit with parenthesis on next line already' => [
             "<?php exit\n(0);",
+        ];
+    }
+
+    /**
+     * @dataProvider provideFix80Cases
+     *
+     * @requires PHP 8.0
+     */
+    public function testFix80(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1?: null|string}>
+     */
+    public static function provideFix80Cases(): iterable
+    {
+        yield 'exit inside match arm' => [
+            "<?php match (\$x) {\n    1 => exit(),\n    default => null,\n};",
+            "<?php match (\$x) {\n    1 => exit,\n    default => null,\n};",
         ];
     }
 }

--- a/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
@@ -14,7 +14,11 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Fixer\LanguageConstruct;
 
+use PhpCsFixer\Fixer\LanguageConstruct\ExitParenthesesFixer;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
  * @internal
@@ -25,11 +29,13 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
  */
+#[CoversClass(ExitParenthesesFixer::class)]
 final class ExitParenthesesFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideFixCases
      */
+    #[DataProvider('provideFixCases')]
     public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
@@ -142,8 +148,10 @@ final class ExitParenthesesFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFix80Cases
      *
-     * @requires PHP 8.0
+     * @requires PHP >= 8.0.0
      */
+    #[DataProvider('provideFix80Cases')]
+    #[RequiresPhp('>= 8.0.0')]
     public function testFix80(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);

--- a/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
@@ -167,6 +167,14 @@ final class ExitParenthesesFixerTest extends AbstractFixerTestCase
         yield 'switch case label uppercase exit is not touched' => [
             '<?php switch ($x) { case EXIT: break; }',
         ];
+
+        yield 'namespace-qualified exit is not touched' => [
+            '<?php \exit;',
+        ];
+
+        yield 'namespace-qualified die is not touched' => [
+            '<?php \die;',
+        ];
     }
 
     /**

--- a/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
@@ -159,6 +159,14 @@ final class ExitParenthesesFixerTest extends AbstractFixerTestCase
         yield 'method call named exit is not touched' => [
             '<?php $foo->exit();',
         ];
+
+        yield 'switch case label exit is not touched' => [
+            '<?php switch ($x) { case exit: break; }',
+        ];
+
+        yield 'switch case label uppercase exit is not touched' => [
+            '<?php switch ($x) { case EXIT: break; }',
+        ];
     }
 
     /**

--- a/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
@@ -167,14 +167,6 @@ final class ExitParenthesesFixerTest extends AbstractFixerTestCase
         yield 'switch case label uppercase exit is not touched' => [
             '<?php switch ($x) { case EXIT: break; }',
         ];
-
-        yield 'namespace-qualified exit is not touched' => [
-            '<?php \exit;',
-        ];
-
-        yield 'namespace-qualified die is not touched' => [
-            '<?php \die;',
-        ];
     }
 
     /**
@@ -197,6 +189,14 @@ final class ExitParenthesesFixerTest extends AbstractFixerTestCase
         yield 'exit inside match arm' => [
             "<?php match (\$x) {\n    1 => exit(),\n    default => null,\n};",
             "<?php match (\$x) {\n    1 => exit,\n    default => null,\n};",
+        ];
+
+        yield 'namespace-qualified exit is not touched' => [
+            '<?php \exit;',
+        ];
+
+        yield 'namespace-qualified die is not touched' => [
+            '<?php \die;',
         ];
     }
 

--- a/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExitParenthesesFixerTest.php
@@ -152,7 +152,7 @@ final class ExitParenthesesFixerTest extends AbstractFixerTestCase
             '<?php echo Foo::exit;',
         ];
 
-        yield 'method named exit on object is not touched' => [
+        yield 'property named exit on object is not touched' => [
             '<?php $foo->exit;',
         ];
 

--- a/tests/Fixtures/Integration/php_compat/PHP8.1.test
+++ b/tests/Fixtures/Integration/php_compat/PHP8.1.test
@@ -21,7 +21,7 @@ final class Foo
 // https://wiki.php.net/rfc/noreturn_type
 function endProgram(): never
 {
-    exit;
+    exit();
 }
 
 // https://wiki.php.net/rfc/fsync_function

--- a/tests/Fixtures/Integration/priority/no_unneeded_control_parentheses,exit_parentheses.test
+++ b/tests/Fixtures/Integration/priority/no_unneeded_control_parentheses,exit_parentheses.test
@@ -1,0 +1,13 @@
+--TEST--
+Integration of fixers: no_unneeded_control_parentheses,exit_parentheses.
+--RULESET--
+{"no_unneeded_control_parentheses": {"statements": ["others"]}, "exit_parentheses": true}
+--EXPECT--
+<?php
+exit();
+die();
+
+--INPUT--
+<?php
+exit();
+die;

--- a/tests/Fixtures/Integration/set/@PER-CS3x0.test-in.php
+++ b/tests/Fixtures/Integration/set/@PER-CS3x0.test-in.php
@@ -78,4 +78,7 @@ argumentsMultilineWithoutComma(
     2
 );
 
+if (!$a) exit;
+if (!$b) die;
+
 ?>

--- a/tests/Fixtures/Integration/set/@PER-CS3x0.test-out.php
+++ b/tests/Fixtures/Integration/set/@PER-CS3x0.test-out.php
@@ -87,3 +87,10 @@ argumentsMultilineWithoutComma(
     1,
     2,
 );
+
+if (!$a) {
+    exit();
+}
+if (!$b) {
+    die();
+}


### PR DESCRIPTION
Introduces `exit_parentheses` fixer enforcing that `exit` and `die` language constructs must be called with parentheses, per PER-CS v3.0 §4.7.

Added to `@PER-CS3x0`.

Ref: https://github.com/php-fig/per-coding-style/blob/master/migration-3.0.md#section-47---method-and-function-calls

Progresses #9191.