### PR TITLE
fix(`GitlabReporter`): attribute each fixer to its actual diff chunk(s)

### DIFF
--- a/dev-tools/phpstan/baseline/argument.type.php
+++ b/dev-tools/phpstan/baseline/argument.type.php
@@ -12,11 +12,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../../src/Console/ConfigurationResolver.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Parameter #1 $diffs of static method PhpCsFixer\\Console\\Report\\FixReport\\GitlabReporter::getLines() expects list<SebastianBergmann\\Diff\\Diff>, array<SebastianBergmann\\Diff\\Diff> given.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Console/Report/FixReport/GitlabReporter.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Parameter #2 $offset of function substr expects int, int|false given.',
     'count' => 1,
     'path' => __DIR__ . '/../../../src/Documentation/FixerDocumentGenerator.php',

--- a/src/Console/Report/FixReport/GitlabReporter.php
+++ b/src/Console/Report/FixReport/GitlabReporter.php
@@ -96,7 +96,9 @@ final class GitlabReporter implements ReporterInterface
                 // Fall back to the combined diff when per-fixer attribution is unavailable
                 // (e.g. legacy callers passing the older shape, or `NullDiffer`).
                 $diffToParse = $fixerDiffs[$fixerName] ?? $change['diff'];
-                $lineRanges = self::getAllLineRanges($this->diffParser->parse($diffToParse));
+                /** @var list<Diff> $parsedDiffs */
+                $parsedDiffs = array_values($this->diffParser->parse($diffToParse));
+                $lineRanges = self::getAllLineRanges($parsedDiffs);
 
                 foreach ($lineRanges as $lines) {
                     $report[] = [

--- a/src/Console/Report/FixReport/GitlabReporter.php
+++ b/src/Console/Report/FixReport/GitlabReporter.php
@@ -74,34 +74,46 @@ final class GitlabReporter implements ReporterInterface
 
         $report = [];
         foreach ($reportSummary->getChanged() as $fileName => $change) {
+            $fixerDiffs = $change['fixerDiffs'] ?? null;
+
             foreach ($change['appliedFixers'] as $fixerName) {
                 $fixer = $this->fixers[$fixerName] ?? null;
+                $description = null !== $fixer
+                    ? $fixer->getDefinition()->getSummary()
+                    : 'PHP-CS-Fixer.'.$fixerName.' (custom rule)';
+                $body = \sprintf(
+                    "%s\n%s",
+                    $about,
+                    null !== $fixer
+                        ? \sprintf(
+                            'Check [docs](https://cs.symfony.com/doc/rules/%s.html) for more information.',
+                            substr($this->documentationLocator->getFixerDocumentationFileRelativePath($fixer), 0, -4), // -4 to drop `.rst`
+                        )
+                        : 'Check performed with a custom rule.',
+                );
 
-                $report[] = [
-                    'check_name' => 'PHP-CS-Fixer.'.$fixerName,
-                    'description' => null !== $fixer
-                        ? $fixer->getDefinition()->getSummary()
-                        : 'PHP-CS-Fixer.'.$fixerName.' (custom rule)',
-                    'content' => [
-                        'body' => \sprintf(
-                            "%s\n%s",
-                            $about,
-                            null !== $fixer
-                                ? \sprintf(
-                                    'Check [docs](https://cs.symfony.com/doc/rules/%s.html) for more information.',
-                                    substr($this->documentationLocator->getFixerDocumentationFileRelativePath($fixer), 0, -4), // -4 to drop `.rst`
-                                )
-                                : 'Check performed with a custom rule.',
-                        ),
-                    ],
-                    'categories' => ['Style'],
-                    'fingerprint' => md5($fileName.$fixerName),
-                    'severity' => 'minor',
-                    'location' => [
-                        'path' => $fileName,
-                        'lines' => self::getLines($this->diffParser->parse($change['diff'])),
-                    ],
-                ];
+                // Prefer per-fixer diff (one entry per chunk inside that fixer's diff).
+                // Fall back to the combined diff when per-fixer attribution is unavailable
+                // (e.g. legacy callers passing the older shape, or `NullDiffer`).
+                $diffToParse = $fixerDiffs[$fixerName] ?? $change['diff'];
+                $lineRanges = self::getAllLineRanges($this->diffParser->parse($diffToParse));
+
+                foreach ($lineRanges as $lines) {
+                    $report[] = [
+                        'check_name' => 'PHP-CS-Fixer.'.$fixerName,
+                        'description' => $description,
+                        'content' => ['body' => $body],
+                        'categories' => ['Style'],
+                        // Include line range in the fingerprint so multiple chunks for the
+                        // same fixer × file remain distinguishable to consumers.
+                        'fingerprint' => md5($fileName.$fixerName.$lines['begin'].'-'.$lines['end']),
+                        'severity' => 'minor',
+                        'location' => [
+                            'path' => $fileName,
+                            'lines' => $lines,
+                        ],
+                    ];
+                }
             }
         }
 
@@ -111,23 +123,26 @@ final class GitlabReporter implements ReporterInterface
     }
 
     /**
+     * Returns one `{begin, end}` range per chunk across all parsed diffs.
+     * Falls back to a single `{begin: 0, end: 0}` when there are no chunks at all
+     * (preserves the original behaviour for empty diffs / `NullDiffer`).
+     *
      * @param list<Diff> $diffs
      *
-     * @return array{begin: int, end: int}
+     * @return non-empty-list<array{begin: int, end: int}>
      */
-    private static function getLines(array $diffs): array
+    private static function getAllLineRanges(array $diffs): array
     {
-        if (isset($diffs[0])) {
-            $firstDiff = $diffs[0];
+        $ranges = [];
 
-            $firstChunk = \Closure::bind(static fn (Diff $diff) => array_shift($diff->chunks), null, $firstDiff)($firstDiff);
-
-            if ($firstChunk instanceof Chunk) {
-                return self::getBeginEndForDiffChunk($firstChunk);
+        foreach ($diffs as $diff) {
+            $chunks = \Closure::bind(static fn (Diff $diff): array => $diff->chunks, null, $diff)($diff);
+            foreach ($chunks as $chunk) {
+                $ranges[] = self::getBeginEndForDiffChunk($chunk);
             }
         }
 
-        return ['begin' => 0, 'end' => 0];
+        return [] !== $ranges ? $ranges : [['begin' => 0, 'end' => 0]];
     }
 
     /**

--- a/src/Console/Report/FixReport/GitlabReporter.php
+++ b/src/Console/Report/FixReport/GitlabReporter.php
@@ -96,6 +96,7 @@ final class GitlabReporter implements ReporterInterface
                 // Fall back to the combined diff when per-fixer attribution is unavailable
                 // (e.g. legacy callers passing the older shape, or `NullDiffer`).
                 $diffToParse = $fixerDiffs[$fixerName] ?? $change['diff'];
+
                 /** @var list<Diff> $parsedDiffs */
                 $parsedDiffs = array_values($this->diffParser->parse($diffToParse));
                 $lineRanges = self::getAllLineRanges($parsedDiffs);

--- a/src/Console/Report/FixReport/ReportSummary.php
+++ b/src/Console/Report/FixReport/ReportSummary.php
@@ -26,7 +26,7 @@ namespace PhpCsFixer\Console\Report\FixReport;
 final class ReportSummary
 {
     /**
-     * @var array<string, array{appliedFixers: list<string>, diff: string}>
+     * @var array<string, array{appliedFixers: list<string>, diff: string, fixerDiffs?: array<string, string>}>
      */
     private array $changed;
 
@@ -43,9 +43,9 @@ final class ReportSummary
     private bool $isDecoratedOutput;
 
     /**
-     * @param array<string, array{appliedFixers: list<string>, diff: string}> $changed
-     * @param int                                                             $time    duration in milliseconds
-     * @param int                                                             $memory  memory usage in bytes
+     * @param array<string, array{appliedFixers: list<string>, diff: string, fixerDiffs?: array<string, string>}> $changed
+     * @param int                                                                                                 $time    duration in milliseconds
+     * @param int                                                                                                 $memory  memory usage in bytes
      */
     public function __construct(
         array $changed,
@@ -76,7 +76,7 @@ final class ReportSummary
     }
 
     /**
-     * @return array<string, array{appliedFixers: list<string>, diff: string}>
+     * @return array<string, array{appliedFixers: list<string>, diff: string, fixerDiffs?: array<string, string>}>
      */
     public function getChanged(): array
     {

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -24,6 +24,7 @@ use PhpCsFixer\Config\NullRuleCustomisationPolicy;
 use PhpCsFixer\Config\RuleCustomisationPolicyInterface;
 use PhpCsFixer\Console\Command\WorkerCommand;
 use PhpCsFixer\Differ\DifferInterface;
+use PhpCsFixer\Differ\NullDiffer;
 use PhpCsFixer\Error\Error;
 use PhpCsFixer\Error\ErrorsManager;
 use PhpCsFixer\Error\SourceExceptionFactory;
@@ -55,7 +56,7 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * @phpstan-type _RunResult array<string, array{appliedFixers: list<string>, diff: string}>
+ * @phpstan-type _RunResult array<string, array{appliedFixers: list<string>, diff: string, fixerDiffs?: array<string, string>}>
  *
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  * @author Greg Korba <greg@codito.dev>
@@ -545,7 +546,7 @@ final class Runner
     }
 
     /**
-     * @return null|array{appliedFixers: list<string>, diff: string}
+     * @return null|array{appliedFixers: list<string>, diff: string, fixerDiffs?: array<string, string>}
      */
     private function fixFile(\SplFileInfo $file, LintingResultInterface $lintingResult): ?array
     {
@@ -586,6 +587,13 @@ final class Runner
         $new = $old;
 
         $appliedFixers = [];
+        // Per-fixer diff capture is gated on having a real differ. With NullDiffer
+        // we skip the snapshots entirely so no overhead is incurred.
+        $capturePerFixerDiffs = !$this->differ instanceof NullDiffer;
+        $beforeFixerCode = $capturePerFixerDiffs ? $old : '';
+
+        /** @var array<string, string> */
+        $fixerDiffs = [];
 
         $ruleCustomisers = $this->ruleCustomisationPolicy->getRuleCustomisers(); // were already validated
 
@@ -652,7 +660,16 @@ final class Runner
                 if ($tokens->isChanged()) {
                     $tokens->clearEmptyTokens();
                     $tokens->clearChanged();
-                    $appliedFixers[] = $fixer->getName();
+                    $fixerName = $fixer->getName();
+                    $appliedFixers[] = $fixerName;
+                    if ($capturePerFixerDiffs) {
+                        $afterFixerCode = $tokens->generateCode();
+                        $fixerDiff = $this->differ->diff($beforeFixerCode, $afterFixerCode, $file);
+                        // Multiple passes of the same fixer (or the same fixer reverting
+                        // and re-applying a change) concatenate so no information is lost.
+                        $fixerDiffs[$fixerName] = ($fixerDiffs[$fixerName] ?? '').$fixerDiff;
+                        $beforeFixerCode = $afterFixerCode;
+                    }
                     if (filter_var(getenv('PHP_CS_FIXER_DEBUG'), \FILTER_VALIDATE_BOOL)) {
                         try {
                             $this->linter->lintSource($tokens->generateCode())->check();
@@ -694,6 +711,10 @@ final class Runner
                 'appliedFixers' => $appliedFixers,
                 'diff' => $this->differ->diff($old, $new, $file),
             ];
+
+            if ($capturePerFixerDiffs && [] !== $fixerDiffs) {
+                $fixInfo['fixerDiffs'] = $fixerDiffs;
+            }
 
             try {
                 $this->linter->lintSource($new)->check();

--- a/tests/Console/Report/FixReport/GitlabReporterTest.php
+++ b/tests/Console/Report/FixReport/GitlabReporterTest.php
@@ -69,6 +69,30 @@ final class GitlabReporterTest extends AbstractReporterTestCase
         self::assertSame(['begin' => 84, 'end' => 85], $entries[1]['location']['lines']);
     }
 
+    public function testKnownFixerUsesDefinitionAndDocumentationInReport(): void
+    {
+        $diff = "--- Original\n+++ New\n@@ -1,2 +1,1 @@\n-foo\n+bar\n";
+        $report = $this->reporter->generate(new ReportSummary(
+            [
+                'file.php' => [
+                    'appliedFixers' => ['no_unused_imports'],
+                    'diff' => $diff,
+                ],
+            ],
+            1,
+            0,
+            0,
+            false,
+            false,
+            false,
+        ));
+        $entries = json_decode($report, true, 512, \JSON_THROW_ON_ERROR);
+        self::assertCount(1, $entries);
+        self::assertStringNotContainsString('(custom rule)', $entries[0]['description']);
+        self::assertStringContainsString('https://cs.symfony.com/doc/rules/', $entries[0]['content']['body']);
+        self::assertStringContainsString('no_unused_imports', $entries[0]['content']['body']);
+    }
+
     public function testMultipleChunksInSingleFixerDiffEmitOneEntryPerChunk(): void
     {
         $multiChunkDiff = "--- Original\n+++ New\n@@ -10,3 +10,2 @@\n keep1\n-removed_a\n keep2\n@@ -50,3 +49,2 @@\n keep3\n-removed_b\n keep4\n";

--- a/tests/Console/Report/FixReport/GitlabReporterTest.php
+++ b/tests/Console/Report/FixReport/GitlabReporterTest.php
@@ -17,6 +17,7 @@ namespace PhpCsFixer\Tests\Console\Report\FixReport;
 use PhpCsFixer\Console\Application;
 use PhpCsFixer\Console\Report\FixReport\GitlabReporter;
 use PhpCsFixer\Console\Report\FixReport\ReporterInterface;
+use PhpCsFixer\Console\Report\FixReport\ReportSummary;
 use PhpCsFixer\Tests\Test\Assert\AssertJsonSchemaTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -33,6 +34,71 @@ use PHPUnit\Framework\Attributes\CoversClass;
 final class GitlabReporterTest extends AbstractReporterTestCase
 {
     use AssertJsonSchemaTrait;
+
+    public function testPerFixerDiffsAreUsedWhenAvailable(): void
+    {
+        $fixerADiff = "--- Original\n+++ New\n@@ -27,7 +27,6 @@\n use App\\W;\n use App\\X;\n use App\\Y;\n-use App\\UnusedImport;\n use App\\Z;\n \n class Sample\n";
+        $fixerBDiff = "--- Original\n+++ New\n@@ -80,5 +80,5 @@\n }\n \n function bbb()\n {\n-    return 1+1;\n+    return 1 + 1;\n }\n";
+
+        $report = $this->reporter->generate(new ReportSummary(
+            [
+                'someFile.php' => [
+                    'appliedFixers' => ['fixer_a', 'fixer_b'],
+                    'diff' => $fixerADiff.$fixerBDiff,
+                    'fixerDiffs' => [
+                        'fixer_a' => $fixerADiff,
+                        'fixer_b' => $fixerBDiff,
+                    ],
+                ],
+            ],
+            10,
+            0,
+            0,
+            false,
+            false,
+            false,
+        ));
+
+        $entries = json_decode($report, true, 512, \JSON_THROW_ON_ERROR);
+        self::assertCount(2, $entries, 'one entry per fixer at its own location');
+
+        self::assertSame('PHP-CS-Fixer.fixer_a', $entries[0]['check_name']);
+        self::assertSame(['begin' => 30, 'end' => 34], $entries[0]['location']['lines']);
+
+        self::assertSame('PHP-CS-Fixer.fixer_b', $entries[1]['check_name']);
+        self::assertSame(['begin' => 84, 'end' => 85], $entries[1]['location']['lines']);
+    }
+
+    public function testMultipleChunksInSingleFixerDiffEmitOneEntryPerChunk(): void
+    {
+        $multiChunkDiff = "--- Original\n+++ New\n@@ -10,3 +10,2 @@\n keep1\n-removed_a\n keep2\n@@ -50,3 +49,2 @@\n keep3\n-removed_b\n keep4\n";
+
+        $report = $this->reporter->generate(new ReportSummary(
+            [
+                'someFile.php' => [
+                    'appliedFixers' => ['multi_chunk_fixer'],
+                    'diff' => $multiChunkDiff,
+                    'fixerDiffs' => ['multi_chunk_fixer' => $multiChunkDiff],
+                ],
+            ],
+            10,
+            0,
+            0,
+            false,
+            false,
+            false,
+        ));
+
+        $entries = json_decode($report, true, 512, \JSON_THROW_ON_ERROR);
+        self::assertCount(2, $entries);
+        self::assertSame(['begin' => 11, 'end' => 13], $entries[0]['location']['lines']);
+        self::assertSame(['begin' => 51, 'end' => 53], $entries[1]['location']['lines']);
+        self::assertNotSame(
+            $entries[0]['fingerprint'],
+            $entries[1]['fingerprint'],
+            'fingerprints must differ when same fixer reports multiple chunks',
+        );
+    }
 
     protected function createReporter(): ReporterInterface
     {
@@ -61,7 +127,7 @@ final class GitlabReporterTest extends AbstractReporterTestCase
                             "content": {
                                 "body": "{$about}\\nCheck performed with a custom rule."
                             },
-                            "fingerprint": "ad098ea6ea7a28dd85dfcdfc9e2bded0",
+                            "fingerprint": "1a745ca537fc8d1d7a4f332424bc100c",
                             "severity": "minor",
                             "location": {
                                 "path": "someFile.php",
@@ -91,7 +157,7 @@ final class GitlabReporterTest extends AbstractReporterTestCase
                             "content": {
                                 "body": "{$about}\\nCheck performed with a custom rule."
                             },
-                            "fingerprint": "b74e9385c8ae5b1f575c9c8226c7deff",
+                            "fingerprint": "4a6d5ac462516458d5ae8718461dbe0b",
                             "severity": "minor",
                             "location": {
                                 "path": "someFile.php",
@@ -107,7 +173,7 @@ final class GitlabReporterTest extends AbstractReporterTestCase
                             "content": {
                                 "body": "{$about}\\nCheck performed with a custom rule."
                             },
-                            "fingerprint": "acad4672140c737a83c18d1474d84074",
+                            "fingerprint": "41bdef686a7c3912ca9fc00894987b85",
                             "severity": "minor",
                             "location": {
                                 "path": "someFile.php",
@@ -137,7 +203,7 @@ final class GitlabReporterTest extends AbstractReporterTestCase
                             "content": {
                                 "body": "{$about}\\nCheck performed with a custom rule."
                             },
-                            "fingerprint": "b74e9385c8ae5b1f575c9c8226c7deff",
+                            "fingerprint": "4a6d5ac462516458d5ae8718461dbe0b",
                             "severity": "minor",
                             "location": {
                                 "path": "someFile.php",
@@ -153,7 +219,7 @@ final class GitlabReporterTest extends AbstractReporterTestCase
                             "content": {
                                 "body": "{$about}\\nCheck performed with a custom rule."
                             },
-                            "fingerprint": "acad4672140c737a83c18d1474d84074",
+                            "fingerprint": "41bdef686a7c3912ca9fc00894987b85",
                             "severity": "minor",
                             "location": {
                                 "path": "someFile.php",
@@ -169,7 +235,7 @@ final class GitlabReporterTest extends AbstractReporterTestCase
                             "content": {
                                 "body": "{$about}\\nCheck performed with a custom rule."
                             },
-                            "fingerprint": "30e86e533dac0f1b93bbc3a55c6908f8",
+                            "fingerprint": "f0e531c97fedfbd779cb57e610c73648",
                             "severity": "minor",
                             "location": {
                                 "path": "anotherFile.php",


### PR DESCRIPTION
## Summary

Fix GitLab Code Quality reporting so each applied fixer is attributed to its own diff chunk instead of inheriting the first chunk from the file-level combined diff.

## Problem

`Runner` currently reports one combined `diff` per file plus a flat `appliedFixers` list.  
`GitlabReporter` parses that single diff and takes the first chunk for every fixer entry, so multiple fixers on one file can all report the same `location.lines`.

## What changed

- In `Runner::fixFile()`, capture per-fixer incremental diffs (when differ is not `NullDiffer`) by snapshotting code before/after each fixer run.
- Add optional `fixerDiffs` to `fixInfo`, preserving existing payload shape and compatibility.
- In `GitlabReporter::generate()`, prefer `fixerDiffs[$fixerName]` when available, fallback to legacy combined `diff` when not.
- Parse all chunks from the selected fixer diff and emit one report entry per `(fixer, chunk)`.
- Include `begin/end` in fingerprint generation so multiple chunks for the same fixer remain distinct.
- Update `ReportSummary` PHPDoc to include optional `fixerDiffs`.
- Add/adjust tests in `GitlabReporterTest` for per-fixer attribution and multi-chunk behavior.

## Compatibility and scope

- Backward compatible: old callers without `fixerDiffs` continue to work through fallback logic.
- No extra overhead when `NullDiffer` is active (`fixerDiffs` capture is skipped).
- This change fixes attribution only. It does not change existing `begin/end` chunk semantics.

## Verification

- `vendor/bin/phpunit tests/Console/Report/FixReport/GitlabReporterTest.php tests/Runner/`
- `php php-cs-fixer check --diff --format=gitlab <target files>`

Expected result: each fixer entry reports the line range of its own change region, not the first chunk of the file-level diff.
