### PR TITLE
chore: cleanup `PhpdocSingleLineVarSpacingFixer`

### DIFF
--- a/dev-tools/phpstan/baseline/offsetAccess.notFound.php
+++ b/dev-tools/phpstan/baseline/offsetAccess.notFound.php
@@ -672,11 +672,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../../src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Offset int<1, max> might not exist on array.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Offset \'general_phpdoc_tag_rename\' might not exist on non-empty-array<string, PhpCsFixer\\Fixer\\FixerInterface>.',
     'count' => 1,
     'path' => __DIR__ . '/../../../src/Fixer/Phpdoc/PhpdocTagCasingFixer.php',

--- a/src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
@@ -77,6 +77,7 @@ final class PhpdocSingleLineVarSpacingFixer extends AbstractFixer
                 $content = '/** @var';
 
                 for ($i = 1, $m = \count($matches); $i < $m; ++$i) {
+                    \assert(isset($matches[$i]));
                     if ('' !== $matches[$i]) {
                         $content .= ' '.$matches[$i];
                     }


### PR DESCRIPTION
Cleanup also for https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9560