### PR TITLE
chore: .gitattributes - export-ignore for logo.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,4 +27,5 @@
 *.rst   text whitespace=blank-at-eol,blank-at-eof
 *.yml   text whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4
 *.png   binary eol=unset
+
 /tests/Fixtures/**/* -text -filter

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@
 /phpunit.xml.dist export-ignore
 /tests/ export-ignore
 /UPGRADE-v3.md export-ignore
+/logo.md export-ignore
 
 *       text=auto eol=lf
 *.json  text whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4
@@ -26,5 +27,4 @@
 *.rst   text whitespace=blank-at-eol,blank-at-eof
 *.yml   text whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4
 *.png   binary eol=unset
-
 /tests/Fixtures/**/* -text -filter


### PR DESCRIPTION
NOTES: In #9516, logo.png was added to export-ignore, but logo.md was not added to export-ignore.

---- 

Current archive targets other than `./php-cs-fixer`, `src/` will be as follows:
```bash
gh api repos/PHP-CS-Fixer/PHP-CS-Fixer/tarball/HEAD | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -vE '^(php-cs-fixer|src)/' | sort
```

```
composer.json
LICENSE
logo.md
php-cs-fixer
README.md
resources/
resources/.php-cs-fixer.dist.php.template
```

With this PR, the archive targets other than  `./php-cs-fixer`, `src/` will be as follows:
```bash
gh api repos/sasezaki/PHP-CS-Fixer/tarball/patch-gitattributes | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -vE '^(php-cs-fixer|src)/' | sort
```

```
composer.json
LICENSE
php-cs-fixer
README.md
resources/
resources/.php-cs-fixer.dist.php.template
```

Changes:
- Added `/logo.md export-ignore`
  - `/logo.md`: A markdown file describing the project logo; not needed by package consumers.
