### PR TITLE
feat: Config option for specifying composerPath, when composer.json is …

### DIFF
--- a/src/ComposerJsonReader.php
+++ b/src/ComposerJsonReader.php
@@ -26,8 +26,6 @@ use Symfony\Component\Filesystem\Exception\IOException;
  */
 final class ComposerJsonReader
 {
-    private const COMPOSER_FILENAME = 'composer.json';
-
     private bool $isProcessed = false;
 
     private ?string $php = null;
@@ -35,6 +33,13 @@ final class ComposerJsonReader
     private ?string $phpUnit = null;
 
     private static ?self $singleton = null;
+
+    private static ?ConfigInterface $config = null;
+
+    public static function setConfig(ConfigInterface $config): void
+    {
+        self::$config = $config;
+    }
 
     public static function createSingleton(): self
     {
@@ -65,13 +70,15 @@ final class ComposerJsonReader
             return;
         }
 
-        if (!file_exists(self::COMPOSER_FILENAME)) {
-            throw new IOException(\sprintf('Failed to read file "%s".', self::COMPOSER_FILENAME));
+        $composerFilename = (self::$config ?? new Config())->getComposerPath();
+
+        if (!file_exists($composerFilename)) {
+            throw new IOException(\sprintf('Failed to read file "%s".', $composerFilename));
         }
 
-        $readResult = file_get_contents(self::COMPOSER_FILENAME);
+        $readResult = file_get_contents($composerFilename);
         if (false === $readResult) {
-            throw new IOException(\sprintf('Failed to read file "%s".', self::COMPOSER_FILENAME));
+            throw new IOException(\sprintf('Failed to read file "%s".', $composerFilename));
         }
 
         $this->processJson($readResult);

--- a/src/Config.php
+++ b/src/Config.php
@@ -72,6 +72,8 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
 
     private ParallelConfig $parallelConfig;
 
+    private string $composerPath = 'composer.json';
+
     private ?string $phpExecutable = null;
 
     /**
@@ -156,6 +158,11 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
     public function getParallelConfig(): ParallelConfig
     {
         return $this->parallelConfig;
+    }
+
+    public function getComposerPath(): string
+    {
+        return $this->composerPath;
     }
 
     public function getPhpExecutable(): ?string
@@ -263,6 +270,13 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
     public function setParallelConfig(ParallelConfig $config): ConfigInterface
     {
         $this->parallelConfig = $config;
+
+        return $this;
+    }
+
+    public function setComposerPath(string $composerPath): ConfigInterface
+    {
+        $this->composerPath = $composerPath;
 
         return $this;
     }

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -75,6 +75,11 @@ interface ConfigInterface
     public function getName(): string;
 
     /**
+     * Get configured Composer config path, if any.
+     */
+    public function getComposerPath(): string;
+
+    /**
      * Get configured PHP executable, if any.
      *
      * @deprecated
@@ -152,6 +157,13 @@ interface ConfigInterface
      * @return $this
      */
     public function setLineEnding(string $lineEnding): self;
+
+    /**
+     * Set path to the Composer config.
+     *
+     * @return $this
+     */
+    public function setComposerPath(string $composerPath): self;
 
     /**
      * Set PHP executable.

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -22,6 +22,7 @@ use PhpCsFixer\Cache\FileCacheManager;
 use PhpCsFixer\Cache\FileHandler;
 use PhpCsFixer\Cache\NullCacheManager;
 use PhpCsFixer\Cache\Signature;
+use PhpCsFixer\ComposerJsonReader;
 use PhpCsFixer\Config\NullRuleCustomisationPolicy;
 use PhpCsFixer\Config\RuleCustomisationPolicyAwareConfigInterface;
 use PhpCsFixer\Config\RuleCustomisationPolicyInterface;
@@ -297,6 +298,8 @@ final class ConfigurationResolver
                     RuleSets::registerCustomRuleSet($ruleSet);
                 }
             }
+
+            ComposerJsonReader::setConfig($this->config);
         }
 
         return $this->config;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -219,6 +219,30 @@ final class ConfigTest extends TestCase
         self::assertSame($config, $config->setCacheFile('some-directory/some.file'));
     }
 
+    public function testThatComposerPathHasDefaultValue(): void
+    {
+        $config = new Config();
+
+        self::assertSame('composer.json', $config->getComposerPath());
+    }
+
+    public function testThatComposerPathCanBeMutated(): void
+    {
+        $composerPath = 'some-directory/composer.json';
+
+        $config = new Config();
+        $config->setComposerPath($composerPath);
+
+        self::assertSame($composerPath, $config->getComposerPath());
+    }
+
+    public function testThatSetComposerPathHasFluentInterface(): void
+    {
+        $config = new Config();
+
+        self::assertSame($config, $config->setComposerPath('some-directory/composer.json'));
+    }
+
     /**
      * @param list<FixerInterface>     $expected
      * @param iterable<FixerInterface> $suite
@@ -264,6 +288,7 @@ final class ConfigTest extends TestCase
         $config = new Config();
 
         self::assertSame('.php-cs-fixer.cache', $config->getCacheFile());
+        self::assertSame('composer.json', $config->getComposerPath());
         self::assertSame([], $config->getCustomFixers());
         self::assertSame('txt', $config->getFormat());
         self::assertFalse($config->getHideProgress());

--- a/tests/Fixtures/.php-cs-fixer.custom.php
+++ b/tests/Fixtures/.php-cs-fixer.custom.php
@@ -90,6 +90,14 @@ final class CustomConfig implements ConfigInterface, UnsupportedPhpVersionAllowe
     /**
      * {@inheritdoc}
      */
+    public function getComposerPath(): string
+    {
+        return 'composer.json';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getPhpExecutable(): ?string
     {
         return null;
@@ -131,6 +139,14 @@ final class CustomConfig implements ConfigInterface, UnsupportedPhpVersionAllowe
      * {@inheritdoc}
      */
     public function setCacheFile(string $cacheFile): ConfigInterface
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setComposerPath(string $composerPath): ConfigInterface
     {
         return $this;
     }


### PR DESCRIPTION
Adds a new config option 'setComposerPath' for specifying a custom location for composer.json used in PHP version detection.

Fixes #9407 

This will also provide an option for fixing the most popular VSCode extension for php-cs-fixer, junstyle/vscode-php-cs-fixer, when using format on save.  The extension currently has the file open in a temporary directory for formatting, and always fails because php-cs-fixer cannot location composer.json in the temporary directory.
