### PR TITLE
fix: `MultilinePromotedPropertiesFixer` - fix for `new` in initializers

### DIFF
--- a/src/Fixer/FunctionNotation/MultilinePromotedPropertiesFixer.php
+++ b/src/Fixer/FunctionNotation/MultilinePromotedPropertiesFixer.php
@@ -249,7 +249,9 @@ final class MultilinePromotedPropertiesFixer extends AbstractFixer implements Co
         );
 
         $index = $tokens->getPrevMeaningfulToken($closeParenthesis);
-        \assert(\is_int($index));
+        if (!$tokens[$index]->equals(',')) {
+            $index = $closeParenthesis;
+        }
 
         while ($index > $openParenthesis) {
             $index = $tokens->getPrevMeaningfulToken($index);

--- a/tests/Fixer/FunctionNotation/MultilinePromotedPropertiesFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MultilinePromotedPropertiesFixerTest.php
@@ -345,4 +345,67 @@ final class MultilinePromotedPropertiesFixerTest extends AbstractFixerTestCase
             ['keep_blank_lines' => true],
         ];
     }
+
+    /**
+     * @dataProvider provideFix81Cases
+     *
+     * @requires PHP >= 8.1.0
+     */
+    #[DataProvider('provideFix81Cases')]
+    #[RequiresPhp('>= 8.1.0')]
+    public function testFix81(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideFix81Cases(): iterable
+    {
+        yield 'new in initializers' => [
+            <<<'PHP'
+                <?php class Foo
+                {
+                    public function __construct(
+                        public Bar $x = new Bar(),
+                        public Bar $y = new Bar(
+                        )
+                    )
+                    {
+                    }
+                }
+                PHP,
+            <<<'PHP'
+                <?php class Foo
+                {
+                    public function __construct(public Bar $x = new Bar(), public Bar $y = new Bar())
+                    {
+                    }
+                }
+                PHP,
+        ];
+
+        yield 'new in initializers with trailing comma' => [
+            <<<'PHP'
+                <?php class Foo
+                {
+                    public function __construct(
+                        public Bar $x = new Bar(),
+                        public Bar $y = new Bar(),
+                    )
+                    {
+                    }
+                }
+                PHP,
+            <<<'PHP'
+                <?php class Foo
+                {
+                    public function __construct(public Bar $x = new Bar(), public Bar $y = new Bar(),)
+                    {
+                    }
+                }
+                PHP,
+        ];
+    }
 }

--- a/tests/Fixer/FunctionNotation/MultilinePromotedPropertiesFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MultilinePromotedPropertiesFixerTest.php
@@ -369,8 +369,7 @@ final class MultilinePromotedPropertiesFixerTest extends AbstractFixerTestCase
                 {
                     public function __construct(
                         public Bar $x = new Bar(),
-                        public Bar $y = new Bar(
-                        )
+                        public Bar $y = new Bar()
                     )
                     {
                     }


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/9618