### PR TITLE
fix: `PhpdocAddMissingParamAnnotationFixer` - skip attribute tokens when extracting parameter type

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -254,6 +254,12 @@ final class PhpdocAddMissingParamAnnotationFixer extends AbstractFixer implement
         for ($index = $start; $index <= $end; ++$index) {
             $token = $tokens[$index];
 
+            if ($token->isGivenKind(FCT::T_ATTRIBUTE)) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ATTRIBUTE, $index);
+
+                continue;
+            }
+
             if (
                 $token->isComment()
                 || $token->isWhitespace()

--- a/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
@@ -517,11 +517,11 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
     }
 
     /**
-     * @return iterable<int, array{string, string}>
+     * @return iterable<string, array{string, string}>
      */
     public static function provideFix80Cases(): iterable
     {
-        yield [
+        yield 'promoted properties' => [
             '<?php class Foo {
                 /**
                  * @param Bar $x
@@ -543,6 +543,49 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
                     private null|Bar $z,
                 ) {}
             }',
+        ];
+
+        yield 'promoted properties with attributes' => [
+            '<?php class Foo {
+                /**
+                 * @param string $a
+                 * @param ?string $b
+                 * @param int $c
+                 */
+                public function __construct(
+                    #[SomeAttr]
+                    public string $a,
+                    #[AnotherAttr(\'value\')]
+                    public ?string $b,
+                    #[FirstAttr] #[SecondAttr] public int $c,
+                ) {}
+            }',
+            '<?php class Foo {
+                /**
+                 */
+                public function __construct(
+                    #[SomeAttr]
+                    public string $a,
+                    #[AnotherAttr(\'value\')]
+                    public ?string $b,
+                    #[FirstAttr] #[SecondAttr] public int $c,
+                ) {}
+            }',
+        ];
+
+        yield 'function arguments with attributes' => [
+            '<?php
+                /**
+                 * @param string $a
+                 * @param int $b
+                 */
+                function foo(#[SomeAttr] string $a, #[AnotherAttr(\'x\')] int $b) {}
+            ',
+            '<?php
+                /**
+                 */
+                function foo(#[SomeAttr] string $a, #[AnotherAttr(\'x\')] int $b) {}
+            ',
         ];
     }
 


### PR DESCRIPTION
Attributes on parameters (e.g. on promoted constructor properties) leaked into the generated `@param` type, producing invalid PHPDoc like `@param #[Assert\NotBlank]string $x`.

fixes #9633