### PR TITLE
deps: bump PHPStan to 2.2.1

### DIFF
--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -9,7 +9,7 @@
         "phpcompatibility/phpcompatibility-symfony": "^2-alpha1",
         "phpmd/phpmd": "dev-master as 2.16.0",
         "phpstan/extension-installer": "^1.4.3",
-        "phpstan/phpstan": "^2.1.55",
+        "phpstan/phpstan": "^2.2.1",
         "phpstan/phpstan-deprecation-rules": "^2.0.4",
         "phpstan/phpstan-phpunit": "^2.0.16",
         "phpstan/phpstan-strict-rules": "^2.0.11",

--- a/dev-tools/composer.lock
+++ b/dev-tools/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e3e5d8a8a11aed429e6b5ef74769a5c",
+    "content-hash": "e719525f86a9608a7517f567259caeb4",
     "packages": [
         {
             "name": "composer/pcre",
@@ -785,11 +785,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.55",
+            "version": "2.2.1",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9eaac3826ed5e9b8427350a43cac825eeca3f566",
-                "reference": "9eaac3826ed5e9b8427350a43cac825eeca3f566"
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dea9c8f2d25cc849391042b71e429c1a4bf82660",
+                "reference": "dea9c8f2d25cc849391042b71e429c1a4bf82660"
             },
             "require": {
                 "php": "^7.4|^8.0"

--- a/tests/AbstractDoctrineAnnotationFixerTestCase.php
+++ b/tests/AbstractDoctrineAnnotationFixerTestCase.php
@@ -41,7 +41,7 @@ abstract class AbstractDoctrineAnnotationFixerTestCase extends AbstractFixerTest
     {
         $this->expectException(InvalidFixerConfigurationException::class);
 
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Alias/ModernizeStrposFixerTest.php
+++ b/tests/Fixer/Alias/ModernizeStrposFixerTest.php
@@ -51,7 +51,7 @@ final class ModernizeStrposFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage('[modernize_strpos] Invalid configuration: The option "invalid" does not exist. Defined options are: "modernize_stripos".');
 
-        $this->fixer->configure(['invalid' => true]);
+        $this->fixer->configure(['invalid' => true]); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
+++ b/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
@@ -357,7 +357,7 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches($expectedMessage);
 
-        $this->fixer->configure($wrongConfig);
+        $this->fixer->configure($wrongConfig); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+++ b/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
@@ -51,7 +51,7 @@ final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage($message);
 
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/ArrayNotation/ArraySyntaxFixerTest.php
+++ b/tests/Fixer/ArrayNotation/ArraySyntaxFixerTest.php
@@ -42,7 +42,7 @@ final class ArraySyntaxFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches('#^\[array_syntax\] Invalid configuration: The option "a" does not exist\. Defined options are: "syntax"\.$#');
 
-        $this->fixer->configure(['a' => 1]);
+        $this->fixer->configure(['a' => 1]); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/AttributeNotation/OrderedAttributesFixerTest.php
+++ b/tests/Fixer/AttributeNotation/OrderedAttributesFixerTest.php
@@ -51,7 +51,7 @@ final class OrderedAttributesFixerTest extends AbstractFixerTestCase
         self::expectException(InvalidFixerConfigurationException::class);
         self::expectExceptionMessage($expectedExceptionMessage);
 
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/CastNotation/CastSpacesFixerTest.php
+++ b/tests/Fixer/CastNotation/CastSpacesFixerTest.php
@@ -46,7 +46,7 @@ final class CastSpacesFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches($expectedMessage);
 
-        $this->fixer->configure($config);
+        $this->fixer->configure($config); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -50,7 +50,7 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches($exceptionExpression);
 
-        $this->fixer->configure($config);
+        $this->fixer->configure($config); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
@@ -390,7 +390,7 @@ $a = new class{};',
             $this->expectDeprecation($deprecationMessage);
         }
 
-        $this->fixer->configure($config);
+        $this->fixer->configure($config); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/ClassNotation/ModifierKeywordsFixerTest.php
+++ b/tests/Fixer/ClassNotation/ModifierKeywordsFixerTest.php
@@ -1126,7 +1126,7 @@ var_dump(Foo::CAT->test());',
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches($expectedMessage);
 
-        $this->fixer->configure($config);
+        $this->fixer->configure($config); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
+++ b/tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
@@ -40,7 +40,7 @@ final class SingleLineCommentStyleFixerTest extends AbstractFixerTestCase
     {
         $this->expectException(InvalidFixerConfigurationException::class);
 
-        $this->fixer->configure(['abc']);
+        $this->fixer->configure(['abc']); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+++ b/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
@@ -49,7 +49,7 @@ final class NativeConstantInvocationFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage($exceptionExpression);
 
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -176,7 +176,7 @@ switch ($foo) {
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches($expectedExceptionMessage);
 
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -149,7 +149,7 @@ while (2 !== $b = array_pop($c));
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches("#^\\[{$this->fixer->getName()}\\] {$expectedMessage}$#");
 
-        $this->fixer->configure($config);
+        $this->fixer->configure($config); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
@@ -59,7 +59,7 @@ final class FunctionDeclarationFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches($exceptionMessage);
 
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -48,7 +48,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
@@ -44,7 +44,7 @@ final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
             '#^\[return_type_declaration\] Invalid configuration: The option "s" does not exist\. (Known|Defined) options are: "space_before"\.$#',
         );
 
-        $this->fixer->configure(['s' => 9_000]);
+        $this->fixer->configure(['s' => 9_000]); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -2062,7 +2062,7 @@ B#
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage($expectedMessage);
 
-        $this->fixer->configure($wrongConfig);
+        $this->fixer->configure($wrongConfig); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
@@ -134,7 +134,7 @@ final class DeclareEqualNormalizeFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage(\sprintf('[declare_equal_normalize] Invalid configuration: %s', $expectedMessage));
 
-        $this->fixer->configure($config);
+        $this->fixer->configure($config); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
@@ -296,7 +296,7 @@ get_called_class#1
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
-        $this->fixer->configure($config);
+        $this->fixer->configure($config); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/NamespaceNotation/BlankLinesBeforeNamespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/BlankLinesBeforeNamespaceFixerTest.php
@@ -115,7 +115,7 @@ final class BlankLinesBeforeNamespaceFixerTest extends AbstractFixerTestCase
     public function testInvalidConfiguration(array $configuration): void
     {
         $this->expectException(InvalidFixerConfigurationException::class);
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -50,7 +50,7 @@ final class BinaryOperatorSpacesFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches($exceptionExpression);
 
-        $this->fixer->configure($config);
+        $this->fixer->configure($config); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Operator/ConcatSpaceFixerTest.php
+++ b/tests/Fixer/Operator/ConcatSpaceFixerTest.php
@@ -47,7 +47,7 @@ final class ConcatSpaceFixerTest extends AbstractFixerTestCase
         self::expectException(InvalidFixerConfigurationException::class);
         self::expectExceptionMessageMatches($exceptionExpression);
 
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
@@ -75,7 +75,7 @@ final class PhpUnitTestCaseStaticMethodCallsFixerTest extends AbstractFixerTestC
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Phpdoc/AlignMultilineCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/AlignMultilineCommentFixerTest.php
@@ -41,7 +41,7 @@ final class AlignMultilineCommentFixerTest extends AbstractFixerTestCase
     {
         $this->expectException(InvalidFixerConfigurationException::class);
 
-        $this->fixer->configure(['a' => 1]);
+        $this->fixer->configure(['a' => 1]); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Phpdoc/GeneralPhpdocTagRenameFixerTest.php
+++ b/tests/Fixer/Phpdoc/GeneralPhpdocTagRenameFixerTest.php
@@ -271,7 +271,7 @@ final class GeneralPhpdocTagRenameFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage($message);
 
-        $this->fixer->configure($config);
+        $this->fixer->configure($config); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
@@ -49,7 +49,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessageMatches($expectedMessage);
 
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -1595,7 +1595,7 @@ function foo($typeless): void {}',
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage($expectedMessage);
 
-        $this->fixer->configure($config);
+        $this->fixer->configure($config); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
@@ -48,7 +48,7 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches($expectedMessage);
 
-        $this->fixer->configure($config);
+        $this->fixer->configure($config); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
@@ -48,7 +48,7 @@ final class PhpdocOrderFixerTest extends AbstractFixerTestCase
         self::expectException(InvalidFixerConfigurationException::class);
         self::expectExceptionMessage($expectedExceptionMessage);
 
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
@@ -194,7 +194,7 @@ class F
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches(\sprintf('/^\[phpdoc_return_self_reference\] %s$/', preg_quote($message, '/')));
 
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
@@ -972,7 +972,7 @@ final class PhpdocSeparationFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
@@ -428,7 +428,7 @@ final class PhpdocTypesFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches($expectedMessage);
 
-        $this->fixer->configure($configuration);
+        $this->fixer->configure($configuration); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -46,7 +46,7 @@ final class ReturnAssignmentFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches($exceptionExpression);
 
-        $this->fixer->configure($config);
+        $this->fixer->configure($config); // @phpstan-ignore argument.type
     }
 
     /**

--- a/tests/Fixer/Whitespace/SpacesInsideParenthesesFixerTest.php
+++ b/tests/Fixer/Whitespace/SpacesInsideParenthesesFixerTest.php
@@ -48,7 +48,7 @@ final class SpacesInsideParenthesesFixerTest extends AbstractFixerTestCase
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageMatches($expectedMessage);
 
-        $this->fixer->configure($wrongConfig);
+        $this->fixer->configure($wrongConfig); // @phpstan-ignore argument.type
     }
 
     /**


### PR DESCRIPTION

| |number of errors|
|---|--:|
|initial|197|
|after [test: improve data providers return types](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9642)|124|
|after [chore: improve `ArrayIndentationFixer`](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9643)|111|
|after [chore: improve `ControlCaseStructuresAnalyzer`](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9644)|82|
|after [chore: improve `ClassDefinitionFixer`](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9645)|81|
|after [chore: improve `NoSuperfluousPhpdocTagsFixer`](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9646)|70|
|after [chore: improve `NoAliasFunctionsFixer`](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9647)|69|
|after [chore: improve `WorkerException`](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9648)|68|
|after [chore: improve `Token`](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9650)|35|