### PR TITLE
fix: Use `AgentDetector` to detect presence of AI agent only when `@auto` format has been selected

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -62,11 +62,12 @@ The ``--format`` option for the output format. Supported formats are ``@auto`` (
 
 * ``@auto`` aims to auto-select best reporter for given CI or local execution (resolution into best format is outside of BC promise and is future-ready)
 
-  * ``gitlab`` for GitLab
+  * ``gitlab`` when running in GitLab CI
+  * ``json`` when running in an AI agent (for example, when the ``AI_AGENT`` environment variable, or another popular one, is set), unless running in GitLab CI
 
 * ``@auto,{format}`` takes ``@auto`` under CI, and {format} otherwise
 
-When the ``AI_AGENT`` environment variable (or another popular one) is set, the format is unconditionally resolved to the selected best fit for the AI agent (currently ``json``).
+Agent detection only applies when the format is resolved automatically (``@auto``); an explicitly selected format (for example, ``--format=txt``) is never overridden. When both GitLab CI and an AI agent are detected, GitLab CI takes precedence and the format resolves to ``gitlab``.
 
 NOTE: the output for the following formats are generated in accordance with schemas
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -63,7 +63,7 @@ The ``--format`` option for the output format. Supported formats are ``@auto`` (
 * ``@auto`` aims to auto-select best reporter for given CI or local execution (resolution into best format is outside of BC promise and is future-ready)
 
   * ``gitlab`` when running in GitLab CI
-  * ``json`` when running in an AI agent (for example, when the ``AI_AGENT`` environment variable, or another popular one, is set), unless running in GitLab CI
+  * best fit for the AI agent (currently: ``json``) when running in an AI agent (for example, when the ``AI_AGENT`` environment variable, or another popular one, is set), unless running in GitLab CI
 
 * ``@auto,{format}`` takes ``@auto`` under CI, and {format} otherwise
 

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -670,15 +670,6 @@ final class ConfigurationResolver
     private function resolveFormat(): string
     {
         if (null === $this->format) {
-            $agentDetector = new AgentDetector\Detector();
-
-            // When an AI agent is running, we ignore the format configuration entirely and use JSON format.
-            if ($agentDetector->isAgentPresent(array_fill_keys(array_keys(getenv()), ''))) {
-                $this->format = 'json';
-
-                return $this->format;
-            }
-
             $formatCandidate = $this->options['format'] ?? $this->getConfig()->getFormat();
             $parts = explode(',', $formatCandidate);
 
@@ -689,11 +680,21 @@ final class ConfigurationResolver
             $this->format = $parts[0];
 
             if ('@auto' === $this->format) {
-                $this->format = $parts[1] ?? 'txt';
-
                 if (filter_var(getenv('GITLAB_CI'), \FILTER_VALIDATE_BOOL)) {
                     $this->format = 'gitlab';
+
+                    return $this->format;
                 }
+
+                $agentDetector = new AgentDetector\Detector();
+
+                if ($agentDetector->isAgentPresent(array_fill_keys(array_keys(getenv()), ''))) {
+                    $this->format = 'json';
+
+                    return $this->format;
+                }
+
+                $this->format = $parts[1] ?? 'txt';
             }
         }
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1525,7 +1525,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         ];
 
         yield [
-            JsonReporter::class,
+            CheckstyleReporter::class,
             'checkstyle',
             ['AI_AGENT' => 'true'],
         ];
@@ -1536,7 +1536,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         ];
 
         yield [
-            JsonReporter::class,
+            TextReporter::class,
             'txt',
             ['AI_AGENT' => 'true'],
         ];
@@ -1563,7 +1563,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         ];
 
         yield [
-            JsonReporter::class,
+            GitlabReporter::class,
             '@auto',
             [
                 'AI_AGENT' => 'true',


### PR DESCRIPTION
This pull request

- [x] uses `AgentDetector` to detect the presence of AI agent only when `@auto` format has been selected

Related to #9655.