### PR TITLE
refactor: change Fixers execution order to always-deterministic

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -108,7 +108,7 @@ final class Utils
     }
 
     /**
-     * Sort fixers by their priorities.
+     * Sort fixers by their priorities, and by their names if priorities are equal. That is ensuring always deterministic order of fixers.
      *
      * @template T of list<FixerInterface>
      *
@@ -118,13 +118,15 @@ final class Utils
      */
     public static function sortFixers(array $fixers): array
     {
-        // Schwartzian transform is used to improve the efficiency and avoid
-        // `usort(): Array was modified by the user comparison function` warning for mocked objects.
-        return self::stableSort(
-            $fixers,
-            static fn (FixerInterface $fixer): int => $fixer->getPriority(),
-            static fn (int $a, int $b): int => $b <=> $a,
-        );
+        usort($fixers, static function (FixerInterface $a, FixerInterface $b): int {
+            $cmpByPriority = $b->getPriority() <=> $a->getPriority();
+
+            return 0 !== $cmpByPriority
+                ? $cmpByPriority
+                : $a->getName() <=> $b->getName();
+        });
+
+        return $fixers; // @phpstan-ignore return.type (PHPStan cannot understand that the result will still be T template)
     }
 
     /**

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -222,17 +222,17 @@ final class UtilsTest extends TestCase
     {
         $fixers = [
             $this->createFixerDouble('f1', 0),
-            $this->createFixerDouble('f2', -10),
+            $this->createFixerDouble('fy', -10),
             $this->createFixerDouble('f3', 10),
-            $this->createFixerDouble('f4', -10),
+            $this->createFixerDouble('fx', -10),
         ];
 
         self::assertSame(
             [
-                $fixers[2], // f4
+                $fixers[2], // f3
                 $fixers[0], // f1
-                $fixers[1], // f2
-                $fixers[3], // f3
+                $fixers[3], // fx
+                $fixers[1], // fy
             ],
             Utils::sortFixers($fixers),
         );

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -229,10 +229,10 @@ final class UtilsTest extends TestCase
 
         self::assertSame(
             [
-                $fixers[2],
-                $fixers[0],
-                $fixers[1],
-                $fixers[3],
+                $fixers[2], // f4
+                $fixers[0], // f1
+                $fixers[1], // f2
+                $fixers[3], // f3
             ],
             Utils::sortFixers($fixers),
         );

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -221,7 +221,9 @@ final class UtilsTest extends TestCase
     public function testSortFixers(): void
     {
         $fixers = [
-            $this->createFixerDouble('f1', 0),
+            $this->createFixerDouble('f1_a', 0),
+            $this->createFixerDouble('F1_b', 0),
+            $this->createFixerDouble('f1_c', 0),
             $this->createFixerDouble('fy', -10),
             $this->createFixerDouble('f3', 10),
             $this->createFixerDouble('fx', -10),
@@ -229,12 +231,17 @@ final class UtilsTest extends TestCase
 
         self::assertSame(
             [
-                $fixers[2], // f3
-                $fixers[0], // f1
-                $fixers[3], // fx
-                $fixers[1], // fy
+                'f3',
+                'F1_b',
+                'f1_a',
+                'f1_c',
+                'fx',
+                'fy',
             ],
-            Utils::sortFixers($fixers),
+            array_map(
+                static fn (FixerInterface $fixer): string => $fixer->getName(),
+                Utils::sortFixers($fixers),
+            ),
         );
     }
 


### PR DESCRIPTION
currently, order is based on priority and then on order how they were provided from input, eg from I/O, which is not deterministic