### PR TITLE
Register custom fixers for integration tests

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -919,7 +919,9 @@ class Tokens extends \SplFixedArray
             if ('' === $token->getContent()) {
                 throw new \InvalidArgumentException(\sprintf('Non-meaningful (empty) token at position: "%s".', $key));
             }
+        }
 
+        foreach ($sequence as $token) {
             if (!$this->isTokenKindFound($this->extractTokenKind($token))) {
                 return null;
             }
@@ -933,35 +935,17 @@ class Tokens extends \SplFixedArray
         unset($sequence[$firstKey]);
 
         // begin searching for the first token in the sequence (start included)
-        for ($index = $start; $index <= $end; ++$index) {
-            $current = $this[$index];
+        $index = $start - 1;
+        while ($index <= $end) {
+            $index = $this->getNextTokenOfKind($index, [$firstToken], $firstCs);
 
-            if ($firstToken instanceof Token) {
-                if (!$current->equals($firstToken, $firstCs)) {
-                    continue;
-                }
-            } elseif (\is_string($firstToken)) {
-                if ($current->getContent() !== $firstToken) {
-                    continue;
-                }
-            } else {
-                if ($current->getId() !== $firstToken[0]) {
-                    continue;
-                }
-
-                if (isset($firstToken[1])) {
-                    if ($firstCs) {
-                        if ($current->getContent() !== $firstToken[1]) {
-                            continue;
-                        }
-                    } elseif (0 !== strcasecmp($current->getContent(), $firstToken[1])) {
-                        continue;
-                    }
-                }
+            // ensure we found a match and didn't get past the end index
+            if (null === $index || $index > $end) {
+                return null;
             }
 
             // initialise the result array with the current index
-            $result = [$index => $current];
+            $result = [$index => $this[$index]];
 
             // advance cursor to the current position
             $currIdx = $index;
@@ -972,44 +956,16 @@ class Tokens extends \SplFixedArray
 
                 // ensure we didn't go too far
                 if (null === $currIdx || $currIdx > $end) {
+                    return null;
+                }
+
+                if (!$this[$currIdx]->equals($token, self::isKeyCaseSensitive($caseSensitive, $key))) {
+                    // not a match, restart the outer loop
                     continue 2;
                 }
 
-                $current = $this[$currIdx];
-
-                if ($token instanceof Token) {
-                    if (!$current->equals($token, self::isKeyCaseSensitive($caseSensitive, $key))) {
-                        // not a match, restart the outer loop
-                        continue 2;
-                    }
-                } elseif (\is_string($token)) {
-                    if ($current->getContent() !== $token) {
-                        // not a match, restart the outer loop
-                        continue 2;
-                    }
-                } else {
-                    if ($current->getId() !== $token[0]) {
-                        // not a match, restart the outer loop
-                        continue 2;
-                    }
-
-                    if (isset($token[1])) {
-                        $cs = self::isKeyCaseSensitive($caseSensitive, $key);
-
-                        if ($cs) {
-                            if ($current->getContent() !== $token[1]) {
-                                // not a match, restart the outer loop
-                                continue 2;
-                            }
-                        } elseif (0 !== strcasecmp($current->getContent(), $token[1])) {
-                            // not a match, restart the outer loop
-                            continue 2;
-                        }
-                    }
-                }
-
                 // append index to the result array
-                $result[$currIdx] = $current;
+                $result[$currIdx] = $this[$currIdx];
             }
 
             // do we have a complete match?

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -919,9 +919,7 @@ class Tokens extends \SplFixedArray
             if ('' === $token->getContent()) {
                 throw new \InvalidArgumentException(\sprintf('Non-meaningful (empty) token at position: "%s".', $key));
             }
-        }
 
-        foreach ($sequence as $token) {
             if (!$this->isTokenKindFound($this->extractTokenKind($token))) {
                 return null;
             }
@@ -935,17 +933,35 @@ class Tokens extends \SplFixedArray
         unset($sequence[$firstKey]);
 
         // begin searching for the first token in the sequence (start included)
-        $index = $start - 1;
-        while ($index <= $end) {
-            $index = $this->getNextTokenOfKind($index, [$firstToken], $firstCs);
+        for ($index = $start; $index <= $end; ++$index) {
+            $current = $this[$index];
 
-            // ensure we found a match and didn't get past the end index
-            if (null === $index || $index > $end) {
-                return null;
+            if ($firstToken instanceof Token) {
+                if (!$current->equals($firstToken, $firstCs)) {
+                    continue;
+                }
+            } elseif (\is_string($firstToken)) {
+                if ($current->getContent() !== $firstToken) {
+                    continue;
+                }
+            } else {
+                if ($current->getId() !== $firstToken[0]) {
+                    continue;
+                }
+
+                if (isset($firstToken[1])) {
+                    if ($firstCs) {
+                        if ($current->getContent() !== $firstToken[1]) {
+                            continue;
+                        }
+                    } elseif (0 !== strcasecmp($current->getContent(), $firstToken[1])) {
+                        continue;
+                    }
+                }
             }
 
             // initialise the result array with the current index
-            $result = [$index => $this[$index]];
+            $result = [$index => $current];
 
             // advance cursor to the current position
             $currIdx = $index;
@@ -956,16 +972,44 @@ class Tokens extends \SplFixedArray
 
                 // ensure we didn't go too far
                 if (null === $currIdx || $currIdx > $end) {
-                    return null;
-                }
-
-                if (!$this[$currIdx]->equals($token, self::isKeyCaseSensitive($caseSensitive, $key))) {
-                    // not a match, restart the outer loop
                     continue 2;
                 }
 
+                $current = $this[$currIdx];
+
+                if ($token instanceof Token) {
+                    if (!$current->equals($token, self::isKeyCaseSensitive($caseSensitive, $key))) {
+                        // not a match, restart the outer loop
+                        continue 2;
+                    }
+                } elseif (\is_string($token)) {
+                    if ($current->getContent() !== $token) {
+                        // not a match, restart the outer loop
+                        continue 2;
+                    }
+                } else {
+                    if ($current->getId() !== $token[0]) {
+                        // not a match, restart the outer loop
+                        continue 2;
+                    }
+
+                    if (isset($token[1])) {
+                        $cs = self::isKeyCaseSensitive($caseSensitive, $key);
+
+                        if ($cs) {
+                            if ($current->getContent() !== $token[1]) {
+                                // not a match, restart the outer loop
+                                continue 2;
+                            }
+                        } elseif (0 !== strcasecmp($current->getContent(), $token[1])) {
+                            // not a match, restart the outer loop
+                            continue 2;
+                        }
+                    }
+                }
+
                 // append index to the result array
-                $result[$currIdx] = $this[$currIdx];
+                $result[$currIdx] = $current;
             }
 
             // do we have a complete match?

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -362,9 +362,17 @@ abstract class AbstractIntegrationTestCase extends TestCase
     private static function createFixers(IntegrationCase $case): array
     {
         $config = $case->getConfig();
+        $customFixers = [];
+
+        if (isset($config['customFixers'])) {
+            foreach ($config['customFixers'] as $className) {
+                $customFixers[] = new $className();
+            }
+        }
 
         return (new FixerFactory())
             ->registerBuiltInFixers()
+            ->registerCustomFixers($customFixers)
             ->useRuleSet($case->getRuleset())
             ->setWhitespacesConfig(
                 new WhitespacesFixerConfig($config['indent'], $config['lineEnding']),

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -359,7 +359,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
     /**
      * @return list<FixerInterface>
      */
-    private static function createFixers(IntegrationCase $case): array
+    protected static function createFixers(IntegrationCase $case): array
     {
         $config = $case->getConfig();
 

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -362,17 +362,9 @@ abstract class AbstractIntegrationTestCase extends TestCase
     private static function createFixers(IntegrationCase $case): array
     {
         $config = $case->getConfig();
-        $customFixers = [];
-
-        if (isset($config['customFixers'])) {
-            foreach ($config['customFixers'] as $className) {
-                $customFixers[] = new $className();
-            }
-        }
 
         return (new FixerFactory())
             ->registerBuiltInFixers()
-            ->registerCustomFixers($customFixers)
             ->useRuleSet($case->getRuleset())
             ->setWhitespacesConfig(
                 new WhitespacesFixerConfig($config['indent'], $config['lineEnding']),


### PR DESCRIPTION
I propose this new syntax for a fixture
```json
--CONFIG--
{
	"customFixers": ["App\\MyCustomFixer"]
}
```

I want to add integration tests for my fixers and have come up with this code for your consideration. I need your advice on whether this code is a good fit for this project and whether this is the right approach.

Should `AbstractIntegrationTestCase::createFixers()` be made `protected` or even `abstract` so that implementations can override it? Should it be split into two parts, where the first function returns a `FixerFactory`?
