### PR TITLE
test: use correct test precondition failure mode in PharTest

### DIFF
--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -57,7 +57,7 @@ final class PharTest extends AbstractSmokeTestCase
         self::$pharName = 'php-cs-fixer.phar';
 
         if (!file_exists(self::$pharCwd.'/'.self::$pharName)) {
-            self::fail('No phar file available.');
+            throw new \RuntimeException('No phar file available.');
         }
     }
 


### PR DESCRIPTION
In https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9580#issuecomment-4790473701 I discovered that `PharTest` was erroneously using `self::fail()` inside a `setupBeforeClass` method, which doesn't make sense; it let the test fail silently with a simple warning, which is then picked up only by Paraunit with recent PHPUnit version, where the exit code becomes `1`, reporting the error correctly.

This PR should make the failure more clear, with PHPUnit reporting a full error (at least under v12.5).