### PR TITLE
fix: `SelfAccessorFixer` - do not replace constant with same name as class in the middle of a static access chain

### DIFF
--- a/src/Fixer/ClassNotation/SelfAccessorFixer.php
+++ b/src/Fixer/ClassNotation/SelfAccessorFixer.php
@@ -163,7 +163,7 @@ final class SelfAccessorFixer extends AbstractFixer
                 }
                 $prevToken = $tokens[$tokens->getPrevMeaningfulToken($classStartIndex)];
             }
-            if ($prevToken->isGivenKind(\T_STRING) || $prevToken->isObjectOperator()) {
+            if ($prevToken->isGivenKind([\T_STRING, \T_PAAMAYIM_NEKUDOTAYIM]) || $prevToken->isObjectOperator()) {
                 continue;
             }
 

--- a/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
@@ -244,7 +244,7 @@ final class A
     }
 
     /**
-     * @return iterable<int, array{0: string, 1?: string}>
+     * @return iterable<array{0: string, 1?: string}>
      */
     public static function provideFix80Cases(): iterable
     {
@@ -282,6 +282,41 @@ final class A
 
         yield [
             '<?php class Foo { public function f(Bar|C\Foo|Baz $b) {} }',
+        ];
+
+        yield 'replace constant with same name as class in the middle of a static access chain' => [
+            <<<'PHP'
+                <?php
+                class Foo {
+                    public static function create(): self {
+                        return new self();
+                    }
+                }
+                class Bar {
+                    const Baz = 'Foo';
+                }
+                class Baz {
+                    public static function f(): object {
+                        return Bar::self::create();
+                    }
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                class Foo {
+                    public static function create(): self {
+                        return new self();
+                    }
+                }
+                class Bar {
+                    const Baz = 'Foo';
+                }
+                class Baz {
+                    public static function f(): object {
+                        return Bar::Baz::create();
+                    }
+                }
+                PHP,
         ];
     }
 

--- a/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
@@ -284,23 +284,7 @@ final class A
             '<?php class Foo { public function f(Bar|C\Foo|Baz $b) {} }',
         ];
 
-        yield 'replace constant with same name as class in the middle of a static access chain' => [
-            <<<'PHP'
-                <?php
-                class Foo {
-                    public static function create(): self {
-                        return new self();
-                    }
-                }
-                class Bar {
-                    const Baz = 'Foo';
-                }
-                class Baz {
-                    public static function f(): object {
-                        return Bar::self::create();
-                    }
-                }
-                PHP,
+        yield 'do not replace constant with same name as class in the middle of a static access chain' => [
             <<<'PHP'
                 <?php
                 class Foo {


### PR DESCRIPTION
Fixes https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/9715