### PR TITLE
chore: add code coverage ignore annotations to parallel runner and worker

### DIFF
--- a/src/Console/Command/WorkerCommand.php
+++ b/src/Console/Command/WorkerCommand.php
@@ -108,8 +108,8 @@ final class WorkerCommand extends Command
         $tcpConnector = new TcpConnector($loop);
         $tcpConnector
             ->connect(\sprintf('127.0.0.1:%d', $port))
+            // @codeCoverageIgnoreStart
             ->then(
-                /** @codeCoverageIgnore */
                 function (ConnectionInterface $connection) use ($loop, $runner, $identifier): void {
                     $out = new Encoder($connection, \JSON_INVALID_UTF8_IGNORE);
                     $in = new Decoder($connection, true, 512, \JSON_INVALID_UTF8_IGNORE);
@@ -192,6 +192,7 @@ final class WorkerCommand extends Command
                     $errorOutput->writeln($error->getMessage());
                 },
             )
+            // @codeCoverageIgnoreEnd
         ;
 
         $loop->run();

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -489,6 +489,7 @@ final class Runner
 
                 // [REACT] Handle worker's shutdown
                 static function ($exitCode, string $output) use ($processPool, $identifier): void {
+                    // @codeCoverageIgnoreStart
                     $processPool->endProcessIfKnown($identifier);
 
                     if (0 === $exitCode || null === $exitCode) {
@@ -506,6 +507,7 @@ final class Runner
                             json_decode($matches[1][0], true, 512, \JSON_THROW_ON_ERROR),
                         );
                     }
+                    // @codeCoverageIgnoreEnd
                 },
             );
         }


### PR DESCRIPTION
To avoid coverage noise, like:
<img width="1051" height="514" alt="image" src="https://github.com/user-attachments/assets/4cb52fc7-5273-4336-ad6b-5cd7a8dfd9c1" />
