### PR TITLE
fix: `PowToExponentiationFixer` - do not produce two consecutive whitespace tokens

### DIFF
--- a/src/Fixer/Alias/PowToExponentiationFixer.php
+++ b/src/Fixer/Alias/PowToExponentiationFixer.php
@@ -157,7 +157,7 @@ final class PowToExponentiationFixer extends AbstractFunctionReferenceFixer
 
         // clean up the function call tokens prt. II
         $tokens->clearAt($openParenthesisIndex);
-        $tokens->clearAt($functionNameIndex);
+        $tokens->clearTokenAndMergeSurroundingWhitespace($functionNameIndex);
 
         $prevMeaningfulTokenIndex = $tokens->getPrevMeaningfulToken($functionNameIndex);
 

--- a/tests/Fixer/Alias/PowToExponentiationFixerTest.php
+++ b/tests/Fixer/Alias/PowToExponentiationFixerTest.php
@@ -286,6 +286,21 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
+            '<?php
+$a = '.'
+    1**
+    2
+;
+',
+            '<?php
+$a = pow(
+    1,
+    2,
+);
+',
+        ];
+
+        yield [
             '<?php echo 10_0** 2;',
             '<?php echo pow(10_0, 2);',
         ];


### PR DESCRIPTION
Fixes #9734

Converting a multi-line `pow()` call to the `**` operator cleared the function name and opening parenthesis but left the whitespace before the call next to the whitespace inside the parentheses, producing two consecutive whitespace tokens. The tokenizer never emits those, so `StatementIndentationFixer` running afterwards crashed with `TypeError: Cannot access offset of type null on SplFixedArray`. Merging the surrounding whitespace when clearing the name keeps the token stream valid.
