### PR TITLE
fix: `NoSuperfluousPhpdocTagsFixer` with multiple hidden params

### DIFF
--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -493,10 +493,15 @@ final class NoSuperfluousPhpdocTagsFixer extends AbstractFixer implements Config
         // virtualise "hidden params" as if they would be regular ones
         if (true === $this->configuration['allow_hidden_params']) {
             $paramsString = $tokens->generatePartialCode($start, $end);
-            Preg::matchAll('|/\*[^$]*(\$\w+)[^*]*\*/|', $paramsString, $matches);
+            Preg::matchAll('~/\*.*?\*/~s', $paramsString, $matches);
 
-            foreach ($matches[1] as $match) {
-                $argumentsInfo[$match] = self::NO_TYPE_INFO; // HINT: one could try to extract actual type for hidden param, for now we only indicate it's existence
+            foreach ($matches[0] as $comment) {
+                Preg::matchAll('~\$\w+~', $comment, $paramMatches);
+
+                /** @var non-empty-string $hiddenParam */
+                foreach ($paramMatches[0] as $hiddenParam) {
+                    $argumentsInfo[$hiddenParam] = self::NO_TYPE_INFO; // HINT: one could try to extract actual type for hidden param, for now we only indicate it's existence
+                }
             }
         }
 

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -2643,6 +2643,48 @@ static fn ($foo): int => 1;',
             ['allow_hidden_params' => true],
         ];
 
+        yield '@param for multiple hidden parameter with option disabled' => [
+            <<<'EOD'
+                <?php
+                /**
+                 */
+                function foo(array $bundleConfig/* , string $bundleDir1 = null, string $bundleDir2 = null, mixed $bundleDir3 = null */) {}
+                EOD,
+            <<<'EOD'
+                <?php
+                /**
+                 * @param array   $bundleConfig
+                 * @param ?string $bundleDir1
+                 * @param ?string $bundleDir2
+                 * @param mixed $bundleDir3
+                 */
+                function foo(array $bundleConfig/* , string $bundleDir1 = null, string $bundleDir2 = null, mixed $bundleDir3 = null */) {}
+                EOD,
+            ['allow_hidden_params' => false],
+        ];
+
+        yield '@param for multiple hidden parameter with option enabled' => [
+            <<<'EOD'
+                <?php
+                /**
+                 * @param ?string $bundleDir1
+                 * @param ?string $bundleDir2
+                 */
+                function foo(array $bundleConfig/* , string $bundleDir1 = null, string $bundleDir2 = null, mixed $bundleDir3 = null */) {}
+                EOD,
+            <<<'EOD'
+                <?php
+                /**
+                 * @param array   $bundleConfig
+                 * @param ?string $bundleDir1
+                 * @param ?string $bundleDir2
+                 * @param mixed $bundleDir3
+                 */
+                function foo(array $bundleConfig/* , string $bundleDir1 = null, string $bundleDir2 = null, mixed $bundleDir3 = null */) {}
+                EOD,
+            ['allow_hidden_params' => true],
+        ];
+
         yield '@param without space between variable name and description' => [
             <<<'EOD'
                 <?php


### PR DESCRIPTION
Currently, the `allow_hidden_params` option fails when there are multiple consecutive hidden parameters. For example:

```php
function foo(array $bundleConfig/* , string $bundleDir1 = null, string $bundleDir2 = null */) {}
```

Only the first hidden parameter is detected, while the remaining ones are ignored and removed.

This PR updates the parser to extract all hidden parameters from the comment, ensuring that they are all recognized when `allow_hidden_params` is enabled.