### PR TITLE
perf: `Token::equals()` - Avoid building intermediary arrays

### DIFF
--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -134,6 +134,9 @@ final class Token
         }
 
         if ($other instanceof self) {
+            // We access the private properties of $other directly to save function call overhead.
+            // This is only possible because $other is of the same class as `self`.Collapse comment
+
             if ($this->isArray !== $other->isArray) {
                 return false;
             }

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -117,11 +117,11 @@ final class Token
     }
 
     /**
-     * Check if token is equals to given one.
+     * Check if token is equal to given one.
      *
      * If tokens are arrays, then only keys defined in parameter token are checked.
      *
-     * @param _PhpTokenPrototypePartial|Token $other         token or it's prototype
+     * @param _PhpTokenPrototypePartial|Token $other         token or its prototype
      * @param bool                            $caseSensitive perform a case sensitive comparison
      */
     public function equals($other, bool $caseSensitive = true): bool
@@ -134,53 +134,51 @@ final class Token
         }
 
         if ($other instanceof self) {
-            // Inlined getPrototype() on this very hot path.
-            // We access the private properties of $other directly to save function call overhead.
-            // This is only possible because $other is of the same class as `self`.
-            if (!$other->isArray) {
-                $otherPrototype = $other->content;
-            } else {
-                $otherPrototype = [
-                    $other->id,
-                    $other->content,
-                ];
+            if ($this->isArray !== $other->isArray) {
+                return false;
             }
-        } else {
-            $otherPrototype = $other;
+
+            if (!$this->isArray) {
+                return $this->content === $other->content;
+            }
+
+            if ($this->id !== $other->id) {
+                return false;
+            }
+
+            return !$caseSensitive
+                ? 0 === strcasecmp($this->content, $other->content)
+                : $this->content === $other->content;
         }
 
-        if ($this->isArray !== \is_array($otherPrototype)) {
+        if ($this->isArray !== \is_array($other)) {
             return false;
         }
 
         if (!$this->isArray) {
-            return $this->content === $otherPrototype;
+            return $this->content === $other;
         }
 
-        if ($this->id !== $otherPrototype[0]) {
+        if ($this->id !== $other[0]) {
             return false;
         }
 
-        if (isset($otherPrototype[1])) {
+        if (isset($other[1])) {
             if ($caseSensitive) {
-                if ($this->content !== $otherPrototype[1]) {
+                if ($this->content !== $other[1]) {
                     return false;
                 }
-            } elseif (0 !== strcasecmp($this->content, $otherPrototype[1])) {
+            } elseif (0 !== strcasecmp($this->content, $other[1])) {
                 return false;
             }
         }
 
-        \assert(!isset($otherPrototype[2]) || \is_int($otherPrototype[2])); // only assertion as we do not use the value anywhere
-
-        // detect unknown keys
-        unset($otherPrototype[0], $otherPrototype[1]);
-
-        return [] === $otherPrototype;
+        // detect and forbid unknown keys
+        return 2 === \count($other) || !isset($other[2]);
     }
 
     /**
-     * Check if token is equals to one of given.
+     * Check if token is equal to one of given.
      *
      * @param list<_PhpTokenPrototypePartial|Token> $others        array of tokens or token prototypes
      * @param bool                                  $caseSensitive perform a case sensitive comparison


### PR DESCRIPTION
- as requested in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9737#discussion_r3636747335