### PR TITLE
refactor: replace `AttributeAnalyzer::determineAttributeFullyQualifiedName()` with `FullyQualifiedNameAnalyzer`

### DIFF
--- a/src/Fixer/AttributeNotation/GeneralAttributeRemoveFixer.php
+++ b/src/Fixer/AttributeNotation/GeneralAttributeRemoveFixer.php
@@ -24,9 +24,12 @@ use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Analyzer\Analysis\AttributeAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceUseAnalysis;
 use PhpCsFixer\Tokenizer\Analyzer\AttributeAnalyzer;
+use PhpCsFixer\Tokenizer\Analyzer\FullyQualifiedNameAnalyzer;
 use PhpCsFixer\Tokenizer\FCT;
 use PhpCsFixer\Tokenizer\Tokens;
+use Symfony\Component\OptionsResolver\Options;
 
 /**
  * @phpstan-import-type _AttributeItems from AttributeAnalysis
@@ -92,6 +95,8 @@ final class GeneralAttributeRemoveFixer extends AbstractFixer implements Configu
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
+        $fullyQualifiedNameAnalyzer = new FullyQualifiedNameAnalyzer($tokens);
+
         $index = 0;
 
         while (null !== $index = $tokens->getNextTokenOfKind($index, [[\T_ATTRIBUTE]])) {
@@ -101,7 +106,7 @@ final class GeneralAttributeRemoveFixer extends AbstractFixer implements Configu
 
             $removedCount = 0;
             foreach ($attributeAnalysis->getAttributes() as $element) {
-                $fullname = AttributeAnalyzer::determineAttributeFullyQualifiedName($tokens, $element['name'], $element['start']);
+                $fullname = $fullyQualifiedNameAnalyzer->getFullyQualifiedName($element['name'], $element['start'], NamespaceUseAnalysis::TYPE_CLASS);
 
                 if (!\in_array($fullname, $this->configuration['attributes'], true)) {
                     continue;
@@ -139,6 +144,10 @@ final class GeneralAttributeRemoveFixer extends AbstractFixer implements Configu
             (new FixerOptionBuilder('attributes', 'List of FQNs of attributes for removal.'))
                 ->setAllowedTypes(['class-string[]'])
                 ->setDefault([])
+                ->setNormalizer(static fn (Options $options, array $value): array => array_map(
+                    static fn (string $attribute): string => ltrim($attribute, '\\'),
+                    $value,
+                ))
                 ->getOption(),
         ]);
     }

--- a/src/Fixer/Internal/ConfigurableFixerTemplateFixer.php
+++ b/src/Fixer/Internal/ConfigurableFixerTemplateFixer.php
@@ -20,6 +20,7 @@ use PhpCsFixer\AbstractPhpdocToTypeDeclarationFixer;
 use PhpCsFixer\Console\Command\HelpCommand;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\Doctrine\Annotation\Tokens as DoctrineAnnotationTokens;
+use PhpCsFixer\Fixer\AttributeNotation\GeneralAttributeRemoveFixer;
 use PhpCsFixer\Fixer\AttributeNotation\OrderedAttributesFixer;
 use PhpCsFixer\Fixer\Casing\ConstantCaseFixer;
 use PhpCsFixer\Fixer\ClassNotation\FinalInternalClassFixer;
@@ -285,6 +286,8 @@ final class ConfigurableFixerTemplateFixer extends AbstractFixer implements Inte
                 } elseif ($fixer instanceof NoBreakCommentFixer && 'comment_text' === $optionName) {
                     // nothing to do
                 } elseif ($fixer instanceof TrailingCommaInMultilineFixer && 'elements' === $optionName) {
+                    // nothing to do
+                } elseif ($fixer instanceof GeneralAttributeRemoveFixer && 'attributes' === $optionName) {
                     // nothing to do
                 } elseif ($fixer instanceof OrderedAttributesFixer && 'sort_algorithm' === $optionName) {
                     // nothing to do

--- a/src/Fixer/PhpUnit/PhpUnitAttributesFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitAttributesFixer.php
@@ -27,7 +27,9 @@ use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\FixerDefinition\VersionSpecification;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Preg;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceUseAnalysis;
 use PhpCsFixer\Tokenizer\Analyzer\AttributeAnalyzer;
+use PhpCsFixer\Tokenizer\Analyzer\FullyQualifiedNameAnalyzer;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Processor\ImportProcessor;
 use PhpCsFixer\Tokenizer\Token;
@@ -256,9 +258,11 @@ final class PhpUnitAttributesFixer extends AbstractPhpUnitFixer implements Confi
             $insertedClassName .= $token->getContent();
         }
 
+        $fullyQualifiedNameAnalyzer = new FullyQualifiedNameAnalyzer($tokens);
+
         foreach (AttributeAnalyzer::collect($tokens, $attributeIndex) as $attributeAnalysis) {
             foreach ($attributeAnalysis->getAttributes() as $attribute) {
-                $className = ltrim(AttributeAnalyzer::determineAttributeFullyQualifiedName($tokens, $attribute['name'], $attribute['start']), '\\');
+                $className = $fullyQualifiedNameAnalyzer->getFullyQualifiedName($attribute['name'], $attribute['start'], NamespaceUseAnalysis::TYPE_CLASS);
 
                 if ($insertedClassName === $className) {
                     return true;

--- a/src/Tokenizer/Analyzer/AttributeAnalyzer.php
+++ b/src/Tokenizer/Analyzer/AttributeAnalyzer.php
@@ -16,7 +16,6 @@ namespace PhpCsFixer\Tokenizer\Analyzer;
 
 use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Analyzer\Analysis\AttributeAnalysis;
-use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceUseAnalysis;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\FCT;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -129,34 +128,6 @@ final class AttributeAnalyzer
             $closingIndex,
             self::collectAttributes($tokens, $index, $closingIndex),
         );
-    }
-
-    public static function determineAttributeFullyQualifiedName(Tokens $tokens, string $name, int $index): string
-    {
-        if ('\\' === $name[0]) {
-            return $name;
-        }
-
-        if (!$tokens[$index]->isGivenKind([\T_STRING, \T_NS_SEPARATOR])) {
-            $index = $tokens->getNextTokenOfKind($index, [[\T_STRING], [\T_NS_SEPARATOR]]);
-        }
-
-        [$namespaceAnalysis, $namespaceUseAnalyses] = NamespacesAnalyzer::collectNamespaceAnalysis($tokens, $index);
-        $namespace = $namespaceAnalysis->getFullName();
-        $firstTokenOfName = $tokens[$index]->getContent();
-        $namespaceUseAnalysis = $namespaceUseAnalyses[$firstTokenOfName] ?? false;
-
-        if ($namespaceUseAnalysis instanceof NamespaceUseAnalysis) {
-            $namespace = $namespaceUseAnalysis->getFullName();
-
-            if ($name === $firstTokenOfName) {
-                return $namespace;
-            }
-
-            $name = substr((string) strstr($name, '\\'), 1);
-        }
-
-        return $namespace.'\\'.$name;
     }
 
     /**

--- a/src/Tokenizer/Analyzer/NamespacesAnalyzer.php
+++ b/src/Tokenizer/Analyzer/NamespacesAnalyzer.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace PhpCsFixer\Tokenizer\Analyzer;
 
 use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceAnalysis;
-use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceUseAnalysis;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**
@@ -94,25 +93,5 @@ final class NamespacesAnalyzer
         }
 
         throw new \LogicException(\sprintf('Unable to get the namespace at index %d.', $index));
-    }
-
-    /**
-     * @return array{NamespaceAnalysis, array<string, NamespaceUseAnalysis>}
-     */
-    public static function collectNamespaceAnalysis(Tokens $tokens, int $startIndex): array
-    {
-        $namespaceAnalysis = (new self())->getNamespaceAt($tokens, $startIndex);
-        $namespaceUseAnalyses = (new NamespaceUsesAnalyzer())->getDeclarationsInNamespace($tokens, $namespaceAnalysis);
-
-        $uses = [];
-        foreach ($namespaceUseAnalyses as $use) {
-            if (!$use->isClass()) {
-                continue;
-            }
-
-            $uses[$use->getShortName()] = $use;
-        }
-
-        return [$namespaceAnalysis, $uses];
     }
 }

--- a/tests/Fixer/AttributeNotation/GeneralAttributeRemoveFixerTest.php
+++ b/tests/Fixer/AttributeNotation/GeneralAttributeRemoveFixerTest.php
@@ -139,7 +139,6 @@ final class GeneralAttributeRemoveFixerTest extends AbstractFixerTestCase
                 use A\B\Bar as BarAlias;
                 use A\B as AB;
 
-                #[\A\B\Quux(prop1: [1, 2, 4], prop2: true, prop3: \'foo bar\')]
                 function f() {}
             }
 


### PR DESCRIPTION
The `AttributeAnalyzer::determineAttributeFullyQualifiedName()` method was originally extracted from `OrderedAttributesFixer` in #8339. Later, in #8048, `FullyQualifiedNameAnalyzer` was introduced, and `OrderedAttributesFixer` was updated to use it, while the other fixers continued using `determineAttributeFullyQualifiedName()`.

This PR replaces the remaining usages of `determineAttributeFullyQualifiedName()` with `FullyQualifiedNameAnalyzer`, so all fixers use the same implementation.