### PR TITLE
test: ProjectCodeTest - restore the duplicate check in data providers

### DIFF
--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -1066,7 +1066,7 @@ final class ProjectCodeTest extends TestCase
                 }
             }
             if (!$foundInDuplicates) {
-                $alreadyFoundCases[$candidateKey] = $candidateData;
+                $alreadyFoundCases[$candidateKey] = $serializedCandidateData;
             }
         }
 
@@ -1329,6 +1329,17 @@ final class ProjectCodeTest extends TestCase
                 $serialized[$key] = 'Closure#'.spl_object_id($value);
             } elseif ($value instanceof \SplFileInfo) {
                 $serialized[$key] = 'SplFileInfo('.$value->getPathname().')';
+            } elseif (\is_object($value)) {
+                // An object may hold a closure somewhere in its graph: an Error keeps the
+                // Throwable it was created from, and with zend.exception_ignore_args=Off
+                // - the default of php.ini-development - that exception's trace keeps the
+                // arguments of every frame. serialize() refuses those, so fall back to a
+                // printable representation, which is stable enough to compare cases.
+                try {
+                    $serialized[$key] = serialize($value);
+                } catch (\Exception $e) {
+                    $serialized[$key] = print_r($value, true);
+                }
             } else {
                 $serialized[$key] = $value;
             }

--- a/tests/Fixer/ClassNotation/StringableForToStringFixerTest.php
+++ b/tests/Fixer/ClassNotation/StringableForToStringFixerTest.php
@@ -195,8 +195,6 @@ final class StringableForToStringFixerTest extends AbstractFixerTestCase
             'Foo\Stringable, Bar\Stringable',
             'Stringable\Foo, Stringable\Bar',
             '\Stringable\Foo, Stringable\Bar',
-            'Foo\Stringable\Bar',
-            '\Foo\Stringable\Bar',
         ];
 
         foreach ($implementedInterfacesCases as $implementedInterface) {

--- a/tests/Fixer/ListNotation/ListSyntaxFixerTest.php
+++ b/tests/Fixer/ListNotation/ListSyntaxFixerTest.php
@@ -224,11 +224,6 @@ $a;#
         ];
 
         yield [
-            '<?php [$a, $b,, [$c, $d]] = $a;',
-            '<?php list($a, $b,, list($c, $d)) = $a;',
-        ];
-
-        yield [
             '<?php [&$a, $b] = $a;',
             '<?php list(&$a, $b) = $a;',
         ];

--- a/tests/Fixer/Operator/NewWithParenthesesFixerTest.php
+++ b/tests/Fixer/Operator/NewWithParenthesesFixerTest.php
@@ -686,15 +686,6 @@ final class NewWithParenthesesFixerTest extends AbstractFixerTestCase
 
         yield [
             '<?php
-                    $a = new Foo() <=> 1;
-                ',
-            '<?php
-                    $a = new Foo <=> 1;
-                ',
-        ];
-
-        yield [
-            '<?php
                     $a = new class() {use SomeTrait;};
                     $a = new class() implements Foo{};
                     $a = new class() /**/ extends Bar1{};

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
@@ -630,11 +630,11 @@ $a# 5
             self::generateTest('$this->assertSame(1.0, %s($a));'),
         ];
 
-        yield 'do not fix 5' => [
+        yield 'do not fix 4' => [
             self::generateTest('$this->assertSame(1, "%s");'),
         ];
 
-        yield 'do not fix 6' => [
+        yield 'do not fix 5' => [
             self::generateTest('$this->test(); // $this->assertSame($b, %s($a));'),
         ];
     }

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
@@ -637,7 +637,6 @@ $a# 5
         yield 'do not fix 6' => [
             self::generateTest('$this->test(); // $this->assertSame($b, %s($a));'),
         ];
-
     }
 
     private static function generateTest(string $content): string

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
@@ -390,6 +390,24 @@ $a#
             self::generateTest('self::assertTrue(is_resource($resource));'),
         ];
 
+        // These do not contain a "%s" placeholder, so running them once per function
+        // would just repeat the same case.
+        yield 'do not fix - assertSame with a single argument' => [
+            self::generateTest('$this->assertSame(1);'),
+        ];
+
+        yield 'do not fix - count inside an expression' => [
+            self::generateTest('$this->assertSame(2, count($array) - 1);'),
+        ];
+
+        yield 'do not fix - sizeof in other constructs' => [
+            self::generateTest('
+                    Foo::assertSame(1, sizeof($a));
+                    $this->assertSame(1, sizeof2(2));
+                    $this->assertSame(1, sizeof::foo);
+                '),
+        ];
+
         foreach (self::provideTestAssertCountCases() as $index => $case) {
             foreach (['count', 'sizeof'] as $function) {
                 yield $function.' - '.$index => array_map(
@@ -612,10 +630,6 @@ $a# 5
             self::generateTest('$this->assertSame(1.0, %s($a));'),
         ];
 
-        yield 'do not fix 4' => [
-            self::generateTest('$this->assertSame(1);'),
-        ];
-
         yield 'do not fix 5' => [
             self::generateTest('$this->assertSame(1, "%s");'),
         ];
@@ -624,17 +638,6 @@ $a# 5
             self::generateTest('$this->test(); // $this->assertSame($b, %s($a));'),
         ];
 
-        yield 'do not fix 7' => [
-            self::generateTest('$this->assertSame(2, count($array) - 1);'),
-        ];
-
-        yield 'do not fix 8' => [
-            self::generateTest('
-                    Foo::assertSame(1, sizeof($a));
-                    $this->assertSame(1, sizeof2(2));
-                    $this->assertSame(1, sizeof::foo);
-                '),
-        ];
     }
 
     private static function generateTest(string $content): string


### PR DESCRIPTION
Two problems in `ProjectCodeTest::testDataFromDataProviders`, found while working on #9760.

## The duplicate check never fired

```php
$serializedCandidateData = self::naiveSerialize($candidateData);   // a string
...
if ($serializedCandidateData === $caseData) {                      // $caseData is an array
...
$alreadyFoundCases[$candidateKey] = $candidateData;                // the raw array is stored
```

A string is never identical to an array, so the condition could not be true. I checked it by adding a deliberate duplicate to a provider: on current master it goes unnoticed, both with `zend.exception_ignore_args=On` and `Off`.

Storing the serialized form instead makes the check work again, and it immediately reports eight real duplicates:

```
StringableForToStringFixerTest::provideFixCases: #19 and #24, #20 and #25
ListSyntaxFixerTest::provideFixCases: #4 and #9, "to long - 4" and "to long - 9"
NewWithParenthesesFixerTest::provideFixCases: #41 and #98
PhpUnitDedicateAssertFixerTest::provideFixCases: "count - do not fix 4" and "sizeof - do not fix 4" (same for 7 and 8)
```

They are all removed here, otherwise the check would leave CI red. Notes on each:

- `StringableForToStringFixerTest`: `$implementedInterfacesCases` lists `Foo\Stringable\Bar` and `\Foo\Stringable\Bar` twice.
- `ListSyntaxFixerTest`: `getFixToShortSyntaxCases()` yields `[$a, $b,, [$c, $d]] = $a;` twice, which in turn duplicates the derived `to long -` case.
- `NewWithParenthesesFixerTest`: the `new Foo <=> 1` case appears twice.
- `PhpUnitDedicateAssertFixerTest`: cases 4, 7 and 8 carry no `%s` placeholder, so the `foreach (['count', 'sizeof'])` loop yielded identical data twice. They are moved out of the loop and now run once. Case 7 hardcodes `count(...)` and case 8 hardcodes `sizeof(...)`; if a placeholder was intended there, that is a separate change and I left the coverage exactly as it is.

## The test fails locally with php.ini-development

`naiveSerialize()` replaces closures at the top level and inside arrays, but not inside objects. A `Throwable` keeps a stack trace, and when `zend.exception_ignore_args` is `Off` -- the default of `php.ini-development`, and what Homebrew ships -- that trace holds the arguments of every frame, closures included. `serialize()` then throws:

```
Exception: Serialization of 'Closure' is not allowed
```

Two providers hit this: `ConfigurationResolverTest::provideResolveIntersectionOfPathsCases` (a `LogicException` in the data) and `ErrorOutputTest::provideErrorOutputCases` (an `Error` that holds the `Throwable` it was built from). CI is unaffected because it runs with the production default, so this only bites contributors, on a test that is meant to reassure them.

Objects that refuse to serialize now fall back to `print_r()`, which handles closures and is stable enough for comparing cases.

## Verification

- `--testsuite auto-review` passes with `zend.exception_ignore_args` both `Off` and `On`; on master it errors twice with `Off`.
- With the check restored, a deliberately duplicated case is reported; before the change it was not.
- The four touched fixer test classes pass, and their assertion counts are unchanged apart from the removed duplicates.
