### PR TITLE
fix: `PsrAutoloadingFixer` - do not throw when the file cannot be resolved on disk

### DIFF
--- a/src/Fixer/Basic/PsrAutoloadingFixer.php
+++ b/src/Fixer/Basic/PsrAutoloadingFixer.php
@@ -118,6 +118,13 @@ final class PsrAutoloadingFixer extends AbstractFixer implements ConfigurableFix
             return false;
         }
 
+        $realPath = $file->getRealPath();
+
+        // ignore file that cannot be resolved on disk, since its location is what gets compared to the namespace
+        if (false === $realPath) {
+            return false;
+        }
+
         try {
             $tokens = Tokens::fromCode(\sprintf('<?php class %s {}', $file->getBasename('.php')));
 
@@ -131,7 +138,7 @@ final class PsrAutoloadingFixer extends AbstractFixer implements ConfigurableFix
         }
 
         // ignore stubs/fixtures, since they typically contain invalid files for various reasons
-        return !Preg::match('{[/\\\](stub|fixture)s?[/\\\]}i', $file->getRealPath());
+        return !Preg::match('{[/\\\](stub|fixture)s?[/\\\]}i', $realPath);
     }
 
     protected function configurePostNormalisation(): void

--- a/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
+++ b/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
@@ -430,6 +430,20 @@ class ClassTwo {};
             ['dir' => __FILE__],
             new \SplFileInfo(__FILE__),
         ];
+
+        yield 'file that does not exist, but has a name that can be a class name' => [
+            '<?php namespace Aaa; class Foo {}',
+            null,
+            [],
+            new \SplFileInfo('Bar.php'),
+        ];
+
+        yield 'file that does not exist, but has a name that can be a class name, with "dir" configured' => [
+            '<?php namespace Aaa; class Foo {}',
+            null,
+            ['dir' => __DIR__],
+            new \SplFileInfo('Bar.php'),
+        ];
     }
 
     /**


### PR DESCRIPTION
`PsrAutoloadingFixer::supports()` passes `SplFileInfo::getRealPath()` straight into `Preg::match()`:

```php
// src/Fixer/Basic/PsrAutoloadingFixer.php:134
return !Preg::match('{[/\\\](stub|fixture)s?[/\\\]}i', $file->getRealPath());
```

`getRealPath()` is documented as returning `string|false` and returns `false` whenever the path cannot be resolved, so `supports()` throws a `TypeError` instead of returning a bool.

### Reproduction

```php
$fixer = new PhpCsFixer\Fixer\Basic\PsrAutoloadingFixer();

// A file name that IS a valid class name, but does not exist on disk.
$fixer->supports(new SplFileInfo('fragment.php'));
```

```
TypeError: PhpCsFixer\Preg::match(): Argument #2 ($subject) must be of type string,
false given, called in src/Fixer/Basic/PsrAutoloadingFixer.php on line 134
```

Two earlier guards narrow what can reach line 134: the file needs a `.php` extension, and a basename that is a valid class name. `fragment` satisfies both, which is what makes the call reachable.

This is why the existing test cases don't catch it — `provideFixCases()` already passes non-existent paths such as `'4Foo.php'` and `'Foo.class.php'`, but every one of them is rejected by the identifier check before reaching the `getRealPath()` call.

### This is already visible in the project's own static analysis

`dev-tools/phpstan/baseline/argument.type.php` carries an entry for this very file:

```php
'rawMessage' => 'Parameter #1 $string of function strlen expects string, string|false given.',
'count' => 3,
'path' => __DIR__ . '/../../../src/Fixer/Basic/PsrAutoloadingFixer.php',
```

So PHPStan already knows `getRealPath()` can be `false` here, across several call sites. Those three are in `applyFix()` and stay baselined after this change (PHPStan cannot narrow across method boundaries), but they are only unreachable in practice because `supports()` throws first:

```
164: !str_starts_with($file->getRealPath(), $this->configuration['dir'])
217: \dirname($file->getRealPath())
265: \dirname($file->getRealPath())
274: substr(\dirname($file->getRealPath()), \strlen($root))
```

`str_starts_with(false, ...)` would throw and `dirname(false)` would degrade silently, which is why I fixed this by refusing the file in `supports()` rather than by patching line 134 in isolation — a local fix there would have converted a loud `TypeError` into a quieter failure further in.

### The fix

Resolve the path once and refuse the file when it cannot be resolved. Without a location on disk there is nothing to compare the namespace against, so the fixer cannot do its job:

```php
$realPath = $file->getRealPath();

// ignore file that cannot be resolved on disk, since its location is what gets compared to the namespace
if (false === $realPath) {
    return false;
}
```

Placed after the extension and identifier checks, so files that are cheap to reject do not pay for a filesystem lookup.

### Why this matters in practice

Consumers that call `supports()` directly with a synthetic `SplFileInfo` to test fixer applicability hit this. Laravel Pint's new Blade formatter is one: it probes every fixer with `new SplFileInfo('fragment.php')` before running it over the PHP embedded in a Blade file, so `pint --blade` fails outright for anyone who enables `psr_autoloading` — see [laravel/pint#465](https://github.com/laravel/pint/issues/465). In our own codebase that was 22 of 204 Blade files erroring and a non-zero exit.

### Notes

- Split into two commits per CONTRIBUTING.md: the failing test cases first, then the fix. The first commit alone reproduces the `TypeError` in CI.
- No existing test cases were modified; the two new ones use `yield` with descriptive keys.
- The second case (`with "dir" configured`) mirrors the configuration reported in the Pint issue.

### CI
Both failing checks are pre-existing and unrelated to this change.
PHP nightly tests is declared allow-to-fail: 'yes' # currently not compatible in ci.yml and fails identically on master at 61349eb, this PR's base.
codecov/project reports −0.01%, the same fluctuation that merged PR #9747 reported and that Codecov passed there via its adjusted base; codecov/patch is 100% of diff hit, so every added line is covered.

### Verification

- `PsrAutoloadingFixerTest`: 213 tests, 1733 assertions, OK.
- Full unit suite: 29,476 tests, 687,096 assertions, 0 failures.
- `composer cs:check` on both changed files: clean.
- `composer phpstan` (PHP 8.5.9): no errors, baseline unchanged.