### PR TITLE
fix: `NoUnusedImportsFixer` - do not treat quoted words in comments as usage

### DIFF
--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -176,7 +176,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
 
             if ($token->isComment()
                 && Preg::match(
-                    '/(?<![[:alnum:]\$_])(?<!\\\)'.$import->getShortName().'(?![[:alnum:]_])/i',
+                    '/(?<![[:alnum:]\$_\'"])(?<!\\\)'.$import->getShortName().'(?![[:alnum:]_\'"])/i',
                     $token->getContent(),
                 )
             ) {

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -754,6 +754,61 @@ use Baz;
 /*baz*/',
         ];
 
+        yield 'with_quoted_matches_in_comments' => [
+            <<<'EOF'
+                <?php
+
+                namespace Foo;
+
+                use Vendor\ServerRequestInterface;
+
+                /**
+                 * Structure (array):
+                 *
+                 * "content" => [
+                 *     "title" => "Content",
+                 *     "icon" => "<img...>",
+                 * ],
+                 */
+                final class Bar
+                {
+                    public function baz(ServerRequestInterface $request) {}
+                }
+
+                EOF,
+            <<<'EOF'
+                <?php
+
+                namespace Foo;
+
+                use Vendor\Icon;
+                use Vendor\ServerRequestInterface;
+
+                /**
+                 * Structure (array):
+                 *
+                 * "content" => [
+                 *     "title" => "Content",
+                 *     "icon" => "<img...>",
+                 * ],
+                 */
+                final class Bar
+                {
+                    public function baz(ServerRequestInterface $request) {}
+                }
+
+                EOF,
+        ];
+
+        yield 'with_single_quoted_matches_in_comments' => [
+            "<?php\n\n// 'foo'\n",
+            "<?php\nuse Foo;\n\n// 'foo'\n",
+        ];
+
+        yield 'with_partially_quoted_matches_in_comments' => [
+            "<?php\nuse Foo;\nuse Bar;\n\n// Foo bar, \"Foo\" Bar\n",
+        ];
+
         yield 'with_same_namespace_import_and_unused_import' => [
             <<<'EOF'
                 <?php


### PR DESCRIPTION
Fixes #9764

`no_unused_imports` decides that an import is used when its short name appears anywhere in a comment, matched case-insensitively:

```php
'/(?<![[:alnum:]\$_])(?<!\\\)'.$import->getShortName().'(?![[:alnum:]_])/i'
```

In the reported file the class docblock documents an array shape:

```php
use TYPO3\CMS\Core\Imaging\Icon;

/**
 * "content" => [
 *     "title" => "Content",
 *     "icon" => "<img...>",
 * ],
 */
```

The lowercase `"icon"` string matches the `Icon` import, so it is never removed.

A class, function or constant is never referenced as a quoted string in a comment, so this adds `'` and `"` to the boundary character classes: an occurrence directly surrounded by a quote no longer counts as usage. Unquoted matches (including the existing case-insensitive behaviour covered by `with_case_insensitive_matches_in_comments`) are unchanged, and a quoted occurrence does not suppress an unquoted one elsewhere in the same comment.

Three test cases added to `NoUnusedImportsFixerTest`, covering the reported docblock, single quotes, and the mixed quoted/unquoted case. No existing test cases were modified.


---

**Update:** the first push used constructor property promotion with `readonly` in the `with_quoted_matches_in_comments` fixture, which fails to parse on the PHP 7.4 and 8.0 jobs. The fixture now uses a plain type-hinted parameter instead — the promotion was incidental to what the case actually exercises. Re-verified that the new cases still fail without the `src` change (2 failures, `use Vendor\Icon;` left in place) and pass with it; `NoUnusedImportsFixerTest` is 109 tests / OK, and the project style check reports 0 fixable files.

The `PHP nightly tests` job is failing independently of this PR — `IntegrationTest` with `misc/issue_8828_c.test` hits `zend.max_allowed_stack_size` during linting on 8.6. It fails the same way on recent `master` commits (61349eb, d1fc711, 8122d72, 8d343c9, 2ab241b), so it is not related to this change.
