### PR TITLE
perf: Introduce new candidate check for transformers

### DIFF
--- a/src/Tokenizer/AbstractTransformer.php
+++ b/src/Tokenizer/AbstractTransformer.php
@@ -49,6 +49,11 @@ abstract class AbstractTransformer implements TransformerInterface
         }
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
     abstract public function getCustomTokens(): array;
 
     // @deprecated override `process(Tokens $tokens)` instead

--- a/src/Tokenizer/AbstractTransformer.php
+++ b/src/Tokenizer/AbstractTransformer.php
@@ -49,11 +49,6 @@ abstract class AbstractTransformer implements TransformerInterface
         }
     }
 
-    public function isCandidate(Tokens $tokens): bool
-    {
-        return true;
-    }
-
     abstract public function getCustomTokens(): array;
 
     // @deprecated override `process(Tokens $tokens)` instead

--- a/src/Tokenizer/Transformer/ArrayTypehintTransformer.php
+++ b/src/Tokenizer/Transformer/ArrayTypehintTransformer.php
@@ -35,6 +35,11 @@ final class ArrayTypehintTransformer extends AbstractTransformer
         return 5_00_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$token->isGivenKind(\T_ARRAY)) {

--- a/src/Tokenizer/Transformer/ArrayTypehintTransformer.php
+++ b/src/Tokenizer/Transformer/ArrayTypehintTransformer.php
@@ -37,7 +37,7 @@ final class ArrayTypehintTransformer extends AbstractTransformer
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return true;
+        return $tokens->isTokenKindFound(\T_ARRAY);
     }
 
     public function processToken(Tokens $tokens, Token $token, int $index): void

--- a/src/Tokenizer/Transformer/AttributeTransformer.php
+++ b/src/Tokenizer/Transformer/AttributeTransformer.php
@@ -39,6 +39,11 @@ final class AttributeTransformer extends AbstractTransformer
         return 8_00_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound([\T_ATTRIBUTE]);
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$tokens[$index]->isGivenKind(\T_ATTRIBUTE)) {

--- a/src/Tokenizer/Transformer/AttributeTransformer.php
+++ b/src/Tokenizer/Transformer/AttributeTransformer.php
@@ -41,7 +41,7 @@ final class AttributeTransformer extends AbstractTransformer
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isAnyTokenKindsFound([\T_ATTRIBUTE]);
+        return $tokens->isTokenKindFound(\T_ATTRIBUTE);
     }
 
     public function processToken(Tokens $tokens, Token $token, int $index): void

--- a/src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
+++ b/src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
@@ -42,6 +42,11 @@ final class BraceClassInstantiationTransformer extends AbstractTransformer
         return 5_00_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(\T_NEW);
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$tokens[$index]->equals('(') || !$tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(\T_NEW)) {

--- a/src/Tokenizer/Transformer/BraceTransformer.php
+++ b/src/Tokenizer/Transformer/BraceTransformer.php
@@ -47,7 +47,7 @@ final class BraceTransformer extends AbstractTransformer
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return true;
+        return $tokens->isAnyTokenKindsFound([\T_CURLY_OPEN, \T_DOLLAR_OPEN_CURLY_BRACES, '{']);
     }
 
     public function processToken(Tokens $tokens, Token $token, int $index): void

--- a/src/Tokenizer/Transformer/BraceTransformer.php
+++ b/src/Tokenizer/Transformer/BraceTransformer.php
@@ -45,6 +45,11 @@ final class BraceTransformer extends AbstractTransformer
         return 5_00_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         $this->transformIntoCurlyCloseBrace($tokens, $index);

--- a/src/Tokenizer/Transformer/ClassConstantTransformer.php
+++ b/src/Tokenizer/Transformer/ClassConstantTransformer.php
@@ -35,6 +35,11 @@ final class ClassConstantTransformer extends AbstractTransformer
         return 5_05_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound([\T_CLASS, \T_STRING]);
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$token->equalsAny([

--- a/src/Tokenizer/Transformer/ConstructorPromotionTransformer.php
+++ b/src/Tokenizer/Transformer/ConstructorPromotionTransformer.php
@@ -37,7 +37,7 @@ final class ConstructorPromotionTransformer extends AbstractTransformer
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isAnyTokenKindsFound([\T_FUNCTION]);
+        return $tokens->isTokenKindFound(\T_FUNCTION);
     }
 
     public function processToken(Tokens $tokens, Token $token, int $index): void

--- a/src/Tokenizer/Transformer/ConstructorPromotionTransformer.php
+++ b/src/Tokenizer/Transformer/ConstructorPromotionTransformer.php
@@ -35,6 +35,11 @@ final class ConstructorPromotionTransformer extends AbstractTransformer
         return 8_00_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound([\T_FUNCTION]);
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$tokens[$index]->isGivenKind(\T_FUNCTION)) {

--- a/src/Tokenizer/Transformer/DisjunctiveNormalFormTypeParenthesisTransformer.php
+++ b/src/Tokenizer/Transformer/DisjunctiveNormalFormTypeParenthesisTransformer.php
@@ -41,6 +41,11 @@ final class DisjunctiveNormalFormTypeParenthesisTransformer extends AbstractTran
         return 8_02_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(CT::T_TYPE_ALTERNATION);
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if ($token->equals('(') && $tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind(CT::T_TYPE_ALTERNATION)) {

--- a/src/Tokenizer/Transformer/FirstClassCallableTransformer.php
+++ b/src/Tokenizer/Transformer/FirstClassCallableTransformer.php
@@ -31,6 +31,11 @@ final class FirstClassCallableTransformer extends AbstractTransformer
         return 8_01_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound([\T_ELLIPSIS]);
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (

--- a/src/Tokenizer/Transformer/FirstClassCallableTransformer.php
+++ b/src/Tokenizer/Transformer/FirstClassCallableTransformer.php
@@ -33,7 +33,7 @@ final class FirstClassCallableTransformer extends AbstractTransformer
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isAnyTokenKindsFound([\T_ELLIPSIS]);
+        return $tokens->isTokenKindFound(\T_ELLIPSIS);
     }
 
     public function processToken(Tokens $tokens, Token $token, int $index): void

--- a/src/Tokenizer/Transformer/ImportTransformer.php
+++ b/src/Tokenizer/Transformer/ImportTransformer.php
@@ -45,6 +45,11 @@ final class ImportTransformer extends AbstractTransformer
         return 5_06_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound([\T_CONST, \T_FUNCTION]);
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$token->isGivenKind([\T_CONST, \T_FUNCTION])) {

--- a/src/Tokenizer/Transformer/NameQualifiedTransformer.php
+++ b/src/Tokenizer/Transformer/NameQualifiedTransformer.php
@@ -21,7 +21,7 @@ use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**
- * Transform NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED and T_NAME_RELATIVE into T_NAMESPACE T_NS_SEPARATOR T_STRING.
+ * Transform T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED and T_NAME_RELATIVE into T_NAMESPACE T_NS_SEPARATOR T_STRING.
  *
  * @internal
  *
@@ -41,7 +41,7 @@ final class NameQualifiedTransformer extends AbstractTransformer
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return true;
+        return $tokens->isAnyTokenKindsFound([FCT::T_NAME_QUALIFIED, FCT::T_NAME_FULLY_QUALIFIED, FCT::T_NAME_RELATIVE]);
     }
 
     public function processToken(Tokens $tokens, Token $token, int $index): void

--- a/src/Tokenizer/Transformer/NameQualifiedTransformer.php
+++ b/src/Tokenizer/Transformer/NameQualifiedTransformer.php
@@ -39,6 +39,11 @@ final class NameQualifiedTransformer extends AbstractTransformer
         return 8_00_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if ($token->isGivenKind([FCT::T_NAME_QUALIFIED, FCT::T_NAME_FULLY_QUALIFIED])) {

--- a/src/Tokenizer/Transformer/NamedArgumentTransformer.php
+++ b/src/Tokenizer/Transformer/NamedArgumentTransformer.php
@@ -39,6 +39,11 @@ final class NamedArgumentTransformer extends AbstractTransformer
         return 8_00_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound([\T_STRING]);
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$tokens[$index]->equals(':')) {

--- a/src/Tokenizer/Transformer/NamedArgumentTransformer.php
+++ b/src/Tokenizer/Transformer/NamedArgumentTransformer.php
@@ -41,7 +41,7 @@ final class NamedArgumentTransformer extends AbstractTransformer
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isAnyTokenKindsFound([\T_STRING]);
+        return $tokens->isAllTokenKindsFound([\T_STRING, ':']);
     }
 
     public function processToken(Tokens $tokens, Token $token, int $index): void

--- a/src/Tokenizer/Transformer/NamespaceOperatorTransformer.php
+++ b/src/Tokenizer/Transformer/NamespaceOperatorTransformer.php
@@ -35,6 +35,11 @@ final class NamespaceOperatorTransformer extends AbstractTransformer
         return 5_03_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(\T_NAMESPACE);
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$token->isGivenKind(\T_NAMESPACE)) {

--- a/src/Tokenizer/Transformer/NullableTypeTransformer.php
+++ b/src/Tokenizer/Transformer/NullableTypeTransformer.php
@@ -64,6 +64,11 @@ final class NullableTypeTransformer extends AbstractTransformer
         return 7_01_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$token->equals('?')) {

--- a/src/Tokenizer/Transformer/NullableTypeTransformer.php
+++ b/src/Tokenizer/Transformer/NullableTypeTransformer.php
@@ -66,7 +66,7 @@ final class NullableTypeTransformer extends AbstractTransformer
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return true;
+        return $tokens->isTokenKindFound('?');
     }
 
     public function processToken(Tokens $tokens, Token $token, int $index): void

--- a/src/Tokenizer/Transformer/ReturnRefTransformer.php
+++ b/src/Tokenizer/Transformer/ReturnRefTransformer.php
@@ -35,6 +35,11 @@ final class ReturnRefTransformer extends AbstractTransformer
         return 5_00_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound([\T_FUNCTION, \T_FN]);
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if ($token->equals('&') && $tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind([\T_FUNCTION, \T_FN])) {

--- a/src/Tokenizer/Transformer/SquareBraceTransformer.php
+++ b/src/Tokenizer/Transformer/SquareBraceTransformer.php
@@ -50,7 +50,7 @@ final class SquareBraceTransformer extends AbstractTransformer
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return true;
+        return $tokens->isTokenKindFound('[');
     }
 
     public function processToken(Tokens $tokens, Token $token, int $index): void

--- a/src/Tokenizer/Transformer/SquareBraceTransformer.php
+++ b/src/Tokenizer/Transformer/SquareBraceTransformer.php
@@ -48,6 +48,11 @@ final class SquareBraceTransformer extends AbstractTransformer
         return 5_00_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if ($this->isArrayDestructing($tokens, $index)) {

--- a/src/Tokenizer/Transformer/TypeAlternationTransformer.php
+++ b/src/Tokenizer/Transformer/TypeAlternationTransformer.php
@@ -42,6 +42,11 @@ final class TypeAlternationTransformer extends AbstractTypeTransformer
         return 7_01_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound('|');
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         $this->doProcess($tokens, $index, '|');

--- a/src/Tokenizer/Transformer/TypeColonTransformer.php
+++ b/src/Tokenizer/Transformer/TypeColonTransformer.php
@@ -43,6 +43,11 @@ final class TypeColonTransformer extends AbstractTransformer
         return 7_00_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(':');
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$token->equals(':')) {

--- a/src/Tokenizer/Transformer/TypeIntersectionTransformer.php
+++ b/src/Tokenizer/Transformer/TypeIntersectionTransformer.php
@@ -40,6 +40,11 @@ final class TypeIntersectionTransformer extends AbstractTypeTransformer
         return 8_01_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(\T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG);
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         $this->doProcess($tokens, $index, [\T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG, '&']);

--- a/src/Tokenizer/Transformer/UseTransformer.php
+++ b/src/Tokenizer/Transformer/UseTransformer.php
@@ -46,6 +46,11 @@ final class UseTransformer extends AbstractTransformer
         return 5_03_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(\T_USE);
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if ($token->isGivenKind(\T_USE) && $this->isUseForLambda($tokens, $index)) {

--- a/src/Tokenizer/Transformer/WhitespacyCommentTransformer.php
+++ b/src/Tokenizer/Transformer/WhitespacyCommentTransformer.php
@@ -34,6 +34,11 @@ final class WhitespacyCommentTransformer extends AbstractTransformer
         return 5_00_00;
     }
 
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound([\T_COMMENT, \T_DOC_COMMENT]);
+    }
+
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$token->isComment()) {

--- a/src/Tokenizer/TransformerInterface.php
+++ b/src/Tokenizer/TransformerInterface.php
@@ -64,6 +64,13 @@ interface TransformerInterface
     public function getRequiredPhpVersionId(): int;
 
     /**
+     * Returns whether this transformer should act upon this token collection.
+     *
+     * @see FixerInterface::isCandidate()
+     */
+    public function isCandidate(Tokens $tokens): bool;
+
+    /**
      * Process Token to transform it into custom token when needed.
      */
     public function process(Tokens $tokens): void;

--- a/src/Tokenizer/Transformers.php
+++ b/src/Tokenizer/Transformers.php
@@ -63,9 +63,9 @@ final class Transformers
     public function transform(Tokens $tokens): void
     {
         foreach ($this->items as $transformer) {
-        if (!$transformer->isCandidate($tokens)) {
-            continue;
-        }
+            if (!$transformer->isCandidate($tokens)) {
+                continue;
+            }
 
             $transformer->process($tokens);
         }

--- a/src/Tokenizer/Transformers.php
+++ b/src/Tokenizer/Transformers.php
@@ -63,6 +63,10 @@ final class Transformers
     public function transform(Tokens $tokens): void
     {
         foreach ($this->items as $transformer) {
+        if (!$transformer->isCandidate($tokens)) {
+            continue;
+        }
+
             $transformer->process($tokens);
         }
     }

--- a/tests/Fixtures/Test/AbstractTransformerTest/FooTransformer.php
+++ b/tests/Fixtures/Test/AbstractTransformerTest/FooTransformer.php
@@ -21,21 +21,20 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 final class FooTransformer extends AbstractTransformer
 {
-    /**
-     * {@inheritdoc}
-     */
     public function getRequiredPhpVersionId(): int
     {
         return 50000;
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
     }
 
     public function processToken(Tokens $tokens, Token $token, int $index): void
     {
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getCustomTokens(): array
     {
         return [];


### PR DESCRIPTION
This pull request introduces a new `isCandidate()` method to the transformer architecture, allowing transformers to quickly determine whether they should process a token collection before iterating through all tokens.

## Changes

### Core Changes
- **TransformerInterface**: Added new `isCandidate(Tokens $tokens): bool` method signature with documentation
- **AbstractTransformer**: Implemented default `isCandidate()` returning `true` for all transformers
- **Transformers.php**: Added candidate check in the `transform()` method to skip processing if `isCandidate()` returns `false`

### Transformer-Specific Implementations
Each transformer now includes an optimized `isCandidate()` implementation:

1. **AttributeTransformer** - Checks for `T_ATTRIBUTE` tokens
2. **BraceClassInstantiationTransformer** - Checks for `T_NEW` tokens
3. **ClassConstantTransformer** - Checks for `T_CLASS` or `T_STRING` tokens
4. **ConstructorPromotionTransformer** - Checks for `T_FUNCTION` tokens
5. **DisjunctiveNormalFormTypeParenthesisTransformer** - Checks for `CT::T_TYPE_ALTERNATION`
6. **FirstClassCallableTransformer** - Checks for `T_ELLIPSIS` tokens
7. **ImportTransformer** - Checks for `T_CONST` or `T_FUNCTION` tokens
8. **NamedArgumentTransformer** - Checks for `T_STRING` tokens
9. **ReturnRefTransformer** - Checks for `T_FUNCTION` or `T_FN` tokens
10. **TypeAlternationTransformer** - Checks for pipe (`|`) tokens
11. **TypeColonTransformer** - Checks for colon (`:`) tokens
12. **TypeIntersectionTransformer** - Checks for `T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG`
13. **UseTransformer** - Checks for `T_USE` tokens

## Benefits
- **Performance Optimization**: Avoids unnecessary token iteration for transformers that don't apply to the current token collection
- **Early Exit**: Transformers can skip processing entirely if no relevant tokens are found
- **Consistent Pattern**: Follows the same pattern as `FixerInterface::isCandidate()`
