### PR TITLE
docs: mention MegaLinter in installation doc

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -90,6 +90,12 @@ To integrate PHP CS Fixer as check into Gitlab-CI, you can use a configuration l
         php-cs-fixer check # --format=gitlab ## specify format if not using PHP_CS_FIXER_FUTURE_MODE or v4+
         # use `check .` if your repository not having paths configured in .php-cs-fixer[.dist].php
 
+MegaLinter (CI)
+---------------
+
+`MegaLinter <https://megalinter.io/>`_ is an open-source linters aggregator for CI that runs PHP CS Fixer out of the box,
+among many other linters. See its `PHP CS Fixer descriptor <https://megalinter.io/latest/descriptors/php_php_cs_fixer/>`_ for details.
+
 Homebrew (globally)
 -------------------
 


### PR DESCRIPTION
Hi! I maintain [MegaLinter](https://megalinter.io/), an open-source linters aggregator for CI, and PHP CS Fixer has been embedded in it for years ([descriptor page](https://megalinter.io/latest/descriptors/php_php_cs_fixer/)).

Since the installation doc already covers GitHub Action and GitLab-CI setups, I figured a short mention could help users who want PHP CS Fixer running in CI without wiring it up themselves. Feel free to tweak the wording or placement if you'd prefer it elsewhere.