### PR TITLE
chore: Fix incorrect URL in CommentsAnalyzer.php docblock

### DIFF
--- a/src/Tokenizer/Analyzer/CommentsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/CommentsAnalyzer.php
@@ -189,7 +189,7 @@ final class CommentsAnalyzer
     }
 
     /**
-     * @see https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md#3-definitions
+     * @see https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#3-definitions
      */
     private function isStructuralElement(Tokens $tokens, int $index): bool
     {


### PR DESCRIPTION
### Summary
Updates the documentation reference URL in `CommentsAnalyzer.php` to point to the correct repository.

### Changes
- Fixed the URL in the docblock from `phpDocumentor/fig-standards` to `php-fig/fig-standards`

### Details
The `@see` annotation in the `isStructuralElement()` method was pointing to an outdated or incorrect GitHub URL. This change corrects it to reference the official PHP-FIG standards repository.