### PR TITLE
fix: `SelfStaticAccessorFixer` - do not stop fixing a class after a `static` return type

### DIFF
--- a/src/Fixer/ClassNotation/SelfStaticAccessorFixer.php
+++ b/src/Fixer/ClassNotation/SelfStaticAccessorFixer.php
@@ -213,14 +213,14 @@ final class SelfStaticAccessorFixer extends AbstractFixer
                 continue;
             }
 
-            $staticIndex = $index;
-            $index = $tokens->getNextMeaningfulToken($index);
+            $nextIndex = $tokens->getNextMeaningfulToken($index);
 
-            if (!$tokens[$index]->isGivenKind(\T_DOUBLE_COLON)) {
+            if (!$tokens[$nextIndex]->isGivenKind(\T_DOUBLE_COLON)) {
                 continue;
             }
 
-            $tokens[$staticIndex] = new Token([\T_STRING, 'self']);
+            $tokens[$index] = new Token([\T_STRING, 'self']);
+            $index = $nextIndex;
         }
 
         return $index;

--- a/tests/Fixer/ClassNotation/SelfStaticAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfStaticAccessorFixerTest.php
@@ -383,6 +383,84 @@ $a = static function() { return static::class; };
 $b = function() { return static::class; };
 ',
         ];
+
+        yield 'do not fix inside static lambda in class' => [
+            '<?php
+final class Foo
+{
+    public function Bar()
+    {
+        return static function() {
+            return static::class;
+        };
+    }
+}
+',
+        ];
+    }
+
+    /**
+     * @dataProvider provideFix80Cases
+     *
+     * @requires PHP >= 8.0.0
+     */
+    #[DataProvider('provideFix80Cases')]
+    #[RequiresPhp('>= 8.0.0')]
+    public function testFix80(string $expected, string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideFix80Cases(): iterable
+    {
+        yield 'after method with static return type' => [
+            '<?php
+final class Foo
+{
+    public function bar(): static
+    {
+        return $this;
+    }
+
+    public function baz()
+    {
+        return new self();
+    }
+
+    public function qux()
+    {
+        return self::class;
+    }
+}
+',
+            '<?php
+final class Foo
+{
+    public function bar(): static
+    {
+        return $this;
+    }
+
+    public function baz()
+    {
+        return new static();
+    }
+
+    public function qux()
+    {
+        return static::class;
+    }
+}
+',
+        ];
+
+        yield 'after method with nullable static return type' => [
+            '<?php final class Foo { public function bar(): ?static { return $this; } public function baz() { return self::class; } }',
+            '<?php final class Foo { public function bar(): ?static { return $this; } public function baz() { return static::class; } }',
+        ];
     }
 
     /**


### PR DESCRIPTION
`self_static_accessor` stops fixing a class as soon as it passes a method declaring a `static` return type. Every later reference is left untouched, and nothing is reported:

```php
final class Foo
{
    public function bar(): static { return $this; }

    public function baz() { return new static(); } // not fixed
    public function qux() { return static::class; } // not fixed
}
```

Changing `bar()` to return `self` makes both fix as expected, which is the only difference between the two cases.

`fixClassy()` counts braces to find the end of the class body. When it meets a `T_STATIC` token that is not followed by `::`, `$index` has already been moved onto the token it peeked at, and the loop's `++$index` then steps past it. For a `static` return type that peeked token is the opening brace of the method body, so the brace is never counted while its closing brace still decrements the counter - the walk ends at the end of that method.

The same clobbering stepped over the `T_FUNCTION` branch for `static function`, taking the lambda check with it, so `static::` inside a static closure in a class was fixed despite the "do not fix inside lambda" rule. A case for that is included.

The peek now goes into its own variable, so the token is only consumed once it is known to be part of a `static::` access.