### PR TITLE
fix: normalize multiline DocBlock boundaries

### DIFF
--- a/src/DocBlock/DocBlock.php
+++ b/src/DocBlock/DocBlock.php
@@ -51,10 +51,7 @@ final class DocBlock implements \Stringable
      */
     public function __construct(string $content, ?NamespaceAnalysis $namespace = null, array $namespaceUses = [])
     {
-        foreach (Preg::split('/([^\n\r]+\R*)/', $content, -1, \PREG_SPLIT_NO_EMPTY | \PREG_SPLIT_DELIM_CAPTURE) as $line) {
-            $this->lines[] = new Line($line);
-        }
-
+        $this->setContent($content);
         $this->namespace = $namespace;
         $this->namespaceUses = $namespaceUses;
     }
@@ -126,6 +123,21 @@ final class DocBlock implements \Stringable
     public function makeMultiLine(string $indent, string $lineEnd): void
     {
         if ($this->isMultiLine()) {
+            $content = $initialContent = $this->getContent();
+            $firstLine = $this->getLine(0);
+            $lastLine = $this->getLine(\count($this->lines) - 1);
+
+            if (null !== $firstLine && $firstLine->containsUsefulContent()) {
+                $content = Preg::replace('/\A\/\*\*/', '/**'.$lineEnd.$indent.' *', $content);
+            }
+            if (null !== $lastLine && $lastLine->containsUsefulContent()) {
+                $content = Preg::replace('/\h*\*\/\z/', $lineEnd.$indent.' */', $content);
+            }
+
+            if ($content !== $initialContent) {
+                $this->setContent($content);
+            }
+
             return;
         }
 
@@ -231,6 +243,16 @@ final class DocBlock implements \Stringable
         }
 
         return $index - $start;
+    }
+
+    private function setContent(string $content): void
+    {
+        $this->lines = [];
+        foreach (Preg::split('/([^\n\r]+\R*)/', $content, -1, \PREG_SPLIT_NO_EMPTY | \PREG_SPLIT_DELIM_CAPTURE) as $line) {
+            $this->lines[] = new Line($line);
+        }
+
+        $this->annotations = null;
     }
 
     private function getSingleLineDocBlockEntry(Line $line): string

--- a/tests/DocBlock/DocBlockTest.php
+++ b/tests/DocBlock/DocBlockTest.php
@@ -189,6 +189,23 @@ final class DocBlockTest extends TestCase
             "/**\n\t *@foo\n\t */",
         ];
 
+        yield 'It separates annotations from both boundaries of a multi line doc block' => [
+            "/** @param string \$first\n * @param string \$second */",
+            "/**\n * @param string \$first\n * @param string \$second\n */",
+        ];
+
+        yield 'It separates content from the opening boundary of a multi line doc block' => [
+            "/** Description\n * continued\n */",
+            "/**\n * Description\n * continued\n */",
+        ];
+
+        yield 'It separates content from the closing boundary with indentation and configured line ending' => [
+            "/**\r\n     * Description */",
+            "/**\r\n     * Description\r\n     */",
+            '    ',
+            "\r\n",
+        ];
+
         yield 'It Converts a single line to multi line with no indentation' => [
             '/** Hello */',
             "/**\n * Hello\n */",

--- a/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
@@ -162,6 +162,23 @@ class Foo
 ',
         ];
 
+        yield 'It normalizes boundary lines of an already multi line doc block' => [
+            '<?php
+
+/**
+ * @param string $first
+ * @param string $second
+ */
+function example($first, $second): void {}
+',
+            '<?php
+
+/** @param string $first
+ * @param string $second */
+function example($first, $second): void {}
+',
+        ];
+
         yield 'It does change trait_import and other doc blocks to multi if configured to do so' => [
             '<?php
 


### PR DESCRIPTION
## What

Normalize opening and closing boundary lines when `DocBlock::makeMultiLine()` is called for a DocBlock that already spans multiple physical lines.

This makes `phpdoc_line_span` with `multi` expand hybrid forms such as:

```php
/** @param string $first
 * @param string $second */
```

into:

```php
/**
 * @param string $first
 * @param string $second
 */
```

The root cause was that `makeMultiLine()` returned early whenever `isMultiLine()` was true, without checking whether useful content still shared the opening or closing delimiter line.

The `single` configuration remains unchanged.

Fixes #9777

## Checks

- targeted PHPUnit: 73 tests, 2919 assertions (1 skipped)
- PHPStan on `src/DocBlock/DocBlock.php`: no errors
- PHP CS Fixer dry run on all changed files: no changes required
- PHP 7.4 syntax lint: no errors
- original minimal reproducer: expected multiline normalization, valid output
