### PR TITLE
feat: add CacheAwareFixerInterface for external cache invalidation

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -74,6 +74,7 @@ final class Cache implements CacheInterface
                     'lineEnding' => $this->getSignature()->getLineEnding(),
                     'rules' => $this->getSignature()->getRules(),
                     'ruleCustomisationPolicyVersion' => $this->getSignature()->getRuleCustomisationPolicyVersion(),
+                    'extraFingerprints' => $this->getSignature()->getExtraFingerprints(),
                     'hashes' => $this->hashes,
                 ],
                 \JSON_THROW_ON_ERROR,
@@ -127,6 +128,7 @@ final class Cache implements CacheInterface
             $data['lineEnding'],
             $data['rules'],
             $data['ruleCustomisationPolicyVersion'] ?? NullRuleCustomisationPolicy::VERSION_FOR_CACHE,
+            $data['extraFingerprints'] ?? [],
         );
 
         $cache = new self($signature);

--- a/src/Cache/Signature.php
+++ b/src/Cache/Signature.php
@@ -43,9 +43,15 @@ final class Signature implements SignatureInterface
     private string $ruleCustomisationPolicyVersion;
 
     /**
-     * @param array<string, array<string, mixed>|bool> $rules
+     * @var array<string, string>
      */
-    public function __construct(string $phpVersion, string $fixerVersion, string $indent, string $lineEnding, array $rules, string $ruleCustomisationPolicyVersion)
+    private array $extraFingerprints;
+
+    /**
+     * @param array<string, array<string, mixed>|bool> $rules
+     * @param array<string, string>                    $extraFingerprints
+     */
+    public function __construct(string $phpVersion, string $fixerVersion, string $indent, string $lineEnding, array $rules, string $ruleCustomisationPolicyVersion, array $extraFingerprints = [])
     {
         $this->phpVersion = $phpVersion;
         $this->fixerVersion = $fixerVersion;
@@ -53,6 +59,7 @@ final class Signature implements SignatureInterface
         $this->lineEnding = $lineEnding;
         $this->rules = self::makeJsonEncodable($rules);
         $this->ruleCustomisationPolicyVersion = $ruleCustomisationPolicyVersion;
+        $this->extraFingerprints = $extraFingerprints;
     }
 
     public function getPhpVersion(): string
@@ -85,6 +92,11 @@ final class Signature implements SignatureInterface
         return $this->ruleCustomisationPolicyVersion;
     }
 
+    public function getExtraFingerprints(): array
+    {
+        return $this->extraFingerprints;
+    }
+
     public function equals(SignatureInterface $signature): bool
     {
         return $this->phpVersion === $signature->getPhpVersion()
@@ -92,7 +104,8 @@ final class Signature implements SignatureInterface
             && $this->indent === $signature->getIndent()
             && $this->lineEnding === $signature->getLineEnding()
             && $this->rules === $signature->getRules()
-            && $this->ruleCustomisationPolicyVersion === $signature->getRuleCustomisationPolicyVersion();
+            && $this->ruleCustomisationPolicyVersion === $signature->getRuleCustomisationPolicyVersion()
+            && $this->extraFingerprints === $signature->getExtraFingerprints();
     }
 
     /**

--- a/src/Cache/SignatureInterface.php
+++ b/src/Cache/SignatureInterface.php
@@ -38,5 +38,10 @@ interface SignatureInterface
 
     public function getRuleCustomisationPolicyVersion(): string;
 
+    /**
+     * @return array<string, string>
+     */
+    public function getExtraFingerprints(): array;
+
     public function equals(self $signature): bool;
 }

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -35,6 +35,7 @@ use PhpCsFixer\Differ\DifferInterface;
 use PhpCsFixer\Differ\NullDiffer;
 use PhpCsFixer\Differ\UnifiedDiffer;
 use PhpCsFixer\Finder;
+use PhpCsFixer\Fixer\CacheAwareFixerInterface;
 use PhpCsFixer\Fixer\DeprecatedFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerFactory;
@@ -236,6 +237,14 @@ final class ConfigurationResolver
             if (null === $cacheFile) {
                 $this->cacheManager = new NullCacheManager();
             } else {
+                $extraFingerprints = [];
+
+                foreach ($this->getFixers() as $fixer) {
+                    if ($fixer instanceof CacheAwareFixerInterface) {
+                        $extraFingerprints[$fixer->getName()] = $fixer->getCacheFingerprint();
+                    }
+                }
+
                 $this->cacheManager = new FileCacheManager(
                     new FileHandler($cacheFile),
                     new Signature(
@@ -245,6 +254,7 @@ final class ConfigurationResolver
                         $this->getConfig()->getLineEnding(),
                         $this->getRules(),
                         $this->getRuleCustomisationPolicy()->getPolicyVersionForCache(),
+                        $extraFingerprints,
                     ),
                     $this->isDryRun(),
                     $this->getDirectory(),

--- a/src/Fixer/CacheAwareFixerInterface.php
+++ b/src/Fixer/CacheAwareFixerInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer;
+
+/**
+ * Fixers whose output depends on external state beyond file content and
+ * rule configuration (e.g. versions of external tools) should implement
+ * this interface. The returned fingerprint is included in the cache
+ * signature so that the cache is invalidated when the external state
+ * changes.
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+interface CacheAwareFixerInterface extends FixerInterface
+{
+    /**
+     * Return a fingerprint that represents the external state this fixer
+     * depends on. When this value changes, the cache is invalidated.
+     */
+    public function getCacheFingerprint(): string;
+}

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -255,6 +255,11 @@ final class CacheTest extends TestCase
                 return 'Policy Version';
             }
 
+            public function getExtraFingerprints(): array
+            {
+                return [];
+            }
+
             public function equals(SignatureInterface $signature): bool
             {
                 throw new \LogicException('Not implemented.');

--- a/tests/Cache/FileCacheManagerTest.php
+++ b/tests/Cache/FileCacheManagerTest.php
@@ -309,6 +309,11 @@ final class FileCacheManagerTest extends TestCase
                 throw new \LogicException('Not implemented.');
             }
 
+            public function getExtraFingerprints(): array
+            {
+                throw new \LogicException('Not implemented.');
+            }
+
             public function equals(SignatureInterface $signature): bool
             {
                 return $this->isEqual;


### PR DESCRIPTION
Hello!

Fixers whose output depends on external state beyond file content and rule configuration (e.g. versions of external tools) had no way to participate in cache invalidation. This meant consumers like Laravel Pint had to disable caching entirely when using fixers that delegate to external formatters like Prettier.

This adds a new opt-in `CacheAwareFixerInterface` with a single `getCacheFingerprint()` method. When a fixer implements this interface, its fingerprint is collected by `ConfigurationResolver` and included in the cache `Signature`. A change in any fingerprint invalidates the entire cache, ensuring correctness.


Thanks!