### PR TITLE
refactor: Transformers - move looping over tokens directly into each transformer individually

### DIFF
--- a/src/Tokenizer/AbstractTransformer.php
+++ b/src/Tokenizer/AbstractTransformer.php
@@ -38,5 +38,19 @@ abstract class AbstractTransformer implements TransformerInterface
         return 0;
     }
 
+    public function process(Tokens $tokens): void
+    {
+        if (!method_exists($this, 'processToken')) {
+            throw new \LogicException(\sprintf('Transformer "%s" must provide own "process(Tokens $tokens)" method (preferred) or "processToken(Tokens $tokens, Token $token, int $index)" method (deprecated).', static::class));
+        }
+
+        foreach ($tokens as $index => $token) {
+            $this->processToken($tokens, $token, $index);
+        }
+    }
+
     abstract public function getCustomTokens(): array;
+
+    // @deprecated override `process(Tokens $tokens)` instead
+    // abstract public function processToken(Tokens $tokens, Token $token, int $index): void;
 }

--- a/src/Tokenizer/Transformer/ArrayTypehintTransformer.php
+++ b/src/Tokenizer/Transformer/ArrayTypehintTransformer.php
@@ -35,7 +35,7 @@ final class ArrayTypehintTransformer extends AbstractTransformer
         return 5_00_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$token->isGivenKind(\T_ARRAY)) {
             return;

--- a/src/Tokenizer/Transformer/AttributeTransformer.php
+++ b/src/Tokenizer/Transformer/AttributeTransformer.php
@@ -39,7 +39,7 @@ final class AttributeTransformer extends AbstractTransformer
         return 8_00_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$tokens[$index]->isGivenKind(\T_ATTRIBUTE)) {
             return;

--- a/src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
+++ b/src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
@@ -42,7 +42,7 @@ final class BraceClassInstantiationTransformer extends AbstractTransformer
         return 5_00_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$tokens[$index]->equals('(') || !$tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(\T_NEW)) {
             return;

--- a/src/Tokenizer/Transformer/BraceTransformer.php
+++ b/src/Tokenizer/Transformer/BraceTransformer.php
@@ -45,7 +45,7 @@ final class BraceTransformer extends AbstractTransformer
         return 5_00_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         $this->transformIntoCurlyCloseBrace($tokens, $index);
         $this->transformIntoDollarCloseBrace($tokens, $index);

--- a/src/Tokenizer/Transformer/ClassConstantTransformer.php
+++ b/src/Tokenizer/Transformer/ClassConstantTransformer.php
@@ -35,7 +35,7 @@ final class ClassConstantTransformer extends AbstractTransformer
         return 5_05_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$token->equalsAny([
             [\T_CLASS, 'class'],

--- a/src/Tokenizer/Transformer/ConstructorPromotionTransformer.php
+++ b/src/Tokenizer/Transformer/ConstructorPromotionTransformer.php
@@ -35,7 +35,7 @@ final class ConstructorPromotionTransformer extends AbstractTransformer
         return 8_00_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$tokens[$index]->isGivenKind(\T_FUNCTION)) {
             return;

--- a/src/Tokenizer/Transformer/DisjunctiveNormalFormTypeParenthesisTransformer.php
+++ b/src/Tokenizer/Transformer/DisjunctiveNormalFormTypeParenthesisTransformer.php
@@ -41,7 +41,7 @@ final class DisjunctiveNormalFormTypeParenthesisTransformer extends AbstractTran
         return 8_02_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if ($token->equals('(') && $tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind(CT::T_TYPE_ALTERNATION)) {
             $openIndex = $index;

--- a/src/Tokenizer/Transformer/FirstClassCallableTransformer.php
+++ b/src/Tokenizer/Transformer/FirstClassCallableTransformer.php
@@ -31,7 +31,7 @@ final class FirstClassCallableTransformer extends AbstractTransformer
         return 8_01_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (
             $token->isGivenKind(\T_ELLIPSIS)

--- a/src/Tokenizer/Transformer/ImportTransformer.php
+++ b/src/Tokenizer/Transformer/ImportTransformer.php
@@ -45,7 +45,7 @@ final class ImportTransformer extends AbstractTransformer
         return 5_06_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$token->isGivenKind([\T_CONST, \T_FUNCTION])) {
             return;

--- a/src/Tokenizer/Transformer/NameQualifiedTransformer.php
+++ b/src/Tokenizer/Transformer/NameQualifiedTransformer.php
@@ -39,7 +39,7 @@ final class NameQualifiedTransformer extends AbstractTransformer
         return 8_00_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if ($token->isGivenKind([FCT::T_NAME_QUALIFIED, FCT::T_NAME_FULLY_QUALIFIED])) {
             $this->transformQualified($tokens, $token, $index);

--- a/src/Tokenizer/Transformer/NamedArgumentTransformer.php
+++ b/src/Tokenizer/Transformer/NamedArgumentTransformer.php
@@ -39,7 +39,7 @@ final class NamedArgumentTransformer extends AbstractTransformer
         return 8_00_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$tokens[$index]->equals(':')) {
             return;

--- a/src/Tokenizer/Transformer/NamespaceOperatorTransformer.php
+++ b/src/Tokenizer/Transformer/NamespaceOperatorTransformer.php
@@ -35,7 +35,7 @@ final class NamespaceOperatorTransformer extends AbstractTransformer
         return 5_03_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$token->isGivenKind(\T_NAMESPACE)) {
             return;

--- a/src/Tokenizer/Transformer/NullableTypeTransformer.php
+++ b/src/Tokenizer/Transformer/NullableTypeTransformer.php
@@ -64,7 +64,7 @@ final class NullableTypeTransformer extends AbstractTransformer
         return 7_01_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$token->equals('?')) {
             return;

--- a/src/Tokenizer/Transformer/ReturnRefTransformer.php
+++ b/src/Tokenizer/Transformer/ReturnRefTransformer.php
@@ -35,7 +35,7 @@ final class ReturnRefTransformer extends AbstractTransformer
         return 5_00_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if ($token->equals('&') && $tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind([\T_FUNCTION, \T_FN])) {
             $tokens[$index] = new Token([CT::T_RETURN_REF, '&']);

--- a/src/Tokenizer/Transformer/SquareBraceTransformer.php
+++ b/src/Tokenizer/Transformer/SquareBraceTransformer.php
@@ -48,7 +48,7 @@ final class SquareBraceTransformer extends AbstractTransformer
         return 5_00_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if ($this->isArrayDestructing($tokens, $index)) {
             $this->transformIntoDestructuringSquareBrace($tokens, $index);

--- a/src/Tokenizer/Transformer/TypeAlternationTransformer.php
+++ b/src/Tokenizer/Transformer/TypeAlternationTransformer.php
@@ -42,7 +42,7 @@ final class TypeAlternationTransformer extends AbstractTypeTransformer
         return 7_01_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         $this->doProcess($tokens, $index, '|');
     }

--- a/src/Tokenizer/Transformer/TypeColonTransformer.php
+++ b/src/Tokenizer/Transformer/TypeColonTransformer.php
@@ -43,7 +43,7 @@ final class TypeColonTransformer extends AbstractTransformer
         return 7_00_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$token->equals(':')) {
             return;

--- a/src/Tokenizer/Transformer/TypeIntersectionTransformer.php
+++ b/src/Tokenizer/Transformer/TypeIntersectionTransformer.php
@@ -40,7 +40,7 @@ final class TypeIntersectionTransformer extends AbstractTypeTransformer
         return 8_01_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         $this->doProcess($tokens, $index, [\T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG, '&']);
     }

--- a/src/Tokenizer/Transformer/UseTransformer.php
+++ b/src/Tokenizer/Transformer/UseTransformer.php
@@ -46,7 +46,7 @@ final class UseTransformer extends AbstractTransformer
         return 5_03_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if ($token->isGivenKind(\T_USE) && $this->isUseForLambda($tokens, $index)) {
             $tokens[$index] = new Token([CT::T_USE_LAMBDA, $token->getContent()]);

--- a/src/Tokenizer/Transformer/WhitespacyCommentTransformer.php
+++ b/src/Tokenizer/Transformer/WhitespacyCommentTransformer.php
@@ -34,7 +34,7 @@ final class WhitespacyCommentTransformer extends AbstractTransformer
         return 5_00_00;
     }
 
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
         if (!$token->isComment()) {
             return;

--- a/src/Tokenizer/TransformerInterface.php
+++ b/src/Tokenizer/TransformerInterface.php
@@ -66,5 +66,5 @@ interface TransformerInterface
     /**
      * Process Token to transform it into custom token when needed.
      */
-    public function process(Tokens $tokens, Token $token, int $index): void;
+    public function process(Tokens $tokens): void;
 }

--- a/src/Tokenizer/Transformers.php
+++ b/src/Tokenizer/Transformers.php
@@ -63,9 +63,7 @@ final class Transformers
     public function transform(Tokens $tokens): void
     {
         foreach ($this->items as $transformer) {
-            foreach ($tokens as $index => $token) {
-                $transformer->process($tokens, $token, $index);
-            }
+            $transformer->process($tokens);
         }
     }
 

--- a/tests/Fixtures/Test/AbstractTransformerTest/FooTransformer.php
+++ b/tests/Fixtures/Test/AbstractTransformerTest/FooTransformer.php
@@ -29,10 +29,7 @@ final class FooTransformer extends AbstractTransformer
         return 50000;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function process(Tokens $tokens, Token $token, int $index): void
+    public function processToken(Tokens $tokens, Token $token, int $index): void
     {
     }
 

--- a/tests/Test/AbstractTransformerTestCase.php
+++ b/tests/Test/AbstractTransformerTestCase.php
@@ -106,9 +106,7 @@ abstract class AbstractTransformerTestCase extends TestCase
         Tokens::clearCache();
         $tokens = Tokens::fromCode('<?php ');
 
-        foreach ($tokens as $index => $token) {
-            $this->transformer->process($tokens, $token, $index);
-        }
+        $this->transformer->process($tokens);
 
         self::assertFalse($tokens->isChanged());
     }

--- a/tests/Test/TokensWithObservedTransformers.php
+++ b/tests/Test/TokensWithObservedTransformers.php
@@ -61,9 +61,7 @@ final class TokensWithObservedTransformers extends Tokens
             $this->currentTransformer = $transformer->getName();
             $this->observedModificationsPerTransformer[$this->currentTransformer] = [];
 
-            foreach ($this as $index => $token) {
-                $transformer->process($this, $token, $index);
-            }
+            $transformer->process($this);
         }
 
         $this->currentTransformer = null;

--- a/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php
@@ -57,11 +57,7 @@ final class NameQualifiedTransformerTest extends AbstractTransformerTestCase
             ? Tokens::fromArray($expected)
             : Tokens::fromArray($input);
 
-        $tokenCount = \count($tokens);
-
-        for ($i = 0; $i < $tokenCount; ++$i) {
-            $this->transformer->process($tokens, $tokens[$i], $i);
-        }
+        $this->transformer->process($tokens);
 
         self::assertTokens($expectedTokens, $tokens);
 


### PR DESCRIPTION
Originally we were iterating over each token, and then over transformers. [8 years ago we switched ](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/4104/changes#r235217016)to iterate over transformers first, and there is no need to iterate over tokens in TransformersRunner instead of individual transformers

inspired and partially replacing #9759 