### PR TITLE
CI: fix using `PHP_CS_FIXER_FAST_LINT_TEST_CASES`

### DIFF
--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -26,10 +26,7 @@ use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
 use PhpCsFixer\FixerConfiguration\FixerOptionInterface;
 use PhpCsFixer\FixerDefinition\FileSpecificCodeSampleInterface;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSampleInterface;
-use PhpCsFixer\Linter\CachingLinter;
-use PhpCsFixer\Linter\Linter;
 use PhpCsFixer\Linter\LinterInterface;
-use PhpCsFixer\Linter\ProcessLinter;
 use PhpCsFixer\PhpunitConstraintIsIdenticalString\Constraint\IsIdenticalString;
 use PhpCsFixer\Preg;
 use PhpCsFixer\StdinFileInfo;
@@ -57,6 +54,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 abstract class AbstractFixerTestCase extends TestCase
 {
     use AssertTokensTrait;
+    use LinterProviderTrait;
 
     /**
      * do not modify this structure without prior discussion.
@@ -582,21 +580,6 @@ abstract class AbstractFixerTestCase extends TestCase
         }
 
         return new \ReflectionClass($this->fixer);
-    }
-
-    private function getLinter(): LinterInterface
-    {
-        static $linter = null;
-
-        if (null === $linter) {
-            $linter = new CachingLinter(
-                filter_var(getenv('PHP_CS_FIXER_FAST_LINT_TEST_CASES'), \FILTER_VALIDATE_BOOLEAN)
-                    ? new Linter()
-                    : new ProcessLinter(),
-            );
-        }
-
-        return $linter;
     }
 
     private static function assertValidDescription(string $fixerName, string $descriptionType, string $description): void

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -21,10 +21,7 @@ use PhpCsFixer\Error\ErrorsManager;
 use PhpCsFixer\FileRemoval;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerFactory;
-use PhpCsFixer\Linter\CachingLinter;
-use PhpCsFixer\Linter\Linter;
 use PhpCsFixer\Linter\LinterInterface;
-use PhpCsFixer\Linter\ProcessLinter;
 use PhpCsFixer\PhpunitConstraintIsIdenticalString\Constraint\IsIdenticalString;
 use PhpCsFixer\Runner\Runner;
 use PhpCsFixer\Tests\TestCase;
@@ -81,6 +78,8 @@ use Symfony\Component\Finder\Finder;
  */
 abstract class AbstractIntegrationTestCase extends TestCase
 {
+    use LinterProviderTrait;
+
     protected ?LinterInterface $linter = null;
 
     private static ?FileRemoval $fileRemoval = null;
@@ -401,20 +400,5 @@ abstract class AbstractIntegrationTestCase extends TestCase
         }
 
         return $errorStr;
-    }
-
-    private function getLinter(): LinterInterface
-    {
-        static $linter = null;
-
-        if (null === $linter) {
-            $linter = new CachingLinter(
-                filter_var(getenv('PHP_CS_FIXER_FAST_LINT_TEST_CASES'), \FILTER_VALIDATE_BOOLEAN)
-                    ? new Linter()
-                    : new ProcessLinter(),
-            );
-        }
-
-        return $linter;
     }
 }

--- a/tests/Test/LinterProviderTrait.php
+++ b/tests/Test/LinterProviderTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Test;
+
+use PhpCsFixer\Linter\CachingLinter;
+use PhpCsFixer\Linter\Linter;
+use PhpCsFixer\Linter\LinterInterface;
+use PhpCsFixer\Linter\ProcessLinter;
+
+/**
+ * @internal
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+trait LinterProviderTrait
+{
+    private function getLinter(): LinterInterface
+    {
+        static $linter = null;
+
+        if (null === $linter) {
+            $linter = new CachingLinter(
+                self::shouldFastLintTestCases()
+                    ? new Linter()
+                    : new ProcessLinter(),
+            );
+        }
+
+        return $linter;
+    }
+
+    private static function shouldFastLintTestCases(): bool
+    {
+        $value = getenv('PHP_CS_FIXER_FAST_LINT_TEST_CASES');
+
+        if (false === $value) {
+            return true; // not set - default to fast linting
+        }
+
+        if ('' === $value) {
+            return true; // CI exports the variable as empty string when not configured in the workflow matrix
+        }
+
+        return filter_var($value, \FILTER_VALIDATE_BOOLEAN);
+    }
+}


### PR DESCRIPTION
We want `PHP_CS_FIXER_FAST_LINT_TEST_CASES` to be true by default, and it was passed as an empty string "by default".