### PR TITLE
fix: `StatementIndentationFixer` - do not treat ternary colon as block start

### DIFF
--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -325,6 +325,7 @@ final class StatementIndentationFixer extends AbstractFixer implements Configura
             if ($isPropertyStart || $token->isGivenKind(self::BLOCK_SIGNATURE_FIRST_TOKENS)) {
                 $lastWhitespaceIndex = null;
                 $closingParenthesisIndex = null;
+                $ternaryLevel = 0;
 
                 for ($endIndex = $index + 1, $max = \count($tokens); $endIndex < $max; ++$endIndex) {
                     $endToken = $tokens[$endIndex];
@@ -346,7 +347,19 @@ final class StatementIndentationFixer extends AbstractFixer implements Configura
                         break;
                     }
 
+                    if ($endToken->equals('?')) {
+                        ++$ternaryLevel;
+
+                        continue;
+                    }
+
                     if ($endToken->equals(':')) {
+                        if ($ternaryLevel > 0) {
+                            --$ternaryLevel;
+
+                            continue;
+                        }
+
                         if ($token->isGivenKind([\T_CASE, \T_DEFAULT])) {
                             $caseBlockStarts[$endIndex] = $index;
                         } else {

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -1538,6 +1538,8 @@ $foo = [
                 PHP,
         ];
 
+        // @TODO the `expected` below flattens every nesting level to one indent step instead of indenting deeper
+        // per level; that's not an ideal shape, just the fixer's current (imperfect) behavior
         yield 'multiline nested ternary operator in class constant' => [
             <<<'PHP'
                 <?php

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -1538,6 +1538,56 @@ $foo = [
                 PHP,
         ];
 
+        yield 'multiline nested ternary operator in class constant' => [
+            <<<'PHP'
+                <?php
+                class Foo
+                {
+                    const BAR = A
+                        ? B
+                        ? C
+                        ? D
+                        : E
+                        : F
+                        : G;
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                class Foo
+                {
+                    const BAR = A
+                    ? B
+                        ? C
+                            ? D
+                            : E
+                        : F
+                    : G;
+                }
+                PHP,
+        ];
+
+        yield 'multiline ternary operator in class constant with indentation to adjust' => [
+            <<<'PHP'
+                <?php
+                class Foo
+                {
+                    const BAR = A
+                        ? B
+                        : C;
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                class Foo
+                {
+                    const BAR = A
+                                ? B
+                    : C;
+                }
+                PHP,
+        ];
+
         yield 'braceless if with return' => [
             <<<'PHP'
                 <?php

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -1517,21 +1517,25 @@ $foo = [
                 PHP,
         ];
 
-        yield 'multiline ternary operator as class constant default value' => [
-            '<?php
-class Foo
-{
-    const BAR = BAZ
-        ? 1
-        : 2;
-}',
-            '<?php
-class Foo
-{
-    const BAR = BAZ
-        ? 1
-    : 2;
-}',
+        yield 'multiline ternary operator in class constant' => [
+            <<<'PHP'
+                <?php
+                class Foo
+                {
+                    const BAR = BAZ
+                        ? 1
+                        : 2;
+                }
+                PHP,
+            <<<'PHP'
+                <?php
+                class Foo
+                {
+                    const BAR = BAZ
+                        ? 1
+                    : 2;
+                }
+                PHP,
         ];
 
         yield 'braceless if with return' => [

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -1517,6 +1517,23 @@ $foo = [
                 PHP,
         ];
 
+        yield 'multiline ternary operator as class constant default value' => [
+            '<?php
+class Foo
+{
+    const BAR = BAZ
+        ? 1
+        : 2;
+}',
+            '<?php
+class Foo
+{
+    const BAR = BAZ
+        ? 1
+    : 2;
+}',
+        ];
+
         yield 'braceless if with return' => [
             <<<'PHP'
                 <?php


### PR DESCRIPTION
The scan that finds where a const/property block signature ends stops at the first `:` it sees, assuming it belongs to a control structure's alternative syntax or a switch case/default. A ternary in the default value (e.g. `const HOST = COND ? A : B;`) has a `:` too, so the scan mistakes it for that colon and cuts the signature scope short there, which throws off the indentation of the line right after it. This tracks `?`/`:` pairs so a ternary's colon is skipped instead of ending the scope.

Fixes #9794