### PR TITLE
fix: Strip ANSI escape sequences from diff output

### DIFF
--- a/src/Differ/DiffConsoleFormatter.php
+++ b/src/Differ/DiffConsoleFormatter.php
@@ -28,6 +28,12 @@ use Symfony\Component\Console\Formatter\OutputFormatter;
  */
 final class DiffConsoleFormatter
 {
+    /**
+     * Matches ANSI/VT100 escape sequences: CSI (e.g. colours, cursor movement),
+     * OSC (e.g. window title) terminated by BEL or ST, and other two-byte escapes.
+     */
+    private const ESCAPE_SEQUENCES_PATTERN = '#\x1B(?:\[[0-?]*[ -/]*[@-~]|][^\x07\x1B]*(?:\x07|\x1B\x5C)|[\x40-\x5A\x5C\x5F])#';
+
     private bool $isDecoratedOutput;
 
     private string $template;
@@ -52,6 +58,8 @@ final class DiffConsoleFormatter
                 \PHP_EOL,
                 array_map(
                     static function (string $line) use ($isDecorated, $lineTemplate): string {
+                        $line = Preg::replace(self::ESCAPE_SEQUENCES_PATTERN, '', $line);
+
                         if ($isDecorated) {
                             $count = 0;
                             $line = Preg::replaceCallback(

--- a/tests/Differ/DiffConsoleFormatterTest.php
+++ b/tests/Differ/DiffConsoleFormatterTest.php
@@ -128,5 +128,75 @@ final class DiffConsoleFormatterTest extends TestCase
             (string) mb_convert_encoding("--- Original\n+++ New\n@@ @@\n-ausgefüllt", 'ISO-8859-1'),
             '%s',
         ];
+
+        // CSI sequences (colours, cursor movement) are stripped even when decorated
+        yield [
+            "<fg=green>+hello world</fg=green>",
+            true,
+            '%s',
+            "+hello \x1B[31mworld\x1B[0m",
+            '%s',
+        ];
+
+        yield [
+            '+hello world',
+            false,
+            '%s',
+            "+hello \x1B[31mworld\x1B[0m",
+            '%s',
+        ];
+
+        // OSC terminated by BEL (window title) is stripped
+        yield [
+            '<fg=red>-evil line</fg=red>',
+            true,
+            '%s',
+            "-evil \x1B]0;PWNED\x07line",
+            '%s',
+        ];
+
+        yield [
+            '-evil line',
+            false,
+            '%s',
+            "-evil \x1B]0;PWNED\x07line",
+            '%s',
+        ];
+
+        // OSC terminated by ST (ESC \) – e.g. hyperlinks – is stripped
+        yield [
+            '<fg=green>+foo bar</fg=green>',
+            true,
+            '%s',
+            "+foo \x1B]8;;https://example.com\x1B\\bar",
+            '%s',
+        ];
+
+        // two-byte escapes (e.g. reverse index ESC M) are stripped – pattern covers ESC [@-Z \ _
+        yield [
+            ' context line',
+            true,
+            '%s',
+            " context \x1BMline",
+            '%s',
+        ];
+
+        // cursor movement / erase CSI sequences are stripped
+        yield [
+            '<fg=cyan>@@ -1 +1 @@</fg=cyan>',
+            true,
+            '%s',
+            "@@ \x1B[2J\x1B[999;999H-1 +1 @@",
+            '%s',
+        ];
+
+        // multiple mixed sequences on one line are all stripped
+        yield [
+            '<fg=green>+abc</fg=green>',
+            true,
+            '%s',
+            "+a\x1B[31mb\x1B]0;title\x07c\x1BM",
+            '%s',
+        ];
     }
 }


### PR DESCRIPTION
Diff lines echo the contents of the analysed files, so control sequences embedded in the code under test reach the terminal verbatim -- in both decorated and non-decorated output modes. `DiffConsoleFormatter` escapes Symfony `<tags>`, but ANSI/VT100 sequences pass straight through.

Concretely, a PHP file containing a raw `\x1b]0;PWNED\x07` sequence (e.g. inside a comment) and run through `php-cs-fixer fix --dry-run --diff` re-titles the terminal window of the developer or CI watcher reviewing the output. The same channel allows cursor manipulation and visual alteration of the printed diff while it is being reviewed. This matters most for the common CI setup where fixer runs against contributor-supplied code from pull requests.

This change strips CSI (colours, cursor movement), OSC terminated by BEL or ST (window title, hyperlinks), and other two-byte escape sequences from each diff line before further formatting. Regular diff content, syntax highlighting of `+`/`-`/`@` lines, and non-decorated behaviour are unchanged.

The pattern avoids literal backslashes by using hex escapes (`\x5C`) so it survives PHP single-quote parsing unchanged.
