### PR TITLE
fix: disabling a deprecated fixer also disables its successors

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -707,7 +707,7 @@ final class ConfigurationResolver
             $rules = $this->parseRules();
             $this->validateRules($rules);
 
-            $this->ruleSet = new RuleSet($rules);
+            $this->ruleSet = new RuleSet($this->expandDisabledDeprecatedFixers($rules));
         }
 
         return $this->ruleSet;
@@ -765,6 +765,47 @@ final class ConfigurationResolver
         }
 
         $this->configRulesAreOverridden = true;
+
+        return $rules;
+    }
+
+    /**
+     * Explicitly disabling a deprecated fixer also disables its successors: rule sets
+     * reference the new names, so once a set migrated (e.g. `@PER-CS` referencing
+     * `modifier_keywords`), disabling the old name (`visibility_required`) would
+     * otherwise no longer have any effect. A successor configured explicitly is
+     * left untouched.
+     *
+     * @param array<string, array<string, mixed>|bool> $rules
+     *
+     * @return array<string, array<string, mixed>|bool>
+     */
+    private function expandDisabledDeprecatedFixers(array $rules): array
+    {
+        $deprecatedFixers = [];
+
+        foreach ($this->createFixerFactory()->getFixers() as $fixer) {
+            if ($fixer instanceof DeprecatedFixerInterface) {
+                $deprecatedFixers[$fixer->getName()] = $fixer->getSuccessorsNames();
+            }
+        }
+
+        do {
+            $changed = false;
+
+            foreach ($deprecatedFixers as $name => $successors) {
+                if (false !== ($rules[$name] ?? null)) {
+                    continue;
+                }
+
+                foreach ($successors as $successor) {
+                    if (!\array_key_exists($successor, $rules)) {
+                        $rules[$successor] = false;
+                        $changed = true;
+                    }
+                }
+            }
+        } while ($changed);
 
         return $rules;
     }

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1163,6 +1163,66 @@ final class ConfigurationResolverTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
+    #[Group('legacy')]
+    public function testResolveRulesDisablingDeprecatedFixerDisablesItsSuccessors(): void
+    {
+        $this->expectDeprecation('Rule "visibility_required" is deprecated. Use "modifier_keywords" instead.');
+
+        $config = new Config();
+        $config->setRules([
+            '@PSR2' => true,
+            'visibility_required' => false,
+        ]);
+
+        $resolver = $this->createConfigurationResolver([], $config);
+
+        $rules = $resolver->getRules();
+        self::assertArrayNotHasKey('visibility_required', $rules);
+        self::assertArrayNotHasKey('modifier_keywords', $rules);
+    }
+
+    /**
+     * @group legacy
+     */
+    #[Group('legacy')]
+    public function testResolveRulesDisablingDeprecatedFixerKeepsExplicitlyConfiguredSuccessor(): void
+    {
+        $this->expectDeprecation('Rule "visibility_required" is deprecated. Use "modifier_keywords" instead.');
+
+        $config = new Config();
+        $config->setRules([
+            'visibility_required' => false,
+            'modifier_keywords' => ['elements' => ['method']],
+        ]);
+
+        $resolver = $this->createConfigurationResolver([], $config);
+
+        self::assertSameRules(
+            [
+                'modifier_keywords' => ['elements' => ['method']],
+            ],
+            $resolver->getRules(),
+        );
+    }
+
+    /**
+     * @group legacy
+     */
+    #[Group('legacy')]
+    public function testResolveRulesWithOptionDisablingDeprecatedFixerDisablesItsSuccessors(): void
+    {
+        $this->expectDeprecation('Rule "visibility_required" is deprecated. Use "modifier_keywords" instead.');
+
+        $resolver = $this->createConfigurationResolver(['rules' => '@PSR2,-visibility_required']);
+
+        $rules = $resolver->getRules();
+        self::assertArrayNotHasKey('visibility_required', $rules);
+        self::assertArrayNotHasKey('modifier_keywords', $rules);
+    }
+
     public function testResolveRulesWithOption(): void
     {
         $resolver = $this->createConfigurationResolver(['rules' => 'statement_indentation,-strict_comparison']);


### PR DESCRIPTION
Fixes #9113.

Rule sets reference the new names of renamed fixers, so once a set migrated, explicitly disabling the old name no longer has any effect: with `['@PER-CS' => true, 'visibility_required' => false]`, the set resolves to `modifier_keywords` and the `false` entry removes nothing (the prophecy case from the issue, broken by 3.88+).

`ConfigurationResolver` now expands the disabled deprecated fixers before building the `RuleSet`: an explicit `'old_name' => false` also disables the successors reported by `DeprecatedFixerInterface::getSuccessorsNames()`, transitively, unless a successor is explicitly configured by the user (an explicit value keeps precedence). This lives in the resolver rather than in `RuleSet` because only the resolver knows the registered custom fixers, whose deprecations must expand the same way.

Covered by three tests: config-file flavor, explicit successor precedence, and the `--rules '@PSR2,-visibility_required'` CLI flavor.
