### PR TITLE
fix: `StaticLambdaFixer` - do not make a lambda static when it is the direct subject of bindTo() or call()

### DIFF
--- a/src/Fixer/FunctionNotation/StaticLambdaFixer.php
+++ b/src/Fixer/FunctionNotation/StaticLambdaFixer.php
@@ -126,7 +126,7 @@ final class StaticLambdaFixer extends AbstractFixer
      * Returns 'true' if the lambda itself, wrapped in parentheses, is the direct subject
      * of a '->bindTo(...)' or '->call(...)' invocation: making such a lambda static would
      * produce "Cannot bind an instance to a static closure" (deprecated in PHP 8.5).
-     * 
+     *
      * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_closure_binding_issues
      */
     private function isDirectSubjectOfBinding(Tokens $tokens, int $lambdaIndex, int $lambdaEndIndex): bool

--- a/src/Fixer/FunctionNotation/StaticLambdaFixer.php
+++ b/src/Fixer/FunctionNotation/StaticLambdaFixer.php
@@ -105,6 +105,10 @@ final class StaticLambdaFixer extends AbstractFixer
                 continue;
             }
 
+            if ($this->isDirectSubjectOfBinding($tokens, $index, $lambdaEndIndex)) {
+                continue; // "(function () {})->bindTo($foo)" would warn ("Cannot bind an instance to a static closure") once made static
+            }
+
             // make the lambda static
             $tokens->insertAt(
                 $index,
@@ -116,6 +120,42 @@ final class StaticLambdaFixer extends AbstractFixer
 
             $index -= 4; // fixed after a lambda, closes candidate is at least 4 tokens before that
         }
+    }
+
+    /**
+     * Returns 'true' if the lambda itself, wrapped in parentheses, is the direct subject
+     * of a '->bindTo(...)' or '->call(...)' invocation: making such a lambda static would
+     * produce "Cannot bind an instance to a static closure" (deprecated in PHP 8.5).
+     */
+    private function isDirectSubjectOfBinding(Tokens $tokens, int $lambdaIndex, int $lambdaEndIndex): bool
+    {
+        $afterLambdaIndex = $tokens->getNextMeaningfulToken($lambdaEndIndex);
+
+        if (null === $afterLambdaIndex || !$tokens[$afterLambdaIndex]->equals(')')) {
+            return false;
+        }
+
+        $wrapStartIndex = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS, $afterLambdaIndex);
+
+        if ($tokens->getNextMeaningfulToken($wrapStartIndex) !== $lambdaIndex) {
+            return false; // the parentheses contain more than the lambda
+        }
+
+        $beforeWrapIndex = $tokens->getPrevMeaningfulToken($wrapStartIndex);
+
+        if (null !== $beforeWrapIndex && $tokens[$beforeWrapIndex]->equalsAny([')', ']', [\T_STRING], [\T_VARIABLE], [CT::T_ARRAY_INDEX_BRACE_CLOSE]])) {
+            return false; // the lambda is an argument of a call, whose return value is the subject instead
+        }
+
+        $objectOperatorIndex = $tokens->getNextMeaningfulToken($afterLambdaIndex);
+
+        if (!$tokens[$objectOperatorIndex]->isObjectOperator()) {
+            return false;
+        }
+
+        $methodIndex = $tokens->getNextMeaningfulToken($objectOperatorIndex);
+
+        return $tokens[$methodIndex]->equalsAny([[\T_STRING, 'bindTo'], [\T_STRING, 'call']], false);
     }
 
     /**

--- a/src/Fixer/FunctionNotation/StaticLambdaFixer.php
+++ b/src/Fixer/FunctionNotation/StaticLambdaFixer.php
@@ -126,6 +126,8 @@ final class StaticLambdaFixer extends AbstractFixer
      * Returns 'true' if the lambda itself, wrapped in parentheses, is the direct subject
      * of a '->bindTo(...)' or '->call(...)' invocation: making such a lambda static would
      * produce "Cannot bind an instance to a static closure" (deprecated in PHP 8.5).
+     * 
+     * @see https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_closure_binding_issues
      */
     private function isDirectSubjectOfBinding(Tokens $tokens, int $lambdaIndex, int $lambdaEndIndex): bool
     {

--- a/tests/Fixer/FunctionNotation/StaticLambdaFixerTest.php
+++ b/tests/Fixer/FunctionNotation/StaticLambdaFixerTest.php
@@ -45,6 +45,28 @@ final class StaticLambdaFixerTest extends AbstractFixerTestCase
      */
     public static function provideFixCases(): iterable
     {
+        yield 'do not fix a lambda that is the direct subject of bindTo' => [
+            '<?php $a = (function () { return 1; })->bindTo(new stdClass());',
+        ];
+
+        yield 'do not fix an arrow function that is the direct subject of bindTo (immediately invoked)' => [
+            '<?php $foobar = new Foobar(); echo (fn () => $foobar->sayHello())->bindTo(null, Foobar::class)();',
+        ];
+
+        yield 'do not fix a lambda that is the direct subject of call' => [
+            '<?php $b = (function () { return $x; })->call(new stdClass());',
+        ];
+
+        yield 'fix a lambda argument of a call whose return value is bound' => [
+            '<?php echo foo(static function () { return 1; })->bindTo(new stdClass());',
+            '<?php echo foo(function () { return 1; })->bindTo(new stdClass());',
+        ];
+
+        yield 'fix an immediately invoked lambda' => [
+            '<?php echo (static function () { return 1; })();',
+            '<?php echo (function () { return 1; })();',
+        ];
+
         yield 'sample' => [
             "<?php\n\$a = static function () use (\$b)\n{   echo \$b;\n};",
             "<?php\n\$a = function () use (\$b)\n{   echo \$b;\n};",


### PR DESCRIPTION
Fixes #9415.

`static_lambda` is risky because it cannot see a `bindTo()` happening elsewhere, but the reported case is fully visible to the fixer: the lambda, wrapped in parentheses, is the *direct* subject of `->bindTo(...)` (or `->call(...)`). Making such a lambda static produces "Cannot bind an instance to a static closure", a warning that [PHP 8.5 deprecates](https://wiki.php.net/rfc/deprecations_php_8_5) on the way to an error. The fixer now skips that pattern, while `foo(function () {})->bindTo(...)` (where the subject is the return value of `foo()`) and immediately invoked lambdas keep being fixed. The rule stays risky for the indirect cases.
