### PR TITLE
refactor: Transformers to use `process()` instead of `processToken()`

### DIFF
--- a/src/Tokenizer/Transformer/ArrayTypehintTransformer.php
+++ b/src/Tokenizer/Transformer/ArrayTypehintTransformer.php
@@ -40,17 +40,19 @@ final class ArrayTypehintTransformer extends AbstractTransformer
         return $tokens->isTokenKindFound(\T_ARRAY);
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if (!$token->isGivenKind(\T_ARRAY)) {
-            return;
-        }
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(\T_ARRAY)) {
+                continue;
+            }
 
-        $nextIndex = $tokens->getNextMeaningfulToken($index);
-        $nextToken = $tokens[$nextIndex];
+            $nextIndex = $tokens->getNextMeaningfulToken($index);
+            $nextToken = $tokens[$nextIndex];
 
-        if (!$nextToken->equals('(')) {
-            $tokens[$index] = new Token([CT::T_ARRAY_TYPEHINT, $token->getContent()]);
+            if (!$nextToken->equals('(')) {
+                $tokens[$index] = new Token([CT::T_ARRAY_TYPEHINT, $token->getContent()]);
+            }
         }
     }
 

--- a/src/Tokenizer/Transformer/AttributeTransformer.php
+++ b/src/Tokenizer/Transformer/AttributeTransformer.php
@@ -44,21 +44,23 @@ final class AttributeTransformer extends AbstractTransformer
         return $tokens->isTokenKindFound(\T_ATTRIBUTE);
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if (!$tokens[$index]->isGivenKind(\T_ATTRIBUTE)) {
-            return;
-        }
-
-        do {
-            ++$index;
-
-            if ($tokens[$index]->equals('(')) {
-                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $index) + 1;
+        foreach ($tokens as $index => $token) {
+            if (!$tokens[$index]->isGivenKind(\T_ATTRIBUTE)) {
+                continue;
             }
-        } while (!$tokens[$index]->equals(']'));
 
-        $tokens[$index] = new Token([CT::T_ATTRIBUTE_CLOSE, ']']);
+            do {
+                ++$index;
+
+                if ($tokens[$index]->equals('(')) {
+                    $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $index) + 1;
+                }
+            } while (!$tokens[$index]->equals(']'));
+
+            $tokens[$index] = new Token([CT::T_ATTRIBUTE_CLOSE, ']']);
+        }
     }
 
     public function getCustomTokens(): array

--- a/src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
+++ b/src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
@@ -47,37 +47,39 @@ final class BraceClassInstantiationTransformer extends AbstractTransformer
         return $tokens->isTokenKindFound(\T_NEW);
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if (!$tokens[$index]->equals('(') || !$tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(\T_NEW)) {
-            return;
+        foreach ($tokens as $index => $token) {
+            if (!$tokens[$index]->equals('(') || !$tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(\T_NEW)) {
+                continue;
+            }
+
+            if ($tokens[$tokens->getPrevMeaningfulToken($index)]->equalsAny([
+                ')',
+                ']',
+                [CT::T_ARRAY_INDEX_BRACE_CLOSE],
+                [CT::T_ARRAY_BRACKET_CLOSE],
+                [CT::T_CLASS_INSTANTIATION_PARENTHESIS_CLOSE],
+                [\T_ARRAY],
+                [\T_CLASS],
+                [\T_ELSEIF],
+                [\T_FOR],
+                [\T_FOREACH],
+                [\T_IF],
+                [\T_STATIC],
+                [\T_STRING],
+                [\T_SWITCH],
+                [\T_VARIABLE],
+                [\T_WHILE],
+            ])) {
+                continue;
+            }
+
+            $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $index);
+
+            $tokens[$index] = new Token([CT::T_CLASS_INSTANTIATION_PARENTHESIS_OPEN, '(']);
+            $tokens[$closeIndex] = new Token([CT::T_CLASS_INSTANTIATION_PARENTHESIS_CLOSE, ')']);
         }
-
-        if ($tokens[$tokens->getPrevMeaningfulToken($index)]->equalsAny([
-            ')',
-            ']',
-            [CT::T_ARRAY_INDEX_BRACE_CLOSE],
-            [CT::T_ARRAY_BRACKET_CLOSE],
-            [CT::T_CLASS_INSTANTIATION_PARENTHESIS_CLOSE],
-            [\T_ARRAY],
-            [\T_CLASS],
-            [\T_ELSEIF],
-            [\T_FOR],
-            [\T_FOREACH],
-            [\T_IF],
-            [\T_STATIC],
-            [\T_STRING],
-            [\T_SWITCH],
-            [\T_VARIABLE],
-            [\T_WHILE],
-        ])) {
-            return;
-        }
-
-        $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $index);
-
-        $tokens[$index] = new Token([CT::T_CLASS_INSTANTIATION_PARENTHESIS_OPEN, '(']);
-        $tokens[$closeIndex] = new Token([CT::T_CLASS_INSTANTIATION_PARENTHESIS_CLOSE, ')']);
     }
 
     public function getCustomTokens(): array

--- a/src/Tokenizer/Transformer/BraceTransformer.php
+++ b/src/Tokenizer/Transformer/BraceTransformer.php
@@ -50,16 +50,18 @@ final class BraceTransformer extends AbstractTransformer
         return $tokens->isAnyTokenKindsFound([\T_CURLY_OPEN, \T_DOLLAR_OPEN_CURLY_BRACES, '{']);
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        $this->transformIntoCurlyCloseBrace($tokens, $index);
-        $this->transformIntoDollarCloseBrace($tokens, $index);
-        $this->transformIntoDynamicPropBraces($tokens, $index);
-        $this->transformIntoDynamicVarBraces($tokens, $index);
-        $this->transformIntoPropertyHookBraces($tokens, $index);
-        $this->transformIntoCurlyIndexBraces($tokens, $index);
-        $this->transformIntoGroupUseBraces($tokens, $index);
-        $this->transformIntoDynamicClassConstantFetchBraces($tokens, $index);
+        foreach ($tokens as $index => $token) {
+            $this->transformIntoCurlyCloseBrace($tokens, $index);
+            $this->transformIntoDollarCloseBrace($tokens, $index);
+            $this->transformIntoDynamicPropBraces($tokens, $index);
+            $this->transformIntoDynamicVarBraces($tokens, $index);
+            $this->transformIntoPropertyHookBraces($tokens, $index);
+            $this->transformIntoCurlyIndexBraces($tokens, $index);
+            $this->transformIntoGroupUseBraces($tokens, $index);
+            $this->transformIntoDynamicClassConstantFetchBraces($tokens, $index);
+        }
     }
 
     public function getCustomTokens(): array

--- a/src/Tokenizer/Transformer/ClassConstantTransformer.php
+++ b/src/Tokenizer/Transformer/ClassConstantTransformer.php
@@ -40,20 +40,22 @@ final class ClassConstantTransformer extends AbstractTransformer
         return $tokens->isAnyTokenKindsFound([\T_CLASS, \T_STRING]);
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if (!$token->equalsAny([
-            [\T_CLASS, 'class'],
-            [\T_STRING, 'class'],
-        ], false)) {
-            return;
-        }
+        foreach ($tokens as $index => $token) {
+            if (!$token->equalsAny([
+                [\T_CLASS, 'class'],
+                [\T_STRING, 'class'],
+            ], false)) {
+                continue;
+            }
 
-        $prevIndex = $tokens->getPrevMeaningfulToken($index);
-        $prevToken = $tokens[$prevIndex];
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
+            $prevToken = $tokens[$prevIndex];
 
-        if ($prevToken->isGivenKind(\T_DOUBLE_COLON)) {
-            $tokens[$index] = new Token([CT::T_CLASS_CONSTANT, $token->getContent()]);
+            if ($prevToken->isGivenKind(\T_DOUBLE_COLON)) {
+                $tokens[$index] = new Token([CT::T_CLASS_CONSTANT, $token->getContent()]);
+            }
         }
     }
 

--- a/src/Tokenizer/Transformer/ConstructorPromotionTransformer.php
+++ b/src/Tokenizer/Transformer/ConstructorPromotionTransformer.php
@@ -40,29 +40,31 @@ final class ConstructorPromotionTransformer extends AbstractTransformer
         return $tokens->isTokenKindFound(\T_FUNCTION);
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if (!$tokens[$index]->isGivenKind(\T_FUNCTION)) {
-            return;
-        }
+        foreach ($tokens as $index => $token) {
+            if (!$tokens[$index]->isGivenKind(\T_FUNCTION)) {
+                continue;
+            }
 
-        $functionNameIndex = $tokens->getNextMeaningfulToken($index);
+            $functionNameIndex = $tokens->getNextMeaningfulToken($index);
 
-        if (!$tokens[$functionNameIndex]->isGivenKind(\T_STRING) || '__construct' !== strtolower($tokens[$functionNameIndex]->getContent())) {
-            return;
-        }
+            if (!$tokens[$functionNameIndex]->isGivenKind(\T_STRING) || '__construct' !== strtolower($tokens[$functionNameIndex]->getContent())) {
+                continue;
+            }
 
-        /** @var int $openParenthesisIndex */
-        $openParenthesisIndex = $tokens->getNextMeaningfulToken($functionNameIndex); // we are @ '(' now
-        $closeParenthesisIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $openParenthesisIndex);
+            /** @var int $openParenthesisIndex */
+            $openParenthesisIndex = $tokens->getNextMeaningfulToken($functionNameIndex); // we are @ '(' now
+            $closeParenthesisIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $openParenthesisIndex);
 
-        for ($argsIndex = $openParenthesisIndex; $argsIndex < $closeParenthesisIndex; ++$argsIndex) {
-            if ($tokens[$argsIndex]->isGivenKind(\T_PUBLIC)) {
-                $tokens[$argsIndex] = new Token([CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC, $tokens[$argsIndex]->getContent()]);
-            } elseif ($tokens[$argsIndex]->isGivenKind(\T_PROTECTED)) {
-                $tokens[$argsIndex] = new Token([CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED, $tokens[$argsIndex]->getContent()]);
-            } elseif ($tokens[$argsIndex]->isGivenKind(\T_PRIVATE)) {
-                $tokens[$argsIndex] = new Token([CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE, $tokens[$argsIndex]->getContent()]);
+            for ($argsIndex = $openParenthesisIndex; $argsIndex < $closeParenthesisIndex; ++$argsIndex) {
+                if ($tokens[$argsIndex]->isGivenKind(\T_PUBLIC)) {
+                    $tokens[$argsIndex] = new Token([CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC, $tokens[$argsIndex]->getContent()]);
+                } elseif ($tokens[$argsIndex]->isGivenKind(\T_PROTECTED)) {
+                    $tokens[$argsIndex] = new Token([CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED, $tokens[$argsIndex]->getContent()]);
+                } elseif ($tokens[$argsIndex]->isGivenKind(\T_PRIVATE)) {
+                    $tokens[$argsIndex] = new Token([CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE, $tokens[$argsIndex]->getContent()]);
+                }
             }
         }
     }

--- a/src/Tokenizer/Transformer/DisjunctiveNormalFormTypeParenthesisTransformer.php
+++ b/src/Tokenizer/Transformer/DisjunctiveNormalFormTypeParenthesisTransformer.php
@@ -46,20 +46,22 @@ final class DisjunctiveNormalFormTypeParenthesisTransformer extends AbstractTran
         return $tokens->isTokenKindFound(CT::T_TYPE_ALTERNATION);
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if ($token->equals('(') && $tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind(CT::T_TYPE_ALTERNATION)) {
-            $openIndex = $index;
-            $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $index);
-        } elseif ($token->equals(')') && $tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(CT::T_TYPE_ALTERNATION)) {
-            $openIndex = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS, $index);
-            $closeIndex = $index;
-        } else {
-            return;
-        }
+        foreach ($tokens as $index => $token) {
+            if ($token->equals('(') && $tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind(CT::T_TYPE_ALTERNATION)) {
+                $openIndex = $index;
+                $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $index);
+            } elseif ($token->equals(')') && $tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(CT::T_TYPE_ALTERNATION)) {
+                $openIndex = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS, $index);
+                $closeIndex = $index;
+            } else {
+                continue;
+            }
 
-        $tokens[$openIndex] = new Token([CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_OPEN, '(']);
-        $tokens[$closeIndex] = new Token([CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_CLOSE, ')']);
+            $tokens[$openIndex] = new Token([CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_OPEN, '(']);
+            $tokens[$closeIndex] = new Token([CT::T_DISJUNCTIVE_NORMAL_FORM_TYPE_PARENTHESIS_CLOSE, ')']);
+        }
     }
 
     public function getCustomTokens(): array

--- a/src/Tokenizer/Transformer/FirstClassCallableTransformer.php
+++ b/src/Tokenizer/Transformer/FirstClassCallableTransformer.php
@@ -36,14 +36,16 @@ final class FirstClassCallableTransformer extends AbstractTransformer
         return $tokens->isTokenKindFound(\T_ELLIPSIS);
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if (
-            $token->isGivenKind(\T_ELLIPSIS)
-            && $tokens[$tokens->getPrevMeaningfulToken($index)]->equals('(')
-            && $tokens[$tokens->getNextMeaningfulToken($index)]->equals(')')
-        ) {
-            $tokens[$index] = new Token([CT::T_FIRST_CLASS_CALLABLE, '...']);
+        foreach ($tokens as $index => $token) {
+            if (
+                $token->isGivenKind(\T_ELLIPSIS)
+                && $tokens[$tokens->getPrevMeaningfulToken($index)]->equals('(')
+                && $tokens[$tokens->getNextMeaningfulToken($index)]->equals(')')
+            ) {
+                $tokens[$index] = new Token([CT::T_FIRST_CLASS_CALLABLE, '...']);
+            }
         }
     }
 

--- a/src/Tokenizer/Transformer/ImportTransformer.php
+++ b/src/Tokenizer/Transformer/ImportTransformer.php
@@ -50,26 +50,28 @@ final class ImportTransformer extends AbstractTransformer
         return $tokens->isAnyTokenKindsFound([\T_CONST, \T_FUNCTION]);
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if (!$token->isGivenKind([\T_CONST, \T_FUNCTION])) {
-            return;
-        }
-
-        $prevToken = $tokens[$tokens->getPrevMeaningfulToken($index)];
-
-        if (!$prevToken->isGivenKind(\T_USE)) {
-            $nextToken = $tokens[$tokens->getNextTokenOfKind($index, ['=', '(', [CT::T_RETURN_REF], [CT::T_GROUP_IMPORT_BRACE_CLOSE]])];
-
-            if (!$nextToken->isGivenKind(CT::T_GROUP_IMPORT_BRACE_CLOSE)) {
-                return;
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind([\T_CONST, \T_FUNCTION])) {
+                continue;
             }
-        }
 
-        $tokens[$index] = new Token([
-            $token->isGivenKind(\T_FUNCTION) ? CT::T_FUNCTION_IMPORT : CT::T_CONST_IMPORT,
-            $token->getContent(),
-        ]);
+            $prevToken = $tokens[$tokens->getPrevMeaningfulToken($index)];
+
+            if (!$prevToken->isGivenKind(\T_USE)) {
+                $nextToken = $tokens[$tokens->getNextTokenOfKind($index, ['=', '(', [CT::T_RETURN_REF], [CT::T_GROUP_IMPORT_BRACE_CLOSE]])];
+
+                if (!$nextToken->isGivenKind(CT::T_GROUP_IMPORT_BRACE_CLOSE)) {
+                    continue;
+                }
+            }
+
+            $tokens[$index] = new Token([
+                $token->isGivenKind(\T_FUNCTION) ? CT::T_FUNCTION_IMPORT : CT::T_CONST_IMPORT,
+                $token->getContent(),
+            ]);
+        }
     }
 
     public function getCustomTokens(): array

--- a/src/Tokenizer/Transformer/NamedArgumentTransformer.php
+++ b/src/Tokenizer/Transformer/NamedArgumentTransformer.php
@@ -44,30 +44,32 @@ final class NamedArgumentTransformer extends AbstractTransformer
         return $tokens->isAllTokenKindsFound([\T_STRING, ':']);
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if (!$tokens[$index]->equals(':')) {
-            return;
+        foreach ($tokens as $index => $token) {
+            if (!$tokens[$index]->equals(':')) {
+                continue;
+            }
+
+            $stringIndex = $tokens->getPrevMeaningfulToken($index);
+
+            if (!$tokens[$stringIndex]->isGivenKind(\T_STRING)) {
+                continue;
+            }
+
+            $preStringIndex = $tokens->getPrevMeaningfulToken($stringIndex);
+
+            // if equals any [';', '{', '}', [T_OPEN_TAG]] than it is a goto label
+            // if equals ')' than likely it is a type colon, but sure not a name argument
+            // if equals '?' than it is part of ternary statement
+
+            if (!$tokens[$preStringIndex]->equalsAny([',', '('])) {
+                continue;
+            }
+
+            $tokens[$stringIndex] = new Token([CT::T_NAMED_ARGUMENT_NAME, $tokens[$stringIndex]->getContent()]);
+            $tokens[$index] = new Token([CT::T_NAMED_ARGUMENT_COLON, ':']);
         }
-
-        $stringIndex = $tokens->getPrevMeaningfulToken($index);
-
-        if (!$tokens[$stringIndex]->isGivenKind(\T_STRING)) {
-            return;
-        }
-
-        $preStringIndex = $tokens->getPrevMeaningfulToken($stringIndex);
-
-        // if equals any [';', '{', '}', [T_OPEN_TAG]] than it is a goto label
-        // if equals ')' than likely it is a type colon, but sure not a name argument
-        // if equals '?' than it is part of ternary statement
-
-        if (!$tokens[$preStringIndex]->equalsAny([',', '('])) {
-            return;
-        }
-
-        $tokens[$stringIndex] = new Token([CT::T_NAMED_ARGUMENT_NAME, $tokens[$stringIndex]->getContent()]);
-        $tokens[$index] = new Token([CT::T_NAMED_ARGUMENT_COLON, ':']);
     }
 
     public function getCustomTokens(): array

--- a/src/Tokenizer/Transformer/NamespaceOperatorTransformer.php
+++ b/src/Tokenizer/Transformer/NamespaceOperatorTransformer.php
@@ -40,16 +40,18 @@ final class NamespaceOperatorTransformer extends AbstractTransformer
         return $tokens->isTokenKindFound(\T_NAMESPACE);
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if (!$token->isGivenKind(\T_NAMESPACE)) {
-            return;
-        }
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(\T_NAMESPACE)) {
+                continue;
+            }
 
-        $nextIndex = $tokens->getNextMeaningfulToken($index);
+            $nextIndex = $tokens->getNextMeaningfulToken($index);
 
-        if ($tokens[$nextIndex]->isGivenKind(\T_NS_SEPARATOR)) {
-            $tokens[$index] = new Token([CT::T_NAMESPACE_OPERATOR, $token->getContent()]);
+            if ($tokens[$nextIndex]->isGivenKind(\T_NS_SEPARATOR)) {
+                $tokens[$index] = new Token([CT::T_NAMESPACE_OPERATOR, $token->getContent()]);
+            }
         }
     }
 

--- a/src/Tokenizer/Transformer/NullableTypeTransformer.php
+++ b/src/Tokenizer/Transformer/NullableTypeTransformer.php
@@ -69,26 +69,28 @@ final class NullableTypeTransformer extends AbstractTransformer
         return $tokens->isTokenKindFound('?');
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if (!$token->equals('?')) {
-            return;
+        foreach ($tokens as $index => $token) {
+            if (!$token->equals('?')) {
+                continue;
+            }
+
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
+
+            if (!$tokens[$prevIndex]->equalsAny(self::TYPES)) {
+                continue;
+            }
+
+            if (
+                $tokens[$prevIndex]->isGivenKind(\T_STATIC)
+                && $tokens[$tokens->getPrevMeaningfulToken($prevIndex)]->isGivenKind(\T_INSTANCEOF)
+            ) {
+                continue;
+            }
+
+            $tokens[$index] = new Token([CT::T_NULLABLE_TYPE, '?']);
         }
-
-        $prevIndex = $tokens->getPrevMeaningfulToken($index);
-
-        if (!$tokens[$prevIndex]->equalsAny(self::TYPES)) {
-            return;
-        }
-
-        if (
-            $tokens[$prevIndex]->isGivenKind(\T_STATIC)
-            && $tokens[$tokens->getPrevMeaningfulToken($prevIndex)]->isGivenKind(\T_INSTANCEOF)
-        ) {
-            return;
-        }
-
-        $tokens[$index] = new Token([CT::T_NULLABLE_TYPE, '?']);
     }
 
     public function getCustomTokens(): array

--- a/src/Tokenizer/Transformer/ReturnRefTransformer.php
+++ b/src/Tokenizer/Transformer/ReturnRefTransformer.php
@@ -40,10 +40,12 @@ final class ReturnRefTransformer extends AbstractTransformer
         return $tokens->isAnyTokenKindsFound([\T_FUNCTION, \T_FN]);
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if ($token->equals('&') && $tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind([\T_FUNCTION, \T_FN])) {
-            $tokens[$index] = new Token([CT::T_RETURN_REF, '&']);
+        foreach ($tokens as $index => $token) {
+            if ($token->equals('&') && $tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind([\T_FUNCTION, \T_FN])) {
+                $tokens[$index] = new Token([CT::T_RETURN_REF, '&']);
+            }
         }
     }
 

--- a/src/Tokenizer/Transformer/SquareBraceTransformer.php
+++ b/src/Tokenizer/Transformer/SquareBraceTransformer.php
@@ -53,16 +53,18 @@ final class SquareBraceTransformer extends AbstractTransformer
         return $tokens->isTokenKindFound('[');
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if ($this->isArrayDestructing($tokens, $index)) {
-            $this->transformIntoDestructuringSquareBrace($tokens, $index);
+        foreach ($tokens as $index => $token) {
+            if (!$tokens[$index]->equals('[')) {
+                continue;
+            }
 
-            return;
-        }
-
-        if ($this->isShortArray($tokens, $index)) {
-            $this->transformIntoArraySquareBrace($tokens, $index);
+            if ($this->isArrayDestructing($tokens, $index)) {
+                $this->transformIntoDestructuringSquareBrace($tokens, $index);
+            } elseif ($this->isShortArray($tokens, $index)) {
+                $this->transformIntoArraySquareBrace($tokens, $index);
+            }
         }
     }
 
@@ -95,7 +97,7 @@ final class SquareBraceTransformer extends AbstractTransformer
         $index = $tokens->getNextMeaningfulToken($index);
 
         while ($index < $endIndex) {
-            if ($tokens[$index]->equals('[') && $tokens[$previousMeaningfulIndex]->equalsAny([[CT::T_DESTRUCTURING_BRACKET_OPEN], ','])) {
+            if ($tokens[$index]->equals('[') && ($tokens[$previousMeaningfulIndex]->isGivenKind(CT::T_DESTRUCTURING_BRACKET_OPEN) || $tokens[$previousMeaningfulIndex]->equals(','))) {
                 $tokens[$tokens->findBlockEnd(Tokens::BLOCK_TYPE_INDEX_BRACKET, $index)] = new Token([CT::T_DESTRUCTURING_BRACKET_CLOSE, ']']);
                 $tokens[$index] = new Token([CT::T_DESTRUCTURING_BRACKET_OPEN, '[']);
             }
@@ -115,19 +117,20 @@ final class SquareBraceTransformer extends AbstractTransformer
         }
 
         $prevToken = $tokens[$tokens->getPrevMeaningfulToken($index)];
-        if ($prevToken->equalsAny([
-            ')',
-            ']',
-            '}',
-            '"',
-            [\T_CONSTANT_ENCAPSED_STRING],
-            [\T_STRING],
-            [\T_STRING_VARNAME],
-            [\T_VARIABLE],
-            [CT::T_ARRAY_BRACKET_CLOSE],
-            [CT::T_DYNAMIC_PROP_BRACE_CLOSE],
-            [CT::T_DYNAMIC_VAR_BRACE_CLOSE],
-            [CT::T_ARRAY_INDEX_BRACE_CLOSE],
+
+        if ($prevToken->equalsAny([')', ']', '}', '"'])) {
+            return false;
+        }
+
+        if ($prevToken->isGivenKind([
+            \T_CONSTANT_ENCAPSED_STRING,
+            \T_STRING,
+            \T_STRING_VARNAME,
+            \T_VARIABLE,
+            CT::T_ARRAY_BRACKET_CLOSE,
+            CT::T_DYNAMIC_PROP_BRACE_CLOSE,
+            CT::T_DYNAMIC_VAR_BRACE_CLOSE,
+            CT::T_ARRAY_INDEX_BRACE_CLOSE,
         ])) {
             return false;
         }
@@ -148,18 +151,20 @@ final class SquareBraceTransformer extends AbstractTransformer
 
         $prevIndex = $tokens->getPrevMeaningfulToken($index);
         $prevToken = $tokens[$prevIndex];
-        if ($prevToken->equalsAny([
-            ')',
-            ']',
-            '"',
-            [\T_CONSTANT_ENCAPSED_STRING],
-            [\T_STRING],
-            [\T_STRING_VARNAME],
-            [\T_VARIABLE],
-            [CT::T_ARRAY_BRACKET_CLOSE],
-            [CT::T_DYNAMIC_PROP_BRACE_CLOSE],
-            [CT::T_DYNAMIC_VAR_BRACE_CLOSE],
-            [CT::T_ARRAY_INDEX_BRACE_CLOSE],
+
+        if ($prevToken->equalsAny([')', ']', '"'])) {
+            return false;
+        }
+
+        if ($prevToken->isGivenKind([
+            \T_CONSTANT_ENCAPSED_STRING,
+            \T_STRING,
+            \T_STRING_VARNAME,
+            \T_VARIABLE,
+            CT::T_ARRAY_BRACKET_CLOSE,
+            CT::T_DYNAMIC_PROP_BRACE_CLOSE,
+            CT::T_DYNAMIC_VAR_BRACE_CLOSE,
+            CT::T_ARRAY_INDEX_BRACE_CLOSE,
         ])) {
             return false;
         }

--- a/src/Tokenizer/Transformer/TypeColonTransformer.php
+++ b/src/Tokenizer/Transformer/TypeColonTransformer.php
@@ -48,36 +48,38 @@ final class TypeColonTransformer extends AbstractTransformer
         return $tokens->isTokenKindFound(':');
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if (!$token->equals(':')) {
-            return;
-        }
+        foreach ($tokens as $index => $token) {
+            if (!$tokens[$index]->equals(':')) {
+                continue;
+            }
 
-        $endIndex = $tokens->getPrevMeaningfulToken($index);
+            $endIndex = $tokens->getPrevMeaningfulToken($index);
 
-        if ($tokens[$tokens->getPrevMeaningfulToken($endIndex)]->isGivenKind(FCT::T_ENUM)) {
-            $tokens[$index] = new Token([CT::T_TYPE_COLON, ':']);
+            if ($tokens[$tokens->getPrevMeaningfulToken($endIndex)]->isGivenKind(FCT::T_ENUM)) {
+                $tokens[$index] = new Token([CT::T_TYPE_COLON, ':']);
 
-            return;
-        }
+                continue;
+            }
 
-        if (!$tokens[$endIndex]->equals(')')) {
-            return;
-        }
+            if (!$tokens[$endIndex]->equals(')')) {
+                continue;
+            }
 
-        $startIndex = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS, $endIndex);
-        $prevIndex = $tokens->getPrevMeaningfulToken($startIndex);
-        $prevToken = $tokens[$prevIndex];
-
-        // if this could be a function name we need to take one more step
-        if ($prevToken->isGivenKind(\T_STRING)) {
-            $prevIndex = $tokens->getPrevMeaningfulToken($prevIndex);
+            $startIndex = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS, $endIndex);
+            $prevIndex = $tokens->getPrevMeaningfulToken($startIndex);
             $prevToken = $tokens[$prevIndex];
-        }
 
-        if ($prevToken->isGivenKind([\T_FUNCTION, CT::T_RETURN_REF, CT::T_USE_LAMBDA, \T_FN])) {
-            $tokens[$index] = new Token([CT::T_TYPE_COLON, ':']);
+            // if this could be a function name we need to take one more step
+            if ($prevToken->isGivenKind(\T_STRING)) {
+                $prevIndex = $tokens->getPrevMeaningfulToken($prevIndex);
+                $prevToken = $tokens[$prevIndex];
+            }
+
+            if ($prevToken->isGivenKind([\T_FUNCTION, CT::T_RETURN_REF, CT::T_USE_LAMBDA, \T_FN])) {
+                $tokens[$index] = new Token([CT::T_TYPE_COLON, ':']);
+            }
         }
     }
 

--- a/src/Tokenizer/Transformer/UseTransformer.php
+++ b/src/Tokenizer/Transformer/UseTransformer.php
@@ -33,8 +33,6 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 final class UseTransformer extends AbstractTransformer
 {
-    private const CLASS_TYPES = [\T_TRAIT, FCT::T_ENUM];
-
     public function getPriority(): int
     {
         // Should run after CurlyBraceTransformer and before TypeColonTransformer
@@ -51,39 +49,45 @@ final class UseTransformer extends AbstractTransformer
         return $tokens->isTokenKindFound(\T_USE);
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if ($token->isGivenKind(\T_USE) && $this->isUseForLambda($tokens, $index)) {
-            $tokens[$index] = new Token([CT::T_USE_LAMBDA, $token->getContent()]);
+        $count = $tokens->count();
 
-            return;
-        }
+        for ($index = 0; $index < $count; ++$index) {
+            $id = $tokens[$index]->getId();
 
-        // Only search inside class/trait body for `T_USE` for traits.
-        // Cannot import traits inside interfaces or anywhere else
+            if (\T_USE === $id && $this->isUseForLambda($tokens, $index)) {
+                $tokens[$index] = new Token([CT::T_USE_LAMBDA, $tokens[$index]->getContent()]);
 
-        if ($token->isGivenKind(\T_CLASS)) {
-            if ($tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind(\T_DOUBLE_COLON)) {
-                return;
-            }
-        } elseif (!$token->isGivenKind(self::CLASS_TYPES)) {
-            return;
-        }
-
-        $index = $tokens->getNextTokenOfKind($index, ['{']);
-        $innerLimit = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_BRACE, $index);
-
-        while ($index < $innerLimit) {
-            $token = $tokens[++$index];
-
-            if (!$token->isGivenKind(\T_USE)) {
                 continue;
             }
 
-            if ($this->isUseForLambda($tokens, $index)) {
-                $tokens[$index] = new Token([CT::T_USE_LAMBDA, $token->getContent()]);
-            } else {
-                $tokens[$index] = new Token([CT::T_USE_TRAIT, $token->getContent()]);
+            // Only search inside class/trait body for `T_USE` for traits.
+            // Cannot import traits inside interfaces or anywhere else
+
+            if (\T_CLASS === $id) {
+                if ($tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind(\T_DOUBLE_COLON)) {
+                    continue;
+                }
+            } elseif (\T_TRAIT !== $id && FCT::T_ENUM !== $id) {
+                continue;
+            }
+
+            $index = $tokens->getNextTokenOfKind($index, ['{']);
+            $innerLimit = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_BRACE, $index);
+
+            while ($index < $innerLimit) {
+                $token = $tokens[++$index];
+
+                if (\T_USE !== $token->getId()) {
+                    continue;
+                }
+
+                if ($this->isUseForLambda($tokens, $index)) {
+                    $tokens[$index] = new Token([CT::T_USE_LAMBDA, $token->getContent()]);
+                } else {
+                    $tokens[$index] = new Token([CT::T_USE_TRAIT, $token->getContent()]);
+                }
             }
         }
     }

--- a/src/Tokenizer/Transformer/WhitespacyCommentTransformer.php
+++ b/src/Tokenizer/Transformer/WhitespacyCommentTransformer.php
@@ -39,28 +39,36 @@ final class WhitespacyCommentTransformer extends AbstractTransformer
         return $tokens->isAnyTokenKindsFound([\T_COMMENT, \T_DOC_COMMENT]);
     }
 
-    public function processToken(Tokens $tokens, Token $token, int $index): void
+    public function process(Tokens $tokens): void
     {
-        if (!$token->isComment()) {
-            return;
+        $slices = [];
+
+        foreach ($tokens as $index => $token) {
+            if (!$token->isComment()) {
+                continue;
+            }
+
+            $content = $token->getContent();
+            $trimmedContent = rtrim($content);
+
+            // nothing trimmed, nothing to do
+            if ($content === $trimmedContent) {
+                continue;
+            }
+
+            $whitespaces = substr($content, \strlen($trimmedContent));
+
+            $tokens[$index] = new Token([$token->getId(), $trimmedContent]);
+
+            if (isset($tokens[$index + 1]) && $tokens[$index + 1]->isWhitespace()) {
+                $tokens[$index + 1] = new Token([\T_WHITESPACE, $whitespaces.$tokens[$index + 1]->getContent()]);
+            } else {
+                $slices[$index + 1] = new Token([\T_WHITESPACE, $whitespaces]);
+            }
         }
 
-        $content = $token->getContent();
-        $trimmedContent = rtrim($content);
-
-        // nothing trimmed, nothing to do
-        if ($content === $trimmedContent) {
-            return;
-        }
-
-        $whitespaces = substr($content, \strlen($trimmedContent));
-
-        $tokens[$index] = new Token([$token->getId(), $trimmedContent]);
-
-        if (isset($tokens[$index + 1]) && $tokens[$index + 1]->isWhitespace()) {
-            $tokens[$index + 1] = new Token([\T_WHITESPACE, $whitespaces.$tokens[$index + 1]->getContent()]);
-        } else {
-            $tokens->insertAt($index + 1, new Token([\T_WHITESPACE, $whitespaces]));
+        if ([] !== $slices) {
+            $tokens->insertSlices($slices);
         }
     }
 


### PR DESCRIPTION
- continue the work started in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9782