### PR TITLE
fix: `FunctionsAnalyzer` - detect return type of a closure with a `use` clause

### DIFF
--- a/src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/FunctionsAnalyzer.php
@@ -71,6 +71,12 @@ final class FunctionsAnalyzer
         $argumentsEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $argumentsStart);
         $typeColonIndex = $tokens->getNextMeaningfulToken($argumentsEnd);
 
+        if ($tokens[$typeColonIndex]->isGivenKind(CT::T_USE_LAMBDA)) {
+            $lambdaUseStart = $tokens->getNextTokenOfKind($typeColonIndex, ['(']);
+            $lambdaUseEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $lambdaUseStart);
+            $typeColonIndex = $tokens->getNextMeaningfulToken($lambdaUseEnd);
+        }
+
         if (!$tokens[$typeColonIndex]->isGivenKind(CT::T_TYPE_COLON)) {
             return null;
         }

--- a/tests/Fixer/ClassNotation/OrderedTypesFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedTypesFixerTest.php
@@ -283,6 +283,11 @@ try {
         ];
 
         yield [
+            '<?php $foo = function () use ($bar): null|int {};',
+            '<?php $foo = function () use ($bar): int|null {};',
+        ];
+
+        yield [
             "<?php\ntry {\n    foo();\n} catch (\\Error|\\TypeError) {\n}\n",
             "<?php\ntry {\n    foo();\n} catch (\\TypeError|\\Error) {\n}\n",
         ];

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -2833,6 +2833,23 @@ function foo($a) {}',
             ['import_symbols' => true],
         ];
 
+        yield 'fix closure return type when closure has a use clause' => [
+            <<<'PHP'
+                <?php
+                namespace Foo;
+                use Lib\Package\Bar;
+                $bar = new Bar();
+                $function = function () use ($bar): ?Bar { return $bar; };
+                PHP,
+            <<<'PHP'
+                <?php
+                namespace Foo;
+                $bar = new \Lib\Package\Bar();
+                $function = function () use ($bar): ?\Lib\Package\Bar { return $bar; };
+                PHP,
+            ['import_symbols' => true],
+        ];
+
         yield 'usage of <?=' => [
             <<<'PHP'
                 <?php

--- a/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
@@ -104,6 +104,11 @@ class Dto
 ',
         ];
 
+        yield 'closure with use clause' => [
+            "<?php\n\$bar = function () use (\$baz): ?int {};\n",
+            "<?php\n\$bar = function () use (\$baz): int|null {};\n",
+        ];
+
         yield 'skips more than two atomic types' => [
             "<?php\nstatic fn (int|null|string \$bar): bool => true;\n",
         ];

--- a/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NullableTypeDeclarationFixerTest.php
@@ -188,6 +188,11 @@ class Dto
 ',
         ];
 
+        yield 'closure with use clause' => [
+            "<?php\n\$bar = function () use (\$baz): null|int {};\n",
+            "<?php\n\$bar = function () use (\$baz): ?int {};\n",
+        ];
+
         yield 'space after ?' => [
             '<?php
 class Foo

--- a/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
@@ -766,6 +766,16 @@ class(){};
 
         yield ['<?php function($a): /* not sure if really an array */array {};', 1, new TypeAnalysis('array', 8, 8)];
 
+        yield ['<?php function() use ($a) {};', 1, null];
+
+        yield ['<?php function($a) use ($b): array {};', 1, new TypeAnalysis('array', 13, 13)];
+
+        yield ['<?php function($a) use (&$b): array {};', 1, new TypeAnalysis('array', 14, 14)];
+
+        yield ['<?php function($a) use ($b, $c): \Foo\Bar {};', 1, new TypeAnalysis('\Foo\Bar', 16, 19)];
+
+        yield ['<?php function($a) use ($b): /* not sure if really an array */array {};', 1, new TypeAnalysis('array', 14, 14)];
+
         yield ['<?php fn() => null;', 1, null];
 
         yield ['<?php fn(array $a) => null;', 1, null];
@@ -775,16 +785,6 @@ class(){};
         yield ['<?php fn($a): \Foo\Bar => null;', 1, new TypeAnalysis('\Foo\Bar', 7, 10)];
 
         yield ['<?php fn($a): /* not sure if really an array */array => null;', 1, new TypeAnalysis('array', 8, 8)];
-
-        yield ['<?php function() use ($a) {};', 1, null];
-
-        yield ['<?php function($b) use ($a): array {};', 1, new TypeAnalysis('array', 13, 13)];
-
-        yield ['<?php function($b) use (&$a): array {};', 1, new TypeAnalysis('array', 14, 14)];
-
-        yield ['<?php function($c) use ($a, $b): \Foo\Bar {};', 1, new TypeAnalysis('\Foo\Bar', 16, 19)];
-
-        yield ['<?php function($c) use ($a): /* not sure if really an array */array {};', 1, new TypeAnalysis('array', 14, 14)];
     }
 
     /**

--- a/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
@@ -775,6 +775,16 @@ class(){};
         yield ['<?php fn($a): \Foo\Bar => null;', 1, new TypeAnalysis('\Foo\Bar', 7, 10)];
 
         yield ['<?php fn($a): /* not sure if really an array */array => null;', 1, new TypeAnalysis('array', 8, 8)];
+
+        yield ['<?php function() use ($a) {};', 1, null];
+
+        yield ['<?php function($b) use ($a): array {};', 1, new TypeAnalysis('array', 13, 13)];
+
+        yield ['<?php function($b) use (&$a): array {};', 1, new TypeAnalysis('array', 14, 14)];
+
+        yield ['<?php function($c) use ($a, $b): \Foo\Bar {};', 1, new TypeAnalysis('\Foo\Bar', 16, 19)];
+
+        yield ['<?php function($c) use ($a): /* not sure if really an array */array {};', 1, new TypeAnalysis('array', 14, 14)];
     }
 
     /**


### PR DESCRIPTION
`FunctionsAnalyzer::getFunctionReturnType()` looks for `CT::T_TYPE_COLON` right after the parameter parentheses. For a closure with a `use (...)` clause the next meaningful token is `use`, not the colon, so the method returns `null` and the closure's return type is treated as absent. It now skips the `use (...)` block first.

That made `nullable_type_declaration`, `ordered_types` and `fully_qualified_strict_types` silently leave such return types alone, e.g. `function () use ($bar): int|null {}` stayed untouched while the same closure without the import was fixed.

Fixes #9805
