### PR TITLE
UX: init command - suggest php_unit_test_case_static_method_calls rule

### DIFF
--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -106,8 +106,10 @@ final class InitCommand extends Command
 
         /** @var list<string> $setsBehindAutoSetOnlySafe */
         $setsBehindAutoSetOnlySafe = array_keys($setAuto->getRulesCandidates());
+
         /** @var list<string> $setsBehindAutoSetOnlyRisky */
         $setsBehindAutoSetOnlyRisky = $isRiskyAllowed ? array_keys($setAutoRisky->getRulesCandidates()) : [];
+
         /** @var list<string> $setsBehindAutoSet */
         $setsBehindAutoSet = array_merge(
             $setsBehindAutoSetOnlySafe,

--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -279,6 +279,8 @@ final class InitCommand extends Command
             return null;
         }
 
+        $io->section('PHPUnit additions');
+
         $io->note('PHPUnit methods can be called on the instance or statically. You can decide on your preference.');
 
         $callType = $io->choice(

--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -264,7 +264,7 @@ final class InitCommand extends Command
     }
 
     /**
-     * The `php_unit_test_case_static_method_calls` rule is not part of any automatic set, as there is no wide alignment
+     * The `PhpUnitTestCaseStaticMethodCallsFixer` rule is not part of any automatic set, as there is no wide alignment
      * on the call type to use. Yet the choice is worth making explicitly, so let's ask for it instead of leaving the
      * rule undiscovered.
      *

--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -15,15 +15,18 @@ declare(strict_types=1);
 namespace PhpCsFixer\Console\Command;
 
 use PhpCsFixer\Console\Application;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestCaseStaticMethodCallsFixer;
 use PhpCsFixer\Preg;
 use PhpCsFixer\RuleSet\RuleSetDefinitionInterface;
 use PhpCsFixer\RuleSet\RuleSets;
+use PhpCsFixer\RuleSet\Sets\AutoPHPUnitMigrationRiskySet;
 use PhpCsFixer\RuleSet\Sets\AutoRiskySet;
 use PhpCsFixer\RuleSet\Sets\AutoSet;
 use PhpCsFixer\RuleSet\Sets\PhpCsFixerRiskySet;
 use PhpCsFixer\RuleSet\Sets\PhpCsFixerSet;
 use PhpCsFixer\RuleSet\Sets\SymfonyRiskySet;
 use PhpCsFixer\RuleSet\Sets\SymfonySet;
+use PhpCsFixer\Utils;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -122,6 +125,7 @@ final class InitCommand extends Command
             ),
         );
 
+        /** @var array<string, array<string, mixed>|bool> $rules */
         $rules = [];
 
         $useAutoSet = 'yes' === $io->choice(
@@ -131,9 +135,9 @@ final class InitCommand extends Command
         );
 
         if ($useAutoSet) {
-            $rules[] = $setAuto->getName();
+            $rules[$setAuto->getName()] = true;
             if ($isRiskyAllowed) {
-                $rules[] = $setAutoRisky->getName();
+                $rules[$setAutoRisky->getName()] = true;
             }
         }
 
@@ -181,10 +185,14 @@ final class InitCommand extends Command
             $sets = [$sets];
         }
 
-        $rules = array_merge(
-            $rules,
-            array_unique(array_filter($sets, static fn ($item) => 'none' !== $item)),
-        );
+        foreach (array_filter($sets, static fn ($item) => 'none' !== $item) as $set) {
+            $rules[$set] = true;
+        }
+
+        $phpUnitCallType = $this->askForPhpUnitCallType($io, $setsBehindAutoSet);
+        if (null !== $phpUnitCallType) {
+            $rules[(new PhpUnitTestCaseStaticMethodCallsFixer())->getName()] = ['call_type' => $phpUnitCallType];
+        }
 
         $io->note([
             'By default, PHP CS Fixer will looks for `*.php` files excluding `./vendor/` dir.',
@@ -211,7 +219,8 @@ final class InitCommand extends Command
                 "[\n".implode(
                     ",\n",
                     array_map(
-                        static fn ($item) => "        '{$item}' => true",
+                        static fn (string $name, $configuration): string => \sprintf("        '%s' => %s", $name, Utils::toString($configuration)),
+                        array_keys($rules),
                         $rules,
                     ),
                 )."\n    ]",
@@ -252,5 +261,37 @@ final class InitCommand extends Command
             '<href=$2;fg=bright-blue;options=underscore>$1 ($2)</>',
             $text,
         );
+    }
+
+    /**
+     * The `php_unit_test_case_static_method_calls` rule is not part of any automatic set, as there is no wide alignment
+     * on the call type to use. Yet the choice is worth making explicitly, so let's ask for it instead of leaving the
+     * rule undiscovered.
+     *
+     * @param array<string> $setsBehindAutoSet
+     *
+     * @return null|string the call type to enforce, or `null` to not enforce any
+     */
+    private function askForPhpUnitCallType(SymfonyStyle $io, array $setsBehindAutoSet): ?string
+    {
+        // the rule is risky, so offer it only when the risky PHPUnit migration set is on the table
+        if (!\in_array((new AutoPHPUnitMigrationRiskySet())->getName(), $setsBehindAutoSet, true)) {
+            return null;
+        }
+
+        $io->note('PHPUnit methods can be called on the instance or statically. You can decide on your preference.');
+
+        $callType = $io->choice(
+            'Which call type do you use for PHPUnit methods?',
+            [
+                'this' => '`$this->assertSame()`',
+                'self' => '`self::assertSame()`',
+                'static' => '`static::assertSame()`',
+                'none' => 'none - do not enforce any',
+            ],
+            'none',
+        );
+
+        return 'none' === $callType ? null : $callType;
     }
 }

--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -268,7 +268,7 @@ final class InitCommand extends Command
      * on the call type to use. Yet the choice is worth making explicitly, so let's ask for it instead of leaving the
      * rule undiscovered.
      *
-     * @param array<string> $setsBehindAutoSet
+     * @param array<int, string> $setsBehindAutoSet
      *
      * @return null|string the call type to enforce, or `null` to not enforce any
      */

--- a/src/Console/Command/InitCommand.php
+++ b/src/Console/Command/InitCommand.php
@@ -100,16 +100,16 @@ final class InitCommand extends Command
 
         $io->note("We recommend usage of {$setAutoWithOptionalRiskySetNamesTextual} rulesets. They take insights from your existing `composer.json` to configure project the best. For your current setup, that would mean:");
 
-        $generateSetsBehindAutoSet = static function () use ($setAuto, $setAutoRisky, $isRiskyAllowed): array {
-            $sets = array_merge(
-                array_keys($setAuto->getRulesCandidates()),
-                $isRiskyAllowed ? array_keys($setAutoRisky->getRulesCandidates()) : [],
-            );
-            natcasesort($sets);
-
-            return $sets;
-        };
-        $setsBehindAutoSet = $generateSetsBehindAutoSet();
+        /** @var list<string> $setsBehindAutoSetOnlySafe */
+        $setsBehindAutoSetOnlySafe = array_keys($setAuto->getRulesCandidates());
+        /** @var list<string> $setsBehindAutoSetOnlyRisky */
+        $setsBehindAutoSetOnlyRisky = $isRiskyAllowed ? array_keys($setAutoRisky->getRulesCandidates()) : [];
+        /** @var list<string> $setsBehindAutoSet */
+        $setsBehindAutoSet = array_merge(
+            $setsBehindAutoSetOnlySafe,
+            $setsBehindAutoSetOnlyRisky,
+        );
+        natcasesort($setsBehindAutoSet);
 
         $io->listing(
             array_map(
@@ -128,6 +128,9 @@ final class InitCommand extends Command
         /** @var array<string, array<string, mixed>|bool> $rules */
         $rules = [];
 
+        /** @var list<string> $resolvedSetNames */
+        $resolvedSetNames = [];
+
         $useAutoSet = 'yes' === $io->choice(
             "Do you want to use <fg=blue>{$setAutoWithOptionalRiskySetNamesTextual}</> ruleset?",
             ['yes', 'no'],
@@ -136,8 +139,11 @@ final class InitCommand extends Command
 
         if ($useAutoSet) {
             $rules[$setAuto->getName()] = true;
+            $resolvedSetNames = array_merge($resolvedSetNames, $setsBehindAutoSetOnlySafe);
+
             if ($isRiskyAllowed) {
                 $rules[$setAutoRisky->getName()] = true;
+                $resolvedSetNames = array_merge($resolvedSetNames, $setsBehindAutoSetOnlyRisky);
             }
         }
 
@@ -185,11 +191,15 @@ final class InitCommand extends Command
             $sets = [$sets];
         }
 
-        foreach (array_filter($sets, static fn ($item) => 'none' !== $item) as $set) {
+        /** @var list<string> $sets */
+        $sets = array_filter($sets, static fn ($item) => 'none' !== $item);
+
+        foreach ($sets as $set) {
             $rules[$set] = true;
         }
+        $resolvedSetNames = array_merge($resolvedSetNames, $sets);
 
-        $phpUnitCallType = $this->askForPhpUnitCallType($io, $setsBehindAutoSet);
+        $phpUnitCallType = $this->askForPhpUnitCallType($io, $resolvedSetNames);
         if (null !== $phpUnitCallType) {
             $rules[(new PhpUnitTestCaseStaticMethodCallsFixer())->getName()] = ['call_type' => $phpUnitCallType];
         }
@@ -268,14 +278,14 @@ final class InitCommand extends Command
      * on the call type to use. Yet the choice is worth making explicitly, so let's ask for it instead of leaving the
      * rule undiscovered.
      *
-     * @param array<int, string> $setsBehindAutoSet
+     * @param list<string> $resolvedSetNames
      *
      * @return null|string the call type to enforce, or `null` to not enforce any
      */
-    private function askForPhpUnitCallType(SymfonyStyle $io, array $setsBehindAutoSet): ?string
+    private function askForPhpUnitCallType(SymfonyStyle $io, array $resolvedSetNames): ?string
     {
-        // the rule is risky, so offer it only when the risky PHPUnit migration set is on the table
-        if (!\in_array((new AutoPHPUnitMigrationRiskySet())->getName(), $setsBehindAutoSet, true)) {
+        // the rule is risky, so offer it only when the risky PHPUnit migration set is enabled
+        if (!\in_array((new AutoPHPUnitMigrationRiskySet())->getName(), $resolvedSetNames, true)) {
             return null;
         }
 

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -19,7 +19,6 @@ use PhpCsFixer\AbstractPhpdocToTypeDeclarationFixer;
 use PhpCsFixer\AbstractPhpdocTypesFixer;
 use PhpCsFixer\AbstractProxyFixer;
 use PhpCsFixer\Console\Command\FixCommand;
-use PhpCsFixer\Console\Command\InitCommand;
 use PhpCsFixer\Console\Internal\Command\ParseCommand;
 use PhpCsFixer\DocBlock\Annotation;
 use PhpCsFixer\DocBlock\DocBlock;
@@ -121,7 +120,6 @@ final class ProjectCodeTest extends TestCase
         $testClassName = 'PhpCsFixer\Tests'.substr($className, 10).'Test';
 
         $exceptions = [
-            InitCommand::class,
             DocumentationTag::class,
             DocumentationTagGenerator::class,
         ];

--- a/tests/Console/Command/InitCommandTest.php
+++ b/tests/Console/Command/InitCommandTest.php
@@ -14,14 +14,13 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Console\Command;
 
-use PhpCsFixer\Console\Application;
 use PhpCsFixer\Console\Command\InitCommand;
-use PhpCsFixer\Tests\Test\TestCaseUtils;
 use PhpCsFixer\Tests\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @internal
@@ -35,21 +34,20 @@ final class InitCommandTest extends TestCase
 {
     /**
      * @param list<string> $inputs          answers to the questions asked by the command
-     * @param list<string> $expectedRules   rules expected in the created configuration file
-     * @param list<string> $unexpectedRules rules expected to _not_ be in the created configuration file
+     * @param list<string> $expectedRules   rules expected in the prepared configuration
+     * @param list<string> $unexpectedRules rules expected to _not_ be in the prepared configuration
      *
-     * @dataProvider provideConfigurationIsCreatedCases
+     * @dataProvider provideConfigurationIsPreparedCases
      */
-    #[DataProvider('provideConfigurationIsCreatedCases')]
-    public function testConfigurationIsCreated(
+    #[DataProvider('provideConfigurationIsPreparedCases')]
+    public function testConfigurationIsPrepared(
         array $inputs,
         array $expectedRules,
         array $unexpectedRules,
         bool $isCallTypeQuestionExpected
     ): void {
-        $commandTester = self::executeInTemporaryDirectory($inputs, $configuration);
-
-        self::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+        $output = new BufferedOutput();
+        $configuration = self::prepareConfigurationFileContent($inputs, $output);
 
         foreach ($expectedRules as $expectedRule) {
             self::assertStringContainsString($expectedRule, $configuration);
@@ -61,14 +59,14 @@ final class InitCommandTest extends TestCase
 
         self::assertSame(
             $isCallTypeQuestionExpected,
-            str_contains($commandTester->getDisplay(), 'Which call type do you use for PHPUnit methods?'),
+            str_contains($output->fetch(), 'Which call type do you use for PHPUnit methods?'),
         );
     }
 
     /**
      * @return iterable<string, array{list<string>, list<string>, list<string>, bool}>
      */
-    public static function provideConfigurationIsCreatedCases(): iterable
+    public static function provideConfigurationIsPreparedCases(): iterable
     {
         yield 'a call type is picked' => [
             ['yes', 'yes', 'none', 'this', 'yes'],
@@ -110,61 +108,40 @@ final class InitCommandTest extends TestCase
         ];
     }
 
-    public function testConfigurationIsNotOverwritten(): void
+    /**
+     * @param list<string> $inputs answers to the questions asked by the command
+     */
+    private static function prepareConfigurationFileContent(array $inputs, BufferedOutput $output): string
     {
-        $commandTester = self::executeInTemporaryDirectory(
-            ['yes', 'yes', 'none', 'this', 'yes'],
-            $configuration,
-            'already there',
-        );
+        $input = new ArrayInput([]);
+        $input->setInteractive(true);
+        $input->setStream(self::createInputStream($inputs));
 
-        self::assertSame(Command::FAILURE, $commandTester->getStatusCode());
-        self::assertSame('already there', $configuration);
+        $io = new SymfonyStyle($input, $output);
+
+        return \Closure::bind(
+            static fn (InitCommand $command): string => $command->prepareConfigurationFileContent($io),
+            null,
+            InitCommand::class,
+        )(new InitCommand());
     }
 
     /**
-     * @param list<string> $inputs                answers to the questions asked by the command
-     * @param null|string  $configuration         content of the created configuration file
-     * @param null|string  $existingConfiguration content of the configuration file to create upfront, if any
+     * @param list<string> $inputs
+     *
+     * @return resource
      */
-    private static function executeInTemporaryDirectory(
-        array $inputs,
-        ?string &$configuration,
-        ?string $existingConfiguration = null
-    ): CommandTester {
-        $originalDirectory = getcwd();
-        if (false === $originalDirectory) {
-            throw new \RuntimeException('Unable to determine current working directory.');
+    private static function createInputStream(array $inputs)
+    {
+        $stream = fopen('php://memory', 'r+');
+
+        if (false === $stream) {
+            throw new \RuntimeException('Unable to open the input stream.');
         }
 
-        $temporaryDirectory = TestCaseUtils::createTemporaryDirectory();
+        fwrite($stream, implode(\PHP_EOL, $inputs).\PHP_EOL);
+        rewind($stream);
 
-        try {
-            // the command creates its file in the current working directory
-            chdir($temporaryDirectory);
-
-            if (null !== $existingConfiguration) {
-                file_put_contents('.php-cs-fixer.dist.php', $existingConfiguration);
-            }
-
-            $application = new Application();
-            $application->add(new InitCommand());
-
-            $commandTester = new CommandTester($application->find('init'));
-            $commandTester->setInputs($inputs);
-            $commandTester->execute([]);
-
-            $readResult = @file_get_contents('.php-cs-fixer.dist.php');
-            $configuration = false === $readResult ? null : $readResult;
-
-            return $commandTester;
-        } finally {
-            if (file_exists('.php-cs-fixer.dist.php')) {
-                unlink('.php-cs-fixer.dist.php');
-            }
-
-            chdir($originalDirectory);
-            rmdir($temporaryDirectory);
-        }
+        return $stream;
     }
 }

--- a/tests/Console/Command/InitCommandTest.php
+++ b/tests/Console/Command/InitCommandTest.php
@@ -100,6 +100,23 @@ final class InitCommandTest extends TestCase
             true,
         ];
 
+        yield 'an extra ruleset is picked without the automatic ones 1' => [
+            ['yes', 'no', '@autoPHPUnitMigration:risky', 'this', 'yes'],
+            [
+                "'@autoPHPUnitMigration:risky' => true",
+                "'php_unit_test_case_static_method_calls' => ['call_type' => 'this']",
+            ],
+            [],
+            true,
+        ];
+
+        yield 'an extra ruleset is picked without the automatic ones 2' => [
+            ['yes', 'no', '@Symfony', 'yes'],
+            ["'@Symfony' => true"],
+            ['php_unit_test_case_static_method_calls', "'@auto:risky'"],
+            false,
+        ];
+
         yield 'risky rules are not allowed' => [
             ['no', 'yes', 'none', 'yes'],
             ['setRiskyAllowed(false)', "'@auto' => true"],

--- a/tests/Console/Command/InitCommandTest.php
+++ b/tests/Console/Command/InitCommandTest.php
@@ -43,11 +43,9 @@ final class InitCommandTest extends TestCase
     public function testConfigurationIsPrepared(
         array $inputs,
         array $expectedRules,
-        array $unexpectedRules,
-        bool $isCallTypeQuestionExpected
+        array $unexpectedRules
     ): void {
-        $output = new BufferedOutput();
-        $configuration = self::prepareConfigurationFileContent($inputs, $output);
+        $configuration = self::prepareConfigurationFileContent($inputs);
 
         foreach ($expectedRules as $expectedRule) {
             self::assertStringContainsString($expectedRule, $configuration);
@@ -56,15 +54,10 @@ final class InitCommandTest extends TestCase
         foreach ($unexpectedRules as $unexpectedRule) {
             self::assertStringNotContainsString($unexpectedRule, $configuration);
         }
-
-        self::assertSame(
-            $isCallTypeQuestionExpected,
-            str_contains($output->fetch(), 'Which call type do you use for PHPUnit methods?'),
-        );
     }
 
     /**
-     * @return iterable<string, array{list<string>, list<string>, list<string>, bool}>
+     * @return iterable<string, array{list<string>, list<string>, list<string>}>
      */
     public static function provideConfigurationIsPreparedCases(): iterable
     {
@@ -72,21 +65,18 @@ final class InitCommandTest extends TestCase
             ['yes', 'yes', 'none', 'this', 'yes'],
             ["'php_unit_test_case_static_method_calls' => ['call_type' => 'this']"],
             [],
-            true,
         ];
 
         yield 'another call type is picked' => [
             ['yes', 'yes', 'none', 'self', 'yes'],
             ["'php_unit_test_case_static_method_calls' => ['call_type' => 'self']"],
             [],
-            true,
         ];
 
         yield 'no call type is enforced' => [
             ['yes', 'yes', 'none', 'none', 'yes'],
             ["'@auto' => true", "'@auto:risky' => true"],
             ['php_unit_test_case_static_method_calls', "'none'"],
-            true,
         ];
 
         yield 'an extra ruleset is picked next to the automatic ones' => [
@@ -97,7 +87,6 @@ final class InitCommandTest extends TestCase
                 "'php_unit_test_case_static_method_calls' => ['call_type' => 'this']",
             ],
             [],
-            true,
         ];
 
         yield 'an extra ruleset is picked without the automatic ones 1' => [
@@ -107,34 +96,33 @@ final class InitCommandTest extends TestCase
                 "'php_unit_test_case_static_method_calls' => ['call_type' => 'this']",
             ],
             [],
-            true,
         ];
 
         yield 'an extra ruleset is picked without the automatic ones 2' => [
             ['yes', 'no', '@Symfony', 'yes'],
             ["'@Symfony' => true"],
             ['php_unit_test_case_static_method_calls', "'@auto:risky'"],
-            false,
         ];
 
         yield 'risky rules are not allowed' => [
             ['no', 'yes', 'none', 'yes'],
             ['setRiskyAllowed(false)', "'@auto' => true"],
             ['php_unit_test_case_static_method_calls', "'@auto:risky'"],
-            false,
         ];
     }
 
     /**
      * @param list<string> $inputs answers to the questions asked by the command
      */
-    private static function prepareConfigurationFileContent(array $inputs, BufferedOutput $output): string
+    private static function prepareConfigurationFileContent(array $inputs): string
     {
+        // the answers are read from the input stream, the way Symfony's own
+        // CommandTester::setInputs() feeds them, not from the ArrayInput parameters
         $input = new ArrayInput([]);
         $input->setInteractive(true);
         $input->setStream(self::createInputStream($inputs));
 
-        $io = new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, new BufferedOutput());
 
         return \Closure::bind(
             static fn (InitCommand $command): string => $command->prepareConfigurationFileContent($io),

--- a/tests/Console/Command/InitCommandTest.php
+++ b/tests/Console/Command/InitCommandTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Console\Command;
+
+use PhpCsFixer\Console\Application;
+use PhpCsFixer\Console\Command\InitCommand;
+use PhpCsFixer\Tests\Test\TestCaseUtils;
+use PhpCsFixer\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Console\Command\InitCommand
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+#[CoversClass(InitCommand::class)]
+final class InitCommandTest extends TestCase
+{
+    /**
+     * @param list<string> $inputs          answers to the questions asked by the command
+     * @param list<string> $expectedRules   rules expected in the created configuration file
+     * @param list<string> $unexpectedRules rules expected to _not_ be in the created configuration file
+     *
+     * @dataProvider provideConfigurationIsCreatedCases
+     */
+    #[DataProvider('provideConfigurationIsCreatedCases')]
+    public function testConfigurationIsCreated(
+        array $inputs,
+        array $expectedRules,
+        array $unexpectedRules,
+        bool $isCallTypeQuestionExpected
+    ): void {
+        $commandTester = self::executeInTemporaryDirectory($inputs, $configuration);
+
+        self::assertSame(Command::SUCCESS, $commandTester->getStatusCode());
+
+        foreach ($expectedRules as $expectedRule) {
+            self::assertStringContainsString($expectedRule, $configuration);
+        }
+
+        foreach ($unexpectedRules as $unexpectedRule) {
+            self::assertStringNotContainsString($unexpectedRule, $configuration);
+        }
+
+        self::assertSame(
+            $isCallTypeQuestionExpected,
+            str_contains($commandTester->getDisplay(), 'Which call type do you use for PHPUnit methods?'),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{list<string>, list<string>, list<string>, bool}>
+     */
+    public static function provideConfigurationIsCreatedCases(): iterable
+    {
+        yield 'a call type is picked' => [
+            ['yes', 'yes', 'none', 'this', 'yes'],
+            ["'php_unit_test_case_static_method_calls' => ['call_type' => 'this']"],
+            [],
+            true,
+        ];
+
+        yield 'another call type is picked' => [
+            ['yes', 'yes', 'none', 'self', 'yes'],
+            ["'php_unit_test_case_static_method_calls' => ['call_type' => 'self']"],
+            [],
+            true,
+        ];
+
+        yield 'no call type is enforced' => [
+            ['yes', 'yes', 'none', 'none', 'yes'],
+            ["'@auto' => true", "'@auto:risky' => true"],
+            ['php_unit_test_case_static_method_calls', "'none'"],
+            true,
+        ];
+
+        yield 'an extra ruleset is picked next to the automatic ones' => [
+            ['yes', 'yes', '@Symfony', 'this', 'yes'],
+            [
+                "'@auto' => true",
+                "'@Symfony' => true",
+                "'php_unit_test_case_static_method_calls' => ['call_type' => 'this']",
+            ],
+            [],
+            true,
+        ];
+
+        yield 'risky rules are not allowed' => [
+            ['no', 'yes', 'none', 'yes'],
+            ['setRiskyAllowed(false)', "'@auto' => true"],
+            ['php_unit_test_case_static_method_calls', "'@auto:risky'"],
+            false,
+        ];
+    }
+
+    public function testConfigurationIsNotOverwritten(): void
+    {
+        $commandTester = self::executeInTemporaryDirectory(
+            ['yes', 'yes', 'none', 'this', 'yes'],
+            $configuration,
+            'already there',
+        );
+
+        self::assertSame(Command::FAILURE, $commandTester->getStatusCode());
+        self::assertSame('already there', $configuration);
+    }
+
+    /**
+     * @param list<string> $inputs                answers to the questions asked by the command
+     * @param null|string  $configuration         content of the created configuration file
+     * @param null|string  $existingConfiguration content of the configuration file to create upfront, if any
+     */
+    private static function executeInTemporaryDirectory(
+        array $inputs,
+        ?string &$configuration,
+        ?string $existingConfiguration = null
+    ): CommandTester {
+        $originalDirectory = getcwd();
+        if (false === $originalDirectory) {
+            throw new \RuntimeException('Unable to determine current working directory.');
+        }
+
+        $temporaryDirectory = TestCaseUtils::createTemporaryDirectory();
+
+        try {
+            // the command creates its file in the current working directory
+            chdir($temporaryDirectory);
+
+            if (null !== $existingConfiguration) {
+                file_put_contents('.php-cs-fixer.dist.php', $existingConfiguration);
+            }
+
+            $application = new Application();
+            $application->add(new InitCommand());
+
+            $commandTester = new CommandTester($application->find('init'));
+            $commandTester->setInputs($inputs);
+            $commandTester->execute([]);
+
+            $readResult = @file_get_contents('.php-cs-fixer.dist.php');
+            $configuration = false === $readResult ? null : $readResult;
+
+            return $commandTester;
+        } finally {
+            if (file_exists('.php-cs-fixer.dist.php')) {
+                unlink('.php-cs-fixer.dist.php');
+            }
+
+            chdir($originalDirectory);
+            rmdir($temporaryDirectory);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #9377.

`php_unit_test_case_static_method_calls` was dropped from the PHPUnit migration sets in #9341, because there is no wide alignment on the call type and enabling it blindly produces a massive diff. Nothing suggests it any more, so the rule became close to undiscoverable, while the choice itself is one a project usually has an answer to.

`init` now asks for it. The question only shows up when it can be acted on: risky rules are allowed (the rule is risky) and `composer.json` declares `phpunit/phpunit`, read through `ComposerJsonReader`, the same insight source the `@auto` sets use. Answering `none` (the default) writes nothing, so the flow is unchanged for anyone who does not care.

```
 ! [NOTE] PHPUnit methods can be called on the test case instance
 !        (`$this->assertSame()`) or statically (`self::assertSame()`).
 !
 !        Both are valid, and we do not pick a side for you: switching an
 !        existing codebase from one to the other produces a huge diff.
 !
 !        Yet when you know which one your project follows, we can keep it
 !        consistent for you.

 Which call type do you use for PHPUnit methods? [none - do not enforce any]:
  [this  ] `$this->assertSame()`
  [self  ] `self::assertSame()`
  [static] `static::assertSame()`
  [none  ] none - do not enforce any
```

which lands in the created file as:

```php
    ->setRules([
        '@auto' => true,
        '@auto:risky' => true,
        'php_unit_test_case_static_method_calls' => ['call_type' => 'this']
    ])
```

To carry a configured rule next to the plain sets, `$rules` becomes a map of `name => PHP code of its configuration` instead of a list of names.

The command had no test at all, so this adds `InitCommandTest`, asserting the created file and the questions asked for every branch of the new one (call type picked, `none`, risky not allowed, no PHPUnit, no `composer.json`, broken `composer.json`), plus the pre-existing "configuration file already exists" failure. `InitCommand` therefore leaves the `ProjectCodeTest` exception list.
