### PR TITLE
fix: `ControlStructureBracesFixer` - do not read a body starting with a parenthesis as a condition

### DIFF
--- a/src/Fixer/ControlStructure/ControlStructureBracesFixer.php
+++ b/src/Fixer/ControlStructure/ControlStructureBracesFixer.php
@@ -42,6 +42,17 @@ final class ControlStructureBracesFixer extends AbstractFixer
         \T_SWITCH,
     ];
 
+    /**
+     * Control structures that take no condition, so that a parenthesis
+     * following one of them opens their body rather than closing a condition.
+     */
+    private const CONDITIONLESS_CONTROL_TOKENS = [
+        \T_DO,
+        \T_ELSE,
+        \T_FINALLY,
+        \T_TRY,
+    ];
+
     private const CONTROL_CONTINUATION_TOKENS = [
         \T_IF => [\T_ELSE, \T_ELSEIF],
         \T_DO => [\T_WHILE],
@@ -146,6 +157,10 @@ final class ControlStructureBracesFixer extends AbstractFixer
 
     private function findParenthesisEnd(Tokens $tokens, int $structureTokenIndex): int
     {
+        if ($tokens[$structureTokenIndex]->isGivenKind(self::CONDITIONLESS_CONTROL_TOKENS)) {
+            return $structureTokenIndex;
+        }
+
         $nextIndex = $tokens->getNextMeaningfulToken($structureTokenIndex);
         $nextToken = $tokens[$nextIndex];
 

--- a/tests/Fixer/ControlStructure/ControlStructureBracesFixerTest.php
+++ b/tests/Fixer/ControlStructure/ControlStructureBracesFixerTest.php
@@ -45,6 +45,21 @@ final class ControlStructureBracesFixerTest extends AbstractFixerTestCase
      */
     public static function provideFixCases(): iterable
     {
+        yield 'else with a body starting with a parenthesis' => [
+            '<?php if ($a) { b(); } else { (c() && d()) || e(); }',
+            '<?php if ($a) { b(); } else (c() && d()) || e();',
+        ];
+
+        yield 'nested bracesless control structures with such an else' => [
+            "<?php\nif (is_array(\$d)) {\n    foreach (\$d as \$x) {\n        (f(\$x) && g(\$x)) || h(\$x); } }\nelse {\n    (f(\$d) && g(\$d)) || h(\$d); }\n",
+            "<?php\nif (is_array(\$d))\n    foreach (\$d as \$x)\n        (f(\$x) && g(\$x)) || h(\$x);\nelse\n    (f(\$d) && g(\$d)) || h(\$d);\n",
+        ];
+
+        yield 'do with a body starting with a parenthesis' => [
+            '<?php do { (a() && b()) || c(); } while ($x);',
+            '<?php do (a() && b()) || c(); while ($x);',
+        ];
+
         yield 'if' => [
             '<?php if ($foo) { foo(); }',
             '<?php if ($foo) foo();',


### PR DESCRIPTION
else, do, try and finally take no condition, but findParenthesisEnd() accepts any parenthesis that follows the keyword. When such a body starts with a parenthesised expression, that expression is taken for the condition and the opening brace is inserted inside it.
 
```
  <?php
  if(is_array($d))
      foreach($d as $x)
              (f($x) && g($x)) || h($x);
  else
      (f($d) && g($d)) || h($d);

``` 
  becomes
```
  
  if(is_array($d)) {
      foreach($d as $x) {
              (f($x) && g($x)) || h($x); } }
  else
      (f($d) && g($d)) { || h($d); }
```
 
which does not parse, so the file is rejected by the linter and left untouched — running @PhpCsFixer over a project containing it reports "not fixed due to errors reported during linting after fixing" with no indication of what is wrong.
 
 findParenthesisEnd() now returns the structure token itself for those four keywords, as it already does when no parenthesis follows.