### PR TITLE
fix: `NoSpacesAfterFunctionNameFixer` - do not treat a control structure condition as a callee

### DIFF
--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -32,6 +32,21 @@ use PhpCsFixer\Tokenizer\Tokens;
 final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
 {
     /**
+     * Token kinds whose condition is wrapped in parentheses, so that a
+     * parenthesis following the closing one opens a statement, not a call.
+     */
+    private const CONTROL_STRUCTURE_TOKEN_KINDS = [
+        \T_CATCH,
+        \T_DECLARE,
+        \T_ELSEIF,
+        \T_FOR,
+        \T_FOREACH,
+        \T_IF,
+        \T_SWITCH,
+        \T_WHILE,
+    ];
+
+    /**
      * Token kinds which can work as function calls.
      */
     private const FUNCTIONY_TOKEN_KINDS = [
@@ -123,12 +138,31 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
                     Tokens::BLOCK_TYPE_INDEX_BRACE === $block['type']
                     || Tokens::BLOCK_TYPE_DYNAMIC_VAR_BRACE === $block['type']
                     || Tokens::BLOCK_TYPE_INDEX_BRACKET === $block['type']
-                    || Tokens::BLOCK_TYPE_PARENTHESIS === $block['type']
+                    || (
+                        Tokens::BLOCK_TYPE_PARENTHESIS === $block['type']
+                        && !$this->isControlStructureCondition($tokens, $lastTokenIndex)
+                    )
                 ) {
                     $this->fixFunctionCall($tokens, $index);
                 }
             }
         }
+    }
+
+    /**
+     * Tells whether the given closing parenthesis closes the condition of a
+     * control structure, e.g. the `)` of `foreach ($a as $b)`.
+     *
+     * @param Tokens $tokens       tokens to handle
+     * @param int    $closingIndex index of the closing parenthesis
+     */
+    private function isControlStructureCondition(Tokens $tokens, int $closingIndex): bool
+    {
+        $openingIndex = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS, $closingIndex);
+        $beforeOpeningIndex = $tokens->getPrevMeaningfulToken($openingIndex);
+
+        return null !== $beforeOpeningIndex
+            && $tokens[$beforeOpeningIndex]->isGivenKind(self::CONTROL_STRUCTURE_TOKEN_KINDS);
     }
 
     /**

--- a/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
@@ -53,6 +53,22 @@ final class NoSpacesAfterFunctionNameFixerTest extends AbstractFixerTestCase
             '<?php abc ($a);',
         ];
 
+        yield 'control structure body starting with a parenthesis' => [
+            '<?php if ($a) (f() && g()) || h();',
+        ];
+
+        yield 'loop body starting with a parenthesis' => [
+            '<?php foreach ($a as $b) (f() && g()) || h();',
+        ];
+
+        yield 'while body starting with a parenthesis' => [
+            '<?php while ($a) (f() && g()) || h();',
+        ];
+
+        yield 'for body starting with a parenthesis' => [
+            '<?php for ($i = 0; $i < 1; ++$i) (f() && g()) || h();',
+        ];
+
         yield 'test method call' => [
             '<?php $o->abc($a);',
             '<?php $o->abc ($a);',


### PR DESCRIPTION
 The branch that handles a call on the result of an expression, such as (function () {})(), accepts any preceding parenthesis block. The condition of if, while, for and foreach is such a block, so a body that starts with a parenthesis is pulled up onto the header as though it were an argument list:
 
```
  foreach ($d as $x)
      (f($x) && g($x)) || h($x);

``` 
  becomes 
`foreach ($d as $x)(f($x) && g($x)) || h($x);.`
 
  The result still parses, so this is a formatting bug rather than a correctness one on its own — but it feeds ControlStructureBracesFixer, which then has to brace a body that no longer looks like one.
 
  The parenthesis branch now skips conditions of control structures, using the same keyword list NoEmptyStatementFixer already applies for this.