### PR TITLE
fix: remove all empty lines with the `none` option in `ClassAttributesSeparationFixer`

### DIFF
--- a/doc/rules/class_notation/class_attributes_separation.rst
+++ b/doc/rules/class_notation/class_attributes_separation.rst
@@ -92,6 +92,27 @@ With configuration: ``['elements' => ['const' => 'one']]``.
 Example #4
 ~~~~~~~~~~
 
+With configuration: ``['elements' => ['property' => 'none']]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    class Sample
+    {
+        /** @var int|null */
+        private $foo1;
+   -
+        /** @var string|null */
+        private $foo2;
+   -
+        private $foo3;
+    }
+
+Example #5
+~~~~~~~~~~
+
 With configuration: ``['elements' => ['const' => 'only_if_meta']]``.
 
 .. code-block:: diff
@@ -112,7 +133,7 @@ With configuration: ``['elements' => ['const' => 'only_if_meta']]``.
         const DAY = 86400;
     }
 
-Example #5
+Example #6
 ~~~~~~~~~~
 
 With configuration: ``['elements' => ['property' => 'only_if_meta']]``.

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -133,6 +133,23 @@ final class ClassAttributesSeparationFixer extends AbstractFixer implements Conf
                         <?php
                         class Sample
                         {
+                            /** @var int|null */
+                            private $foo1;
+
+                            /** @var string|null */
+                            private $foo2;
+
+                            private $foo3;
+                        }
+
+                        PHP,
+                    ['elements' => ['property' => self::SPACING_NONE]],
+                ),
+                new CodeSample(
+                    <<<'PHP'
+                        <?php
+                        class Sample
+                        {
                             /** @var int */
                             const SECOND = 1;
                             /** @var int */
@@ -335,7 +352,7 @@ final class ClassAttributesSeparationFixer extends AbstractFixer implements Conf
             $nonWhiteAbove = $this->findCommentBlockStart($tokens, $nonWhiteAbove, $elementAboveEnd);
             $nonWhiteAboveComment = $tokens->getPrevNonWhitespace($nonWhiteAbove);
 
-            $this->correctLineBreaks($tokens, $nonWhiteAboveComment, $nonWhiteAbove, $nonWhiteAboveComment === $class['open'] ? 1 : 2);
+            $this->correctLineBreaks($tokens, $nonWhiteAboveComment, $nonWhiteAbove, $nonWhiteAboveComment === $class['open'] ? 1 : $this->determineRequiredLineCount($tokens, $class, $elementIndex));
 
             return;
         }
@@ -361,19 +378,13 @@ final class ClassAttributesSeparationFixer extends AbstractFixer implements Conf
             \assert(isset($class['elements'][$elementIndex + 1]));
             $aboveElement = $class['elements'][$elementIndex + 1];
 
-            if ($aboveElement['type'] !== $type) {
-                return 2;
-            }
-
-            $aboveElementDocCandidateIndex = $tokens->getPrevNonWhitespace($aboveElement['start']);
-
-            return $tokens[$aboveElementDocCandidateIndex]->isGivenKind([\T_DOC_COMMENT, CT::T_ATTRIBUTE_CLOSE]) ? 2 : 1;
+            return $aboveElement['type'] !== $type ? 2 : 1;
         }
 
         // self::SPACING_ONLY_IF_META === $spacing
-        $aboveElementDocCandidateIndex = $tokens->getPrevNonWhitespace($class['elements'][$elementIndex]['start']);
+        $currentElementDocCandidateIndex = $tokens->getPrevNonWhitespace($class['elements'][$elementIndex]['start']);
 
-        return $tokens[$aboveElementDocCandidateIndex]->isGivenKind([\T_DOC_COMMENT, CT::T_ATTRIBUTE_CLOSE]) ? 2 : 1;
+        return $tokens[$currentElementDocCandidateIndex]->isGivenKind([\T_DOC_COMMENT, CT::T_ATTRIBUTE_CLOSE]) ? 2 : 1;
     }
 
     /**

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -1101,7 +1101,6 @@ class Foo
 {
     /** A */
     private $email;
-
     private $foo0; #0 /* test */
     private $foo1; #1
     private $foo2; /* @2 */
@@ -1128,10 +1127,8 @@ class Foo
 {
     /** @var int */
     const FOO = 1;
-
     /** @var int */
     const BAR = 2;
-
     const BAZ = 3;
     const OTHER = 4;
     const OTHER2 = 5;
@@ -1422,6 +1419,10 @@ abstract class Example
                     {
                         function A() {}
                         function B() {}
+                        /**
+                         * Doc block.
+                         */
+                        function foo() {}
                     }
                 ',
             '<?php
@@ -1430,6 +1431,11 @@ abstract class Example
                         function A() {}
 
                         function B() {}
+
+                        /**
+                         * Doc block.
+                         */
+                        function foo() {}
                     }
                 ',
             ['elements' => ['method' => 'none']],
@@ -2020,9 +2026,12 @@ class Foo
 {
     #[Assert\Email(["message" => "Foo"])]
     private $email;
-
     private $foo1; #1
     private $foo2; /* @2 */
+    /** @var int|null */
+    private $bar1;
+    /** @var string|null */
+    private $bar2;
 }',
             '<?php
 class Foo
@@ -2034,6 +2043,12 @@ class Foo
     private $foo1; #1
 
     private $foo2; /* @2 */
+
+    /** @var int|null */
+    private $bar1;
+
+    /** @var string|null */
+    private $bar2;
 }',
             ['elements' => ['property' => 'none']],
         ];


### PR DESCRIPTION
It seems to me that in cases where the `none` option is explicitly specified, all empty lines should be removed.
In my opinion, the meta should only be taken into account with the `only_if_meta` option.