### PR TITLE
fix: `IsNullFixer` - handle is_null() calls using named arguments

### DIFF
--- a/src/Fixer/LanguageConstruct/IsNullFixer.php
+++ b/src/Fixer/LanguageConstruct/IsNullFixer.php
@@ -30,6 +30,11 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 final class IsNullFixer extends AbstractFixer
 {
+    /**
+     * Name of the single parameter of `is_null()`.
+     */
+    private const PARAMETER_NAME = 'value';
+
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
@@ -95,12 +100,19 @@ final class IsNullFixer extends AbstractFixer
 
             $referenceEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $matches[1]);
 
-            // skip named argument, as the argument name cannot be preserved by the transformation;
             // `is_null()` takes a single parameter, so only the first token inside the parentheses can carry a name
             $possibleNamedArgumentColonIndex = $tokens->getNextMeaningfulToken($next);
 
             if (null !== $possibleNamedArgumentColonIndex && $tokens[$possibleNamedArgumentColonIndex]->isGivenKind(CT::T_NAMED_ARGUMENT_COLON)) {
-                continue;
+                // a name other than the one `is_null()` declares does not resolve to its parameter, so leave such call as is
+                if (!$tokens[$next]->equals([CT::T_NAMED_ARGUMENT_NAME, self::PARAMETER_NAME], true)) {
+                    continue;
+                }
+
+                // the name is redundant for a single-parameter call, drop it to not break the transformation
+                $tokens->clearTokenAndMergeSurroundingWhitespace($possibleNamedArgumentColonIndex);
+                $tokens->clearTokenAndMergeSurroundingWhitespace($next);
+                $tokens->removeTrailingWhitespace($matches[1]);
             }
 
             $prevTokenIndex = $tokens->getPrevMeaningfulToken($matches[0]);

--- a/src/Fixer/LanguageConstruct/IsNullFixer.php
+++ b/src/Fixer/LanguageConstruct/IsNullFixer.php
@@ -19,6 +19,7 @@ use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -92,6 +93,15 @@ final class IsNullFixer extends AbstractFixer
                 continue;
             }
 
+            $referenceEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $matches[1]);
+
+            // skip named arguments, as the argument name cannot be preserved by the transformation
+            for ($namedArgumentTokenIndex = $matches[1]; $namedArgumentTokenIndex <= $referenceEnd; ++$namedArgumentTokenIndex) {
+                if ($tokens[$namedArgumentTokenIndex]->isGivenKind(CT::T_NAMED_ARGUMENT_COLON)) {
+                    continue 2;
+                }
+            }
+
             $prevTokenIndex = $tokens->getPrevMeaningfulToken($matches[0]);
 
             // handle function references with namespaces
@@ -114,7 +124,6 @@ final class IsNullFixer extends AbstractFixer
             }
 
             // before getting rind of `()` around a parameter, ensure it's not assignment/ternary invariant
-            $referenceEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $matches[1]);
             $isContainingDangerousConstructs = false;
 
             for ($paramTokenIndex = $matches[1]; $paramTokenIndex <= $referenceEnd; ++$paramTokenIndex) {

--- a/src/Fixer/LanguageConstruct/IsNullFixer.php
+++ b/src/Fixer/LanguageConstruct/IsNullFixer.php
@@ -95,11 +95,12 @@ final class IsNullFixer extends AbstractFixer
 
             $referenceEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $matches[1]);
 
-            // skip named arguments, as the argument name cannot be preserved by the transformation
-            for ($namedArgumentTokenIndex = $matches[1]; $namedArgumentTokenIndex <= $referenceEnd; ++$namedArgumentTokenIndex) {
-                if ($tokens[$namedArgumentTokenIndex]->isGivenKind(CT::T_NAMED_ARGUMENT_COLON)) {
-                    continue 2;
-                }
+            // skip named argument, as the argument name cannot be preserved by the transformation;
+            // `is_null()` takes a single parameter, so only the first token inside the parentheses can carry a name
+            $possibleNamedArgumentColonIndex = $tokens->getNextMeaningfulToken($next);
+
+            if (null !== $possibleNamedArgumentColonIndex && $tokens[$possibleNamedArgumentColonIndex]->isGivenKind(CT::T_NAMED_ARGUMENT_COLON)) {
+                continue;
             }
 
             $prevTokenIndex = $tokens->getPrevMeaningfulToken($matches[0]);

--- a/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
@@ -320,12 +320,32 @@ final class IsNullFixerTest extends AbstractFixerTestCase
      */
     public static function provideFix80Cases(): iterable
     {
-        yield 'named argument is left untouched' => [
-            '<?php $x = is_null(value: $x);',
+        yield 'named argument matching the parameter name is fixed' => [
+            '<?php $x = null === $y;',
+            '<?php $x = is_null(value: $y);',
         ];
 
-        yield 'inverted named argument is left untouched' => [
-            '<?php $x = !is_null(value: $x);',
+        yield 'inverted named argument matching the parameter name is fixed' => [
+            '<?php $x = null !== $y;',
+            '<?php $x = !is_null(value: $y);',
+        ];
+
+        yield 'named argument with extra whitespace and trailing comma is fixed' => [
+            '<?php $x = null === $y;',
+            '<?php $x = is_null(  value:   $y ,  );',
+        ];
+
+        yield 'named argument wrapping an expression is fixed' => [
+            '<?php $x = null === ($y ?? $z);',
+            '<?php $x = is_null(value: $y ?? $z);',
+        ];
+
+        yield 'named argument not matching the parameter name is left untouched' => [
+            '<?php $x = is_null(notValue: $y);',
+        ];
+
+        yield 'named argument matching the parameter name only case-insensitively is left untouched' => [
+            '<?php $x = is_null(Value: $y);',
         ];
 
         yield 'named argument in a nested call is still fixed' => [

--- a/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
@@ -304,6 +304,32 @@ final class IsNullFixerTest extends AbstractFixerTestCase
     }
 
     /**
+     * @dataProvider provideFix80Cases
+     *
+     * @requires PHP >= 8.0
+     */
+    #[DataProvider('provideFix80Cases')]
+    #[RequiresPhp('>= 8.0.0')]
+    public function testFix80(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1?: string}>
+     */
+    public static function provideFix80Cases(): iterable
+    {
+        yield 'named argument is left untouched' => [
+            '<?php $x = is_null(value: $x);',
+        ];
+
+        yield 'inverted named argument is left untouched' => [
+            '<?php $x = !is_null(value: $x);',
+        ];
+    }
+
+    /**
      * @dataProvider provideFix81Cases
      *
      * @requires PHP >= 8.1.0

--- a/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
@@ -306,7 +306,7 @@ final class IsNullFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFix80Cases
      *
-     * @requires PHP >= 8.0
+     * @requires PHP >= 8.0.0
      */
     #[DataProvider('provideFix80Cases')]
     #[RequiresPhp('>= 8.0.0')]
@@ -326,6 +326,11 @@ final class IsNullFixerTest extends AbstractFixerTestCase
 
         yield 'inverted named argument is left untouched' => [
             '<?php $x = !is_null(value: $x);',
+        ];
+
+        yield 'named argument in a nested call is still fixed' => [
+            '<?php $x = null === strlen(string: $y);',
+            '<?php $x = is_null(strlen(string: $y));',
         ];
     }
 


### PR DESCRIPTION
When \`is_null()\` is called with the \`value:\` named argument, the fixer strips the parentheses and inserts \`null ===\`/\`null !==\` before the remaining tokens without removing the argument name, producing \`null === value: $x\`, which is invalid PHP. It now skips the transformation whenever a named argument colon is found inside the call.

Fixes #9827