### PR TITLE
fix: `IsNullFixer` - do not fix is_null() calls using argument unpacking

### DIFF
--- a/src/Fixer/LanguageConstruct/IsNullFixer.php
+++ b/src/Fixer/LanguageConstruct/IsNullFixer.php
@@ -98,6 +98,11 @@ final class IsNullFixer extends AbstractFixer
                 continue;
             }
 
+            // an unpacked argument is not a value that can be compared to `null`, so leave such call as is
+            if ($tokens[$next]->isGivenKind(\T_ELLIPSIS)) {
+                continue;
+            }
+
             $referenceEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $matches[1]);
 
             // `is_null()` takes a single parameter, so only the first token inside the parentheses can carry a name

--- a/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
@@ -301,6 +301,19 @@ final class IsNullFixerTest extends AbstractFixerTestCase
             '<?php $a === (int) (null === $x) + (int) (null !== $y);',
             '<?php $a === (int) is_null($x) + (int) !is_null($y);',
         ];
+
+        yield [
+            '<?php $a = is_null(...$args);',
+        ];
+
+        yield [
+            '<?php $a = !is_null(...$args);',
+        ];
+
+        yield [
+            '<?php $a = null === strlen(...$args);',
+            '<?php $a = is_null(strlen(...$args));',
+        ];
     }
 
     /**

--- a/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
@@ -302,12 +302,17 @@ final class IsNullFixerTest extends AbstractFixerTestCase
             '<?php $a === (int) is_null($x) + (int) !is_null($y);',
         ];
 
+        // argument unpacking
         yield [
             '<?php $a = is_null(...$args);',
         ];
 
         yield [
             '<?php $a = !is_null(...$args);',
+        ];
+
+        yield [
+            '<?php $a = \is_null(...$args);',
         ];
 
         yield [


### PR DESCRIPTION
`is_null(...$args)` was rewritten to `null === ...$args`, which is not valid PHP. Argument unpacking spreads a variadic list rather than passing a single value, so the call has no comparable operand and the fixer now leaves it alone.

Fixes #9829
