### PR TITLE
fix: handle missing terminator after `??` in `AssignNullCoalescingToCoalesceEqualFixer`

### DIFF
--- a/src/Fixer/Operator/AssignNullCoalescingToCoalesceEqualFixer.php
+++ b/src/Fixer/Operator/AssignNullCoalescingToCoalesceEqualFixer.php
@@ -64,7 +64,7 @@ final class AssignNullCoalescingToCoalesceEqualFixer extends AbstractShortOperat
 
         $nextIndex = $tokens->getNextTokenOfKind($index, ['?', ';', [\T_CLOSE_TAG]]);
 
-        return !$tokens[$nextIndex]->equals('?');
+        return null === $nextIndex || !$tokens[$nextIndex]->equals('?');
     }
 
     protected function getReplacementToken(Token $token): Token

--- a/tests/Fixer/Operator/AssignNullCoalescingToCoalesceEqualFixerTest.php
+++ b/tests/Fixer/Operator/AssignNullCoalescingToCoalesceEqualFixerTest.php
@@ -195,6 +195,18 @@ final class AssignNullCoalescingToCoalesceEqualFixerTest extends AbstractFixerTe
             ',
         ];
 
+        yield 'do not fix, no ";", "?" nor close tag after "??"' => [
+            '<?php
+                foreach ($a ?? [] as $b) {}
+                while ($a ?? false) {}
+            ',
+        ];
+
+        yield 'assignment, no ";", "?" nor close tag after "??"' => [
+            '<?php if ($a ??= 1) {}',
+            '<?php if ($a = $a ?? 1) {}',
+        ];
+
         yield 'do not fix because of precedence 1' => [
             '<?php $a = $a ?? $b ? $c : $d;',
         ];


### PR DESCRIPTION
Hello!


`isOperatorTokenCandidate()` searches forward from the `??` for `?`, `;` or `T_CLOSE_TAG` to rule out a `? :` ternary, then dereferences the result without a null check. Valid code can have none of those tokens after a `??`, e.g. `foreach ($a ?? [] as $b) {}`, where the coalesce is followed only by `)`, `{` and `}`. `getNextTokenOfKind()` then returns null and `$tokens[null]` throws "Cannot access offset of type null on SplFixedArray", aborting the run for the whole file.

When no such token is found there is no ternary to worry about, so the operator is a candidate.

Thanks!