### PR TITLE
feat: add `GitHubReporter`

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -58,20 +58,22 @@ which will use the intersection of the paths from the config file and from the a
 
     php php-cs-fixer.phar fix --path-mode=intersection /path/to/dir
 
-The ``--format`` option for the output format. Supported formats are ``@auto`` (default one on v4+), ``txt`` (default one on v3), ``checkstyle``, ``gitlab``, ``json``, ``junit`` and ``xml``.
+The ``--format`` option for the output format. Supported formats are ``@auto`` (default one on v4+), ``txt`` (default one on v3), ``checkstyle``, ``github``, ``gitlab``, ``json``, ``junit`` and ``xml``.
 
 * ``@auto`` aims to auto-select best reporter for given CI or local execution (resolution into best format is outside of BC promise and is future-ready)
 
+  * ``github`` when running in GitHub Actions
   * ``gitlab`` when running in GitLab CI
-  * best fit for the AI agent (currently: ``json``) when running in an AI agent (for example, when the ``AI_AGENT`` environment variable, or another popular one, is set), unless running in GitLab CI
+  * best fit for the AI agent (currently: ``json``) when running in an AI agent (for example, when the ``AI_AGENT`` environment variable, or another popular one, is set), unless running in GitHub Actions or GitLab CI
 
 * ``@auto,{format}`` takes ``@auto`` under CI, and {format} otherwise
 
-Agent detection only applies when the format is resolved automatically (``@auto``); an explicitly selected format (for example, ``--format=txt``) is never overridden. When both GitLab CI and an AI agent are detected, GitLab CI takes precedence and the format resolves to ``gitlab``.
+Agent detection only applies when the format is resolved automatically (``@auto``); an explicitly selected format (for example, ``--format=txt``) is never overridden. When several environments are detected at once, GitHub Actions takes precedence over GitLab CI, and both take precedence over an AI agent.
 
 NOTE: the output for the following formats are generated in accordance with schemas
 
 * ``checkstyle`` follows the common `"checkstyle" XML schema </doc/schemas/fix/checkstyle.xsd>`_
+* ``github`` follows the `GitHub Actions workflow commands <https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message>`_
 * ``gitlab`` follows the `codeclimate JSON schema </doc/schemas/fix/codeclimate.json>`_
 * ``json`` follows the `own JSON schema </doc/schemas/fix/schema.json>`_
 * ``junit`` follows the `JUnit XML schema from Jenkins </doc/schemas/fix/junit-10.xsd>`_
@@ -276,6 +278,12 @@ Then, add the following command to your CI:
     vendor/bin/php-cs-fixer check --config=.php-cs-fixer.dist.php -v --show-progress=dots --stop-on-violation --using-cache=no ${EXTRA_ARGS}
 
 Where ``$COMMIT_RANGE`` is your range of commits, e.g. ``${{github.event.before}}...${{github.event.after}}`` or ``HEAD~..HEAD``.
+
+GitHub Actions Workflow Commands Integration
+############################################
+
+If you want to integrate with GitHub Actions' workflow commands, in order for the report to contain correct line numbers, you
+will need to use both ``--format=github`` and ``--diff`` arguments.
 
 GitLab Code Quality Integration
 ###############################

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -106,15 +106,17 @@ use Symfony\Component\Stopwatch\Stopwatch;
 
                 <info>$ php %command.full_name% --path-mode=intersection /path/to/dir</info>
 
-            The <comment>--format</comment> option for the output format. Supported formats are `@auto` (default one on v4+), `txt` (default one on v3), `json`, `xml`, `checkstyle`, `junit` and `gitlab`.
+            The <comment>--format</comment> option for the output format. Supported formats are `@auto` (default one on v4+), `txt` (default one on v3), `json`, `xml`, `checkstyle`, `junit`, `github` and `gitlab`.
 
             * `@auto` aims to auto-select best reporter for given CI or local execution (resolution into best format is outside of BC promise and is future-ready)
+              * `github` for GitHub Actions
               * `gitlab` for GitLab
             * `@auto,{format}` takes `@auto` under CI, and {format} otherwise
 
             NOTE: the output for the following formats are generated in accordance with schemas
 
             * `checkstyle` follows the common `"checkstyle" XML schema </doc/schemas/fix/checkstyle.xsd>`_
+            * `github` follows the `GitHub Actions workflow commands <https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message>`_
             * `gitlab` follows the `codeclimate JSON schema </doc/schemas/fix/codeclimate.json>`_
             * `json` follows the `own JSON schema </doc/schemas/fix/schema.json>`_
             * `junit` follows the `JUnit XML schema from Jenkins </doc/schemas/fix/junit-10.xsd>`_

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -680,6 +680,12 @@ final class ConfigurationResolver
             $this->format = $parts[0];
 
             if ('@auto' === $this->format) {
+                if (filter_var(getenv('GITHUB_ACTIONS'), \FILTER_VALIDATE_BOOL)) {
+                    $this->format = 'github';
+
+                    return $this->format;
+                }
+
                 if (filter_var(getenv('GITLAB_CI'), \FILTER_VALIDATE_BOOL)) {
                     $this->format = 'gitlab';
 

--- a/src/Console/Report/FixReport/GitHubReporter.php
+++ b/src/Console/Report/FixReport/GitHubReporter.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Console\Report\FixReport;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerFactory;
+use SebastianBergmann\Diff\Parser;
+
+/**
+ * Generates a report in the GitHub Actions workflow command format, so that
+ * findings are rendered as file annotations on pull requests.
+ *
+ * @author HypeMC <hypemc@gmail.com>
+ *
+ * @see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+ *
+ * @readonly
+ *
+ * @internal
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+final class GitHubReporter implements ReporterInterface
+{
+    private Parser $diffParser;
+
+    /**
+     * @var array<string, FixerInterface>
+     */
+    private array $fixers;
+
+    public function __construct()
+    {
+        $this->diffParser = new Parser();
+
+        $fixerFactory = new FixerFactory();
+        $fixerFactory->registerBuiltInFixers();
+
+        $this->fixers = $this->createFixers($fixerFactory);
+    }
+
+    public function getFormat(): string
+    {
+        return 'github';
+    }
+
+    /**
+     * Process changed files array. Returns generated report.
+     */
+    public function generate(ReportSummary $reportSummary): string
+    {
+        $report = '';
+
+        foreach ($reportSummary->getChanged() as $fileName => $change) {
+            $lines = LineExtractor::getLines(
+                array_values( // before PHPUnit 13, result of `->parse(...)` is array and not list
+                    $this->diffParser->parse($change['diff']),
+                ),
+            );
+
+            foreach ($change['appliedFixers'] as $fixerName) {
+                $fixer = $this->fixers[$fixerName] ?? null;
+
+                $title = 'PHP-CS-Fixer.'.$fixerName;
+                $message = null !== $fixer
+                    ? $fixer->getDefinition()->getSummary()
+                    : $title.' (custom rule)';
+
+                $report .= \sprintf(
+                    '::error file=%s,line=%d,title=%s::%s',
+                    self::escapeProperty($fileName),
+                    $lines['begin'],
+                    self::escapeProperty($title),
+                    self::escapeData($message),
+                ).\PHP_EOL;
+            }
+        }
+
+        return $report;
+    }
+
+    /**
+     * Escape a workflow command property value.
+     *
+     * @see https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts
+     */
+    private static function escapeProperty(string $value): string
+    {
+        return str_replace(
+            ['%', "\r", "\n", ':', ','],
+            ['%25', '%0D', '%0A', '%3A', '%2C'],
+            $value,
+        );
+    }
+
+    /**
+     * Escape a workflow command message (data) value.
+     *
+     * @see https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts
+     */
+    private static function escapeData(string $value): string
+    {
+        return str_replace(
+            ['%', "\r", "\n"],
+            ['%25', '%0D', '%0A'],
+            $value,
+        );
+    }
+
+    /**
+     * @return array<string, FixerInterface>
+     */
+    private function createFixers(FixerFactory $fixerFactory): array
+    {
+        $fixers = [];
+
+        foreach ($fixerFactory->getFixers() as $fixer) {
+            $fixers[$fixer->getName()] = $fixer;
+        }
+
+        ksort($fixers);
+
+        return $fixers;
+    }
+}

--- a/src/Console/Report/FixReport/GitlabReporter.php
+++ b/src/Console/Report/FixReport/GitlabReporter.php
@@ -18,9 +18,6 @@ use PhpCsFixer\Console\Application;
 use PhpCsFixer\Documentation\DocumentationLocator;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerFactory;
-use SebastianBergmann\Diff\Chunk;
-use SebastianBergmann\Diff\Diff;
-use SebastianBergmann\Diff\Line;
 use SebastianBergmann\Diff\Parser;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 
@@ -99,7 +96,7 @@ final class GitlabReporter implements ReporterInterface
                     'severity' => 'minor',
                     'location' => [
                         'path' => $fileName,
-                        'lines' => self::getLines(
+                        'lines' => LineExtractor::getLines(
                             array_values( // before PHPUnit 13, result of `->parse(...)` is array and not list
                                 $this->diffParser->parse($change['diff']),
                             ),
@@ -112,52 +109,6 @@ final class GitlabReporter implements ReporterInterface
         $jsonString = json_encode($report, \JSON_THROW_ON_ERROR);
 
         return $reportSummary->isDecoratedOutput() ? OutputFormatter::escape($jsonString) : $jsonString;
-    }
-
-    /**
-     * @param list<Diff> $diffs
-     *
-     * @return array{begin: int, end: int}
-     */
-    private static function getLines(array $diffs): array
-    {
-        if (isset($diffs[0])) {
-            $firstDiff = $diffs[0];
-
-            $firstChunk = \Closure::bind(static fn (Diff $diff) => array_shift($diff->chunks), null, $firstDiff)($firstDiff);
-
-            if ($firstChunk instanceof Chunk) {
-                return self::getBeginEndForDiffChunk($firstChunk);
-            }
-        }
-
-        return ['begin' => 0, 'end' => 0];
-    }
-
-    /**
-     * @return array{begin: int, end: int}
-     */
-    private static function getBeginEndForDiffChunk(Chunk $chunk): array
-    {
-        $start = \Closure::bind(static fn (Chunk $chunk): int => $chunk->start, null, $chunk)($chunk);
-        $startRange = \Closure::bind(static fn (Chunk $chunk): int => $chunk->startRange, null, $chunk)($chunk);
-        $lines = \Closure::bind(static fn (Chunk $chunk): array => $chunk->lines, null, $chunk)($chunk);
-
-        \assert(\count($lines) > 0);
-
-        $firstModifiedLineOffset = array_find_key($lines, static function (Line $line): bool {
-            $type = \Closure::bind(static fn (Line $line): int => $line->type, null, $line)($line);
-
-            return Line::UNCHANGED !== $type;
-        });
-        \assert(\is_int($firstModifiedLineOffset));
-
-        return [
-            // offset the start by where the first line is actually modified
-            'begin' => $start + $firstModifiedLineOffset,
-            // it's not where last modification takes place, only where diff (with --context) ends
-            'end' => $start + $startRange,
-        ];
     }
 
     /**

--- a/src/Console/Report/FixReport/LineExtractor.php
+++ b/src/Console/Report/FixReport/LineExtractor.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Console\Report\FixReport;
+
+use SebastianBergmann\Diff\Chunk;
+use SebastianBergmann\Diff\Diff;
+use SebastianBergmann\Diff\Line;
+
+/**
+ * Extracts the modified line range out of a parsed diff, shared by reporters
+ * that annotate findings with line numbers (GitLab, GitHub).
+ *
+ * @author Hans-Christian Otto <c.otto@suora.com>
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @readonly
+ *
+ * @internal
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+final class LineExtractor
+{
+    /**
+     * @param list<Diff> $diffs
+     *
+     * @return array{begin: int, end: int}
+     */
+    public static function getLines(array $diffs): array
+    {
+        if (isset($diffs[0])) {
+            $firstDiff = $diffs[0];
+
+            $firstChunk = \Closure::bind(static fn (Diff $diff) => array_shift($diff->chunks), null, $firstDiff)($firstDiff);
+
+            if ($firstChunk instanceof Chunk) {
+                return self::getBeginEndForDiffChunk($firstChunk);
+            }
+        }
+
+        return ['begin' => 0, 'end' => 0];
+    }
+
+    /**
+     * @return array{begin: int, end: int}
+     */
+    private static function getBeginEndForDiffChunk(Chunk $chunk): array
+    {
+        $start = \Closure::bind(static fn (Chunk $chunk): int => $chunk->start, null, $chunk)($chunk);
+        $startRange = \Closure::bind(static fn (Chunk $chunk): int => $chunk->startRange, null, $chunk)($chunk);
+        $lines = \Closure::bind(static fn (Chunk $chunk): array => $chunk->lines, null, $chunk)($chunk);
+
+        \assert(\count($lines) > 0);
+
+        $firstModifiedLineOffset = array_find_key($lines, static function (Line $line): bool {
+            $type = \Closure::bind(static fn (Line $line): int => $line->type, null, $line)($line);
+
+            return Line::UNCHANGED !== $type;
+        });
+        \assert(\is_int($firstModifiedLineOffset));
+
+        return [
+            // offset the start by where the first line is actually modified
+            'begin' => $start + $firstModifiedLineOffset,
+            // it's not where last modification takes place, only where diff (with --context) ends
+            'end' => $start + $startRange,
+        ];
+    }
+}

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -23,6 +23,7 @@ use PhpCsFixer\Console\Command\FixCommand;
 use PhpCsFixer\Console\ConfigurationResolver;
 use PhpCsFixer\Console\Output\Progress\ProgressOutputType;
 use PhpCsFixer\Console\Report\FixReport\CheckstyleReporter;
+use PhpCsFixer\Console\Report\FixReport\GitHubReporter;
 use PhpCsFixer\Console\Report\FixReport\GitlabReporter;
 use PhpCsFixer\Console\Report\FixReport\JsonReporter;
 use PhpCsFixer\Console\Report\FixReport\TextReporter;
@@ -311,7 +312,7 @@ final class ConfigurationResolverTest extends TestCase
     public function testResolveConfigFileChooseFileWithInvalidFormat(): void
     {
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessageMatches('/^The format "xls" is not defined, supported are "checkstyle", "gitlab", "json", "junit", "txt" and "xml"\.$/');
+        $this->expectExceptionMessageMatches('/^The format "xls" is not defined, supported are "checkstyle", "github", "gitlab", "json", "junit", "txt" and "xml"\.$/');
 
         $dirBase = self::getFixtureDir();
 
@@ -1543,7 +1544,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         yield [
             TextReporter::class,
             '@auto',
-            ['GITLAB_CI' => ''],
+            ['GITHUB_ACTIONS' => '', 'GITLAB_CI' => ''],
         ];
 
         yield [
@@ -1551,14 +1552,39 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
             '@auto',
             [
                 'AI_AGENT' => 'true',
+                'GITHUB_ACTIONS' => '',
                 'GITLAB_CI' => '',
+            ],
+        ];
+
+        yield [
+            GitHubReporter::class,
+            '@auto',
+            ['GITHUB_ACTIONS' => 'true'],
+        ];
+
+        yield [
+            GitHubReporter::class,
+            '@auto',
+            [
+                'AI_AGENT' => 'true',
+                'GITHUB_ACTIONS' => 'true',
+            ],
+        ];
+
+        yield [
+            GitHubReporter::class,
+            '@auto',
+            [
+                'GITHUB_ACTIONS' => 'true',
+                'GITLAB_CI' => 'true',
             ],
         ];
 
         yield [
             GitlabReporter::class,
             '@auto',
-            ['GITLAB_CI' => 'true'],
+            ['GITHUB_ACTIONS' => '', 'GITLAB_CI' => 'true'],
         ];
 
         yield [
@@ -1566,6 +1592,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
             '@auto',
             [
                 'AI_AGENT' => 'true',
+                'GITHUB_ACTIONS' => '',
                 'GITLAB_CI' => 'true',
             ],
         ];
@@ -1573,12 +1600,13 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         yield [
             JsonReporter::class,
             '@auto,json',
+            ['GITHUB_ACTIONS' => '', 'GITLAB_CI' => ''],
         ];
 
         yield [
             JsonReporter::class,
             '@auto,json',
-            ['AI_AGENT' => 'true'],
+            ['AI_AGENT' => 'true', 'GITHUB_ACTIONS' => '', 'GITLAB_CI' => ''],
         ];
     }
 

--- a/tests/Console/Report/FixReport/GitHubReporterTest.php
+++ b/tests/Console/Report/FixReport/GitHubReporterTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Console\Report\FixReport;
+
+use PhpCsFixer\Console\Report\FixReport\GitHubReporter;
+use PhpCsFixer\Console\Report\FixReport\ReporterInterface;
+use PhpCsFixer\Console\Report\FixReport\ReportSummary;
+use PhpCsFixer\Fixer\Basic\EncodingFixer;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @author HypeMC <hypemc@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Console\Report\FixReport\GitHubReporter
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+#[CoversClass(GitHubReporter::class)]
+final class GitHubReporterTest extends AbstractReporterTestCase
+{
+    /**
+     * For a built-in fixer the annotation message is the fixer's summary
+     * (custom rules fall back to the "(custom rule)" message).
+     */
+    public function testGeneratedReportUsesBuiltInFixerSummaryAsMessage(): void
+    {
+        $fixer = new EncodingFixer();
+
+        $reportSummary = new ReportSummary(
+            [
+                'someFile.php' => [
+                    'appliedFixers' => [$fixer->getName()],
+                    'diff' => '',
+                ],
+            ],
+            10,
+            0,
+            0,
+            false,
+            false,
+            false,
+        );
+
+        self::assertSame(
+            \sprintf(
+                '::error file=someFile.php,line=0,title=PHP-CS-Fixer.%s::%s',
+                $fixer->getName(),
+                $fixer->getDefinition()->getSummary(),
+            ).\PHP_EOL,
+            $this->createReporter()->generate($reportSummary),
+        );
+    }
+
+    /**
+     * Characters that are meaningful in the workflow command syntax must be
+     * percent-encoded so they cannot break out of the `::error ...::` command.
+     */
+    public function testGeneratedReportEscapesWorkflowCommandCharacters(): void
+    {
+        $reportSummary = new ReportSummary(
+            [
+                "weird %:,\nname.php" => [
+                    'appliedFixers' => ['some_fixer_name_here'],
+                    'diff' => '',
+                ],
+            ],
+            10,
+            0,
+            0,
+            false,
+            false,
+            false,
+        );
+
+        self::assertSame(
+            '::error file=weird %25%3A%2C%0Aname.php,line=0,title=PHP-CS-Fixer.some_fixer_name_here::PHP-CS-Fixer.some_fixer_name_here (custom rule)'.\PHP_EOL,
+            $this->createReporter()->generate($reportSummary),
+        );
+    }
+
+    protected function createReporter(): ReporterInterface
+    {
+        return new GitHubReporter();
+    }
+
+    protected function getFormat(): string
+    {
+        return 'github';
+    }
+
+    protected static function createNoErrorReport(): string
+    {
+        return '';
+    }
+
+    protected static function createSimpleReport(): string
+    {
+        return '::error file=someFile.php,line=5,title=PHP-CS-Fixer.some_fixer_name_here::PHP-CS-Fixer.some_fixer_name_here (custom rule)'.\PHP_EOL;
+    }
+
+    protected static function createWithDiffReport(): string
+    {
+        return self::createSimpleReport();
+    }
+
+    protected static function createWithAppliedFixersReport(): string
+    {
+        return '::error file=someFile.php,line=0,title=PHP-CS-Fixer.some_fixer_name_here_1::PHP-CS-Fixer.some_fixer_name_here_1 (custom rule)'.\PHP_EOL
+            .'::error file=someFile.php,line=0,title=PHP-CS-Fixer.some_fixer_name_here_2::PHP-CS-Fixer.some_fixer_name_here_2 (custom rule)'.\PHP_EOL;
+    }
+
+    protected static function createWithTimeAndMemoryReport(): string
+    {
+        return self::createSimpleReport();
+    }
+
+    protected static function createComplexReport(): string
+    {
+        return '::error file=someFile.php,line=0,title=PHP-CS-Fixer.some_fixer_name_here_1::PHP-CS-Fixer.some_fixer_name_here_1 (custom rule)'.\PHP_EOL
+            .'::error file=someFile.php,line=0,title=PHP-CS-Fixer.some_fixer_name_here_2::PHP-CS-Fixer.some_fixer_name_here_2 (custom rule)'.\PHP_EOL
+            .'::error file=anotherFile.php,line=0,title=PHP-CS-Fixer.another_fixer_name_here::PHP-CS-Fixer.another_fixer_name_here (custom rule)'.\PHP_EOL;
+    }
+
+    protected static function createDryRunWithNoTimeReport(): string
+    {
+        return '';
+    }
+
+    protected function assertFormat(string $expected, string $input): void
+    {
+        self::assertSame($expected, $input);
+    }
+}

--- a/tests/Console/Report/FixReport/LineExtractorTest.php
+++ b/tests/Console/Report/FixReport/LineExtractorTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Console\Report\FixReport;
+
+use PhpCsFixer\Console\Report\FixReport\LineExtractor;
+use PhpCsFixer\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SebastianBergmann\Diff\Parser;
+
+/**
+ * @author HypeMC <hypemc@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Console\Report\FixReport\LineExtractor
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+#[CoversClass(LineExtractor::class)]
+final class LineExtractorTest extends TestCase
+{
+    /**
+     * @param array{begin: int, end: int} $expected
+     *
+     * @dataProvider provideGetLinesCases
+     */
+    #[DataProvider('provideGetLinesCases')]
+    public function testGetLines(array $expected, string $diff): void
+    {
+        $parser = new Parser();
+
+        self::assertSame($expected, LineExtractor::getLines(array_values($parser->parse($diff))));
+    }
+
+    /**
+     * @return iterable<string, array{array{begin: int, end: int}, string}>
+     */
+    public static function provideGetLinesCases(): iterable
+    {
+        yield 'empty diff' => [
+            ['begin' => 0, 'end' => 0],
+            '',
+        ];
+
+        yield 'simple diff' => [
+            ['begin' => 5, 'end' => 9],
+            '--- Original
++++ New
+@@ -2,7 +2,7 @@
+
+ class Foo
+ {
+-    public function bar($foo = 1, $bar)
++    public function bar($foo, $bar)
+     {
+     }
+ }',
+        ];
+
+        yield 'diff with multiple chunks (only first one is used)' => [
+            ['begin' => 5, 'end' => 9],
+            '--- Original
++++ New
+@@ -2,7 +2,7 @@
+
+ class Foo
+ {
+-    public function bar($foo = 1, $bar)
++    public function bar($foo, $bar)
+     {
+     }
+ }
+@@ -12,4 +12,4 @@
+ {
+-    public function baz()
++    public function qux()
+     {
+     }',
+        ];
+
+        yield 'diff with modification on the first line of the chunk' => [
+            ['begin' => 2, 'end' => 6],
+            '--- Original
++++ New
+@@ -2,4 +2,4 @@
+-class Foo
++class Bar
+ {
+ }',
+        ];
+
+        yield 'diff with modification after some unchanged lines' => [
+            ['begin' => 8, 'end' => 13],
+            '--- Original
++++ New
+@@ -8,5 +8,5 @@
+-        $a = 1;
++        $a = 2;
+         $b = 2;
+     }',
+        ];
+    }
+}

--- a/tests/Console/Report/FixReport/ReporterFactoryTest.php
+++ b/tests/Console/Report/FixReport/ReporterFactoryTest.php
@@ -52,7 +52,7 @@ final class ReporterFactoryTest extends TestCase
 
         $builder->registerBuiltInReporters();
         self::assertSame(
-            ['checkstyle', 'gitlab', 'json', 'junit', 'txt', 'xml'],
+            ['checkstyle', 'github', 'gitlab', 'json', 'junit', 'txt', 'xml'],
             $builder->getFormats(),
         );
     }

--- a/tests/TextDiffTest.php
+++ b/tests/TextDiffTest.php
@@ -109,7 +109,7 @@ final class TextDiffTest extends TestCase
         sort($formats);
 
         self::assertSame(
-            ['checkstyle', 'gitlab', 'json', 'junit', 'txt', 'xml'],
+            ['checkstyle', 'github', 'gitlab', 'json', 'junit', 'txt', 'xml'],
             $formats,
         );
     }


### PR DESCRIPTION
## Summary

Adds a `github` output format so violations are rendered as [GitHub Actions workflow command](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message) annotations (`::error file=…,line=…,title=…::…`), showing findings directly on the pull-request file diff.

Closes #5482

This revives the approach from the stale, never-reviewed PR #9382 by HypeMC (closed only by the stale bot, not on review), rebased onto current `master` and kept minimal. Authorship of the reporter is credited to HypeMC via `@author` tags.

### What it does

- New `GitHubReporter` (`--format=github`), auto-selected by `@auto` when `GITHUB_ACTIONS` is set — mirroring the existing `GITLAB_CI` → `gitlab` behaviour. Precedence when several environments are detected: GitHub Actions > GitLab CI > AI-agent detection.
- The diff line-range logic used by `GitlabReporter` is extracted into a shared, unit-tested `LineExtractor` (no duplication). Because current `master` already wraps the parser result with `array_values(...)`, no PHPStan baseline change is required.
- Docs (`doc/usage.rst`) and the `fix` command help text list the new format and its CI integration.
- Line numbers mirror `GitlabReporter` exactly (first diff chunk; requires `--diff` for correct line numbers). Improving the line-mapping is a pre-existing concern shared with `gitlab` and intentionally left out of scope here.

### Escaping

Property values (`file`, `title`) escape `%`, `\r`, `\n`, `:`, `,`; the message escapes `%`, `\r`, `\n`, per the GitHub Actions toolkit. Covered by a dedicated regression test.

## Test verification (RED → GREEN)

New feature ⇒ TDD: the new tests fail on `master` (feature absent) and pass with the change.

**RED** — production code reverted to `master`, new tests applied (`vendor/bin/phpunit`):

```
ReporterFactoryTest / TextDiffTest::testAllFormatsCovered
  Failed asserting that two arrays are identical (missing 'github').
Class or interface "PhpCsFixer\Console\Report\FixReport\GitHubReporter" does not exist
Class or interface "PhpCsFixer\Console\Report\FixReport\LineExtractor" does not exist
Tests: 32, Assertions: 24, Errors: 14, Failures: 2.
```

ConfigurationResolver cases (RED):

```
testGetReporter ... Class "…\GitHubReporter" does not exist
testResolveConfigFileChooseFileWithInvalidFormat ... message '… "checkstyle", "gitlab", …'
  does not match '… "checkstyle", "github", "gitlab", …'
Tests: 14, Assertions: 12, Errors: 3, Failures: 1.
```

**GREEN** — with the change:

```
# LineExtractor + GitHub/Gitlab reporters + factory + TextDiff (+ escaping test)
OK (42 tests)

# ConfigurationResolver reporter + invalid-format cases
OK (14 tests)
```

## Local validation

- `composer cs:fix` → `Fixed 0 of 1291 files` (already conforms).
- `composer phpstan` → `[OK] No errors`.
- `composer docs` → idempotent (no changes; docs in sync).
- Impacted suites (`ConfigurationResolverTest`, `FixCommandTest`, all `FixReport` reporter tests, `TextDiffTest`) → `OK (234 tests)`.
- Full unit + auto-review suites run against both `master` and this branch produce the same result (the branch adds no new failure; the only pre-existing red is `FileHandlerTest::testWriteThrowsIOExceptionIfFileCanNotBeWritten`, an environment artifact of running the suite as root).
