### PR TITLE
feat: add fixer annotation mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 PHP_CS_FIXER_FAST_LINT_TEST_CASES= # `0` / `1`, default is `1` - run PHP CS Fixer in fast lint mode
 PHP_CS_FIXER_FUTURE_MODE= # `0` / `1`, default is `0` - run PHP CS Fixer in future mode
 PHP_CS_FIXER_NON_MONOLITHIC= # `0` / `1`, default is `0` - run PHP CS Fixer for non-monolithic mode (not officially supported)
-PHP_CS_FIXER_IGNORE_MISMATCHED_RULES_EXCEPTIONS= # `0` / `1`, default is `0` - do not stop execution on mismatched rules exceptions
 
 ## @deprecated
 ## @TODO remove in 4.0
 PHP_CS_FIXER_IGNORE_ENV= # `0` / `1`, default is `0` - ignore environment variables; use Config::setUnsupportedPhpVersionAllowed instead
+PHP_CS_FIXER_IGNORE_MISMATCHED_RULES_EXCEPTIONS= # `0` / `1`, default is `0` - use Config::setFixerAnnotationMode for annotations and correct mismatched Rule Customisation Policy entries
 PHP_CS_FIXER_PARALLEL= # no effect; use Config::setParallelConfig instead
 
 ## @internal

--- a/doc/rules_exceptions.rst
+++ b/doc/rules_exceptions.rst
@@ -61,6 +61,38 @@ Just put this annotation in comment anywhere on top or bottom of the file, and t
     // @php-cs-fixer-ignore no_empty_statement    Works Also
     // @php-cs-fixer-ignore no_extra_blank_lines  on bottom of file
 
+By default, annotations may only refer to rules enabled in the runtime ruleset. The
+annotation mode can be configured with ``Config::setFixerAnnotationMode()``:
+
+.. code-block:: php
+
+    <?php
+
+    use PhpCsFixer\Config;
+    use PhpCsFixer\Config\FixerAnnotationMode;
+
+    return (new Config())
+        // Reject every @php-cs-fixer-ignore annotation.
+        ->setFixerAnnotationMode(FixerAnnotationMode::FORBIDDEN)
+    ;
+
+The available modes are:
+
+* ``FixerAnnotationMode::FORBIDDEN``: annotations are rejected;
+* ``FixerAnnotationMode::MATCHING``: annotations are accepted only for enabled
+  rules (the default);
+* ``FixerAnnotationMode::ALL``: annotations may refer to any rule.
+
+The ``--fixer-annotation-mode`` command-line option accepts the corresponding
+``forbidden``, ``matching``, and ``all`` values and overrides the configured mode.
+
+The ``PHP_CS_FIXER_IGNORE_MISMATCHED_RULES_EXCEPTIONS`` environment variable is
+deprecated. For annotations, its enabled behaviour is equivalent to
+``FixerAnnotationMode::ALL``. The environment variable also bypasses validation
+of mismatched Rule Customisation Policy entries; that separate legacy behaviour
+is not part of the annotation mode, so those entries must be corrected when
+migrating away from the environment variable.
+
 Configuring exceptions via ``Rule Customisation Policy``
 --------------------------------------------------------
 

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -66,7 +66,7 @@ parameters:
         -
             message: '/^Unused PhpCsFixer\\[a-zA-Z\\]+Interface::[a-zA-Z]+$/'
             path: src
-            count: 19
+            count: 20
 
         -
             message: '/^AnonymousClass/'

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -74,6 +74,7 @@ final class Cache implements CacheInterface
                     'lineEnding' => $this->getSignature()->getLineEnding(),
                     'rules' => $this->getSignature()->getRules(),
                     'ruleCustomisationPolicyVersion' => $this->getSignature()->getRuleCustomisationPolicyVersion(),
+                    'fixerAnnotationMode' => $this->getSignature()->getFixerAnnotationMode(),
                     'hashes' => $this->hashes,
                 ],
                 \JSON_THROW_ON_ERROR,
@@ -108,6 +109,7 @@ final class Cache implements CacheInterface
             'lineEnding',
             'rules',
             // 'ruleCustomisationPolicyVersion', // @TODO v4: require me
+            'fixerAnnotationMode',
             'hashes',
         ];
 
@@ -127,6 +129,7 @@ final class Cache implements CacheInterface
             $data['lineEnding'],
             $data['rules'],
             $data['ruleCustomisationPolicyVersion'] ?? NullRuleCustomisationPolicy::VERSION_FOR_CACHE,
+            $data['fixerAnnotationMode'],
         );
 
         $cache = new self($signature);

--- a/src/Cache/Signature.php
+++ b/src/Cache/Signature.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Cache;
 
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\Future;
 
 /**
@@ -43,9 +44,15 @@ final class Signature implements SignatureInterface
     private string $ruleCustomisationPolicyVersion;
 
     /**
-     * @param array<string, array<string, mixed>|bool> $rules
+     * @var FixerAnnotationMode::ALL|FixerAnnotationMode::FORBIDDEN|FixerAnnotationMode::MATCHING
      */
-    public function __construct(string $phpVersion, string $fixerVersion, string $indent, string $lineEnding, array $rules, string $ruleCustomisationPolicyVersion)
+    private string $fixerAnnotationMode;
+
+    /**
+     * @param array<string, array<string, mixed>|bool>                                              $rules
+     * @param FixerAnnotationMode::ALL|FixerAnnotationMode::FORBIDDEN|FixerAnnotationMode::MATCHING $fixerAnnotationMode
+     */
+    public function __construct(string $phpVersion, string $fixerVersion, string $indent, string $lineEnding, array $rules, string $ruleCustomisationPolicyVersion, string $fixerAnnotationMode = FixerAnnotationMode::MATCHING)
     {
         $this->phpVersion = $phpVersion;
         $this->fixerVersion = $fixerVersion;
@@ -53,6 +60,7 @@ final class Signature implements SignatureInterface
         $this->lineEnding = $lineEnding;
         $this->rules = self::makeJsonEncodable($rules);
         $this->ruleCustomisationPolicyVersion = $ruleCustomisationPolicyVersion;
+        $this->fixerAnnotationMode = $fixerAnnotationMode;
     }
 
     public function getPhpVersion(): string
@@ -85,6 +93,11 @@ final class Signature implements SignatureInterface
         return $this->ruleCustomisationPolicyVersion;
     }
 
+    public function getFixerAnnotationMode(): string
+    {
+        return $this->fixerAnnotationMode;
+    }
+
     public function equals(SignatureInterface $signature): bool
     {
         return $this->phpVersion === $signature->getPhpVersion()
@@ -92,7 +105,8 @@ final class Signature implements SignatureInterface
             && $this->indent === $signature->getIndent()
             && $this->lineEnding === $signature->getLineEnding()
             && $this->rules === $signature->getRules()
-            && $this->ruleCustomisationPolicyVersion === $signature->getRuleCustomisationPolicyVersion();
+            && $this->ruleCustomisationPolicyVersion === $signature->getRuleCustomisationPolicyVersion()
+            && $this->fixerAnnotationMode === $signature->getFixerAnnotationMode();
     }
 
     /**

--- a/src/Cache/SignatureInterface.php
+++ b/src/Cache/SignatureInterface.php
@@ -38,5 +38,7 @@ interface SignatureInterface
 
     public function getRuleCustomisationPolicyVersion(): string;
 
+    public function getFixerAnnotationMode(): string;
+
     public function equals(self $signature): bool;
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace PhpCsFixer;
 
+use PhpCsFixer\Config\FixerAnnotationAwareConfigInterface;
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\Config\RuleCustomisationPolicyAwareConfigInterface;
 use PhpCsFixer\Config\RuleCustomisationPolicyInterface;
 use PhpCsFixer\Fixer\FixerInterface;
@@ -30,7 +32,7 @@ use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
  *
  * @api-extendable
  */
-class Config implements ConfigInterface, ParallelAwareConfigInterface, UnsupportedPhpVersionAllowedConfigInterface, CustomRulesetsAwareConfigInterface, RuleCustomisationPolicyAwareConfigInterface
+class Config implements ConfigInterface, ParallelAwareConfigInterface, UnsupportedPhpVersionAllowedConfigInterface, CustomRulesetsAwareConfigInterface, RuleCustomisationPolicyAwareConfigInterface, FixerAnnotationAwareConfigInterface
 {
     /**
      * @var non-empty-string
@@ -87,12 +89,18 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
 
     private ?RuleCustomisationPolicyInterface $ruleCustomisationPolicy = null;
 
+    /**
+     * @var FixerAnnotationMode::ALL|FixerAnnotationMode::FORBIDDEN|FixerAnnotationMode::MATCHING
+     */
+    private string $fixerAnnotationMode;
+
     public function __construct(string $name = 'default')
     {
         $this->name = $name.(Future::isFutureModeEnabled() ? ' (future mode)' : '');
         $this->rules = Future::getV4OrV3(['@PER-CS' => true], ['@PSR12' => true]); // @TODO 4.0 | 3.x switch to '@auto' for v4
         $this->format = Future::getV4OrV3('@auto', 'txt');
         $this->parallelConfig = ParallelConfigFactory::detect();
+        $this->fixerAnnotationMode = FixerAnnotationMode::getDefault();
 
         // @TODO 4.0 cleanup
         if (false !== getenv('PHP_CS_FIXER_IGNORE_ENV')) {
@@ -131,6 +139,14 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
     public function getFormat(): string
     {
         return $this->format;
+    }
+
+    /**
+     * @return FixerAnnotationMode::ALL|FixerAnnotationMode::FORBIDDEN|FixerAnnotationMode::MATCHING
+     */
+    public function getFixerAnnotationMode(): string
+    {
+        return $this->fixerAnnotationMode;
     }
 
     public function getHideProgress(): bool
@@ -229,6 +245,22 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
     public function setFormat(string $format): ConfigInterface
     {
         $this->format = $format;
+
+        return $this;
+    }
+
+    /**
+     * @param FixerAnnotationMode::ALL|FixerAnnotationMode::FORBIDDEN|FixerAnnotationMode::MATCHING $fixerAnnotationMode
+     *
+     * @return $this
+     */
+    public function setFixerAnnotationMode(string $fixerAnnotationMode): ConfigInterface
+    {
+        if (!\in_array($fixerAnnotationMode, FixerAnnotationMode::all(), true)) {
+            throw new \InvalidArgumentException(\sprintf('Unknown fixer annotation mode "%s".', $fixerAnnotationMode));
+        }
+
+        $this->fixerAnnotationMode = $fixerAnnotationMode;
 
         return $this;
     }

--- a/src/Config/FixerAnnotationAwareConfigInterface.php
+++ b/src/Config/FixerAnnotationAwareConfigInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Config;
+
+use PhpCsFixer\ConfigInterface;
+
+/**
+ * EXPERIMENTAL: This feature is experimental and does not fall under the backward compatibility promise.
+ *
+ * @TODO 4.0 Include support for this in main ConfigInterface
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+interface FixerAnnotationAwareConfigInterface extends ConfigInterface
+{
+    /**
+     * @param FixerAnnotationMode::ALL|FixerAnnotationMode::FORBIDDEN|FixerAnnotationMode::MATCHING $fixerAnnotationMode
+     *
+     * @return $this
+     */
+    public function setFixerAnnotationMode(string $fixerAnnotationMode): ConfigInterface;
+
+    /**
+     * @return FixerAnnotationMode::ALL|FixerAnnotationMode::FORBIDDEN|FixerAnnotationMode::MATCHING
+     */
+    public function getFixerAnnotationMode(): string;
+}

--- a/src/Config/FixerAnnotationMode.php
+++ b/src/Config/FixerAnnotationMode.php
@@ -35,6 +35,9 @@ final class FixerAnnotationMode
         self::ALL,
     ];
 
+    /**
+     * @codeCoverageIgnore
+     */
     private function __construct() {}
 
     /**

--- a/src/Config/FixerAnnotationMode.php
+++ b/src/Config/FixerAnnotationMode.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Config;
+
+use PhpCsFixer\Future;
+
+/**
+ * EXPERIMENTAL: This feature is experimental and does not fall under the backward compatibility promise.
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+final class FixerAnnotationMode
+{
+    public const FORBIDDEN = 'forbidden';
+    public const MATCHING = 'matching';
+    public const ALL = 'all';
+
+    private const LEGACY_ENV_VAR = 'PHP_CS_FIXER_IGNORE_MISMATCHED_RULES_EXCEPTIONS';
+
+    private const VALUES = [
+        self::FORBIDDEN,
+        self::MATCHING,
+        self::ALL,
+    ];
+
+    private function __construct() {}
+
+    /**
+     * @return non-empty-list<self::ALL|self::FORBIDDEN|self::MATCHING>
+     */
+    public static function all(): array
+    {
+        return self::VALUES;
+    }
+
+    /**
+     * @return self::ALL|self::FORBIDDEN|self::MATCHING
+     */
+    public static function getDefault(): string
+    {
+        if (self::legacyEnvironmentVariableIsEnabled()) {
+            Future::triggerDeprecation(new \RuntimeException(\sprintf(
+                'Environment variable "%s" is deprecated; use Config::setFixerAnnotationMode() or --fixer-annotation-mode instead.',
+                self::LEGACY_ENV_VAR,
+            )));
+
+            return self::ALL;
+        }
+
+        return self::MATCHING;
+    }
+
+    public static function legacyEnvironmentVariableIsEnabled(): bool
+    {
+        return true === filter_var(getenv(self::LEGACY_ENV_VAR), \FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace PhpCsFixer\Console\Command;
 
 use PhpCsFixer\Config;
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
 use PhpCsFixer\Console\Application;
@@ -209,6 +210,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
                 new InputArgument('path', InputArgument::IS_ARRAY, 'The path(s) that rules will be run against (each path can be a file or directory).'),
                 new InputOption('path-mode', '', InputOption::VALUE_REQUIRED, HelpCommand::getDescriptionWithAllowedValues('Specify path mode (%s).', ConfigurationResolver::PATH_MODE_VALUES), ConfigurationResolver::PATH_MODE_OVERRIDE, ConfigurationResolver::PATH_MODE_VALUES),
                 new InputOption('allow-risky', '', InputOption::VALUE_REQUIRED, HelpCommand::getDescriptionWithAllowedValues('Are risky fixers allowed (%s).', ConfigurationResolver::BOOL_VALUES), null, ConfigurationResolver::BOOL_VALUES),
+                new InputOption('fixer-annotation-mode', '', InputOption::VALUE_REQUIRED, HelpCommand::getDescriptionWithAllowedValues('Control @php-cs-fixer-ignore annotations (%s).', FixerAnnotationMode::all()), null, FixerAnnotationMode::all()),
                 new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The path to a config file.'),
                 new InputOption('dry-run', '', InputOption::VALUE_NONE, 'Only shows which files would have been modified.'),
                 new InputOption('rules', '', InputOption::VALUE_REQUIRED, 'List of rules that should be run against configured paths.', null, static function () {
@@ -245,6 +247,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
             $this->defaultConfig,
             [
                 'allow-risky' => $input->getOption('allow-risky'),
+                'fixer-annotation-mode' => $input->getOption('fixer-annotation-mode'),
                 'config' => $passedConfig,
                 'dry-run' => $this->isDryRun($input),
                 'rules' => $passedRules,
@@ -393,6 +396,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
             $input,
             $resolver->getConfigFile(),
             $resolver->getRuleCustomisationPolicy(),
+            $resolver->getFixerAnnotationMode(),
         );
 
         $this->eventDispatcher->addListener(FileProcessed::NAME, [$progressOutput, 'onFixerFileProcessed']);

--- a/src/Console/Command/WorkerCommand.php
+++ b/src/Console/Command/WorkerCommand.php
@@ -18,6 +18,7 @@ use Clue\React\NDJson\Decoder;
 use Clue\React\NDJson\Encoder;
 use PhpCsFixer\Cache\NullCacheManager;
 use PhpCsFixer\Config;
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\Console\ConfigurationResolver;
 use PhpCsFixer\Error\ErrorsManager;
 use PhpCsFixer\Runner\Event\FileProcessed;
@@ -77,6 +78,7 @@ final class WorkerCommand extends Command
                 new InputOption('port', null, InputOption::VALUE_REQUIRED, 'Specifies parallelisation server\'s port.'),
                 new InputOption('identifier', null, InputOption::VALUE_REQUIRED, 'Specifies parallelisation process\' identifier.'),
                 new InputOption('allow-risky', '', InputOption::VALUE_REQUIRED, HelpCommand::getDescriptionWithAllowedValues('Are risky fixers allowed (%s).', ConfigurationResolver::BOOL_VALUES), null, ConfigurationResolver::BOOL_VALUES),
+                new InputOption('fixer-annotation-mode', '', InputOption::VALUE_REQUIRED, HelpCommand::getDescriptionWithAllowedValues('Control @php-cs-fixer-ignore annotations (%s).', FixerAnnotationMode::all()), null, FixerAnnotationMode::all()),
                 new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The path to a config file.'),
                 new InputOption('dry-run', '', InputOption::VALUE_NONE, 'Only shows which files would have been modified.'),
                 new InputOption('rules', '', InputOption::VALUE_REQUIRED, 'List of rules that should be run against configured paths.'),
@@ -218,6 +220,7 @@ final class WorkerCommand extends Command
             new Config(),
             [
                 'allow-risky' => $input->getOption('allow-risky'),
+                'fixer-annotation-mode' => $input->getOption('fixer-annotation-mode'),
                 'config' => $passedConfig,
                 'dry-run' => $input->getOption('dry-run'),
                 'rules' => $passedRules,
@@ -247,6 +250,7 @@ final class WorkerCommand extends Command
             null,
             $this->configurationResolver->getConfigFile(),
             $this->configurationResolver->getRuleCustomisationPolicy(),
+            $this->configurationResolver->getFixerAnnotationMode(),
         );
     }
 }

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -22,6 +22,8 @@ use PhpCsFixer\Cache\FileCacheManager;
 use PhpCsFixer\Cache\FileHandler;
 use PhpCsFixer\Cache\NullCacheManager;
 use PhpCsFixer\Cache\Signature;
+use PhpCsFixer\Config\FixerAnnotationAwareConfigInterface;
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\Config\NullRuleCustomisationPolicy;
 use PhpCsFixer\Config\RuleCustomisationPolicyAwareConfigInterface;
 use PhpCsFixer\Config\RuleCustomisationPolicyInterface;
@@ -63,6 +65,7 @@ use Symfony\Component\Finder\Finder as SymfonyFinder;
  *
  * @phpstan-type _Options array{
  *      allow-risky: null|string,
+ *      fixer-annotation-mode: null|string,
  *      cache-file: null|string,
  *      config: null|string,
  *      diff: null|string,
@@ -140,6 +143,7 @@ final class ConfigurationResolver
      */
     private array $options = [
         'allow-risky' => null,
+        'fixer-annotation-mode' => null,
         'cache-file' => null,
         'config' => null,
         'diff' => null,
@@ -194,6 +198,11 @@ final class ConfigurationResolver
     private ?FixerFactory $fixerFactory = null;
 
     /**
+     * @var null|FixerAnnotationMode::ALL|FixerAnnotationMode::FORBIDDEN|FixerAnnotationMode::MATCHING
+     */
+    private ?string $fixerAnnotationMode = null;
+
+    /**
      * @param array<string, mixed> $options
      */
     public function __construct(
@@ -245,6 +254,7 @@ final class ConfigurationResolver
                         $this->getConfig()->getLineEnding(),
                         $this->getRules(),
                         $this->getRuleCustomisationPolicy()->getPolicyVersionForCache(),
+                        $this->getFixerAnnotationMode(),
                     ),
                     $this->isDryRun(),
                     $this->getDirectory(),
@@ -552,6 +562,35 @@ final class ConfigurationResolver
         }
 
         return $this->finder;
+    }
+
+    /**
+     * @return FixerAnnotationMode::ALL|FixerAnnotationMode::FORBIDDEN|FixerAnnotationMode::MATCHING
+     */
+    public function getFixerAnnotationMode(): string
+    {
+        if (null === $this->fixerAnnotationMode) {
+            $mode = $this->options['fixer-annotation-mode'];
+
+            if (null === $mode) {
+                $config = $this->getConfig();
+                $mode = $config instanceof FixerAnnotationAwareConfigInterface
+                    ? $config->getFixerAnnotationMode()
+                    : FixerAnnotationMode::getDefault();
+            }
+
+            if (!\in_array($mode, FixerAnnotationMode::all(), true)) {
+                throw new InvalidConfigurationException(\sprintf(
+                    'The fixer annotation mode "%s" is not defined, supported are %s.',
+                    $mode,
+                    Utils::naturalLanguageJoin(FixerAnnotationMode::all()),
+                ));
+            }
+
+            $this->fixerAnnotationMode = $mode;
+        }
+
+        return $this->fixerAnnotationMode;
     }
 
     /**

--- a/src/Runner/Parallel/ProcessFactory.php
+++ b/src/Runner/Parallel/ProcessFactory.php
@@ -91,7 +91,7 @@ final class ProcessFactory
             $commandArgs[] = '--stop-on-violation';
         }
 
-        foreach (['allow-risky', 'config', 'rules', 'using-cache', 'cache-file'] as $option) {
+        foreach (['allow-risky', 'fixer-annotation-mode', 'config', 'rules', 'using-cache', 'cache-file'] as $option) {
             $optionValue = $input->getOption($option);
 
             if (null !== $optionValue) {

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -20,6 +20,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Cache\CacheManagerInterface;
 use PhpCsFixer\Cache\Directory;
 use PhpCsFixer\Cache\DirectoryInterface;
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\Config\NullRuleCustomisationPolicy;
 use PhpCsFixer\Config\RuleCustomisationPolicyInterface;
 use PhpCsFixer\Console\Command\WorkerCommand;
@@ -122,8 +123,16 @@ final class Runner
     private RuleCustomisationPolicyInterface $ruleCustomisationPolicy;
 
     /**
-     * @param null|\Traversable<array-key, \SplFileInfo> $fileIterator
-     * @param list<FixerInterface>                       $fixers
+     * @var FixerAnnotationMode::ALL|FixerAnnotationMode::FORBIDDEN|FixerAnnotationMode::MATCHING
+     */
+    private string $fixerAnnotationMode;
+
+    private bool $ignoreMismatchedRulesExceptions;
+
+    /**
+     * @param null|\Traversable<array-key, \SplFileInfo>                                                 $fileIterator
+     * @param list<FixerInterface>                                                                       $fixers
+     * @param null|FixerAnnotationMode::ALL|FixerAnnotationMode::FORBIDDEN|FixerAnnotationMode::MATCHING $fixerAnnotationMode
      */
     public function __construct(
         ?\Traversable $fileIterator,
@@ -140,7 +149,8 @@ final class Runner
         ?ParallelConfig $parallelConfig = null,
         ?InputInterface $input = null,
         ?string $configFile = null,
-        ?RuleCustomisationPolicyInterface $ruleCustomisationPolicy = null
+        ?RuleCustomisationPolicyInterface $ruleCustomisationPolicy = null,
+        ?string $fixerAnnotationMode = null
     ) {
         // Required only for main process (calculating workers count)
         $this->fileCount = null !== $fileIterator ? \count(iterator_to_array($fileIterator)) : 0;
@@ -168,6 +178,12 @@ final class Runner
         $this->input = $input;
         $this->configFile = $configFile;
         $this->ruleCustomisationPolicy = $ruleCustomisationPolicy ?? new NullRuleCustomisationPolicy();
+        $this->ignoreMismatchedRulesExceptions = FixerAnnotationMode::legacyEnvironmentVariableIsEnabled();
+        $this->fixerAnnotationMode = $fixerAnnotationMode ?? FixerAnnotationMode::getDefault();
+
+        if (!\in_array($this->fixerAnnotationMode, FixerAnnotationMode::all(), true)) {
+            throw new \InvalidArgumentException(\sprintf('Unknown fixer annotation mode "%s".', $this->fixerAnnotationMode));
+        }
     }
 
     /**
@@ -203,15 +219,17 @@ final class Runner
         }
 
         $ruleCustomisers = $this->ruleCustomisationPolicy->getRuleCustomisers();
-        $this->validateRulesNamesForExceptions(
-            array_keys($ruleCustomisers),
-            <<<'EOT'
-                Rule Customisation Policy contains customisers for rules that are not in the current set of enabled rules:
-                %s
+        if (!$this->ignoreMismatchedRulesExceptions) {
+            $this->validateRulesNamesForExceptions(
+                array_keys($ruleCustomisers),
+                <<<'EOT'
+                    Rule Customisation Policy contains customisers for rules that are not in the current set of enabled rules:
+                    %s
 
-                Please check your configuration to ensure that these rules are included, or update your Rule Customisation Policy if they have been replaced by other rules in the version of PHP CS Fixer you are using.
-                EOT,
-        );
+                    Please check your configuration to ensure that these rules are included, or update your Rule Customisation Policy if they have been replaced by other rules in the version of PHP CS Fixer you are using.
+                    EOT,
+            );
+        }
 
         // @TODO 4.0: Remove condition and its body, as no longer needed when param will be required in the constructor.
         // This is a fallback only in case someone calls `new Runner()` in a custom repo and does not provide v4-ready params in v3-codebase.
@@ -235,10 +253,6 @@ final class Runner
      */
     private function validateRulesNamesForExceptions(array $ruleExceptions, string $errorTemplate): void
     {
-        if (true === filter_var(getenv('PHP_CS_FIXER_IGNORE_MISMATCHED_RULES_EXCEPTIONS'), \FILTER_VALIDATE_BOOLEAN)) {
-            return;
-        }
-
         if ([] === $ruleExceptions) {
             return;
         }
@@ -610,15 +624,24 @@ final class Runner
             );
         }
 
-        $this->validateRulesNamesForExceptions(
-            $rulesIgnoredByAnnotations,
-            <<<EOT
-                @php-cs-fixer-ignore annotation(s) used for rules that are not in the current set of enabled rules:
-                %s
+        if ([] !== $rulesIgnoredByAnnotations && FixerAnnotationMode::FORBIDDEN === $this->fixerAnnotationMode) {
+            throw new \RuntimeException(\sprintf(
+                '@php-cs-fixer-ignore annotation(s) are forbidden in "%s". Please remove them.',
+                $filePathname,
+            ));
+        }
 
-                Please check your annotation(s) usage in {$filePathname} to ensure that these rules are included, or update your annotation(s) usage if they have been replaced by other rules in the version of PHP CS Fixer you are using.
-                EOT,
-        );
+        if (FixerAnnotationMode::MATCHING === $this->fixerAnnotationMode) {
+            $this->validateRulesNamesForExceptions(
+                $rulesIgnoredByAnnotations,
+                <<<EOT
+                    @php-cs-fixer-ignore annotation(s) used for rules that are not in the current set of enabled rules:
+                    %s
+
+                    Please check your annotation(s) usage in {$filePathname} to ensure that these rules are included, or update your annotation(s) usage if they have been replaced by other rules in the version of PHP CS Fixer you are using.
+                    EOT,
+            );
+        }
 
         try {
             foreach ($this->fixers as $fixer) {

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -19,6 +19,7 @@ use PhpCsFixer\Cache\CacheInterface;
 use PhpCsFixer\Cache\Signature;
 use PhpCsFixer\Cache\SignatureInterface;
 use PhpCsFixer\Config;
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\Hasher;
 use PhpCsFixer\Tests\TestCase;
 use PhpCsFixer\ToolInfo;
@@ -139,6 +140,7 @@ final class CacheTest extends TestCase
                 'bar' => false,
             ],
             'ruleCustomisationPolicyVersion' => '1.2.3',
+            'fixerAnnotationMode' => FixerAnnotationMode::MATCHING,
             'hashes' => [],
         ];
 
@@ -188,6 +190,7 @@ final class CacheTest extends TestCase
                 'bar' => true,
             ],
             'fooBar',
+            FixerAnnotationMode::ALL,
         )];
 
         yield [new Signature(
@@ -201,6 +204,24 @@ final class CacheTest extends TestCase
             ],
             'fooBar',
         )];
+    }
+
+    public function testFromLegacyJsonWithoutFixerAnnotationModeIsRejected(): void
+    {
+        $json = json_encode([
+            'php' => \PHP_VERSION,
+            'version' => '3.0',
+            'indent' => '    ',
+            'lineEnding' => "\n",
+            'rules' => [],
+            'ruleCustomisationPolicyVersion' => '1',
+            'hashes' => [],
+        ], \JSON_THROW_ON_ERROR);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('JSON data is missing keys "fixerAnnotationMode"');
+
+        Cache::fromJson($json);
     }
 
     public function testToJsonThrowsExceptionOnInvalid(): void
@@ -253,6 +274,11 @@ final class CacheTest extends TestCase
             public function getRuleCustomisationPolicyVersion(): string
             {
                 return 'Policy Version';
+            }
+
+            public function getFixerAnnotationMode(): string
+            {
+                return FixerAnnotationMode::MATCHING;
             }
 
             public function equals(SignatureInterface $signature): bool

--- a/tests/Cache/FileCacheManagerTest.php
+++ b/tests/Cache/FileCacheManagerTest.php
@@ -18,8 +18,11 @@ use PhpCsFixer\Cache\CacheInterface;
 use PhpCsFixer\Cache\CacheManagerInterface;
 use PhpCsFixer\Cache\DirectoryInterface;
 use PhpCsFixer\Cache\FileCacheManager;
+use PhpCsFixer\Cache\FileHandler;
 use PhpCsFixer\Cache\FileHandlerInterface;
+use PhpCsFixer\Cache\Signature;
 use PhpCsFixer\Cache\SignatureInterface;
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\Hasher;
 use PhpCsFixer\Tests\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -126,6 +129,50 @@ final class FileCacheManagerTest extends TestCase
         $manager = new FileCacheManager($handler, $signature);
 
         self::assertFalse($manager->needFixing($file, $fileContent));
+    }
+
+    public function testLegacyCacheWithoutFixerAnnotationModeIsInvalidated(): void
+    {
+        $cacheFile = tempnam(sys_get_temp_dir(), 'php-cs-fixer-cache-');
+        if (false === $cacheFile) {
+            throw new \RuntimeException('Unable to create a temporary cache file.');
+        }
+
+        $file = 'hello.php';
+        $fileContent = '<?php echo "Hello!"';
+        $signature = new Signature(
+            \PHP_VERSION,
+            '3.0',
+            '    ',
+            "\n",
+            [],
+            '1',
+            FixerAnnotationMode::MATCHING,
+        );
+        $manager = null;
+
+        try {
+            $bytesWritten = file_put_contents($cacheFile, json_encode([
+                'php' => $signature->getPhpVersion(),
+                'version' => $signature->getFixerVersion(),
+                'indent' => $signature->getIndent(),
+                'lineEnding' => $signature->getLineEnding(),
+                'rules' => $signature->getRules(),
+                'ruleCustomisationPolicyVersion' => $signature->getRuleCustomisationPolicyVersion(),
+                'hashes' => [$file => Hasher::calculate($fileContent)],
+            ], \JSON_THROW_ON_ERROR));
+
+            if (false === $bytesWritten) {
+                throw new \RuntimeException('Unable to write the temporary cache file.');
+            }
+
+            $manager = new FileCacheManager(new FileHandler($cacheFile), $signature);
+
+            self::assertTrue($manager->needFixing($file, $fileContent));
+        } finally {
+            unset($manager);
+            @unlink($cacheFile);
+        }
     }
 
     public function testNeedFixingUsesRelativePathToFile(): void
@@ -307,6 +354,11 @@ final class FileCacheManagerTest extends TestCase
             public function getRuleCustomisationPolicyVersion(): string
             {
                 throw new \LogicException('Not implemented.');
+            }
+
+            public function getFixerAnnotationMode(): string
+            {
+                return FixerAnnotationMode::MATCHING;
             }
 
             public function equals(SignatureInterface $signature): bool

--- a/tests/Cache/SignatureTest.php
+++ b/tests/Cache/SignatureTest.php
@@ -16,6 +16,7 @@ namespace PhpCsFixer\Tests\Cache;
 
 use PhpCsFixer\Cache\Signature;
 use PhpCsFixer\Cache\SignatureInterface;
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\Tests\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -54,8 +55,9 @@ final class SignatureTest extends TestCase
         $lineEnding = \PHP_EOL;
         $rules = ['foo' => true, 'bar' => false];
         $ruleCustomisationPolicyVersion = '123';
+        $fixerAnnotationMode = FixerAnnotationMode::FORBIDDEN;
 
-        $signature = new Signature($php, $version, $indent, $lineEnding, $rules, $ruleCustomisationPolicyVersion);
+        $signature = new Signature($php, $version, $indent, $lineEnding, $rules, $ruleCustomisationPolicyVersion, $fixerAnnotationMode);
 
         self::assertSame($php, $signature->getPhpVersion());
         self::assertSame($version, $signature->getFixerVersion());
@@ -63,6 +65,7 @@ final class SignatureTest extends TestCase
         self::assertSame($lineEnding, $signature->getLineEnding());
         self::assertSame($rules, $signature->getRules());
         self::assertSame($ruleCustomisationPolicyVersion, $signature->getRuleCustomisationPolicyVersion());
+        self::assertSame($fixerAnnotationMode, $signature->getFixerAnnotationMode());
     }
 
     /**
@@ -116,6 +119,11 @@ final class SignatureTest extends TestCase
         yield 'ruleCustomisationPolicyVersion' => [
             $base,
             new Signature($php, $version, $indent, $lineEnding, $rules, '2'),
+        ];
+
+        yield 'fixerAnnotationMode' => [
+            $base,
+            new Signature($php, $version, $indent, $lineEnding, $rules, $ruleCustomisationPolicyVersion, FixerAnnotationMode::ALL),
         ];
     }
 

--- a/tests/Config/FixerAnnotationModeTest.php
+++ b/tests/Config/FixerAnnotationModeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Config;
+
+use PhpCsFixer\Config\FixerAnnotationMode;
+use PhpCsFixer\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Config\FixerAnnotationMode
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+#[CoversClass(FixerAnnotationMode::class)]
+final class FixerAnnotationModeTest extends TestCase
+{
+    private const LEGACY_ENV_VAR = 'PHP_CS_FIXER_IGNORE_MISMATCHED_RULES_EXCEPTIONS';
+
+    public function testAll(): void
+    {
+        self::assertSame([
+            FixerAnnotationMode::FORBIDDEN,
+            FixerAnnotationMode::MATCHING,
+            FixerAnnotationMode::ALL,
+        ], FixerAnnotationMode::all());
+    }
+
+    public function testDefault(): void
+    {
+        $previousValue = getenv(self::LEGACY_ENV_VAR);
+        putenv(self::LEGACY_ENV_VAR);
+
+        try {
+            self::assertSame(FixerAnnotationMode::MATCHING, FixerAnnotationMode::getDefault());
+            self::assertFalse(FixerAnnotationMode::legacyEnvironmentVariableIsEnabled());
+        } finally {
+            putenv(false === $previousValue ? self::LEGACY_ENV_VAR : self::LEGACY_ENV_VAR.'='.$previousValue);
+        }
+    }
+
+    public function testLegacyEnvironmentVariable(): void
+    {
+        $previousValue = getenv(self::LEGACY_ENV_VAR);
+        putenv(self::LEGACY_ENV_VAR.'=1');
+
+        $this->expectDeprecation(\sprintf(
+            'Environment variable "%s" is deprecated; use Config::setFixerAnnotationMode() or --fixer-annotation-mode instead.',
+            self::LEGACY_ENV_VAR,
+        ));
+
+        try {
+            self::assertTrue(FixerAnnotationMode::legacyEnvironmentVariableIsEnabled());
+            self::assertSame(FixerAnnotationMode::ALL, FixerAnnotationMode::getDefault());
+        } finally {
+            putenv(false === $previousValue ? self::LEGACY_ENV_VAR : self::LEGACY_ENV_VAR.'='.$previousValue);
+        }
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace PhpCsFixer\Tests;
 
 use PhpCsFixer\Config;
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\Config\NullRuleCustomisationPolicy;
 use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
 use PhpCsFixer\Console\Application;
@@ -44,6 +45,8 @@ use Symfony\Component\Finder\Finder as SymfonyFinder;
 #[CoversClass(Config::class)]
 final class ConfigTest extends TestCase
 {
+    private const LEGACY_FIXER_ANNOTATION_ENV = 'PHP_CS_FIXER_IGNORE_MISMATCHED_RULES_EXCEPTIONS';
+
     public function testFutureMode(): void
     {
         $futureMode = getenv('PHP_CS_FIXER_FUTURE_MODE');
@@ -261,7 +264,14 @@ final class ConfigTest extends TestCase
 
     public function testConfigDefault(): void
     {
-        $config = new Config();
+        $previousLegacyFixerAnnotationValue = getenv(self::LEGACY_FIXER_ANNOTATION_ENV);
+        putenv(self::LEGACY_FIXER_ANNOTATION_ENV);
+
+        try {
+            $config = new Config();
+        } finally {
+            putenv(false === $previousLegacyFixerAnnotationValue ? self::LEGACY_FIXER_ANNOTATION_ENV : self::LEGACY_FIXER_ANNOTATION_ENV.'='.$previousLegacyFixerAnnotationValue);
+        }
 
         self::assertSame('.php-cs-fixer.cache', $config->getCacheFile());
         self::assertSame([], $config->getCustomFixers());
@@ -306,12 +316,41 @@ final class ConfigTest extends TestCase
 
         self::assertNull($config->getRuleCustomisationPolicy());
 
+        self::assertSame(FixerAnnotationMode::MATCHING, $config->getFixerAnnotationMode());
+        $config->setFixerAnnotationMode(FixerAnnotationMode::FORBIDDEN);
+        self::assertSame(FixerAnnotationMode::FORBIDDEN, $config->getFixerAnnotationMode());
+
         $ruleCustomisationPolicy = new NullRuleCustomisationPolicy();
         $config->setRuleCustomisationPolicy($ruleCustomisationPolicy);
         self::assertSame($ruleCustomisationPolicy, $config->getRuleCustomisationPolicy());
 
         $config->setRuleCustomisationPolicy(null);
         self::assertNull($config->getRuleCustomisationPolicy());
+    }
+
+    public function testInvalidFixerAnnotationMode(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown fixer annotation mode "invalid".');
+
+        (new Config())->setFixerAnnotationMode('invalid'); // @phpstan-ignore argument.type (we explicitly test an invalid mode)
+    }
+
+    public function testLegacyFixerAnnotationEnvironmentVariable(): void
+    {
+        $previousValue = getenv(self::LEGACY_FIXER_ANNOTATION_ENV);
+        putenv(self::LEGACY_FIXER_ANNOTATION_ENV.'=1');
+
+        $this->expectDeprecation(\sprintf(
+            'Environment variable "%s" is deprecated; use Config::setFixerAnnotationMode() or --fixer-annotation-mode instead.',
+            self::LEGACY_FIXER_ANNOTATION_ENV,
+        ));
+
+        try {
+            self::assertSame(FixerAnnotationMode::ALL, (new Config())->getFixerAnnotationMode());
+        } finally {
+            putenv(false === $previousValue ? self::LEGACY_FIXER_ANNOTATION_ENV : self::LEGACY_FIXER_ANNOTATION_ENV.'='.$previousValue);
+        }
     }
 
     public function testConfigConstructorWithName(): void

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Console\Command;
 
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
 use PhpCsFixer\Console\Application;
@@ -107,6 +108,21 @@ final class FixCommandTest extends TestCase
 
         self::assertStringContainsString('Running analysis on 1 core sequentially.', $cmdTester->getDisplay());
         self::assertStringContainsString('(header_comment)', $cmdTester->getDisplay());
+        self::assertSame(8, $cmdTester->getStatusCode());
+    }
+
+    /**
+     * @covers \PhpCsFixer\Runner\Runner::fixSequential
+     */
+    public function testSequentialRunAllowsMismatchedFixerAnnotationWhenConfigured(): void
+    {
+        $cmdTester = $this->doTestExecute([
+            'path' => [__DIR__.'/../../Fixtures/FixerTest/rule-ignored-by-tag/B-with-ignore-tag.php'],
+            '--rules' => 'native_function_invocation',
+            '--fixer-annotation-mode' => FixerAnnotationMode::ALL,
+        ]);
+
+        self::assertStringNotContainsString('@php-cs-fixer-ignore annotation(s) used for rules', $cmdTester->getDisplay());
         self::assertSame(8, $cmdTester->getStatusCode());
     }
 

--- a/tests/Console/Command/WorkerCommandTest.php
+++ b/tests/Console/Command/WorkerCommandTest.php
@@ -16,9 +16,11 @@ namespace PhpCsFixer\Tests\Console\Command;
 
 use Clue\React\NDJson\Decoder;
 use Clue\React\NDJson\Encoder;
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\Console\Application;
 use PhpCsFixer\Console\Command\FixCommand;
 use PhpCsFixer\Console\Command\WorkerCommand;
+use PhpCsFixer\Console\ConfigurationResolver;
 use PhpCsFixer\Runner\Event\FileProcessed;
 use PhpCsFixer\Runner\Parallel\ParallelAction;
 use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
@@ -100,7 +102,10 @@ final class WorkerCommandTest extends TestCase
             $processIdentifier,
             new ArrayInput(
                 [
-                    '--config' => __DIR__.'/../../Fixtures/.php-cs-fixer.parallel.php',
+                    '--allow-risky' => 'yes',
+                    '--config' => ConfigurationResolver::IGNORE_CONFIG_FILE,
+                    '--rules' => 'native_function_invocation',
+                    '--fixer-annotation-mode' => FixerAnnotationMode::ALL,
                 ],
                 (new FixCommand(new ToolInfo()))->getDefinition(),
             ),
@@ -139,7 +144,7 @@ final class WorkerCommandTest extends TestCase
                         \assert(\array_key_exists('action', $data));
                         if (ParallelAction::WORKER_HELLO === $data['action']) {
                             $encoder->write(['action' => ParallelAction::RUNNER_REQUEST_ANALYSIS, 'files' => [
-                                realpath(__DIR__.$ds.'..'.$ds.'..').$ds.'Fixtures'.$ds.'FixerTest'.$ds.'fix'.$ds.'somefile.php',
+                                realpath(__DIR__.$ds.'..'.$ds.'..').$ds.'Fixtures'.$ds.'FixerTest'.$ds.'rule-ignored-by-tag'.$ds.'B-with-ignore-tag.php',
                             ]]);
 
                             return;
@@ -158,9 +163,16 @@ final class WorkerCommandTest extends TestCase
 
         // Start worker in the async process, handle communication with server and wait for it to exit
         $process->start($streamSelectLoop);
+        $processOutput = '';
+        $process->stdout->on('data', static function (string $chunk) use (&$processOutput): void {
+            $processOutput .= $chunk;
+        });
+        $process->stderr->on('data', static function (string $chunk) use (&$processOutput): void {
+            $processOutput .= $chunk;
+        });
         $streamSelectLoop->run();
 
-        self::assertSame(Command::SUCCESS, $process->getExitCode());
+        self::assertSame(Command::SUCCESS, $process->getExitCode(), $processOutput);
         self::assertCount(3, $workerScope['messages']);
 
         self::assertArrayHasKey('action', $workerScope['messages'][0]);

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1120,6 +1120,8 @@ final class ConfigurationResolverTest extends TestCase
                 $cacheManager->setFileHash(__FILE__, self::TEST_TOOL_VERSION);
             }
 
+            clearstatcache(true, $cacheFile);
+
             $cache = (new FileHandler($cacheFile))->read();
             self::assertNotNull($cache);
             self::assertSame(FixerAnnotationMode::FORBIDDEN, $cache->getSignature()->getFixerAnnotationMode());

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -17,6 +17,7 @@ namespace PhpCsFixer\Tests\Console;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Cache\NullCacheManager;
 use PhpCsFixer\Config;
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
 use PhpCsFixer\Console\Command\FixCommand;
@@ -70,6 +71,36 @@ final class ConfigurationResolverTest extends TestCase
         $resolver = $this->createConfigurationResolver([], $config);
 
         self::assertSame($parallelConfig, $resolver->getParallelConfig());
+    }
+
+    public function testResolveFixerAnnotationModeFromConfig(): void
+    {
+        $config = (new Config())->setFixerAnnotationMode(FixerAnnotationMode::FORBIDDEN);
+
+        self::assertSame(
+            FixerAnnotationMode::FORBIDDEN,
+            $this->createConfigurationResolver([], $config)->getFixerAnnotationMode(),
+        );
+    }
+
+    public function testCliFixerAnnotationModeOverridesConfig(): void
+    {
+        $config = (new Config())->setFixerAnnotationMode(FixerAnnotationMode::FORBIDDEN);
+
+        self::assertSame(
+            FixerAnnotationMode::ALL,
+            $this->createConfigurationResolver(['fixer-annotation-mode' => FixerAnnotationMode::ALL], $config)->getFixerAnnotationMode(),
+        );
+    }
+
+    public function testInvalidCliFixerAnnotationMode(): void
+    {
+        $resolver = $this->createConfigurationResolver(['fixer-annotation-mode' => 'invalid']);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The fixer annotation mode "invalid" is not defined, supported are "forbidden", "matching" and "all".');
+
+        $resolver->getFixerAnnotationMode();
     }
 
     public function testDefaultParallelConfigFallbacksToAutoDetect(): void
@@ -1260,7 +1291,7 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
 
         $options = $definition->getOptions();
         self::assertSame(
-            ['path-mode', 'allow-risky', 'config', 'dry-run', 'rules', 'using-cache', 'allow-unsupported-php-version', 'cache-file', 'diff', 'format', 'stop-on-violation', 'show-progress', 'sequential'],
+            ['path-mode', 'allow-risky', 'fixer-annotation-mode', 'config', 'dry-run', 'rules', 'using-cache', 'allow-unsupported-php-version', 'cache-file', 'diff', 'format', 'stop-on-violation', 'show-progress', 'sequential'],
             array_keys($options),
             'Expected options mismatch, possibly test needs updating.',
         );

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
 namespace PhpCsFixer\Tests\Console;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Cache\FileCacheManager;
+use PhpCsFixer\Cache\FileHandler;
 use PhpCsFixer\Cache\NullCacheManager;
 use PhpCsFixer\Config;
 use PhpCsFixer\Config\FixerAnnotationMode;
@@ -64,6 +66,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[CoversClass(ConfigurationResolver::class)]
 final class ConfigurationResolverTest extends TestCase
 {
+    private const CACHE_FILE_PREFIX = 'php-cs-fixer-cache-';
+    private const LEGACY_FIXER_ANNOTATION_ENV_VAR = 'PHP_CS_FIXER_IGNORE_MISMATCHED_RULES_EXCEPTIONS';
+    private const TEST_TOOL_VERSION = 'test-version';
+
     public function testResolveParallelConfig(): void
     {
         $parallelConfig = new ParallelConfig();
@@ -81,6 +87,21 @@ final class ConfigurationResolverTest extends TestCase
             FixerAnnotationMode::FORBIDDEN,
             $this->createConfigurationResolver([], $config)->getFixerAnnotationMode(),
         );
+    }
+
+    public function testResolveDefaultFixerAnnotationModeForLegacyConfig(): void
+    {
+        $previousValue = getenv(self::LEGACY_FIXER_ANNOTATION_ENV_VAR);
+        putenv(self::LEGACY_FIXER_ANNOTATION_ENV_VAR);
+
+        try {
+            self::assertSame(
+                FixerAnnotationMode::MATCHING,
+                $this->createConfigurationResolver([], self::createStub(ConfigInterface::class))->getFixerAnnotationMode(),
+            );
+        } finally {
+            putenv(false === $previousValue ? self::LEGACY_FIXER_ANNOTATION_ENV_VAR : self::LEGACY_FIXER_ANNOTATION_ENV_VAR.'='.$previousValue);
+        }
     }
 
     public function testCliFixerAnnotationModeOverridesConfig(): void
@@ -1071,6 +1092,39 @@ final class ConfigurationResolverTest extends TestCase
         self::assertInstanceOf(NullCacheManager::class, $cacheManager);
 
         self::assertFalse($resolver->getLinter()->isAsync());
+    }
+
+    public function testCacheManagerSignatureIncludesFixerAnnotationMode(): void
+    {
+        $cacheFile = tempnam(sys_get_temp_dir(), self::CACHE_FILE_PREFIX);
+        if (false === $cacheFile) {
+            throw new \RuntimeException('Unable to create a temporary cache file.');
+        }
+
+        $toolInfo = self::createStub(ToolInfoInterface::class);
+        $toolInfo->method('getVersion')->willReturn(self::TEST_TOOL_VERSION);
+        $toolInfo->method('isInstalledAsPhar')->willReturn(true);
+
+        $config = (new Config())
+            ->setCacheFile($cacheFile)
+            ->setFixerAnnotationMode(FixerAnnotationMode::FORBIDDEN)
+        ;
+
+        try {
+            $resolver = $this->createConfigurationResolver(['dry-run' => false], $config, '', $toolInfo);
+
+            self::assertInstanceOf(FileCacheManager::class, $resolver->getCacheManager());
+
+            unset($resolver);
+
+            $cache = (new FileHandler($cacheFile))->read();
+            self::assertNotNull($cache);
+            self::assertSame(FixerAnnotationMode::FORBIDDEN, $cache->getSignature()->getFixerAnnotationMode());
+        } finally {
+            if (file_exists($cacheFile) && !unlink($cacheFile)) {
+                throw new \RuntimeException(\sprintf('Unable to remove temporary cache file "%s".', $cacheFile));
+            }
+        }
     }
 
     public function testResolveCacheFileWithOption(): void

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1113,14 +1113,19 @@ final class ConfigurationResolverTest extends TestCase
         try {
             $resolver = $this->createConfigurationResolver(['dry-run' => false], $config, '', $toolInfo);
 
-            self::assertInstanceOf(FileCacheManager::class, $resolver->getCacheManager());
+            $cacheManager = $resolver->getCacheManager();
+            self::assertInstanceOf(FileCacheManager::class, $cacheManager);
 
-            unset($resolver);
+            for ($i = 0; $i < FileCacheManager::WRITE_FREQUENCY; ++$i) {
+                $cacheManager->setFileHash(__FILE__, self::TEST_TOOL_VERSION);
+            }
 
             $cache = (new FileHandler($cacheFile))->read();
             self::assertNotNull($cache);
             self::assertSame(FixerAnnotationMode::FORBIDDEN, $cache->getSignature()->getFixerAnnotationMode());
         } finally {
+            unset($resolver, $cacheManager);
+
             if (file_exists($cacheFile) && !unlink($cacheFile)) {
                 throw new \RuntimeException(\sprintf('Unable to remove temporary cache file "%s".', $cacheFile));
             }

--- a/tests/Runner/Parallel/ProcessFactoryTest.php
+++ b/tests/Runner/Parallel/ProcessFactoryTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Runner\Parallel;
 
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\Console\Command\FixCommand;
 use PhpCsFixer\Preg;
 use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
@@ -169,6 +170,14 @@ final class ProcessFactoryTest extends TestCase
             self::IS_WINDOWS
                 ? '--allow-risky="yes"'
                 : '--allow-risky=\'yes\'',
+        ];
+
+        yield 'fixer annotation mode' => [
+            ['--fixer-annotation-mode' => FixerAnnotationMode::FORBIDDEN],
+            self::createRunnerConfig(false),
+            self::IS_WINDOWS
+                ? '--fixer-annotation-mode="forbidden"'
+                : '--fixer-annotation-mode=\'forbidden\'',
         ];
 
         yield 'config' => [

--- a/tests/Runner/RunnerTest.php
+++ b/tests/Runner/RunnerTest.php
@@ -16,6 +16,7 @@ namespace PhpCsFixer\Tests\Runner;
 
 use PhpCsFixer\Cache\Directory;
 use PhpCsFixer\Cache\NullCacheManager;
+use PhpCsFixer\Config\FixerAnnotationMode;
 use PhpCsFixer\Config\RuleCustomisationPolicyInterface;
 use PhpCsFixer\Console\Command\FixCommand;
 use PhpCsFixer\Console\ConfigurationResolver;
@@ -52,6 +53,8 @@ use Symfony\Component\Finder\Finder;
 #[CoversClass(Runner::class)]
 final class RunnerTest extends TestCase
 {
+    private const FIXER_ANNOTATION_FIXTURE_FILE = 'B-with-ignore-tag.php';
+
     /**
      * @covers \PhpCsFixer\Runner\Runner::fix
      * @covers \PhpCsFixer\Runner\Runner::fixFile
@@ -376,6 +379,48 @@ final class RunnerTest extends TestCase
         );
     }
 
+    public function testFixerAnnotationCanBeForbidden(): void
+    {
+        $runner = $this->createRunnerForFixerAnnotation(
+            [new Fixer\Basic\NumericLiteralSeparatorFixer()],
+            new ErrorsManager(),
+            FixerAnnotationMode::FORBIDDEN,
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(\sprintf(
+            '@php-cs-fixer-ignore annotation(s) are forbidden in "%s". Please remove them.',
+            self::getFixerAnnotationFixturePath(),
+        ));
+
+        $runner->fix();
+    }
+
+    public function testFixerAnnotationOutsideRuntimeRulesetIsRejectedInMatchingMode(): void
+    {
+        $runner = $this->createRunnerForFixerAnnotation(
+            [new Fixer\FunctionNotation\NativeFunctionInvocationFixer()],
+            new ErrorsManager(),
+            FixerAnnotationMode::MATCHING,
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('@php-cs-fixer-ignore annotation(s) used for rules that are not in the current set of enabled rules:');
+
+        $runner->fix();
+    }
+
+    public function testFixerAnnotationOutsideRuntimeRulesetIsAcceptedInAllMode(): void
+    {
+        $runner = $this->createRunnerForFixerAnnotation(
+            [new Fixer\FunctionNotation\NativeFunctionInvocationFixer()],
+            new ErrorsManager(),
+            FixerAnnotationMode::ALL,
+        );
+
+        self::assertArrayHasKey('B-with-ignore-tag.php', $runner->fix());
+    }
+
     /**
      * @param non-empty-string                                                  $path
      * @param _RuleCustomisationPolicyCallback                                  $arraySyntaxCustomiser
@@ -586,6 +631,38 @@ final class RunnerTest extends TestCase
                 return 'some-diff';
             }
         };
+    }
+
+    /**
+     * @param list<FixerInterface>                                                                  $fixers
+     * @param FixerAnnotationMode::ALL|FixerAnnotationMode::FORBIDDEN|FixerAnnotationMode::MATCHING $fixerAnnotationMode
+     */
+    private function createRunnerForFixerAnnotation(array $fixers, ErrorsManager $errorsManager, string $fixerAnnotationMode): Runner
+    {
+        $file = self::getFixerAnnotationFixturePath();
+
+        return new Runner(
+            new \ArrayIterator([new \SplFileInfo($file)]),
+            $fixers,
+            new NullDiffer(),
+            null,
+            $errorsManager,
+            new Linter(),
+            true,
+            new NullCacheManager(),
+            new Directory(\dirname($file)),
+            false,
+            null,
+            null,
+            null,
+            null,
+            $fixerAnnotationMode,
+        );
+    }
+
+    private static function getFixerAnnotationFixturePath(): string
+    {
+        return \dirname(__DIR__).'/Fixtures/FixerTest/rule-ignored-by-tag/'.self::FIXER_ANNOTATION_FIXTURE_FILE;
     }
 
     private function createLinterDouble(): LinterInterface

--- a/tests/Runner/RunnerTest.php
+++ b/tests/Runner/RunnerTest.php
@@ -418,7 +418,16 @@ final class RunnerTest extends TestCase
             FixerAnnotationMode::ALL,
         );
 
-        self::assertArrayHasKey('B-with-ignore-tag.php', $runner->fix());
+        self::assertCount(1, $runner->fix());
+    }
+
+    public function testInvalidFixerAnnotationModeIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown fixer annotation mode "invalid".');
+
+        // @phpstan-ignore-next-line argument.type We intentionally exercise invalid constructor input.
+        $this->createRunnerForFixerAnnotation([], new ErrorsManager(), 'invalid');
     }
 
     /**


### PR DESCRIPTION
Fixes #9463.

This adds a tri-state fixer-annotation policy:

- `forbidden`: reject any `@php-cs-fixer-ignore` annotation;
- `matching` (default): permit annotations only for rules enabled at runtime;
- `all`: permit annotations for any rule.

The policy is configurable through `Config::setFixerAnnotationMode()` and the `--fixer-annotation-mode` CLI option, including parallel workers. The deprecated `PHP_CS_FIXER_IGNORE_MISMATCHED_RULES_EXCEPTIONS` environment variable remains compatible and maps annotation handling to `all`.

Cache signatures now include the selected mode; caches created before this field existed are invalidated safely.

Validation includes RED/GREEN and revert-to-RED proofs, 256 focused tests, sequential and parallel CLI checks, the repository's local CI gates, a backward-compatibility check, and 94.81% changed-line coverage. The only terminal local-suite failure is the same baseline PHP 8.5 future-mode formatter proposal affecting 277 untouched upstream files.
