### PR TITLE
feat: allow setting minimum PHP version in `Config`

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -66,7 +66,7 @@ parameters:
         -
             message: '/^Unused PhpCsFixer\\[a-zA-Z\\]+Interface::[a-zA-Z]+$/'
             path: src
-            count: 19
+            count: 20
 
         -
             message: '/^AnonymousClass/'

--- a/src/ComposerJsonReader.php
+++ b/src/ComposerJsonReader.php
@@ -36,6 +36,11 @@ final class ComposerJsonReader
 
     private static ?self $singleton = null;
 
+    /**
+     * @var null|non-empty-string
+     */
+    private static ?string $phpOverride = null;
+
     public static function createSingleton(): self
     {
         if (null === self::$singleton) {
@@ -45,8 +50,20 @@ final class ComposerJsonReader
         return self::$singleton;
     }
 
+    /**
+     * @param null|non-empty-string $php major.minor version, e.g. "8.1", or null to rely on composer.json detection
+     */
+    public static function setPhpOverride(?string $php): void
+    {
+        self::$phpOverride = $php;
+    }
+
     public function getPhp(): ?string
     {
+        if (null !== self::$phpOverride) {
+            return self::$phpOverride;
+        }
+
         $this->processFile();
 
         return $this->php;

--- a/src/Config.php
+++ b/src/Config.php
@@ -30,7 +30,7 @@ use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
  *
  * @api-extendable
  */
-class Config implements ConfigInterface, ParallelAwareConfigInterface, UnsupportedPhpVersionAllowedConfigInterface, CustomRulesetsAwareConfigInterface, RuleCustomisationPolicyAwareConfigInterface
+class Config implements ConfigInterface, ParallelAwareConfigInterface, UnsupportedPhpVersionAllowedConfigInterface, CustomRulesetsAwareConfigInterface, RuleCustomisationPolicyAwareConfigInterface, MinimumPhpVersionAwareConfigInterface
 {
     /**
      * @var non-empty-string
@@ -73,6 +73,11 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
     private ParallelConfig $parallelConfig;
 
     private ?string $phpExecutable = null;
+
+    /**
+     * @var null|non-empty-string
+     */
+    private ?string $minimumPhpVersion = null;
 
     /**
      * @TODO: 4.0 - update to @PER
@@ -188,6 +193,11 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
         return $this->ruleCustomisationPolicy;
     }
 
+    public function getMinimumPhpVersion(): ?string
+    {
+        return $this->minimumPhpVersion;
+    }
+
     public function registerCustomFixers(iterable $fixers): ConfigInterface
     {
         foreach ($fixers as $fixer) {
@@ -298,6 +308,13 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
     public function setUnsupportedPhpVersionAllowed(bool $isUnsupportedPhpVersionAllowed): ConfigInterface
     {
         $this->isUnsupportedPhpVersionAllowed = $isUnsupportedPhpVersionAllowed;
+
+        return $this;
+    }
+
+    public function setMinimumPhpVersion(?string $minimumPhpVersion): ConfigInterface
+    {
+        $this->minimumPhpVersion = $minimumPhpVersion;
 
         return $this;
     }

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -22,6 +22,7 @@ use PhpCsFixer\Cache\FileCacheManager;
 use PhpCsFixer\Cache\FileHandler;
 use PhpCsFixer\Cache\NullCacheManager;
 use PhpCsFixer\Cache\Signature;
+use PhpCsFixer\ComposerJsonReader;
 use PhpCsFixer\Config\NullRuleCustomisationPolicy;
 use PhpCsFixer\Config\RuleCustomisationPolicyAwareConfigInterface;
 use PhpCsFixer\Config\RuleCustomisationPolicyInterface;
@@ -41,6 +42,7 @@ use PhpCsFixer\FixerFactory;
 use PhpCsFixer\Future;
 use PhpCsFixer\Linter\Linter;
 use PhpCsFixer\Linter\LinterInterface;
+use PhpCsFixer\MinimumPhpVersionAwareConfigInterface;
 use PhpCsFixer\ParallelAwareConfigInterface;
 use PhpCsFixer\RuleSet\RuleSet;
 use PhpCsFixer\RuleSet\RuleSetInterface;
@@ -296,6 +298,10 @@ final class ConfigurationResolver
                 foreach ($this->config->getCustomRuleSets() as $ruleSet) {
                     RuleSets::registerCustomRuleSet($ruleSet);
                 }
+            }
+
+            if ($this->config instanceof MinimumPhpVersionAwareConfigInterface) {
+                ComposerJsonReader::setPhpOverride($this->config->getMinimumPhpVersion());
             }
         }
 

--- a/src/MinimumPhpVersionAwareConfigInterface.php
+++ b/src/MinimumPhpVersionAwareConfigInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer;
+
+/**
+ * @TODO 4.0 Include in main ConfigInterface
+ *
+ * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
+ */
+interface MinimumPhpVersionAwareConfigInterface extends ConfigInterface
+{
+    /**
+     * Returns the minimum PHP version supported by the project, overriding detection from composer.json.
+     *
+     * @return null|non-empty-string major.minor version, e.g. "8.1", or null when relying on composer.json detection
+     */
+    public function getMinimumPhpVersion(): ?string;
+
+    /**
+     * @param null|non-empty-string $minimumPhpVersion major.minor version, e.g. "8.1"
+     *
+     * @return $this
+     */
+    public function setMinimumPhpVersion(?string $minimumPhpVersion): ConfigInterface;
+}

--- a/tests/ComposerJsonReaderTest.php
+++ b/tests/ComposerJsonReaderTest.php
@@ -37,6 +37,17 @@ final class ComposerJsonReaderTest extends TestCase
         self::assertSame($instance, ComposerJsonReader::createSingleton());
     }
 
+    public function testGetPhpReturnsConfiguredOverrideWithoutReadingComposerJson(): void
+    {
+        try {
+            ComposerJsonReader::setPhpOverride('8.1');
+
+            self::assertSame('8.1', (new ComposerJsonReader())->getPhp());
+        } finally {
+            ComposerJsonReader::setPhpOverride(null);
+        }
+    }
+
     /**
      * @dataProvider provideGetPhpUnitCases
      */

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -275,6 +275,7 @@ final class ConfigTest extends TestCase
         self::assertSame(['@PSR12' => true], $config->getRules());
         self::assertTrue($config->getUsingCache());
         self::assertSame(filter_var(getenv('PHP_CS_FIXER_IGNORE_ENV'), \FILTER_VALIDATE_BOOL), $config->getUnsupportedPhpVersionAllowed());
+        self::assertNull($config->getMinimumPhpVersion());
 
         $finder = $config->getFinder();
         self::assertInstanceOf(Finder::class, $finder);
@@ -303,6 +304,12 @@ final class ConfigTest extends TestCase
 
         $config->setUnsupportedPhpVersionAllowed(true);
         self::assertTrue($config->getUnsupportedPhpVersionAllowed());
+
+        self::assertSame($config, $config->setMinimumPhpVersion('8.1'));
+        self::assertSame('8.1', $config->getMinimumPhpVersion());
+
+        $config->setMinimumPhpVersion(null);
+        self::assertNull($config->getMinimumPhpVersion());
 
         self::assertNull($config->getRuleCustomisationPolicy());
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -16,6 +16,7 @@ namespace PhpCsFixer\Tests\Console;
 
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Cache\NullCacheManager;
+use PhpCsFixer\ComposerJsonReader;
 use PhpCsFixer\Config;
 use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
@@ -122,6 +123,19 @@ final class ConfigurationResolverTest extends TestCase
         ], $config);
 
         self::assertSame('none', $resolver->getProgressType());
+    }
+
+    public function testResolveConfigMinimumPhpVersionOverridesComposerDetection(): void
+    {
+        try {
+            $config = (new Config())->setMinimumPhpVersion('8.1');
+
+            $this->createConfigurationResolver([], $config)->getConfig();
+
+            self::assertSame('8.1', ComposerJsonReader::createSingleton()->getPhp());
+        } finally {
+            ComposerJsonReader::setPhpOverride(null);
+        }
     }
 
     public function testResolveProgressWithNegativeConfigAndPositiveOption(): void


### PR DESCRIPTION
Add `Config::setMinimumPhpVersion()` (via new `MinimumPhpVersionAwareConfigInterface`) so projects without a readable composer.json can declare their minimum PHP version; `ConfigurationResolver` feeds it into `ComposerJsonReader`, the single source for PHP-version detection (auto-migration rule sets, version warnings).

## Test verification (RED → GREEN)

With the fix reverted, the new test fails (RED):

```

Runtime:       PHP 8.4.25
Configuration: /fixer/phpunit.xml.dist

E....................................E.........................  63 / 191 ( 32%)
............................................................... 126 / 191 ( 65%)
.............................................................E. 189 / 191 ( 98%)
..                                                              191 / 191 (100%)

Time: 00:05.154, Memory: 46.00 MB

There were 3 errors:

1) PhpCsFixer\Tests\ComposerJsonReaderTest::testGetPhpReturnsConfiguredOverrideWithoutReadingComposerJson
Error: Call to undefined method PhpCsFixer\ComposerJsonReader::setPhpOverride()

/fixer/tests/ComposerJsonReaderTest.php:47

Caused by
Error: Call to undefined method PhpCsFixer\ComposerJsonReader::setPhpOverride()

/fixer/tests/ComposerJsonReaderTest.php:43

2) PhpCsFixer\Tests\Console\ConfigurationResolverTest::testResolveConfigMinimumPhpVersionOverridesComposerDetection
Error: Call to undefined method PhpCsFixer\ComposerJsonReader::setPhpOverride()

/fixer/tests/Console/ConfigurationResolverTest.php:137

Caused by
Error: Call to undefined method PhpCsFixer\Config::setMinimumPhpVersion()

/fixer/tests/Console/ConfigurationResolverTest.php:131

3) PhpCsFixer\Tests\ConfigTest::testConfigDefault
Error: Call to undefined method PhpCsFixer\Config::getMinimumPhpVersion()

/fixer/tests/ConfigTest.php:278

ERRORS!
Tests: 191, Assertions: 311, Errors: 3.
```

With the fix applied, the test passes (GREEN):

```
GREEN attempt 1/2 (exit 0)
PHPUnit 13.0.6 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.25
Configuration: /fixer/phpunit.xml.dist

...............................................................  63 / 191 ( 32%)
............................................................... 126 / 191 ( 65%)
............................................................... 189 / 191 ( 98%)
..                                                              191 / 191 (100%)

Time: 00:05.257, Memory: 46.00 MB

OK (191 tests, 329 assertions)
```

## Full local suite

Command: `docker compose run --rm php-8.5 sh -c 'git config --global --add safe.directory /fixer; composer phpstan' && docker compose run --rm php-8.4 sh -c 'php php-cs-fixer check --config=.php-cs-fixer.dist.php --path-mode=intersection src tests' && docker compose run --rm php-8.4 vendor/bin/phpunit --no-coverage`

```
...........S...SS.......................................... 28851 / 54560 ( 52%)
........................................................... 28910 / 54560 ( 52%)
........................................................... 28969 / 54560 ( 53%)
........S.................................................. 29028 / 54560 ( 53%)
.S...............................S......................... 29087 / 54560 ( 53%)
.............SS............................................ 29146 / 54560 ( 53%)
........................................................... 29205 / 54560 ( 53%)
........................................................... 29264 / 54560 ( 53%)
........................................................... 29323 / 54560 ( 53%)
........................................................... 29382 / 54560 ( 53%)
........................................................... 29441 / 54560 ( 53%)
........................................................... 29500 / 54560 ( 54%)
.............................S....S.S....S........S........ 29559 / 54560 ( 54%)
.....S..................................................... 29618 / 54560 ( 54%)
........................................................... 29677 / 54560 ( 54%)
...........................S............................... 29736 / 54560 ( 54%)
........................................................... 29795 / 54560 ( 54%)
......S.................................................... 29854 / 54560 ( 54%)
........................................................... 29913 / 54560 ( 54%)
........................................................... 29972 / 54560 ( 54%)
.R...........F............F....FEE........................

An error occurred inside PHPUnit.

Message:  Call to undefined method PHPUnit\Event\Test\BeforeFirstTestMethodFailed::test()
Location: /fixer/vendor/phpunit/phpunit/src/Runner/TestResult/Collector.php:283

#0 /fixer/vendor/phpunit/phpunit/src/Runner/TestResult/Subscriber/TestSuiteFinishedSubscriber.php(24): PHPUnit\TestRunner\TestResult\Collector->testSuiteFinished(Object(PHPUnit\Event\TestSuite\Finished))
#1 /fixer/vendor/phpunit/phpunit/src/Event/Dispatcher/DirectDispatcher.php(106): PHPUnit\TestRunner\TestResult\TestSuiteFinishedSubscriber->notify(Object(PHPUnit\Event\TestSuite\Finished))
#2 /fixer/vendor/phpunit/phpunit/src/Event/Dispatcher/DeferringDispatcher.php(47): PHPUnit\Event\DirectDispatcher->dispatch(Object(PHPUnit\Event\TestSuite\Finished))
#3 /fixer/vendor/phpunit/phpunit/src/Event/Emitter/DispatchingEmitter.php(1299): PHPUnit\Event\DeferringDispatcher->dispatch(Object(PHPUnit\Event\TestSuite\Finished))
#4 /fixer/vendor/phpunit/phpunit/src/Framework/TestSuite.php(380): PHPUnit\Event\DispatchingEmitter->testSuiteFinished(Object(PHPUnit\Event\TestSuite\TestSuiteForTestMethodWithDataProvider))
#5 /fixer/vendor/phpunit/phpunit/src/Framework/TestSuite.php(375): PHPUnit\Framework\TestSuite->run()
#6 /fixer/vendor/phpunit/phpunit/src/Framework/TestSuite.php(375): PHPUnit\Framework\TestSuite->run()
#7 /fixer/vendor/phpunit/phpunit/src/Framework/TestSuite.php(375): PHPUnit\Framework\TestSuite->run()
#8 /fixer/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(64): PHPUnit\Framework\TestSuite->run()
#9 /fixer/vendor/phpunit/phpunit/src/TextUI/Application.php(229): PHPUnit\TextUI\TestRunner->run(Object(PHPUnit\TextUI\Configuration\Configuration), Object(PHPUnit\Runner\ResultCache\DefaultResultCache), Object(PHPUnit\Framework\TestSuite))
#10 /fixer/vendor/phpunit/phpunit/phpunit(104): PHPUnit\TextUI\Application->run(Array)
#11 /fixer/vendor/bin/phpunit(122): include('/fixer/vendor/p...')
#12 {main}
```

Fix #9732
