### PR TITLE
fix: `UseArrowFunctionsFixer` - do not convert closure in constant-expressions

### DIFF
--- a/doc/rules/function_notation/use_arrow_functions.rst
+++ b/doc/rules/function_notation/use_arrow_functions.rst
@@ -4,6 +4,12 @@ Rule ``use_arrow_functions``
 
 Anonymous functions with return as the only statement must use arrow functions.
 
+Description
+-----------
+
+Closures in constant expressions (attributes, constants, and property or
+parameter defaults) are not converted.
+
 Warning
 -------
 

--- a/src/Fixer/FunctionNotation/UseArrowFunctionsFixer.php
+++ b/src/Fixer/FunctionNotation/UseArrowFunctionsFixer.php
@@ -19,6 +19,7 @@ use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\FCT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
@@ -45,7 +46,7 @@ final class UseArrowFunctionsFixer extends AbstractFixer
                         SAMPLE,
                 ),
             ],
-            null,
+            'Closures in constant expressions (attributes, constants, and property or parameter defaults) are not converted.',
             'Risky when using `isset()` on outside variables that are not imported with `use ()`.',
         );
     }
@@ -73,14 +74,9 @@ final class UseArrowFunctionsFixer extends AbstractFixer
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
         $analyzer = new TokensAnalyzer($tokens);
+        $constantExpressionClosures = null;
 
         for ($index = $tokens->count() - 1; $index > 0; --$index) {
-            if ($tokens[$index]->isGivenKind(CT::T_ATTRIBUTE_CLOSE)) {
-                $index = $tokens->findBlockStart(Tokens::BLOCK_TYPE_ATTRIBUTE, $index);
-
-                continue;
-            }
-
             if (!$tokens[$index]->isGivenKind(\T_FUNCTION) || !$analyzer->isLambda($index)) {
                 continue;
             }
@@ -167,9 +163,109 @@ final class UseArrowFunctionsFixer extends AbstractFixer
                 continue;
             }
 
+            $constantExpressionClosures ??= $this->getConstantExpressionClosures($tokens);
+
+            if (isset($constantExpressionClosures[$index])) {
+                continue;
+            }
+
             // Transform the function to an arrow function
             $this->transform($tokens, $index, $useStart, $useEnd, $braceOpen, $return, $semicolon, $braceClose);
         }
+    }
+
+    /**
+     * Constant-expression restrictions do not extend into closure bodies or
+     * property hooks: these contain ordinary executable code. Collect nested
+     * scopes before fixing, then classify each closure in its innermost scope.
+     * The backward fixing pass leaves earlier closure indices unchanged.
+     *
+     * @return array<int, true>
+     */
+    private function getConstantExpressionClosures(Tokens $tokens): array
+    {
+        /** @var list<array{start: int, end: int, constant: bool}> $scopes */
+        $scopes = [];
+
+        foreach ($tokens as $index => $token) {
+            if ($token->isGivenKind(FCT::T_ATTRIBUTE)) {
+                $scopes[] = ['start' => $index + 1, 'end' => $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ATTRIBUTE, $index) - 1, 'constant' => true];
+            } elseif ($token->isClassy()) {
+                /** @var int $bodyOpen */
+                $bodyOpen = $tokens->getNextTokenOfKind($index, ['{', '(', [CT::T_CLASS_INSTANTIATION_PARENTHESIS_OPEN]]);
+
+                if (!$tokens[$bodyOpen]->equals('{')) {
+                    $blockType = $tokens[$bodyOpen]->equals('(') ? Tokens::BLOCK_TYPE_PARENTHESIS : Tokens::BLOCK_TYPE_CLASS_INSTANTIATION_PARENTHESIS;
+                    $argumentsEnd = $tokens->findBlockEnd($blockType, $bodyOpen);
+
+                    /** @var int $bodyOpen */
+                    $bodyOpen = $tokens->getNextTokenOfKind($argumentsEnd, ['{']);
+                }
+
+                $scopes[] = ['start' => $bodyOpen + 1, 'end' => $tokens->findBlockEnd(Tokens::BLOCK_TYPE_BRACE, $bodyOpen) - 1, 'constant' => true];
+            } elseif ($token->isGivenKind([\T_FUNCTION, \T_FN])) {
+                /** @var int $parametersOpen */
+                $parametersOpen = $tokens->getNextTokenOfKind($index, ['(']);
+                $parametersEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS, $parametersOpen);
+                $scopes[] = ['start' => $parametersOpen + 1, 'end' => $parametersEnd - 1, 'constant' => true];
+
+                if ($token->isGivenKind(\T_FUNCTION)) {
+                    /** @var int $bodyOpen */
+                    $bodyOpen = $tokens->getNextTokenOfKind($parametersEnd, ['{', ';']);
+
+                    if ($tokens[$bodyOpen]->equals('{')) {
+                        $scopes[] = ['start' => $bodyOpen + 1, 'end' => $tokens->findBlockEnd(Tokens::BLOCK_TYPE_BRACE, $bodyOpen) - 1, 'constant' => false];
+                    }
+                }
+            } elseif ($token->isGivenKind(\T_CONST)) {
+                $scopes[] = ['start' => $index + 1, 'end' => $this->findConstantDeclarationEnd($tokens, $index) - 1, 'constant' => true];
+            } elseif ($token->isGivenKind(CT::T_PROPERTY_HOOK_BRACE_OPEN)) {
+                $scopes[] = ['start' => $index + 1, 'end' => $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PROPERTY_HOOK, $index) - 1, 'constant' => false];
+            }
+        }
+
+        $scopes = array_filter($scopes, static fn (array $scope): bool => $scope['start'] <= $scope['end']);
+        usort($scopes, static fn (array $left, array $right): int => $left['start'] === $right['start']
+            ? $right['end'] <=> $left['end']
+            : $left['start'] <=> $right['start']);
+
+        $stack = [['end' => $tokens->count(), 'constant' => false]];
+        $scopeIndex = 0;
+        $closures = [];
+
+        foreach ($tokens as $index => $token) {
+            while (\count($stack) > 1 && $stack[\count($stack) - 1]['end'] < $index) {
+                array_pop($stack);
+            }
+
+            while (isset($scopes[$scopeIndex]) && $scopes[$scopeIndex]['start'] === $index) {
+                $stack[] = $scopes[$scopeIndex];
+                ++$scopeIndex;
+            }
+
+            if ($token->isGivenKind(\T_FUNCTION) && $stack[\count($stack) - 1]['constant']) {
+                $closures[$index] = true;
+            }
+        }
+
+        return $closures;
+    }
+
+    private function findConstantDeclarationEnd(Tokens $tokens, int $index): int
+    {
+        for ($count = $tokens->count(); $index < $count; ++$index) {
+            if ($tokens[$index]->equals(';') || $tokens[$index]->isGivenKind(\T_CLOSE_TAG)) {
+                return $index;
+            }
+
+            $block = Tokens::detectBlockType($tokens[$index]);
+
+            if (null !== $block && $block['isStart']) {
+                $index = $tokens->findBlockEnd($block['type'], $index);
+            }
+        }
+
+        return $tokens->count();
     }
 
     private function transform(Tokens $tokens, int $index, ?int $useStart, ?int $useEnd, int $braceOpen, int $return, int $semicolon, int $braceClose): void

--- a/src/Fixer/FunctionNotation/UseArrowFunctionsFixer.php
+++ b/src/Fixer/FunctionNotation/UseArrowFunctionsFixer.php
@@ -225,9 +225,7 @@ final class UseArrowFunctionsFixer extends AbstractFixer
         }
 
         $scopes = array_filter($scopes, static fn (array $scope): bool => $scope['start'] <= $scope['end']);
-        usort($scopes, static fn (array $left, array $right): int => $left['start'] === $right['start']
-            ? $right['end'] <=> $left['end']
-            : $left['start'] <=> $right['start']);
+        usort($scopes, static fn (array $left, array $right): int => $left['start'] <=> $right['start']);
 
         $stack = [['end' => $tokens->count(), 'constant' => false]];
         $scopeIndex = 0;
@@ -253,19 +251,17 @@ final class UseArrowFunctionsFixer extends AbstractFixer
 
     private function findConstantDeclarationEnd(Tokens $tokens, int $index): int
     {
-        for ($count = $tokens->count(); $index < $count; ++$index) {
-            if ($tokens[$index]->equals(';') || $tokens[$index]->isGivenKind(\T_CLOSE_TAG)) {
-                return $index;
-            }
-
+        while (!$tokens[$index]->equals(';') && !$tokens[$index]->isGivenKind(\T_CLOSE_TAG)) {
             $block = Tokens::detectBlockType($tokens[$index]);
 
             if (null !== $block && $block['isStart']) {
                 $index = $tokens->findBlockEnd($block['type'], $index);
             }
+
+            ++$index;
         }
 
-        return $tokens->count();
+        return $index;
     }
 
     private function transform(Tokens $tokens, int $index, ?int $useStart, ?int $useEnd, int $braceOpen, int $return, int $semicolon, int $braceClose): void

--- a/tests/Fixer/FunctionNotation/UseArrowFunctionsFixerTest.php
+++ b/tests/Fixer/FunctionNotation/UseArrowFunctionsFixerTest.php
@@ -315,6 +315,51 @@ $load = function ($path) use ($data) {
      */
     public static function provideFix85Cases(): iterable
     {
+        foreach ([
+            'global constant' => '<?php const CALLBACK = static function () { return 1; };',
+            'class constant' => '<?php class Holder { const CALLBACK = static function () { return 1; }; }',
+            'property default' => '<?php class Holder { public $callback = static function () { return 1; }; }',
+            'parameter default' => '<?php function take($callback = static function () { return 1; }) {}',
+            'reference-returning declaration parameter' => '<?php function &take($callback = static function () { return 1; }) { return $callback; }',
+            'abstract declaration parameter' => '<?php interface Factory { public function take($callback = static function () { return 1; }); }',
+            'arrow function parameter default' => '<?php $take = fn ($callback = static function () { return 1; }) => $callback;',
+            'array in constant' => '<?php const CALLBACKS = [static function () { return 1; }, static function () { return 2; }];',
+            'new expression in parameter default' => '<?php function take($holder = new Holder(static function () { return 1; })) {}',
+            'constant before close tag' => '<?php const CALLBACK = static function () { return 1; } ?>',
+        ] as $context => $code) {
+            yield 'preserve closure in '.$context => [$code];
+        }
+
+        yield 'convert runtime closure after a constant declaration' => [
+            '<?php const CALLBACK = static function () { return 1; }; $runtime = static fn () => 2;',
+            '<?php const CALLBACK = static function () { return 1; }; $runtime = static function () { return 2; };',
+        ];
+
+        yield 'convert enclosing runtime closure but preserve its default' => [
+            '<?php $take = fn ($callback = static function () { return 1; }) => $callback;',
+            '<?php $take = function ($callback = static function () { return 1; }) { return $callback; };',
+        ];
+
+        yield 'convert runtime closure in constant closure body' => [
+            '<?php const CALLBACK = static function () { return fn () => 1; };',
+            '<?php const CALLBACK = static function () { return function () { return 1; }; };',
+        ];
+
+        yield 'convert runtime closure in attribute closure body' => [
+            '<?php #[Callback(static function () { return fn () => 1; })] class Holder {}',
+            '<?php #[Callback(static function () { return function () { return 1; }; })] class Holder {}',
+        ];
+
+        yield 'anonymous class arguments are runtime, defaults are constant' => [
+            '<?php $holder = new class(static fn () => 1) { public $callback = static function () { return 2; }; };',
+            '<?php $holder = new class(static function () { return 1; }) { public $callback = static function () { return 2; }; };',
+        ];
+
+        yield 'property hook body is runtime' => [
+            '<?php class Holder { public Closure $callback { get => static fn () => 1; } }',
+            '<?php class Holder { public Closure $callback { get => static function () { return 1; }; } }',
+        ];
+
         yield 'do not convert closure in attribute' => [
             <<<'PHP'
                 <?php


### PR DESCRIPTION
Fixes #9838.

`use_arrow_functions` can turn a valid PHP 8.5 constant-expression closure into an invalid arrow function. #9416 handled attribute arguments, but global/class constants and property/parameter defaults still reproduce the problem. The fix command exits successfully; native `php -l` then rejects the written file with `Constant expression contains invalid operations`.

This change classifies closures by their innermost constant-expression or executable scope. Constant-expression closures are preserved, while ordinary closures remain convertible, including those inside a constant closure's body, anonymous-class constructor arguments and property hooks. Parameter defaults remain protected even when their enclosing runtime closure is converted. Scope collection is lazy and runs once, before the first eligible conversion.

The first commit adds regression coverage; the second adds the guard and regenerated rule documentation. A follow-up simplifies two unreachable scope-traversal branches: scope starts are distinct tokens, and an unterminated constant declaration is rejected by `TOKEN_PARSE` before fixing. This does not add no-op closure conversion or change any rulesets.

### Validation

- The targeted suite has 15 failures on the original fixer and passes with this change (54 PHPUnit invocations, including inherited checks).
- `composer docs` and the full `composer qa` pass on PHP 8.5.9. QA ran as an unprivileged user with 1 GiB shared memory and a 1 GiB PHP memory limit; the container defaults were too small for the parallel runner. Existing skips, incomplete tests and deprecation output are retained.
- Targeted PCOV coverage reports 115/115 statements covered in the fixer, with no coverage exclusions or threshold changes. Full QA and the runtime checks below were repeated after the scope simplification.
- All 44 input/expected-output data sets pass native PHP lint (88 files). This checks the compile-time restriction that token parsing alone misses.
- Six end-to-end CLI cases compile and execute identically before/after formatting. Only the runtime cases change, and a second cache-disabled pass changes no files.
